### PR TITLE
Keep Story 3.1 app docs aligned with the external action repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -447,6 +447,15 @@ repository:
 Typical PR usage:
 
 ```yaml
+name: DeployWhisper
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+
 jobs:
   deploywhisper:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Story 3.1 now ships from the dedicated deploywhisper/analyze-action repository, so the app repo should document the same copy-paste workflow shape users see there. This updates the app README to include the pull_request trigger and permissions block instead of a job-only fragment.

Constraint: The Marketplace action runtime and packaging live outside this repo
Rejected: Leave the README as a job fragment | it no longer meets the story's copy-paste example requirement
Confidence: high
Scope-risk: narrow
Reversibility: clean
Directive: When Story 3.1 changes, update app docs only after verifying the canonical action repo example
Tested: git diff --check -- README.md; action repo README cross-check
Not-tested: GitHub README rendering after push

## What does this PR do?

<!-- Brief description of changes -->

## Type of change
- [ ] Feature (new functionality)
- [ ] Bugfix (non-breaking fix)
- [ ] Release preparation
- [ ] Hotfix (critical production fix)
- [ ] Docs / refactor / chore

## Checklist
- [ ] I have followed the branch naming convention
- [ ] Tests pass locally (`pytest tests/ -v`)
- [ ] Linting passes (`ruff check .`)
- [ ] Docker build succeeds
- [ ] I have updated docs if needed
- [ ] No secrets or .env values committed

## Related issue
Closes #