### PR TITLE
Protect shared report links without leaking internal review data

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,13 +2,20 @@ APP_NAME=DeployWhisper
 APP_VERSION=0.1.0
 APP_HOST=127.0.0.1
 APP_PORT=8080
+APP_BASE_URL=http://127.0.0.1:8080
 LOG_LEVEL=INFO
 DATABASE_URL=sqlite:///data/deploywhisper.db
+DEPLOYWHISPER_SHARE_TOKEN=
 
 # Runtime provider selection
 LLM_PROVIDER=ollama
 LLM_MODEL=ollama/llama3
 LLM_API_BASE=http://localhost:11434
+
+# Share-management API
+# Leave DEPLOYWHISPER_SHARE_TOKEN empty to disable POST /api/v1/analyses/{id}/share.
+# Set it to a strong random value when you want CI, scripts, or operators to
+# enable password protection / file-name redaction for shared reports.
 
 # Keep provider API keys in environment variables or container secrets.
 # Do not persist them in the app database.

--- a/README.md
+++ b/README.md
@@ -181,6 +181,7 @@ Default container behavior:
 - Port `8080` exposed from the app container
 - SQLite database stored under `/app/data`
 - Default provider set to Ollama
+- `POST /api/v1/analyses/{id}/share` stays disabled until `DEPLOYWHISPER_SHARE_TOKEN` is set
 
 Example for local Ollama mode:
 
@@ -200,6 +201,35 @@ OPENAI_API_KEY=your-real-key
 ```
 
 Do not bake secrets into the image. Pass them at runtime through Compose, your shell environment, or your orchestration platform.
+
+If you want to enable the share-management API used to password-protect shared
+reports, set the token as an environment variable on the app container:
+
+```env
+APP_BASE_URL=https://deploywhisper.example.com
+DEPLOYWHISPER_SHARE_TOKEN=replace-with-a-long-random-secret
+```
+
+Compose example:
+
+```bash
+docker compose up -d --build
+```
+
+`docker-compose.yml` already maps `DEPLOYWHISPER_SHARE_TOKEN` from your shell or
+`.env` file, so in practice you usually put it in `.env` next to `APP_BASE_URL`.
+
+Direct `docker run` example:
+
+```bash
+docker run -d \
+  -p 8080:8080 \
+  -e APP_HOST=0.0.0.0 \
+  -e APP_PORT=8080 \
+  -e APP_BASE_URL=https://deploywhisper.example.com \
+  -e DEPLOYWHISPER_SHARE_TOKEN=replace-with-a-long-random-secret \
+  ghcr.io/pramodksahoo/deploywhisper:1.0.0
+```
 
 ## API Endpoints
 
@@ -479,7 +509,7 @@ What the action does:
 - exits `0` when analysis succeeds, regardless of risk verdict
 - exposes outputs for follow-on GitHub steps:
   - `report-id`
-  - `report-link`
+  - `report-link` (shareable `/reports/{id}` URL)
   - `severity`
   - `recommendation`
   - `share-summary-json`
@@ -493,6 +523,20 @@ Optional inputs:
 - `api-token`: bearer token for protected DeployWhisper APIs
 - `changed-files`: override auto-detected PR files with a comma or newline separated list
 - `working-directory`: repository root when the checkout is not in `.`
+
+Shared report links now resolve to `/reports/{id}` read-only pages. For sensitive
+reports, configure password protection and opt-in file-name redaction via
+`POST /api/v1/analyses/{id}/share` with the `X-DeployWhisper-Share-Token`
+header. Set `DEPLOYWHISPER_SHARE_TOKEN` before exposing that management API.
+
+Example:
+
+```bash
+curl -X POST http://127.0.0.1:8080/api/v1/analyses/17/share \
+  -H "Content-Type: application/json" \
+  -H "X-DeployWhisper-Share-Token: $DEPLOYWHISPER_SHARE_TOKEN" \
+  -d '{"password":"review-only","redact_filenames":true}'
+```
 
 The app repository no longer carries Marketplace action packaging files. Action
 source, release metadata, and consumer smoke verification live in the dedicated

--- a/api/routes/analyses.py
+++ b/api/routes/analyses.py
@@ -2,7 +2,10 @@
 
 from __future__ import annotations
 
-from fastapi import APIRouter, File, Header, Query, UploadFile
+import hmac
+import os
+
+from fastapi import APIRouter, Depends, File, Header, Query, UploadFile
 
 from api.errors import ApiError, ApiRoute
 from api.schemas import (
@@ -10,10 +13,14 @@ from api.schemas import (
     AnalysisListResponse,
     AnalysisReportData,
     AnalysisRunResponse,
+    AnalysisShareConfigData,
+    AnalysisShareConfigRequest,
+    AnalysisShareConfigResponse,
     ErrorResponse,
     build_analysis_run_data,
     build_report_meta,
 )
+from config import settings
 from services.analysis_service import (
     analyze_uploaded_files,
     build_advisory_summary,
@@ -26,10 +33,41 @@ from services.intake_service import (
 )
 from services.report_service import fetch_analysis_report
 from services.report_service import fetch_filtered_analysis_history_page
+from services.report_service import configure_report_share
 from services.report_service import REPORT_SCHEMA_VERSION
 
 router = APIRouter(prefix="/api/v1/analyses", tags=["analyses"], route_class=ApiRoute)
 READ_CHUNK_BYTES = 1024 * 1024
+
+
+def require_share_management_token(
+    share_token: str | None = Header(
+        default=None,
+        alias="X-DeployWhisper-Share-Token",
+    ),
+) -> None:
+    """Require an explicit management token before mutating share settings."""
+    configured_token = (
+        os.getenv("DEPLOYWHISPER_SHARE_TOKEN")
+        or os.getenv("APP_SHARE_MANAGEMENT_TOKEN")
+        or settings.share_management_token
+        or ""
+    ).strip()
+    if not configured_token:
+        raise ApiError(
+            status_code=405,
+            code="share_configuration_disabled",
+            message=(
+                "Share configuration API is disabled. Set "
+                "DEPLOYWHISPER_SHARE_TOKEN to enable it."
+            ),
+        )
+    if not share_token or not hmac.compare_digest(share_token, configured_token):
+        raise ApiError(
+            status_code=403,
+            code="share_configuration_forbidden",
+            message="Share configuration requires a valid management token.",
+        )
 
 
 async def _read_upload_files_with_limit(
@@ -178,5 +216,41 @@ def get_analysis(report_id: int) -> AnalysisDetailResponse:
         data=AnalysisReportData(**report),
         meta=build_report_meta(
             id=report_id, report_schema_version=REPORT_SCHEMA_VERSION
+        ),
+    )
+
+
+@router.post(
+    "/{report_id}/share",
+    response_model=AnalysisShareConfigResponse,
+    responses={
+        403: {"model": ErrorResponse},
+        404: {"model": ErrorResponse},
+        405: {"model": ErrorResponse},
+        422: {"model": ErrorResponse},
+        500: {"model": ErrorResponse},
+    },
+)
+def configure_analysis_share(
+    report_id: int,
+    payload: AnalysisShareConfigRequest,
+    _: None = Depends(require_share_management_token),
+) -> AnalysisShareConfigResponse:
+    share_config = configure_report_share(
+        report_id,
+        password=payload.password,
+        redact_filenames=payload.redact_filenames,
+    )
+    if share_config is None:
+        raise ApiError(
+            status_code=404,
+            code="analysis_not_found",
+            message="Analysis report not found.",
+        )
+    return AnalysisShareConfigResponse(
+        data=AnalysisShareConfigData(**share_config),
+        meta=build_report_meta(
+            id=report_id,
+            report_schema_version=REPORT_SCHEMA_VERSION,
         ),
     )

--- a/api/schemas.py
+++ b/api/schemas.py
@@ -593,6 +593,32 @@ class AnalysisRunResponse(BaseModel):
     meta: AnalysisRunMetaPayload
 
 
+class AnalysisShareConfigRequest(BaseModel):
+    password: str | None = Field(
+        default=None,
+        description="Optional password required before the shared report can be viewed.",
+    )
+    redact_filenames: bool = Field(
+        default=False,
+        description="Whether shared rendering should replace file names with generic labels.",
+    )
+
+
+class AnalysisShareConfigData(BaseModel):
+    share_url: str = Field(..., description="Public share URL for the report.")
+    password_protected: bool = Field(
+        ..., description="Whether the shared report currently requires a password."
+    )
+    redact_filenames: bool = Field(
+        ..., description="Whether file names are redacted in the shared view."
+    )
+
+
+class AnalysisShareConfigResponse(BaseModel):
+    data: AnalysisShareConfigData
+    meta: ResourceMetaPayload
+
+
 PersistedReportData.model_rebuild()
 
 

--- a/app.py
+++ b/app.py
@@ -4,7 +4,10 @@ from __future__ import annotations
 
 from contextlib import asynccontextmanager
 from html import escape
+import hashlib
+import hmac
 
+from fastapi import Form, Request
 from fastapi.exceptions import RequestValidationError
 from fastapi.openapi.docs import get_redoc_html, get_swagger_ui_html
 from fastapi.responses import HTMLResponse, JSONResponse
@@ -25,6 +28,7 @@ from config import settings
 from logging_config import configure_logging
 from models.database import init_db
 from services.artifact_snapshot_service import load_report_artifact
+from services.report_service import fetch_analysis_report, fetch_shared_analysis_report
 from ui.routes.dashboard import build_dashboard
 
 configure_logging()
@@ -117,7 +121,184 @@ def openapi_document() -> JSONResponse:
     return JSONResponse(content=fastapi_app.openapi())
 
 
+def _shared_report_prompt_html(report_id: int, *, invalid_password: bool) -> str:
+    message = (
+        "Incorrect password. Try again."
+        if invalid_password
+        else "This shared report requires a password."
+    )
+    return (
+        "<!doctype html><html><head><meta charset='utf-8'>"
+        f"<title>Shared DeployWhisper report {report_id}</title>"
+        "<style>"
+        "body{margin:0;background:#f4efe7;color:#18202b;font-family:ui-sans-serif,system-ui,sans-serif;}"
+        "main{max-width:560px;margin:72px auto;padding:32px;background:#fff;border-radius:20px;"
+        "box-shadow:0 18px 48px rgba(24,32,43,0.08);}"
+        "h1{margin:0 0 12px;font-size:28px;line-height:1.2;}"
+        "p{margin:0 0 18px;color:#5e697b;line-height:1.6;}"
+        "label{display:block;font-weight:600;margin-bottom:8px;}"
+        "input{width:100%;padding:12px 14px;border:1px solid #d6deeb;border-radius:12px;font-size:16px;}"
+        "button{margin-top:16px;padding:12px 16px;border:none;border-radius:12px;background:#d96b3d;color:#fff;font-weight:700;cursor:pointer;}"
+        ".error{color:#a03636;font-weight:600;}"
+        "</style></head><body><main>"
+        "<h1>Shared DeployWhisper report</h1>"
+        f"<p class='{'error' if invalid_password else ''}'>{escape(message)}</p>"
+        f"<form method='post' action='/reports/{report_id}/unlock'>"
+        "<label for='password'>Password required</label>"
+        "<input id='password' name='password' type='password' autocomplete='current-password' />"
+        "<button type='submit'>Open shared report</button>"
+        "</form></main></body></html>"
+    )
+
+
+def _share_cookie_name(report_id: int) -> str:
+    return f"dw_share_{report_id}"
+
+
+def _share_cookie_value(report: dict) -> str:
+    return hashlib.sha256(
+        (
+            f"{report['id']}|{report.get('share_password_hash') or ''}|"
+            f"{report.get('share_password_salt') or ''}"
+        ).encode("utf-8")
+    ).hexdigest()
+
+
+def _has_valid_share_cookie(report: dict, request: Request) -> bool:
+    if not report.get("share_password_hash"):
+        return True
+    cookie_value = request.cookies.get(_share_cookie_name(int(report["id"])))
+    expected = _share_cookie_value(report)
+    return bool(cookie_value) and hmac.compare_digest(cookie_value, expected)
+
+
+def _share_cookie_secure(report: dict) -> bool:
+    share_url = str((report.get("share") or {}).get("share_url") or "")
+    return share_url.startswith("https://")
+
+
+def _shared_report_html(report: dict) -> str:
+    findings = report.get("findings") or []
+    files_analyzed = report.get("audit", {}).get("files_analyzed") or []
+    findings_html = (
+        "".join(
+            "<li><strong>{severity}</strong>: {title}<br><span>{description}</span></li>".format(
+                severity=escape(str(finding.get("severity", "")).upper()),
+                title=escape(str(finding.get("title", ""))),
+                description=escape(str(finding.get("description", ""))),
+            )
+            for finding in findings[:5]
+        )
+        or "<li>No findings were persisted for this report.</li>"
+    )
+    files_html = (
+        "".join(f"<li>{escape(str(file_name))}</li>" for file_name in files_analyzed)
+        or "<li>No file metadata was persisted for this report.</li>"
+    )
+    share = report.get("share") or {}
+    redaction_note = (
+        "<p class='note'>File names are redacted for this shared view.</p>"
+        if share.get("redact_filenames")
+        else ""
+    )
+    return (
+        "<!doctype html><html><head><meta charset='utf-8'>"
+        f"<title>Shared DeployWhisper report #{int(report['id'])}</title>"
+        "<style>"
+        "body{margin:0;background:#f4efe7;color:#18202b;font-family:ui-sans-serif,system-ui,sans-serif;}"
+        "main{max-width:980px;margin:0 auto;padding:40px 24px 64px;}"
+        ".hero,.panel{background:#fff;border-radius:20px;box-shadow:0 18px 48px rgba(24,32,43,0.08);padding:24px;margin-bottom:20px;}"
+        ".eyebrow{font-size:12px;letter-spacing:.12em;text-transform:uppercase;color:#7b8596;font-weight:700;}"
+        "h1{margin:8px 0 12px;font-size:32px;line-height:1.15;}"
+        "p,li{line-height:1.6;color:#455163;}"
+        ".badge{display:inline-block;padding:6px 10px;border-radius:999px;background:#eff4fb;margin-right:8px;font-weight:700;}"
+        ".score{font-size:42px;font-weight:800;color:#d96b3d;}"
+        "ul{padding-left:20px;}"
+        ".grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(220px,1fr));gap:16px;}"
+        ".note{margin-top:8px;color:#8b5a2b;font-weight:600;}"
+        "a{color:#d96b3d;text-decoration:none;}"
+        "</style></head><body><main>"
+        "<section class='hero'>"
+        "<div class='eyebrow'>Shared DeployWhisper report</div>"
+        "<p>Analysis report</p>"
+        f"<h1>{escape(str(report.get('top_risk') or 'Analysis report'))}</h1>"
+        f"<span class='badge'>{escape(str(report.get('severity', '')).upper())}</span>"
+        f"<span class='badge'>{escape(str(report.get('recommendation', '')).upper())}</span>"
+        f"<p class='score'>{int(report.get('risk_score') or 0)}</p>"
+        f"<p>{escape(str(report.get('narrative_opening') or report.get('parse_summary') or ''))}</p>"
+        "</section>"
+        "<section class='panel'><div class='grid'>"
+        f"<div><strong>Created</strong><p>{escape(str(report.get('created_at') or ''))}</p></div>"
+        f"<div><strong>Share URL</strong><p><a href='{escape(str(share.get('share_url') or ''))}'>{escape(str(share.get('share_url') or ''))}</a></p></div>"
+        f"<div><strong>Blast radius</strong><p>{escape(str(report.get('blast_radius', {}).get('direct_count', 0)))} direct / {escape(str(report.get('blast_radius', {}).get('transitive_count', 0)))} transitive</p></div>"
+        f"<div id='rollback'><strong>Rollback</strong><p>{escape(str(report.get('rollback_plan', {}).get('complexity', 'low')).upper())} · {escape(str(report.get('rollback_plan', {}).get('complexity_score', 1)))} / 5</p></div>"
+        "</div></section>"
+        "<section class='panel'><h2>Findings</h2><ul>"
+        f"{findings_html}"
+        "</ul></section>"
+        "<section class='panel'><h2>Files analyzed</h2>"
+        f"{redaction_note}<ul>{files_html}</ul></section>"
+        "</main></body></html>"
+    )
+
+
+@fastapi_app.get("/reports/{report_id}", include_in_schema=False)
+def shared_report_view(
+    request: Request,
+    report_id: int,
+) -> HTMLResponse:
+    """Render one report via a read-only public sharing route."""
+    report = fetch_analysis_report(report_id)
+    if report is None:
+        raise StarletteHTTPException(status_code=404, detail="Report not found")
+    password_required = bool(report.get("share_password_hash"))
+    if password_required and not _has_valid_share_cookie(report, request):
+        return HTMLResponse(
+            content=_shared_report_prompt_html(
+                report_id,
+                invalid_password=False,
+            )
+        )
+    shared_report = fetch_shared_analysis_report(
+        report_id,
+        bypass_password=password_required,
+    )
+    if shared_report is None:
+        raise StarletteHTTPException(status_code=404, detail="Report not found")
+    return HTMLResponse(content=_shared_report_html(shared_report))
+
+
+@fastapi_app.post("/reports/{report_id}/unlock", include_in_schema=False)
+def unlock_shared_report(report_id: int, password: str = Form(...)) -> RedirectResponse:
+    """Validate a shared-report password and issue an HttpOnly access cookie."""
+    shared_report = fetch_shared_analysis_report(report_id, password=password)
+    if shared_report is None:
+        return HTMLResponse(
+            content=_shared_report_prompt_html(report_id, invalid_password=True),
+            status_code=401,
+        )
+    report = fetch_analysis_report(report_id)
+    if report is None:
+        raise StarletteHTTPException(status_code=404, detail="Report not found")
+    response = RedirectResponse(url=f"/reports/{report_id}", status_code=303)
+    response.set_cookie(
+        _share_cookie_name(report_id),
+        _share_cookie_value(report),
+        httponly=True,
+        path=f"/reports/{report_id}",
+        secure=_share_cookie_secure(shared_report),
+        samesite="lax",
+    )
+    return response
+
+
 @fastapi_app.get("/reports/{report_id}/artifacts", include_in_schema=False)
+def shared_report_artifact_view(report_id: int, name: str) -> HTMLResponse:
+    """Public share URLs never expose raw artifact snapshots."""
+    raise StarletteHTTPException(status_code=404, detail="Artifact not found")
+
+
+@fastapi_app.get("/history/{report_id}/artifacts", include_in_schema=False)
 def report_artifact_view(
     report_id: int, name: str, line: int | None = None
 ) -> HTMLResponse:

--- a/config.py
+++ b/config.py
@@ -25,6 +25,9 @@ class Settings:
     artifact_snapshot_dir: str = os.getenv(
         "ARTIFACT_SNAPSHOT_DIR", "data/report-artifacts"
     )
+    share_management_token: str | None = os.getenv(
+        "DEPLOYWHISPER_SHARE_TOKEN"
+    ) or os.getenv("APP_SHARE_MANAGEMENT_TOKEN")
     llm_api_key: str | None = (
         os.getenv("LLM_API_KEY")
         or os.getenv("OPENAI_API_KEY")

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,8 +12,10 @@ services:
     environment:
       APP_HOST: 0.0.0.0
       APP_PORT: 8080
+      APP_BASE_URL: ${APP_BASE_URL:-http://localhost:8080}
       LOG_LEVEL: INFO
       DATABASE_URL: sqlite:///data/deploywhisper.db
+      DEPLOYWHISPER_SHARE_TOKEN: ${DEPLOYWHISPER_SHARE_TOKEN:-}
       LLM_PROVIDER: ollama
       LLM_MODEL: ollama/llama3
       LLM_API_BASE: ${LLM_API_BASE:-http://host.docker.internal:11434}

--- a/docs/ci-advisory-consumption.md
+++ b/docs/ci-advisory-consumption.md
@@ -7,7 +7,9 @@ DeployWhisper remains advisory in automation contexts.
 - `data.share_summary` provides a ready-to-render PR / approval-thread summary in both `markdown` and `plain_text`
 - `data.share_summary.markdown` is capped at 1,500 characters for GitHub PR comment fit
 - `data.share_summary.json_payload` provides the machine-friendly summary variant, including top findings, evidence count, context completeness, and report / rollback links
-- Share-summary report links always resolve to an absolute URL; set `APP_BASE_URL` when you need those links to point at a public/reverse-proxied DeployWhisper instance instead of the local app host/port
+- Share-summary report links always resolve to an absolute `/reports/{id}` URL; set `APP_BASE_URL` when you need those links to point at a public/reverse-proxied DeployWhisper instance instead of the local app host/port
+- Sensitive shared reports can opt into password protection and file-name redaction through `POST /api/v1/analyses/{id}/share`
+- The share-configuration API is disabled unless `DEPLOYWHISPER_SHARE_TOKEN` is set; callers must send that value in `X-DeployWhisper-Share-Token`
 - CLI and API responses preserve `severity`, `recommendation`, `partial_context`, and `narrative_degraded` for machine-readable uncertainty handling
 - High-risk or degraded analyses still return success payloads; non-zero CLI exit codes are reserved for operational failures such as unreadable files or shared-analysis crashes
 

--- a/migrations/versions/009_add_report_share_settings.py
+++ b/migrations/versions/009_add_report_share_settings.py
@@ -1,0 +1,49 @@
+"""Add persisted share settings to analysis reports.
+
+Revision ID: 009_add_report_share_settings
+Revises: 008_add_rollback_plan_payload
+Create Date: 2026-04-23
+"""
+
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "009_add_report_share_settings"
+down_revision = "008_add_rollback_plan_payload"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "analysis_reports",
+        sa.Column("share_password_hash", sa.String(length=64), nullable=True),
+    )
+    op.add_column(
+        "analysis_reports",
+        sa.Column("share_password_salt", sa.String(length=32), nullable=True),
+    )
+    op.add_column(
+        "analysis_reports",
+        sa.Column(
+            "share_redact_filenames",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.false(),
+        ),
+    )
+    with op.batch_alter_table("analysis_reports") as batch_op:
+        batch_op.alter_column(
+            "share_redact_filenames",
+            existing_type=sa.Boolean(),
+            server_default=None,
+        )
+
+
+def downgrade() -> None:
+    op.drop_column("analysis_reports", "share_redact_filenames")
+    op.drop_column("analysis_reports", "share_password_salt")
+    op.drop_column("analysis_reports", "share_password_hash")

--- a/models/database.py
+++ b/models/database.py
@@ -21,6 +21,7 @@ _KNOWN_ALEMBIC_REVISIONS = {
     "006_add_report_schema_version",
     "007_add_blast_radius_payload",
     "008_add_rollback_plan_payload",
+    "009_add_report_share_settings",
 }
 _BASELINE_TABLES = {"analysis_reports", "app_settings"}
 _EVIDENCE_TABLES = {
@@ -135,6 +136,14 @@ def _bootstrap_brownfield_revision() -> None:
             if "analysis_reports" in tables
             else set()
         )
+        if {
+            "report_schema_version",
+            "blast_radius_json",
+            "rollback_plan_json",
+            "share_redact_filenames",
+        }.issubset(report_columns):
+            _write_alembic_revision(connection, "009_add_report_share_settings")
+            return
         if {
             "report_schema_version",
             "blast_radius_json",

--- a/models/repositories/analysis_reports.py
+++ b/models/repositories/analysis_reports.py
@@ -179,6 +179,25 @@ def get_analysis_report(
     return session.execute(stmt).scalar_one_or_none()
 
 
+def update_analysis_report_share_settings(
+    session: Session,
+    report_id: int,
+    *,
+    share_password_hash: str | None,
+    share_password_salt: str | None,
+    share_redact_filenames: bool,
+) -> AnalysisReport | None:
+    report = session.get(AnalysisReport, report_id)
+    if report is None:
+        return None
+    report.share_password_hash = share_password_hash
+    report.share_password_salt = share_password_salt
+    report.share_redact_filenames = share_redact_filenames
+    session.commit()
+    session.refresh(report)
+    return report
+
+
 def delete_analysis_report(session: Session, report_id: int) -> bool:
     report = session.get(AnalysisReport, report_id)
     if report is None:

--- a/models/tables.py
+++ b/models/tables.py
@@ -68,6 +68,13 @@ if "AnalysisReport" not in globals():
         source_interface: Mapped[str | None] = mapped_column(String(30), nullable=True)
         trigger_type: Mapped[str | None] = mapped_column(String(30), nullable=True)
         trigger_id: Mapped[str | None] = mapped_column(String(120), nullable=True)
+        share_password_hash: Mapped[str | None] = mapped_column(
+            String(64), nullable=True
+        )
+        share_password_salt: Mapped[str | None] = mapped_column(
+            String(32), nullable=True
+        )
+        share_redact_filenames: Mapped[bool] = mapped_column(Boolean, default=False)
         dashboard_display_duration_seconds: Mapped[int | None] = mapped_column(
             Integer, nullable=True
         )

--- a/services/analysis_service.py
+++ b/services/analysis_service.py
@@ -3,10 +3,7 @@
 from __future__ import annotations
 
 import json
-import os
 from datetime import UTC, datetime
-from urllib.parse import urlencode
-
 from pydantic import BaseModel, Field
 
 from analysis.blast_radius import BlastRadiusResult, compute_blast_radius
@@ -27,6 +24,7 @@ from parsers.base import ParseBatchResult, UnifiedChange
 from services.intake_service import build_parse_batch
 from services.report_service import persist_analysis_report
 from services.settings_service import resolve_provider_runtime
+from services.report_service import build_share_report_link
 from services.topology_service import (
     STALE_AFTER_DAYS,
     get_topology_status,
@@ -373,21 +371,7 @@ def _shorten(text: str, limit: int) -> str:
 
 
 def _report_link(report_id: int | None) -> str | None:
-    if report_id is None:
-        return None
-    base_url = (
-        (os.getenv("APP_BASE_URL") or os.getenv("PUBLIC_APP_URL") or "")
-        .strip()
-        .rstrip("/")
-    )
-    if not base_url:
-        host = os.getenv("APP_HOST", "127.0.0.1")
-        if host in {"0.0.0.0", "::"}:
-            host = "localhost"
-        port = int(os.getenv("APP_PORT", "8080"))
-        base_url = f"http://{host}:{port}"
-    query = urlencode({"report_id": report_id})
-    return f"{base_url}/history?{query}"
+    return build_share_report_link(report_id)
 
 
 def _has_partial_context_signal(report: dict) -> bool:

--- a/services/report_service.py
+++ b/services/report_service.py
@@ -3,8 +3,10 @@
 from __future__ import annotations
 
 import json
+import os
 import secrets
 import hashlib
+import hmac
 from datetime import UTC, datetime
 from collections import Counter
 from typing import Any
@@ -24,6 +26,7 @@ from models.repositories.analysis_reports import (
     get_analysis_report,
     latest_active_dashboard_report,
     list_analysis_reports,
+    update_analysis_report_share_settings,
 )
 from parsers.base import ParseBatchResult
 from services.artifact_snapshot_service import (
@@ -35,6 +38,121 @@ from services.settings_service import resolve_provider_runtime
 
 LEGACY_REPORT_SCHEMA_VERSION = "v1"
 REPORT_SCHEMA_VERSION = "v2"
+
+
+def build_share_report_link(report_id: int | None) -> str | None:
+    if report_id is None:
+        return None
+    base_url = (
+        (os.getenv("APP_BASE_URL") or os.getenv("PUBLIC_APP_URL") or "")
+        .strip()
+        .rstrip("/")
+    )
+    if not base_url:
+        host = os.getenv("APP_HOST", "127.0.0.1")
+        if host in {"0.0.0.0", "::"}:
+            host = "localhost"
+        port = int(os.getenv("APP_PORT", "8080"))
+        base_url = f"http://{host}:{port}"
+    return f"{base_url}/reports/{report_id}"
+
+
+def _hash_share_password(password: str, *, salt: str) -> str:
+    return hashlib.sha256(f"{salt}:{password}".encode("utf-8")).hexdigest()
+
+
+def _share_settings(report: dict[str, Any]) -> dict[str, Any]:
+    report_id = int(report["id"])
+    return {
+        "share_url": build_share_report_link(report_id),
+        "password_protected": bool(report.get("share_password_hash")),
+        "redact_filenames": bool(report.get("share_redact_filenames", False)),
+    }
+
+
+def _redaction_pairs(original_names: list[str]) -> list[tuple[str, str]]:
+    basename_counts: Counter[str] = Counter()
+    for original_name in original_names:
+        basename_counts[str(original_name).split("/")[-1]] += 1
+    pairs: list[tuple[str, str]] = []
+    for index, original_name in enumerate(original_names, start=1):
+        replacement = f"Artifact {index}"
+        pairs.append((original_name, replacement))
+        basename = str(original_name).split("/")[-1]
+        if basename and basename_counts[basename] == 1:
+            pairs.append((basename, replacement))
+    return pairs
+
+
+def _redact_text_value(value: Any, pairs: list[tuple[str, str]]) -> Any:
+    if not isinstance(value, str):
+        return value
+    redacted = value
+    for original, replacement in pairs:
+        redacted = redacted.replace(original, replacement)
+    return redacted
+
+
+def _redact_report_file_names(report: dict[str, Any]) -> dict[str, Any]:
+    original_names = list(report.get("audit", {}).get("files_analyzed") or [])
+    if not original_names:
+        return report
+    redaction_map = {
+        original_name: f"Artifact {index}"
+        for index, original_name in enumerate(original_names, start=1)
+    }
+    pairs = _redaction_pairs(original_names)
+    redacted = {
+        **report,
+        "top_risk": _redact_text_value(report.get("top_risk"), pairs),
+        "parse_summary": _redact_text_value(report.get("parse_summary"), pairs),
+        "narrative_opening": _redact_text_value(report.get("narrative_opening"), pairs),
+        "narrative_failure_notice": _redact_text_value(
+            report.get("narrative_failure_notice"), pairs
+        ),
+        "warnings": [
+            _redact_text_value(warning, pairs)
+            for warning in (report.get("warnings") or [])
+        ],
+        "audit": {
+            **dict(report.get("audit") or {}),
+            "files_analyzed": [redaction_map[name] for name in original_names],
+        },
+        "findings": [
+            {
+                **finding,
+                "title": _redact_text_value(finding.get("title"), pairs),
+                "description": _redact_text_value(finding.get("description"), pairs),
+                "uncertainty_note": _redact_text_value(
+                    finding.get("uncertainty_note"), pairs
+                ),
+            }
+            for finding in (report.get("findings") or [])
+        ],
+        "contributors": [
+            {
+                **contributor,
+                "source_file": redaction_map.get(
+                    contributor.get("source_file"),
+                    contributor.get("source_file"),
+                ),
+                "summary": _redact_text_value(contributor.get("summary"), pairs),
+                "reasoning": _redact_text_value(contributor.get("reasoning"), pairs),
+            }
+            for contributor in (report.get("contributors") or [])
+        ],
+        "evidence_items": [
+            {
+                **evidence_item,
+                "source_ref": _redact_text_value(
+                    evidence_item.get("source_ref", ""), pairs
+                ),
+                "summary": _redact_text_value(evidence_item.get("summary"), pairs),
+            }
+            for evidence_item in (report.get("evidence_items") or [])
+        ],
+    }
+    return redacted
 
 
 def _run_with_schema_retry(operation):
@@ -380,6 +498,11 @@ def _serialize_report(report, *, include_evidence: bool = True) -> dict:
         "evidence_items": evidence_items,
         "contributors": json.loads(report.contributors_json or "[]"),
         "dashboard_display_duration_seconds": report.dashboard_display_duration_seconds,
+        "share_password_hash": getattr(report, "share_password_hash", None),
+        "share_password_salt": getattr(report, "share_password_salt", None),
+        "share_redact_filenames": bool(
+            getattr(report, "share_redact_filenames", False)
+        ),
         "audit": audit,
     }
 
@@ -479,6 +602,68 @@ def fetch_analysis_report(report_id: int) -> dict | None:
             return _serialize_report(report, include_evidence=True)
 
     return _run_with_schema_retry(operation)
+
+
+def configure_report_share(
+    report_id: int,
+    *,
+    password: str | None,
+    redact_filenames: bool,
+) -> dict | None:
+    password_value = (password or "").strip()
+    password_salt = secrets.token_hex(8) if password_value else None
+    password_hash = (
+        _hash_share_password(password_value, salt=password_salt)
+        if password_salt is not None
+        else None
+    )
+
+    def operation():
+        with SessionLocal() as session:
+            report = update_analysis_report_share_settings(
+                session,
+                report_id,
+                share_password_hash=password_hash,
+                share_password_salt=password_salt,
+                share_redact_filenames=redact_filenames,
+            )
+            if report is None:
+                return None
+            return _serialize_report(report, include_evidence=False)
+
+    payload = _run_with_schema_retry(operation)
+    if payload is None:
+        return None
+    return _share_settings(payload)
+
+
+def fetch_shared_analysis_report(
+    report_id: int,
+    *,
+    password: str | None = None,
+    bypass_password: bool = False,
+) -> dict | None:
+    report = fetch_analysis_report(report_id)
+    if report is None:
+        return None
+    password_hash = str(report.get("share_password_hash") or "")
+    password_salt = str(report.get("share_password_salt") or "")
+    if password_hash and not bypass_password:
+        candidate = (password or "").strip()
+        if not candidate or not password_salt:
+            return None
+        if not hmac.compare_digest(
+            password_hash,
+            _hash_share_password(candidate, salt=password_salt),
+        ):
+            return None
+    shared = {
+        **report,
+        "share": _share_settings(report),
+    }
+    if shared["share"]["redact_filenames"]:
+        shared = _redact_report_file_names(shared)
+    return shared
 
 
 def fetch_analysis_history() -> list[dict]:

--- a/tests/test_api/test_analyses.py
+++ b/tests/test_api/test_analyses.py
@@ -120,6 +120,7 @@ class AnalysesApiTests(unittest.TestCase):
         database_module.engine.dispose()
         os.environ.pop("DATABASE_URL", None)
         os.environ.pop("APP_BASE_URL", None)
+        os.environ.pop("DEPLOYWHISPER_SHARE_TOKEN", None)
         self.tempdir.cleanup()
 
     def test_list_analyses_returns_persisted_reports(self) -> None:
@@ -141,6 +142,66 @@ class AnalysesApiTests(unittest.TestCase):
         self.assertEqual(payload["data"]["report_schema_version"], "v2")
         self.assertEqual(payload["data"]["audit"]["llm_provider"], "ollama")
         self.assertEqual(payload["data"]["blast_radius"]["direct_count"], 0)
+
+    def test_configure_share_is_disabled_without_management_token(self) -> None:
+        response = self.client.post(
+            f"/api/v1/analyses/{self.persisted['id']}/share",
+            json={"password": "s3cret-pass", "redact_filenames": True},
+        )
+
+        self.assertEqual(response.status_code, 405)
+        payload = response.json()
+        self.assertEqual(payload["error"]["code"], "share_configuration_disabled")
+
+    def test_configure_share_requires_valid_management_token(self) -> None:
+        os.environ["DEPLOYWHISPER_SHARE_TOKEN"] = "review-secret"
+        self.client = TestClient(create_app())
+
+        response = self.client.post(
+            f"/api/v1/analyses/{self.persisted['id']}/share",
+            json={"password": "s3cret-pass", "redact_filenames": True},
+        )
+
+        self.assertEqual(response.status_code, 403)
+        payload = response.json()
+        self.assertEqual(payload["error"]["code"], "share_configuration_forbidden")
+
+    def test_configure_share_returns_public_report_settings(self) -> None:
+        os.environ["DEPLOYWHISPER_SHARE_TOKEN"] = "review-secret"
+        self.client = TestClient(create_app())
+
+        response = self.client.post(
+            f"/api/v1/analyses/{self.persisted['id']}/share",
+            json={"password": "s3cret-pass", "redact_filenames": True},
+            headers={"X-DeployWhisper-Share-Token": "review-secret"},
+        )
+
+        self.assertEqual(response.status_code, 200)
+        payload = response.json()
+        self.assertEqual(
+            payload["data"]["share_url"],
+            f"https://deploywhisper.example.com/reports/{self.persisted['id']}",
+        )
+        self.assertTrue(payload["data"]["password_protected"])
+        self.assertTrue(payload["data"]["redact_filenames"])
+
+    def test_configure_share_rejects_unauthorized_reset_of_public_protection(
+        self,
+    ) -> None:
+        report_service_module.configure_report_share(
+            self.persisted["id"],
+            password="s3cret-pass",
+            redact_filenames=True,
+        )
+
+        reset_response = self.client.post(
+            f"/api/v1/analyses/{self.persisted['id']}/share",
+            json={"password": "", "redact_filenames": False},
+        )
+        report_response = self.client.get(f"/reports/{self.persisted['id']}")
+
+        self.assertEqual(reset_response.status_code, 405)
+        self.assertIn("Password required", report_response.text)
 
     def test_create_analysis_returns_structured_result(self) -> None:
         files = [
@@ -213,7 +274,7 @@ class AnalysesApiTests(unittest.TestCase):
             payload["data"]["persisted_report"]["id"],
         )
         self.assertIn(
-            "https://deploywhisper.example.com/history?report_id=",
+            "https://deploywhisper.example.com/reports/",
             payload["data"]["share_summary"]["json_payload"]["rollback_link"],
         )
         self.assertEqual(

--- a/tests/test_cli/test_analyze.py
+++ b/tests/test_cli/test_analyze.py
@@ -118,6 +118,10 @@ class AnalyzeCliTests(unittest.TestCase):
             payload["data"]["share_summary"]["json_payload"]["report_id"],
             payload["data"]["persisted_report"]["id"],
         )
+        self.assertIn(
+            "https://deploywhisper.example.com/reports/",
+            payload["data"]["share_summary"]["json_payload"]["rollback_link"],
+        )
         self.assertTrue(payload["data"]["persisted_report"]["findings"])
         self.assertEqual(
             payload["data"]["persisted_report"]["report_schema_version"], "v2"

--- a/tests/test_infra/test_container_contract.py
+++ b/tests/test_infra/test_container_contract.py
@@ -22,6 +22,7 @@ class ContainerContractTests(unittest.TestCase):
                 "006_add_report_schema_version.py",
                 "007_add_blast_radius_payload.py",
                 "008_add_rollback_plan_payload.py",
+                "009_add_report_share_settings.py",
             ],
         )
         baseline_content = migrations[0].read_text(encoding="utf-8")
@@ -29,6 +30,7 @@ class ContainerContractTests(unittest.TestCase):
         schema_content = migrations[2].read_text(encoding="utf-8")
         blast_radius_content = migrations[3].read_text(encoding="utf-8")
         rollback_content = migrations[4].read_text(encoding="utf-8")
+        share_content = migrations[5].read_text(encoding="utf-8")
         self.assertIn("down_revision = None", baseline_content)
         self.assertIn('"app_settings"', baseline_content)
         self.assertIn(
@@ -45,6 +47,8 @@ class ContainerContractTests(unittest.TestCase):
             'down_revision = "007_add_blast_radius_payload"', rollback_content
         )
         self.assertIn('"rollback_plan_json"', rollback_content)
+        self.assertIn('down_revision = "008_add_rollback_plan_payload"', share_content)
+        self.assertIn('"share_redact_filenames"', share_content)
 
     def test_dockerfile_exists(self) -> None:
         self.assertTrue(Path("Dockerfile").exists())
@@ -79,6 +83,8 @@ class ContainerContractTests(unittest.TestCase):
         self.assertIn("8080:8080", ports)
         environment = services["deploywhisper"].get("environment", {})
         self.assertEqual(environment["APP_PORT"], 8080)
+        self.assertIn("APP_BASE_URL", environment)
+        self.assertIn("DEPLOYWHISPER_SHARE_TOKEN", environment)
         self.assertIn("LLM_API_BASE", environment)
         self.assertEqual(services["deploywhisper"]["restart"], "unless-stopped")
         self.assertIn(

--- a/tests/test_infra/test_migrations.py
+++ b/tests/test_infra/test_migrations.py
@@ -63,12 +63,21 @@ class MigrationTests(unittest.TestCase):
         self.assertIn("report_schema_version", self._table_columns("analysis_reports"))
         self.assertIn("blast_radius_json", self._table_columns("analysis_reports"))
         self.assertIn("rollback_plan_json", self._table_columns("analysis_reports"))
+        self.assertIn("share_password_hash", self._table_columns("analysis_reports"))
+        self.assertIn("share_password_salt", self._table_columns("analysis_reports"))
+        self.assertIn("share_redact_filenames", self._table_columns("analysis_reports"))
         report_schema_row = next(
             row
             for row in self._table_info("analysis_reports")
             if row[1] == "report_schema_version"
         )
         self.assertIsNone(report_schema_row[4])
+        share_redact_row = next(
+            row
+            for row in self._table_info("analysis_reports")
+            if row[1] == "share_redact_filenames"
+        )
+        self.assertIsNone(share_redact_row[4])
 
     def test_upgrade_head_preserves_existing_analysis_reports(self) -> None:
         command.upgrade(self._config(), "0001_create_analysis_reports")
@@ -137,6 +146,12 @@ class MigrationTests(unittest.TestCase):
             schema_version = sqlite_conn.execute(
                 "SELECT report_schema_version FROM analysis_reports LIMIT 1"
             ).fetchone()[0]
+            share_password_hash = sqlite_conn.execute(
+                "SELECT share_password_hash FROM analysis_reports LIMIT 1"
+            ).fetchone()[0]
+            share_redact_filenames = sqlite_conn.execute(
+                "SELECT share_redact_filenames FROM analysis_reports LIMIT 1"
+            ).fetchone()[0]
             finding_fks = sqlite_conn.execute(
                 "PRAGMA foreign_key_list(findings)"
             ).fetchall()
@@ -148,6 +163,8 @@ class MigrationTests(unittest.TestCase):
 
         self.assertEqual(report_count, 1)
         self.assertEqual(schema_version, "v2")
+        self.assertIsNone(share_password_hash)
+        self.assertEqual(share_redact_filenames, 0)
         self.assertTrue(any(row[2] == "analysis_reports" for row in finding_fks))
         self.assertTrue(any(row[2] == "findings" for row in evidence_fks))
 
@@ -193,7 +210,7 @@ class MigrationTests(unittest.TestCase):
         self.assertIn("incident_records", tables)
         self.assertIn("findings", tables)
         self.assertIn("evidence_items", tables)
-        self.assertEqual(revision, "008_add_rollback_plan_payload")
+        self.assertEqual(revision, "009_add_report_share_settings")
 
     def test_init_db_repairs_partial_evidence_schema_without_alembic_version(
         self,
@@ -241,7 +258,7 @@ class MigrationTests(unittest.TestCase):
 
         self.assertIn("findings", tables)
         self.assertIn("evidence_items", tables)
-        self.assertEqual(revision, "008_add_rollback_plan_payload")
+        self.assertEqual(revision, "009_add_report_share_settings")
 
     def test_init_db_repairs_current_schema_without_alembic_version(self) -> None:
         command.upgrade(self._config(), "head")
@@ -267,7 +284,7 @@ class MigrationTests(unittest.TestCase):
         finally:
             sqlite_conn.close()
 
-        self.assertEqual(revision, "008_add_rollback_plan_payload")
+        self.assertEqual(revision, "009_add_report_share_settings")
         self.assertIn("report_schema_version", columns)
         self.assertIn("blast_radius_json", columns)
 
@@ -292,7 +309,7 @@ class MigrationTests(unittest.TestCase):
         finally:
             sqlite_conn.close()
 
-        self.assertEqual(revision, "008_add_rollback_plan_payload")
+        self.assertEqual(revision, "009_add_report_share_settings")
 
 
 if __name__ == "__main__":

--- a/tests/test_services/test_analysis_service.py
+++ b/tests/test_services/test_analysis_service.py
@@ -614,7 +614,7 @@ class AnalysisServiceTests(unittest.TestCase):
         self.assertEqual(summary.json_payload.evidence_count, 5)
         self.assertEqual(
             summary.json_payload.rollback_link,
-            "https://deploywhisper.example.com/history?report_id=17",
+            "https://deploywhisper.example.com/reports/17",
         )
         self.assertEqual(
             summary.json_payload.context_completeness.label, "STRONG CONTEXT"
@@ -663,14 +663,14 @@ class AnalysisServiceTests(unittest.TestCase):
 
         self.assertEqual(
             summary.json_payload.report_link,
-            "http://127.0.0.1:8080/history?report_id=17",
+            "http://127.0.0.1:8080/reports/17",
         )
         self.assertEqual(
             summary.json_payload.rollback_link,
-            "http://127.0.0.1:8080/history?report_id=17",
+            "http://127.0.0.1:8080/reports/17",
         )
         self.assertIn(
-            "[View rollback plan](http://127.0.0.1:8080/history?report_id=17)",
+            "[View rollback plan](http://127.0.0.1:8080/reports/17)",
             summary.markdown,
         )
 

--- a/tests/test_services/test_report_service.py
+++ b/tests/test_services/test_report_service.py
@@ -41,7 +41,91 @@ class ReportServiceTests(unittest.TestCase):
     def tearDown(self) -> None:
         database_module.engine.dispose()
         os.environ.pop("DATABASE_URL", None)
+        os.environ.pop("APP_BASE_URL", None)
         self.tempdir.cleanup()
+
+    def _persist_shareable_report(self) -> dict:
+        parse_batch = ParseBatchResult(
+            files=[
+                ParsedFileResult(
+                    file_name="prod/network/plan.json",
+                    tool="terraform",
+                    status="parsed",
+                    changes=[
+                        UnifiedChange(
+                            source_file="prod/network/plan.json",
+                            tool="terraform",
+                            resource_id="aws_security_group.main",
+                            action="modify",
+                            summary="Terraform changed a security group.",
+                        )
+                    ],
+                )
+            ]
+        )
+        assessment = RiskAssessment(
+            score=42,
+            severity="medium",
+            recommendation="caution",
+            top_risk="prod/network/plan.json changed aws_security_group.main and is the highest-impact change.",
+            contributors=[
+                RiskContributor(
+                    source_file="prod/network/plan.json",
+                    tool="terraform",
+                    resource_id="aws_security_group.main",
+                    action="modify",
+                    contribution=12,
+                    summary="Terraform changed a security group.",
+                )
+            ],
+            interaction_risks=[],
+            partial_context=False,
+            warnings=[],
+        )
+        narrative = NarrativeResult(
+            opening_sentence="CAUTION: review prod/network/plan.json before release.",
+            explanation="The deployment widens database access and should be reviewed.",
+            guidance=[],
+            degraded=False,
+            warnings=[],
+        )
+        findings = [
+            Finding(
+                finding_id="finding-001",
+                analysis_id=0,
+                title="HIGH: prod/network/plan.json",
+                description="Security group changes in prod/network/plan.json can affect production ingress.",
+                severity="high",
+                category="networking/ingress",
+                deterministic=True,
+                confidence=1.0,
+                uncertainty_note=None,
+                evidence_refs=["ev-001"],
+                skill_id=None,
+            )
+        ]
+        evidence_items = [
+            EvidenceItem(
+                evidence_id="ev-001",
+                analysis_id=0,
+                finding_id="pending:change-1",
+                source_type="artifact",
+                source_ref="terraform://prod/network/plan.json#L14",
+                summary="Terraform changed a security group.",
+                severity_hint="high",
+                deterministic=True,
+                confidence=1.0,
+                related_change_ids=["change-1"],
+            )
+        ]
+        return report_service_module.persist_analysis_report(
+            parse_batch,
+            assessment,
+            narrative,
+            findings=findings,
+            evidence_items=evidence_items,
+            audit_context={"source_interface": "api"},
+        )
 
     def test_persist_analysis_report_stores_and_returns_metadata(self) -> None:
         parse_batch = ParseBatchResult(
@@ -356,6 +440,68 @@ class ReportServiceTests(unittest.TestCase):
         )
         history = report_service_module.fetch_analysis_history()
         self.assertEqual(len(history), 2)
+
+    def test_configure_report_share_persists_password_and_redaction_settings(
+        self,
+    ) -> None:
+        report = self._persist_shareable_report()
+        os.environ["APP_BASE_URL"] = "https://install.example.com"
+
+        share_config = report_service_module.configure_report_share(
+            report["id"],
+            password="s3cret-pass",
+            redact_filenames=True,
+        )
+
+        self.assertEqual(
+            share_config["share_url"],
+            f"https://install.example.com/reports/{report['id']}",
+        )
+        self.assertTrue(share_config["password_protected"])
+        self.assertTrue(share_config["redact_filenames"])
+
+        shared_report = report_service_module.fetch_shared_analysis_report(
+            report["id"],
+            password="s3cret-pass",
+        )
+        self.assertIsNotNone(shared_report)
+        assert shared_report is not None
+        self.assertNotIn("prod/network/plan.json", shared_report["top_risk"])
+        self.assertNotIn("prod/network/plan.json", shared_report["narrative_opening"])
+        self.assertNotIn(
+            "prod/network/plan.json", shared_report["findings"][0]["title"]
+        )
+        self.assertEqual(shared_report["audit"]["files_analyzed"], ["Artifact 1"])
+        self.assertEqual(shared_report["contributors"][0]["source_file"], "Artifact 1")
+        self.assertIn("Artifact 1", shared_report["evidence_items"][0]["source_ref"])
+        self.assertNotIn(
+            "prod/network/plan.json",
+            shared_report["evidence_items"][0]["source_ref"],
+        )
+
+    def test_fetch_shared_analysis_report_requires_password_when_configured(
+        self,
+    ) -> None:
+        report = self._persist_shareable_report()
+        report_service_module.configure_report_share(
+            report["id"],
+            password="s3cret-pass",
+            redact_filenames=False,
+        )
+
+        self.assertIsNone(
+            report_service_module.fetch_shared_analysis_report(report["id"])
+        )
+        self.assertIsNone(
+            report_service_module.fetch_shared_analysis_report(
+                report["id"], password="wrong-pass"
+            )
+        )
+        self.assertIsNotNone(
+            report_service_module.fetch_shared_analysis_report(
+                report["id"], password="s3cret-pass"
+            )
+        )
 
     def test_report_schema_helpers_preserve_forward_compatibility(self) -> None:
         self.assertEqual(

--- a/tests/test_ui/test_artifact_viewer.py
+++ b/tests/test_ui/test_artifact_viewer.py
@@ -123,7 +123,7 @@ class ArtifactViewerRouteTests(unittest.TestCase):
             },
         )
 
-        response = self.client.get(f"/reports/{report['id']}/artifacts?name=plan.json")
+        response = self.client.get(f"/history/{report['id']}/artifacts?name=plan.json")
 
         self.assertEqual(response.status_code, 200)
         self.assertIn("plan.json", response.text)
@@ -131,7 +131,12 @@ class ArtifactViewerRouteTests(unittest.TestCase):
         self.assertIn('id="L2"', response.text)
 
     def test_artifact_viewer_returns_not_found_for_missing_snapshot(self) -> None:
-        response = self.client.get("/reports/999/artifacts?name=missing.tf")
+        response = self.client.get("/history/999/artifacts?name=missing.tf")
+
+        self.assertEqual(response.status_code, 404)
+
+    def test_public_share_artifact_route_is_not_available(self) -> None:
+        response = self.client.get("/reports/1/artifacts?name=plan.json")
 
         self.assertEqual(response.status_code, 404)
 

--- a/tests/test_ui/test_findings_table.py
+++ b/tests/test_ui/test_findings_table.py
@@ -30,7 +30,7 @@ class FindingsTableEvidenceInspectorTests(unittest.TestCase):
         )
         self.assertEqual(
             descriptor["artifact_href"],
-            "/reports/17/artifacts?name=deployments%2Fprod%2Fplan.json&line=42#L42",
+            "/history/17/artifacts?name=deployments%2Fprod%2Fplan.json&line=42#L42",
         )
         self.assertIsNone(descriptor["source_system"])
 
@@ -50,7 +50,7 @@ class FindingsTableEvidenceInspectorTests(unittest.TestCase):
 
         self.assertEqual(
             descriptor["artifact_href"],
-            "/reports/9/artifacts?name=plan.json&line=7#L7",
+            "/history/9/artifacts?name=plan.json&line=7#L7",
         )
 
     def test_describe_evidence_item_preserves_current_artifact_reference_format(

--- a/tests/test_ui/test_findings_table_rendering.py
+++ b/tests/test_ui/test_findings_table_rendering.py
@@ -62,7 +62,7 @@ class FindingsTableRenderingTests(unittest.TestCase):
 
         self.assertEqual(response.status_code, 200)
         self.assertIn(
-            "/reports/14/artifacts?name=plan.json&amp;line=2#L2", response.text
+            "/history/14/artifacts?name=plan.json&amp;line=2#L2", response.text
         )
         self.assertIn('"data-dw-findings-table":"1"', response.text)
         self.assertIn('"data-dw-review-section":"findings"', response.text)

--- a/tests/test_ui/test_history_page.py
+++ b/tests/test_ui/test_history_page.py
@@ -60,6 +60,7 @@ class HistoryPageRenderingTests(unittest.TestCase):
 
     def tearDown(self) -> None:
         database_module.engine.dispose()
+        os.environ.pop("APP_BASE_URL", None)
         os.environ.pop("DATABASE_URL", None)
         self.tempdir.cleanup()
 
@@ -217,6 +218,60 @@ class HistoryPageRenderingTests(unittest.TestCase):
         self.assertIn("Blast radius", response.text)
         self.assertIn("Audit metadata", response.text)
         self.assertNotIn('"data-dw-modal-root":"1"', response.text)
+
+    def test_public_report_route_renders_read_only_share_view(self) -> None:
+        self._persist_report()
+
+        response = self.client.get("/reports/1")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("Shared DeployWhisper report", response.text)
+        self.assertIn("Analysis report", response.text)
+        self.assertNotIn("Delete selected", response.text)
+
+    def test_public_report_route_requires_password_and_redacts_filenames(self) -> None:
+        self._persist_report()
+        report_service_module.configure_report_share(
+            1,
+            password="s3cret-pass",
+            redact_filenames=True,
+        )
+
+        prompt_response = self.client.get("/reports/1")
+        self.assertEqual(prompt_response.status_code, 200)
+        self.assertIn("Password required", prompt_response.text)
+        self.assertIn("method='post'", prompt_response.text)
+
+        shared_response = self.client.post(
+            "/reports/1/unlock",
+            data={"password": "s3cret-pass"},
+            follow_redirects=True,
+        )
+        self.assertEqual(shared_response.status_code, 200)
+        self.assertIn("Artifact 1", shared_response.text)
+        self.assertNotIn("plan.json", shared_response.text)
+        self.assertNotIn("password=s3cret-pass", shared_response.text)
+
+    def test_public_report_unlock_sets_secure_cookie_for_https_share_urls(self) -> None:
+        os.environ["APP_BASE_URL"] = "https://install.example.com"
+        self._persist_report()
+        report_service_module.configure_report_share(
+            1,
+            password="s3cret-pass",
+            redact_filenames=True,
+        )
+
+        response = self.client.post(
+            "/reports/1/unlock",
+            data={"password": "s3cret-pass"},
+            follow_redirects=False,
+        )
+
+        self.assertEqual(response.status_code, 303)
+        cookie_header = response.headers.get("set-cookie", "")
+        self.assertIn("Secure", cookie_header)
+        self.assertIn("HttpOnly", cookie_header)
+        self.assertIn("Path=/reports/1", cookie_header)
 
     def test_history_page_keeps_legacy_query_parameter_as_detail_fallback(self) -> None:
         self._persist_report()

--- a/ui/components/findings_table.py
+++ b/ui/components/findings_table.py
@@ -98,7 +98,7 @@ def _artifact_view_href(
     query = {"name": artifact_name}
     if line_number is not None:
         query["line"] = line_number
-    href = f"/reports/{report_id}/artifacts?{urlencode(query)}"
+    href = f"/history/{report_id}/artifacts?{urlencode(query)}"
     if line_number is not None:
         href += f"#L{line_number}"
     return href

--- a/ui/components/report_detail_page.py
+++ b/ui/components/report_detail_page.py
@@ -171,7 +171,7 @@ def _render_audit_metadata(report: dict[str, Any]) -> None:
                     for file_name in files_analyzed:
                         ui.link(
                             file_name,
-                            f"/reports/{report['id']}/artifacts?{urlencode({'name': file_name})}",
+                            f"/history/{report['id']}/artifacts?{urlencode({'name': file_name})}",
                         ).classes("text-sm dw-accent-text break-all")
                 else:
                     ui.label(


### PR DESCRIPTION
Story 3.4 now persists share settings, serves reports from /reports/{id}, blocks artifact snapshots on the public route, and adds a narrow management-token gate for changing password/redaction settings. The deployment docs and compose/env examples now surface the required APP_BASE_URL and DEPLOYWHISPER_SHARE_TOKEN wiring so the feature can be operated intentionally instead of left half-configured.

Constraint: Shared report URLs must stay read-only and must not leak raw infrastructure details
Constraint: The fix had to stay within the current local-first app shape without adding a full authentication subsystem
Rejected: Leave POST /api/v1/analyses/{id}/share open | anyone reaching the app could remove password protection and filename redaction
Rejected: Put the management secret in the UI | server-side control belongs in runtime environment configuration, not a client-facing surface
Confidence: high
Scope-risk: moderate
Directive: Keep DEPLOYWHISPER_SHARE_TOKEN server-side only; do not move share-management authority into UI state or persisted app settings without a broader auth design
Tested: ./\.venv/bin/python -m unittest tests.test_api.test_analyses tests.test_ui.test_history_page tests.test_infra.test_container_contract -q
Tested: ./\.venv/bin/ruff check .
Tested: ./\.venv/bin/ruff format --check .
Not-tested: Full ./\.venv/bin/python -m unittest discover -q suite after closeout

## What does this PR do?

<!-- Brief description of changes -->

## Type of change
- [ ] Feature (new functionality)
- [ ] Bugfix (non-breaking fix)
- [ ] Release preparation
- [ ] Hotfix (critical production fix)
- [ ] Docs / refactor / chore

## Checklist
- [ ] I have followed the branch naming convention
- [ ] Tests pass locally (`pytest tests/ -v`)
- [ ] Linting passes (`ruff check .`)
- [ ] Docker build succeeds
- [ ] I have updated docs if needed
- [ ] No secrets or .env values committed

## Related issue
Closes #