### PR TITLE
Keep report comparisons accurate and scoped to accessible history

### DIFF
--- a/README.md
+++ b/README.md
@@ -528,6 +528,9 @@ Shared report links now resolve to `/reports/{id}` read-only pages. For sensitiv
 reports, configure password protection and opt-in file-name redaction via
 `POST /api/v1/analyses/{id}/share` with the `X-DeployWhisper-Share-Token`
 header. Set `DEPLOYWHISPER_SHARE_TOKEN` before exposing that management API.
+When a prior scan exists for the same analyzed artifact set, the shared report
+page also exposes a `Compare with previous` view with risk-score, findings, and
+evidence deltas.
 
 Example:
 

--- a/app.py
+++ b/app.py
@@ -28,7 +28,11 @@ from config import settings
 from logging_config import configure_logging
 from models.database import init_db
 from services.artifact_snapshot_service import load_report_artifact
-from services.report_service import fetch_analysis_report, fetch_shared_analysis_report
+from services.report_service import (
+    fetch_analysis_report,
+    fetch_shared_analysis_report,
+    fetch_shared_report_comparison,
+)
 from ui.routes.dashboard import build_dashboard
 
 configure_logging()
@@ -177,7 +181,149 @@ def _share_cookie_secure(report: dict) -> bool:
     return share_url.startswith("https://")
 
 
-def _shared_report_html(report: dict) -> str:
+def _shared_report_diff_list(
+    items: list[dict],
+    *,
+    empty_message: str,
+    include_severity: bool = True,
+) -> str:
+    if not items:
+        return f"<p class='empty'>{escape(empty_message)}</p>"
+    rows: list[str] = []
+    for item in items:
+        severity_html = ""
+        if include_severity:
+            severity_html = "<span class='diff-chip'>{severity}</span>".format(
+                severity=escape(str(item.get("severity") or "unknown").upper())
+            )
+        source_ref = str(item.get("source_ref") or "")
+        source_ref_html = f"<code>{escape(source_ref)}</code>" if source_ref else ""
+        finding_title = str(item.get("finding_title") or "")
+        finding_html = (
+            f"<p class='diff-meta'>{escape(finding_title)}</p>" if finding_title else ""
+        )
+        description = str(item.get("description") or item.get("summary") or "")
+        rows.append(
+            "<li>{severity}<strong>{title}</strong>{finding}<p>{description}</p>{source_ref}</li>".format(
+                severity=severity_html,
+                title=escape(str(item.get("title") or item.get("source_type") or "")),
+                finding=finding_html,
+                description=escape(description),
+                source_ref=source_ref_html,
+            )
+        )
+    return f"<ul class='diff-list'>{''.join(rows)}</ul>"
+
+
+def _shared_report_severity_change_list(items: list[dict]) -> str:
+    if not items:
+        return "<p class='empty'>No finding severity changed.</p>"
+    rows = []
+    for item in items:
+        transition = (
+            f"{escape(str(item.get('previous_severity') or 'unknown').upper())} → "
+            f"{escape(str(item.get('current_severity') or 'unknown').upper())}"
+        )
+        rows.append(
+            "<li><strong>{title}</strong><p>{description}</p><span class='diff-transition'>{transition}</span></li>".format(
+                title=escape(str(item.get("title") or "Untitled finding")),
+                description=escape(str(item.get("description") or "")),
+                transition=transition,
+            )
+        )
+    return f"<ul class='diff-list'>{''.join(rows)}</ul>"
+
+
+def _shared_report_comparison_html(
+    report: dict,
+    comparison: dict | None,
+    *,
+    show_comparison: bool,
+) -> str:
+    if comparison is None:
+        if not show_comparison:
+            return (
+                "<section class='panel'><div class='hero-actions'>"
+                f"<a class='button button-secondary' href='/reports/{int(report['id'])}?compare=previous#report-comparison'>Compare with previous</a>"
+                "</div></section>"
+            )
+        return (
+            "<section class='panel'><div class='hero-actions'>"
+            f"<a class='button button-secondary' href='/reports/{int(report['id'])}'>Back to report overview</a>"
+            "</div><p class='note'>The previous comparable report is not available in this shared context.</p></section>"
+        )
+
+    compare_action = (
+        f"/reports/{int(report['id'])}"
+        if show_comparison
+        else f"/reports/{int(report['id'])}?compare=previous"
+    )
+    compare_label = (
+        "Back to report overview" if show_comparison else "Compare with previous"
+    )
+    compare_controls = (
+        "<section class='panel'><div class='hero-actions'>"
+        f"<a class='button button-secondary' href='{compare_action}#report-comparison'>{compare_label}</a>"
+        "</div></section>"
+    )
+    if not show_comparison:
+        return compare_controls
+
+    score_delta = int(comparison.get("risk_score_delta") or 0)
+    score_prefix = "+" if score_delta > 0 else ""
+    delta_class = (
+        "delta-worse"
+        if score_delta > 0
+        else "delta-better"
+        if score_delta < 0
+        else "delta-flat"
+    )
+    comparison_section = (
+        "<section class='panel' id='report-comparison'>"
+        "<div class='comparison-header'>"
+        "<div>"
+        f"<div class='eyebrow'>Comparison</div><h2>Comparison with report #{int(comparison['previous_report']['id'])}</h2>"
+        "<p>Side-by-side changes against the previous scan of the same analyzed artifacts.</p>"
+        "</div>"
+        "<div class='delta-card'>"
+        "<div class='delta-label'>Risk score delta</div>"
+        f"<div class='delta-value {delta_class}'>{score_prefix}{score_delta}</div>"
+        f"<div class='delta-meta'>{int(comparison['previous_report']['risk_score'])} → {int(comparison['current_report']['risk_score'])}</div>"
+        "</div>"
+        "</div>"
+        "<div class='comparison-grid'>"
+        "<section class='comparison-column'>"
+        "<h3>Previous report</h3>"
+        f"<p class='diff-meta'>Report #{int(comparison['previous_report']['id'])} · {escape(str(comparison['previous_report']['severity']).upper())} · {escape(str(comparison['previous_report']['recommendation']).upper())}</p>"
+        "<h4>Findings removed</h4>"
+        f"{_shared_report_diff_list(comparison['findings']['removed'], empty_message='No findings were removed.')}"
+        "<h4>Evidence removed</h4>"
+        f"{_shared_report_diff_list(comparison['evidence']['removed'], empty_message='No evidence was removed.', include_severity=False)}"
+        "</section>"
+        "<section class='comparison-column'>"
+        "<h3>Current report</h3>"
+        f"<p class='diff-meta'>Report #{int(comparison['current_report']['id'])} · {escape(str(comparison['current_report']['severity']).upper())} · {escape(str(comparison['current_report']['recommendation']).upper())}</p>"
+        "<h4>Findings added</h4>"
+        f"{_shared_report_diff_list(comparison['findings']['added'], empty_message='No findings were added.')}"
+        "<h4>Evidence added</h4>"
+        f"{_shared_report_diff_list(comparison['evidence']['added'], empty_message='No evidence was added.', include_severity=False)}"
+        "</section>"
+        "</div>"
+        "<section class='comparison-severity'>"
+        "<h3>Severity changes</h3>"
+        f"{_shared_report_severity_change_list(comparison['findings']['severity_changed'])}"
+        "</section>"
+        "</section>"
+    )
+    return compare_controls + comparison_section
+
+
+def _shared_report_html(
+    report: dict,
+    *,
+    comparison: dict | None = None,
+    show_comparison: bool = False,
+) -> str:
     findings = report.get("findings") or []
     files_analyzed = report.get("audit", {}).get("files_analyzed") or []
     findings_html = (
@@ -216,6 +362,28 @@ def _shared_report_html(report: dict) -> str:
         "ul{padding-left:20px;}"
         ".grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(220px,1fr));gap:16px;}"
         ".note{margin-top:8px;color:#8b5a2b;font-weight:600;}"
+        ".empty{margin:0;color:#7b8596;}"
+        ".hero-actions{margin-top:20px;display:flex;gap:12px;flex-wrap:wrap;}"
+        ".button{display:inline-flex;align-items:center;justify-content:center;padding:12px 16px;border-radius:12px;font-weight:700;text-decoration:none;}"
+        ".button-secondary{border:1px solid rgba(24,32,43,0.12);background:#fff7f1;color:#d96b3d;}"
+        ".button-disabled{background:#f1ede5;color:#7b8596;cursor:not-allowed;}"
+        ".comparison-header{display:flex;align-items:flex-start;justify-content:space-between;gap:16px;flex-wrap:wrap;}"
+        ".comparison-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(280px,1fr));gap:16px;margin-top:20px;}"
+        ".comparison-column,.comparison-severity{background:#fbf8f2;border-radius:16px;padding:18px;}"
+        ".comparison-severity{margin-top:16px;}"
+        ".delta-card{min-width:180px;padding:18px;border-radius:18px;background:#18202b;color:#fff;}"
+        ".delta-label{font-size:12px;letter-spacing:.08em;text-transform:uppercase;color:#b3bfd1;font-weight:700;}"
+        ".delta-value{font-size:42px;font-weight:800;line-height:1.1;margin-top:6px;}"
+        ".delta-meta{font-size:14px;color:#dbe6f6;margin-top:6px;}"
+        ".delta-worse{color:#ffb199;}"
+        ".delta-better{color:#9fe4b8;}"
+        ".delta-flat{color:#edf0f8;}"
+        ".diff-list{padding-left:20px;margin:12px 0 0;display:grid;gap:12px;}"
+        ".diff-list li{color:#455163;}"
+        ".diff-chip{display:inline-block;margin-right:8px;padding:4px 8px;border-radius:999px;background:#eff4fb;font-size:12px;font-weight:700;}"
+        ".diff-meta{margin:4px 0 6px;font-size:13px;color:#7b8596;}"
+        ".diff-transition{display:inline-block;margin-left:8px;font-weight:700;color:#18202b;}"
+        "code{display:inline-block;margin-top:6px;padding:4px 6px;border-radius:8px;background:#f1ede5;color:#455163;word-break:break-all;}"
         "a{color:#d96b3d;text-decoration:none;}"
         "</style></head><body><main>"
         "<section class='hero'>"
@@ -226,6 +394,7 @@ def _shared_report_html(report: dict) -> str:
         f"<span class='badge'>{escape(str(report.get('recommendation', '')).upper())}</span>"
         f"<p class='score'>{int(report.get('risk_score') or 0)}</p>"
         f"<p>{escape(str(report.get('narrative_opening') or report.get('parse_summary') or ''))}</p>"
+        f"{_shared_report_comparison_html(report, comparison, show_comparison=show_comparison)}"
         "</section>"
         "<section class='panel'><div class='grid'>"
         f"<div><strong>Created</strong><p>{escape(str(report.get('created_at') or ''))}</p></div>"
@@ -246,6 +415,7 @@ def _shared_report_html(report: dict) -> str:
 def shared_report_view(
     request: Request,
     report_id: int,
+    compare: str | None = None,
 ) -> HTMLResponse:
     """Render one report via a read-only public sharing route."""
     report = fetch_analysis_report(report_id)
@@ -265,7 +435,19 @@ def shared_report_view(
     )
     if shared_report is None:
         raise StarletteHTTPException(status_code=404, detail="Report not found")
-    return HTMLResponse(content=_shared_report_html(shared_report))
+    comparison = None
+    if compare == "previous":
+        comparison = fetch_shared_report_comparison(
+            report_id,
+            bypass_password=password_required,
+        )
+    return HTMLResponse(
+        content=_shared_report_html(
+            shared_report,
+            comparison=comparison,
+            show_comparison=compare == "previous",
+        )
+    )
 
 
 @fastapi_app.post("/reports/{report_id}/unlock", include_in_schema=False)

--- a/services/report_service.py
+++ b/services/report_service.py
@@ -7,8 +7,9 @@ import os
 import secrets
 import hashlib
 import hmac
+import re
 from datetime import UTC, datetime
-from collections import Counter
+from collections import Counter, defaultdict
 from typing import Any
 
 from analysis.blast_radius import BlastRadiusResult
@@ -38,6 +39,10 @@ from services.settings_service import resolve_provider_runtime
 
 LEGACY_REPORT_SCHEMA_VERSION = "v1"
 REPORT_SCHEMA_VERSION = "v2"
+_SEVERITY_PREFIX_PATTERN = re.compile(
+    r"^\s*(critical|high|medium|low|info|warning|caution)\s*[:\-]\s*",
+    flags=re.IGNORECASE,
+)
 
 
 def build_share_report_link(report_id: int | None) -> str | None:
@@ -219,6 +224,437 @@ def _default_rollback_plan_payload() -> dict[str, Any]:
 def _artifact_signature(files_analyzed: list[str]) -> tuple[str, ...]:
     """Normalize analyzed-file identity for history diff grouping."""
     return tuple(sorted(str(name) for name in files_analyzed if str(name).strip()))
+
+
+def _normalize_free_text(value: Any) -> str:
+    text = str(value or "").strip().lower()
+    return " ".join(text.split())
+
+
+def _normalize_finding_text(value: Any) -> str:
+    return _normalize_free_text(_SEVERITY_PREFIX_PATTERN.sub("", str(value or "")))
+
+
+def _finding_fingerprint(finding: dict[str, Any]) -> str:
+    return "|".join(
+        [
+            _normalize_free_text(finding.get("category")),
+            _normalize_finding_text(finding.get("title")),
+            _normalize_finding_text(finding.get("description")),
+        ]
+    )
+
+
+def _evidence_fingerprint(evidence_item: dict[str, Any]) -> str:
+    related_change_ids = ",".join(
+        sorted(
+            str(change_id)
+            for change_id in evidence_item.get("related_change_ids") or []
+        )
+    )
+    return "|".join(
+        [
+            _normalize_free_text(evidence_item.get("source_type")),
+            _normalize_free_text(evidence_item.get("source_ref")),
+            _normalize_free_text(evidence_item.get("summary")),
+            _normalize_free_text(evidence_item.get("severity_hint")),
+            related_change_ids,
+        ]
+    )
+
+
+def _comparison_report_summary(report: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "id": int(report["id"]),
+        "created_at": report["created_at"],
+        "risk_score": int(report.get("risk_score") or 0),
+        "severity": str(report.get("severity") or "unknown"),
+        "recommendation": str(report.get("recommendation") or "unknown"),
+        "top_risk": str(report.get("top_risk") or ""),
+    }
+
+
+def _comparison_finding_summary(
+    finding: dict[str, Any],
+    *,
+    evidence_items: list[dict[str, Any]] | None = None,
+) -> dict[str, Any]:
+    evidence_rows = evidence_items or []
+    return {
+        "title": str(finding.get("title") or "Untitled finding"),
+        "severity": str(finding.get("severity") or "unknown"),
+        "description": str(finding.get("description") or ""),
+        "category": str(finding.get("category") or ""),
+        "evidence_count": len(evidence_rows),
+    }
+
+
+def _comparison_evidence_summary(
+    evidence_item: dict[str, Any],
+    *,
+    finding_title: str,
+) -> dict[str, Any]:
+    return {
+        "finding_title": finding_title,
+        "source_type": str(evidence_item.get("source_type") or "unknown"),
+        "source_ref": str(evidence_item.get("source_ref") or ""),
+        "summary": str(evidence_item.get("summary") or ""),
+        "severity_hint": str(evidence_item.get("severity_hint") or "unknown"),
+    }
+
+
+def _comparison_finding_sort_key(
+    finding: dict[str, Any],
+    *,
+    evidence_items: list[dict[str, Any]],
+) -> tuple[Any, ...]:
+    evidence_key = tuple(
+        sorted(_evidence_fingerprint(evidence_item) for evidence_item in evidence_items)
+    )
+    return (
+        evidence_key,
+        str(finding.get("severity") or "unknown"),
+        f"{float(finding.get('confidence') or 0.0):.6f}",
+        str(finding.get("uncertainty_note") or ""),
+        str(finding.get("skill_id") or ""),
+    )
+
+
+def _report_finding_maps(
+    report: dict[str, Any],
+) -> tuple[dict[str, list[dict[str, Any]]], dict[str, list[dict[str, Any]]]]:
+    findings_by_fingerprint: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    evidence_by_finding_id: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    for evidence_item in report.get("evidence_items") or []:
+        evidence_by_finding_id[str(evidence_item.get("finding_id") or "")].append(
+            evidence_item
+        )
+    for finding in report.get("findings") or []:
+        findings_by_fingerprint[_finding_fingerprint(finding)].append(finding)
+    return dict(findings_by_fingerprint), evidence_by_finding_id
+
+
+def _evidence_diff(
+    *,
+    previous_finding: dict[str, Any],
+    current_finding: dict[str, Any],
+    previous_evidence_items: list[dict[str, Any]],
+    current_evidence_items: list[dict[str, Any]],
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    previous_by_fingerprint = {
+        _evidence_fingerprint(evidence_item): evidence_item
+        for evidence_item in previous_evidence_items
+    }
+    current_by_fingerprint = {
+        _evidence_fingerprint(evidence_item): evidence_item
+        for evidence_item in current_evidence_items
+    }
+    added = [
+        _comparison_evidence_summary(
+            current_by_fingerprint[fingerprint],
+            finding_title=str(current_finding.get("title") or "Untitled finding"),
+        )
+        for fingerprint in sorted(
+            set(current_by_fingerprint) - set(previous_by_fingerprint)
+        )
+    ]
+    removed = [
+        _comparison_evidence_summary(
+            previous_by_fingerprint[fingerprint],
+            finding_title=str(previous_finding.get("title") or "Untitled finding"),
+        )
+        for fingerprint in sorted(
+            set(previous_by_fingerprint) - set(current_by_fingerprint)
+        )
+    ]
+    return added, removed
+
+
+def _build_report_comparison(
+    current_report: dict[str, Any],
+    previous_report: dict[str, Any],
+) -> dict[str, Any]:
+    current_findings, current_evidence_by_finding = _report_finding_maps(current_report)
+    previous_findings, previous_evidence_by_finding = _report_finding_maps(
+        previous_report
+    )
+    findings_added: list[dict[str, Any]] = []
+    findings_removed: list[dict[str, Any]] = []
+    severity_changed: list[dict[str, Any]] = []
+    evidence_added: list[dict[str, Any]] = []
+    evidence_removed: list[dict[str, Any]] = []
+
+    for fingerprint in sorted(set(previous_findings) | set(current_findings)):
+        previous_group = sorted(
+            previous_findings.get(fingerprint, []),
+            key=lambda finding: _comparison_finding_sort_key(
+                finding,
+                evidence_items=previous_evidence_by_finding.get(
+                    str(finding.get("finding_id") or ""),
+                    [],
+                ),
+            ),
+        )
+        current_group = sorted(
+            current_findings.get(fingerprint, []),
+            key=lambda finding: _comparison_finding_sort_key(
+                finding,
+                evidence_items=current_evidence_by_finding.get(
+                    str(finding.get("finding_id") or ""),
+                    [],
+                ),
+            ),
+        )
+        shared_count = min(len(previous_group), len(current_group))
+
+        for current_finding in current_group[shared_count:]:
+            current_evidence = current_evidence_by_finding.get(
+                str(current_finding.get("finding_id") or ""),
+                [],
+            )
+            findings_added.append(
+                _comparison_finding_summary(
+                    current_finding,
+                    evidence_items=current_evidence,
+                )
+            )
+            evidence_added.extend(
+                _comparison_evidence_summary(
+                    evidence_item,
+                    finding_title=str(
+                        current_finding.get("title") or "Untitled finding"
+                    ),
+                )
+                for evidence_item in current_evidence
+            )
+        for previous_finding in previous_group[shared_count:]:
+            previous_evidence = previous_evidence_by_finding.get(
+                str(previous_finding.get("finding_id") or ""),
+                [],
+            )
+            findings_removed.append(
+                _comparison_finding_summary(
+                    previous_finding,
+                    evidence_items=previous_evidence,
+                )
+            )
+            evidence_removed.extend(
+                _comparison_evidence_summary(
+                    evidence_item,
+                    finding_title=str(
+                        previous_finding.get("title") or "Untitled finding"
+                    ),
+                )
+                for evidence_item in previous_evidence
+            )
+
+        for previous_finding, current_finding in zip(
+            previous_group[:shared_count],
+            current_group[:shared_count],
+        ):
+            previous_evidence = previous_evidence_by_finding.get(
+                str(previous_finding.get("finding_id") or ""),
+                [],
+            )
+            current_evidence = current_evidence_by_finding.get(
+                str(current_finding.get("finding_id") or ""),
+                [],
+            )
+            if str(previous_finding.get("severity")) != str(
+                current_finding.get("severity")
+            ):
+                severity_changed.append(
+                    {
+                        "title": str(
+                            current_finding.get("title") or "Untitled finding"
+                        ),
+                        "description": str(
+                            current_finding.get("description")
+                            or previous_finding.get("description")
+                            or ""
+                        ),
+                        "previous_severity": str(
+                            previous_finding.get("severity") or "unknown"
+                        ),
+                        "current_severity": str(
+                            current_finding.get("severity") or "unknown"
+                        ),
+                    }
+                )
+            added, removed = _evidence_diff(
+                previous_finding=previous_finding,
+                current_finding=current_finding,
+                previous_evidence_items=previous_evidence,
+                current_evidence_items=current_evidence,
+            )
+            evidence_added.extend(added)
+            evidence_removed.extend(removed)
+
+    current_score = int(current_report.get("risk_score") or 0)
+    previous_score = int(previous_report.get("risk_score") or 0)
+    risk_score_delta = current_score - previous_score
+    if risk_score_delta > 0:
+        score_direction = "up"
+    elif risk_score_delta < 0:
+        score_direction = "down"
+    else:
+        score_direction = "flat"
+    return {
+        "previous_report": _comparison_report_summary(previous_report),
+        "current_report": _comparison_report_summary(current_report),
+        "risk_score_delta": risk_score_delta,
+        "risk_score_direction": score_direction,
+        "findings": {
+            "added": findings_added,
+            "removed": findings_removed,
+            "severity_changed": severity_changed,
+        },
+        "evidence": {
+            "added": evidence_added,
+            "removed": evidence_removed,
+        },
+        "summary": {
+            "findings_added": len(findings_added),
+            "findings_removed": len(findings_removed),
+            "severity_changes": len(severity_changed),
+            "evidence_added": len(evidence_added),
+            "evidence_removed": len(evidence_removed),
+        },
+    }
+
+
+def _find_previous_comparable_report(
+    current_report: dict[str, Any],
+    candidate_reports: list[dict[str, Any]],
+) -> dict[str, Any] | None:
+    current_signature = _artifact_signature(
+        current_report.get("audit", {}).get("files_analyzed") or []
+    )
+    if not current_signature:
+        return None
+    current_id = int(current_report["id"])
+    previous_candidates = sorted(
+        (
+            report
+            for report in candidate_reports
+            if int(report["id"]) < current_id
+            and _artifact_signature(report.get("audit", {}).get("files_analyzed") or [])
+            == current_signature
+        ),
+        key=lambda report: int(report["id"]),
+        reverse=True,
+    )
+    return previous_candidates[0] if previous_candidates else None
+
+
+def _list_serialized_reports(*, include_evidence: bool) -> list[dict[str, Any]]:
+    def operation():
+        with SessionLocal() as session:
+            reports = list_analysis_reports(session, include_evidence=include_evidence)
+            return [
+                _serialize_report(report, include_evidence=include_evidence)
+                for report in reports
+            ]
+
+    return _run_with_schema_retry(operation)
+
+
+def fetch_previous_comparable_report(
+    report_id: int,
+    *,
+    previous_report_id: int | None = None,
+) -> dict | None:
+    current_report = fetch_analysis_report(report_id)
+    if current_report is None:
+        return None
+    if previous_report_id is not None:
+        return fetch_analysis_report(previous_report_id)
+    serialized_reports = _list_serialized_reports(include_evidence=False)
+    return _find_previous_comparable_report(current_report, serialized_reports)
+
+
+def _redact_report_comparison(
+    comparison: dict[str, Any],
+    *,
+    current_report: dict[str, Any],
+    previous_report: dict[str, Any],
+) -> dict[str, Any]:
+    names: list[str] = []
+    for report in (current_report, previous_report):
+        for original_name in report.get("audit", {}).get("files_analyzed") or []:
+            if original_name not in names:
+                names.append(original_name)
+    pairs = _redaction_pairs(names)
+    redacted = {
+        **comparison,
+        "previous_report": {
+            **comparison["previous_report"],
+            "top_risk": _redact_text_value(
+                comparison["previous_report"].get("top_risk"),
+                pairs,
+            ),
+        },
+        "current_report": {
+            **comparison["current_report"],
+            "top_risk": _redact_text_value(
+                comparison["current_report"].get("top_risk"),
+                pairs,
+            ),
+        },
+        "findings": {
+            "added": [
+                {
+                    **item,
+                    "title": _redact_text_value(item.get("title"), pairs),
+                    "description": _redact_text_value(item.get("description"), pairs),
+                }
+                for item in comparison["findings"]["added"]
+            ],
+            "removed": [
+                {
+                    **item,
+                    "title": _redact_text_value(item.get("title"), pairs),
+                    "description": _redact_text_value(item.get("description"), pairs),
+                }
+                for item in comparison["findings"]["removed"]
+            ],
+            "severity_changed": [
+                {
+                    **item,
+                    "title": _redact_text_value(item.get("title"), pairs),
+                    "description": _redact_text_value(item.get("description"), pairs),
+                }
+                for item in comparison["findings"]["severity_changed"]
+            ],
+        },
+        "evidence": {
+            "added": [
+                {
+                    **item,
+                    "finding_title": _redact_text_value(
+                        item.get("finding_title"),
+                        pairs,
+                    ),
+                    "source_ref": _redact_text_value(item.get("source_ref"), pairs),
+                    "summary": _redact_text_value(item.get("summary"), pairs),
+                }
+                for item in comparison["evidence"]["added"]
+            ],
+            "removed": [
+                {
+                    **item,
+                    "finding_title": _redact_text_value(
+                        item.get("finding_title"),
+                        pairs,
+                    ),
+                    "source_ref": _redact_text_value(item.get("source_ref"), pairs),
+                    "summary": _redact_text_value(item.get("summary"), pairs),
+                }
+                for item in comparison["evidence"]["removed"]
+            ],
+        },
+    }
+    return redacted
 
 
 def _build_previous_scan_diff(
@@ -604,6 +1040,27 @@ def fetch_analysis_report(report_id: int) -> dict | None:
     return _run_with_schema_retry(operation)
 
 
+def fetch_report_comparison(
+    report_id: int,
+    *,
+    previous_report_id: int | None = None,
+) -> dict | None:
+    current_report = fetch_analysis_report(report_id)
+    if current_report is None:
+        return None
+    previous_report = fetch_previous_comparable_report(
+        report_id,
+        previous_report_id=previous_report_id,
+    )
+    if previous_report is None:
+        return None
+    if previous_report_id is None:
+        previous_report = fetch_analysis_report(int(previous_report["id"]))
+        if previous_report is None:
+            return None
+    return _build_report_comparison(current_report, previous_report)
+
+
 def configure_report_share(
     report_id: int,
     *,
@@ -664,6 +1121,46 @@ def fetch_shared_analysis_report(
     if shared["share"]["redact_filenames"]:
         shared = _redact_report_file_names(shared)
     return shared
+
+
+def fetch_shared_report_comparison(
+    report_id: int,
+    *,
+    password: str | None = None,
+    bypass_password: bool = False,
+) -> dict | None:
+    shared_current_report = fetch_shared_analysis_report(
+        report_id,
+        password=password,
+        bypass_password=bypass_password,
+    )
+    if shared_current_report is None:
+        return None
+    previous_report = fetch_previous_comparable_report(report_id)
+    if previous_report is None:
+        return None
+    shared_previous_report = fetch_shared_analysis_report(
+        int(previous_report["id"]),
+        password=password,
+        bypass_password=False,
+    )
+    if shared_previous_report is None:
+        return None
+    current_report = fetch_analysis_report(report_id)
+    previous_report = fetch_analysis_report(int(previous_report["id"]))
+    if current_report is None or previous_report is None:
+        return None
+    comparison = _build_report_comparison(current_report, previous_report)
+    if not (
+        shared_current_report["share"]["redact_filenames"]
+        or shared_previous_report["share"]["redact_filenames"]
+    ):
+        return comparison
+    return _redact_report_comparison(
+        comparison,
+        current_report=current_report,
+        previous_report=previous_report,
+    )
 
 
 def fetch_analysis_history() -> list[dict]:

--- a/tests/test_services/test_report_service.py
+++ b/tests/test_services/test_report_service.py
@@ -127,6 +127,69 @@ class ReportServiceTests(unittest.TestCase):
             audit_context={"source_interface": "api"},
         )
 
+    def _persist_comparison_report(
+        self,
+        *,
+        score: int,
+        severity: str,
+        recommendation: str,
+        top_risk: str,
+        findings: list[Finding],
+        evidence_items: list[EvidenceItem],
+    ) -> dict:
+        parse_batch = ParseBatchResult(
+            files=[
+                ParsedFileResult(
+                    file_name="prod/network/plan.json",
+                    tool="terraform",
+                    status="parsed",
+                    changes=[
+                        UnifiedChange(
+                            source_file="prod/network/plan.json",
+                            tool="terraform",
+                            resource_id="aws_security_group.main",
+                            action="modify",
+                            summary=top_risk,
+                        )
+                    ],
+                )
+            ]
+        )
+        assessment = RiskAssessment(
+            score=score,
+            severity=severity,
+            recommendation=recommendation,
+            top_risk=top_risk,
+            contributors=[
+                RiskContributor(
+                    source_file="prod/network/plan.json",
+                    tool="terraform",
+                    resource_id="aws_security_group.main",
+                    action="modify",
+                    contribution=18,
+                    summary=top_risk,
+                )
+            ],
+            interaction_risks=[],
+            partial_context=False,
+            warnings=[],
+        )
+        narrative = NarrativeResult(
+            opening_sentence=f"{severity.upper()}: {top_risk}",
+            explanation="Comparison test narrative.",
+            guidance=[],
+            degraded=False,
+            warnings=[],
+        )
+        return report_service_module.persist_analysis_report(
+            parse_batch,
+            assessment,
+            narrative,
+            findings=findings,
+            evidence_items=evidence_items,
+            audit_context={"source_interface": "api", "trigger_type": "pull_request"},
+        )
+
     def test_persist_analysis_report_stores_and_returns_metadata(self) -> None:
         parse_batch = ParseBatchResult(
             files=[
@@ -500,6 +563,614 @@ class ReportServiceTests(unittest.TestCase):
         self.assertIsNotNone(
             report_service_module.fetch_shared_analysis_report(
                 report["id"], password="s3cret-pass"
+            )
+        )
+
+    def test_fetch_report_comparison_returns_findings_and_evidence_deltas(self) -> None:
+        previous = self._persist_comparison_report(
+            score=42,
+            severity="medium",
+            recommendation="caution",
+            top_risk="Security group review is still pending.",
+            findings=[
+                Finding(
+                    finding_id="finding-shared",
+                    analysis_id=0,
+                    title="MEDIUM: aws_security_group.main",
+                    description="Security group ingress is broader than expected.",
+                    severity="medium",
+                    category="networking/ingress",
+                    deterministic=True,
+                    confidence=1.0,
+                    uncertainty_note=None,
+                    evidence_refs=["ev-shared", "ev-old"],
+                    skill_id=None,
+                ),
+                Finding(
+                    finding_id="finding-removed",
+                    analysis_id=0,
+                    title="LOW: aws_cloudwatch_log_group.api",
+                    description="Log retention is unset.",
+                    severity="low",
+                    category="observability/logging",
+                    deterministic=True,
+                    confidence=0.82,
+                    uncertainty_note=None,
+                    evidence_refs=["ev-removed"],
+                    skill_id=None,
+                ),
+            ],
+            evidence_items=[
+                EvidenceItem(
+                    evidence_id="ev-shared",
+                    analysis_id=0,
+                    finding_id="pending:shared",
+                    source_type="artifact",
+                    source_ref="terraform://prod/network/plan.json#L14",
+                    summary="Ingress stays open to the VPC.",
+                    severity_hint="medium",
+                    deterministic=True,
+                    confidence=1.0,
+                    related_change_ids=["change-1"],
+                ),
+                EvidenceItem(
+                    evidence_id="ev-old",
+                    analysis_id=0,
+                    finding_id="pending:shared",
+                    source_type="artifact",
+                    source_ref="terraform://prod/network/plan.json#L22",
+                    summary="Port 22 remains reachable.",
+                    severity_hint="medium",
+                    deterministic=True,
+                    confidence=1.0,
+                    related_change_ids=["change-2"],
+                ),
+                EvidenceItem(
+                    evidence_id="ev-removed",
+                    analysis_id=0,
+                    finding_id="pending:removed",
+                    source_type="artifact",
+                    source_ref="terraform://prod/network/plan.json#L31",
+                    summary="No retention override is configured.",
+                    severity_hint="low",
+                    deterministic=True,
+                    confidence=0.82,
+                    related_change_ids=["change-3"],
+                ),
+            ],
+        )
+        current = self._persist_comparison_report(
+            score=71,
+            severity="critical",
+            recommendation="no-go",
+            top_risk="Security group exposure widened after the latest commit.",
+            findings=[
+                Finding(
+                    finding_id="finding-shared",
+                    analysis_id=0,
+                    title="CRITICAL: aws_security_group.main",
+                    description="Security group ingress is broader than expected.",
+                    severity="critical",
+                    category="networking/ingress",
+                    deterministic=True,
+                    confidence=1.0,
+                    uncertainty_note=None,
+                    evidence_refs=["ev-shared", "ev-new"],
+                    skill_id=None,
+                ),
+                Finding(
+                    finding_id="finding-added",
+                    analysis_id=0,
+                    title="HIGH: aws_db_instance.main",
+                    description="Storage encryption is still disabled.",
+                    severity="high",
+                    category="data/encryption",
+                    deterministic=True,
+                    confidence=0.93,
+                    uncertainty_note=None,
+                    evidence_refs=["ev-added"],
+                    skill_id=None,
+                ),
+            ],
+            evidence_items=[
+                EvidenceItem(
+                    evidence_id="ev-shared",
+                    analysis_id=0,
+                    finding_id="pending:shared",
+                    source_type="artifact",
+                    source_ref="terraform://prod/network/plan.json#L14",
+                    summary="Ingress stays open to the VPC.",
+                    severity_hint="critical",
+                    deterministic=True,
+                    confidence=1.0,
+                    related_change_ids=["change-1"],
+                ),
+                EvidenceItem(
+                    evidence_id="ev-new",
+                    analysis_id=0,
+                    finding_id="pending:shared",
+                    source_type="artifact",
+                    source_ref="terraform://prod/network/plan.json#L26",
+                    summary="Port 3306 is newly reachable.",
+                    severity_hint="critical",
+                    deterministic=True,
+                    confidence=1.0,
+                    related_change_ids=["change-4"],
+                ),
+                EvidenceItem(
+                    evidence_id="ev-added",
+                    analysis_id=0,
+                    finding_id="pending:added",
+                    source_type="artifact",
+                    source_ref="terraform://prod/network/plan.json#L40",
+                    summary="Storage encryption is set to false.",
+                    severity_hint="high",
+                    deterministic=True,
+                    confidence=0.93,
+                    related_change_ids=["change-5"],
+                ),
+            ],
+        )
+
+        comparison = report_service_module.fetch_report_comparison(current["id"])
+
+        self.assertIsNotNone(comparison)
+        assert comparison is not None
+        self.assertEqual(comparison["previous_report"]["id"], previous["id"])
+        self.assertEqual(comparison["current_report"]["id"], current["id"])
+        self.assertEqual(comparison["risk_score_delta"], 29)
+        self.assertEqual(
+            comparison["findings"]["added"][0]["title"], "HIGH: aws_db_instance.main"
+        )
+        self.assertEqual(
+            comparison["findings"]["removed"][0]["title"],
+            "LOW: aws_cloudwatch_log_group.api",
+        )
+        self.assertEqual(
+            comparison["findings"]["severity_changed"][0]["previous_severity"],
+            "medium",
+        )
+        self.assertEqual(
+            comparison["findings"]["severity_changed"][0]["current_severity"],
+            "critical",
+        )
+        self.assertIn(
+            "terraform://prod/network/plan.json#L26",
+            {item["source_ref"] for item in comparison["evidence"]["added"]},
+        )
+        self.assertIn(
+            "terraform://prod/network/plan.json#L22",
+            {item["source_ref"] for item in comparison["evidence"]["removed"]},
+        )
+
+    def test_fetch_report_comparison_preserves_duplicate_findings(self) -> None:
+        previous = self._persist_comparison_report(
+            score=42,
+            severity="medium",
+            recommendation="caution",
+            top_risk="Duplicate security findings still need review.",
+            findings=[
+                Finding(
+                    finding_id="finding-dup-a",
+                    analysis_id=0,
+                    title="MEDIUM: aws_security_group.main",
+                    description="Security group ingress is broader than expected.",
+                    severity="medium",
+                    category="networking/ingress",
+                    deterministic=True,
+                    confidence=1.0,
+                    uncertainty_note=None,
+                    evidence_refs=["ev-dup-a"],
+                    skill_id=None,
+                ),
+                Finding(
+                    finding_id="finding-dup-b",
+                    analysis_id=0,
+                    title="MEDIUM: aws_security_group.main",
+                    description="Security group ingress is broader than expected.",
+                    severity="medium",
+                    category="networking/ingress",
+                    deterministic=True,
+                    confidence=0.91,
+                    uncertainty_note=None,
+                    evidence_refs=["ev-dup-b"],
+                    skill_id=None,
+                ),
+            ],
+            evidence_items=[
+                EvidenceItem(
+                    evidence_id="ev-dup-a",
+                    analysis_id=0,
+                    finding_id="pending:dup-a",
+                    source_type="artifact",
+                    source_ref="terraform://prod/network/plan.json#L14",
+                    summary="Ingress stays open to the VPC.",
+                    severity_hint="medium",
+                    deterministic=True,
+                    confidence=1.0,
+                    related_change_ids=["change-1"],
+                ),
+                EvidenceItem(
+                    evidence_id="ev-dup-b",
+                    analysis_id=0,
+                    finding_id="pending:dup-b",
+                    source_type="artifact",
+                    source_ref="terraform://prod/network/plan.json#L22",
+                    summary="Port 22 remains reachable.",
+                    severity_hint="medium",
+                    deterministic=True,
+                    confidence=0.91,
+                    related_change_ids=["change-2"],
+                ),
+            ],
+        )
+        current = self._persist_comparison_report(
+            score=51,
+            severity="medium",
+            recommendation="caution",
+            top_risk="One duplicate finding remains after the latest commit.",
+            findings=[
+                Finding(
+                    finding_id="finding-dup-a",
+                    analysis_id=0,
+                    title="MEDIUM: aws_security_group.main",
+                    description="Security group ingress is broader than expected.",
+                    severity="medium",
+                    category="networking/ingress",
+                    deterministic=True,
+                    confidence=1.0,
+                    uncertainty_note=None,
+                    evidence_refs=["ev-dup-a"],
+                    skill_id=None,
+                ),
+            ],
+            evidence_items=[
+                EvidenceItem(
+                    evidence_id="ev-dup-a",
+                    analysis_id=0,
+                    finding_id="pending:dup-a",
+                    source_type="artifact",
+                    source_ref="terraform://prod/network/plan.json#L14",
+                    summary="Ingress stays open to the VPC.",
+                    severity_hint="medium",
+                    deterministic=True,
+                    confidence=1.0,
+                    related_change_ids=["change-1"],
+                ),
+            ],
+        )
+
+        comparison = report_service_module.fetch_report_comparison(current["id"])
+
+        self.assertIsNotNone(comparison)
+        assert comparison is not None
+        self.assertEqual(comparison["previous_report"]["id"], previous["id"])
+        self.assertEqual(len(comparison["findings"]["removed"]), 1)
+        self.assertEqual(
+            comparison["findings"]["removed"][0]["title"],
+            "MEDIUM: aws_security_group.main",
+        )
+        self.assertIn(
+            "terraform://prod/network/plan.json#L22",
+            {item["source_ref"] for item in comparison["evidence"]["removed"]},
+        )
+
+    def test_fetch_report_comparison_is_stable_when_duplicate_finding_order_flips(
+        self,
+    ) -> None:
+        self._persist_comparison_report(
+            score=42,
+            severity="medium",
+            recommendation="caution",
+            top_risk="Duplicate findings exist in one order.",
+            findings=[
+                Finding(
+                    finding_id="finding-dup-a",
+                    analysis_id=0,
+                    title="MEDIUM: aws_security_group.main",
+                    description="Security group ingress is broader than expected.",
+                    severity="medium",
+                    category="networking/ingress",
+                    deterministic=True,
+                    confidence=1.0,
+                    uncertainty_note=None,
+                    evidence_refs=["ev-dup-a"],
+                    skill_id=None,
+                ),
+                Finding(
+                    finding_id="finding-dup-b",
+                    analysis_id=0,
+                    title="MEDIUM: aws_security_group.main",
+                    description="Security group ingress is broader than expected.",
+                    severity="medium",
+                    category="networking/ingress",
+                    deterministic=True,
+                    confidence=0.91,
+                    uncertainty_note=None,
+                    evidence_refs=["ev-dup-b"],
+                    skill_id=None,
+                ),
+            ],
+            evidence_items=[
+                EvidenceItem(
+                    evidence_id="ev-dup-a",
+                    analysis_id=0,
+                    finding_id="pending:dup-a",
+                    source_type="artifact",
+                    source_ref="terraform://prod/network/plan.json#L14",
+                    summary="Ingress stays open to the VPC.",
+                    severity_hint="medium",
+                    deterministic=True,
+                    confidence=1.0,
+                    related_change_ids=["change-1"],
+                ),
+                EvidenceItem(
+                    evidence_id="ev-dup-b",
+                    analysis_id=0,
+                    finding_id="pending:dup-b",
+                    source_type="artifact",
+                    source_ref="terraform://prod/network/plan.json#L22",
+                    summary="Port 22 remains reachable.",
+                    severity_hint="medium",
+                    deterministic=True,
+                    confidence=0.91,
+                    related_change_ids=["change-2"],
+                ),
+            ],
+        )
+        current = self._persist_comparison_report(
+            score=42,
+            severity="medium",
+            recommendation="caution",
+            top_risk="Duplicate findings exist in reversed order.",
+            findings=[
+                Finding(
+                    finding_id="finding-dup-b",
+                    analysis_id=0,
+                    title="MEDIUM: aws_security_group.main",
+                    description="Security group ingress is broader than expected.",
+                    severity="medium",
+                    category="networking/ingress",
+                    deterministic=True,
+                    confidence=0.91,
+                    uncertainty_note=None,
+                    evidence_refs=["ev-dup-b"],
+                    skill_id=None,
+                ),
+                Finding(
+                    finding_id="finding-dup-a",
+                    analysis_id=0,
+                    title="MEDIUM: aws_security_group.main",
+                    description="Security group ingress is broader than expected.",
+                    severity="medium",
+                    category="networking/ingress",
+                    deterministic=True,
+                    confidence=1.0,
+                    uncertainty_note=None,
+                    evidence_refs=["ev-dup-a"],
+                    skill_id=None,
+                ),
+            ],
+            evidence_items=[
+                EvidenceItem(
+                    evidence_id="ev-dup-b",
+                    analysis_id=0,
+                    finding_id="pending:dup-b",
+                    source_type="artifact",
+                    source_ref="terraform://prod/network/plan.json#L22",
+                    summary="Port 22 remains reachable.",
+                    severity_hint="medium",
+                    deterministic=True,
+                    confidence=0.91,
+                    related_change_ids=["change-2"],
+                ),
+                EvidenceItem(
+                    evidence_id="ev-dup-a",
+                    analysis_id=0,
+                    finding_id="pending:dup-a",
+                    source_type="artifact",
+                    source_ref="terraform://prod/network/plan.json#L14",
+                    summary="Ingress stays open to the VPC.",
+                    severity_hint="medium",
+                    deterministic=True,
+                    confidence=1.0,
+                    related_change_ids=["change-1"],
+                ),
+            ],
+        )
+
+        comparison = report_service_module.fetch_report_comparison(current["id"])
+
+        self.assertIsNotNone(comparison)
+        assert comparison is not None
+        self.assertEqual(comparison["previous_report"]["id"], 1)
+        self.assertEqual(comparison["current_report"]["id"], current["id"])
+        self.assertEqual(comparison["findings"]["added"], [])
+        self.assertEqual(comparison["findings"]["removed"], [])
+        self.assertEqual(comparison["findings"]["severity_changed"], [])
+        self.assertEqual(comparison["evidence"]["added"], [])
+        self.assertEqual(comparison["evidence"]["removed"], [])
+
+    def test_fetch_shared_report_comparison_respects_filename_redaction(self) -> None:
+        self._persist_comparison_report(
+            score=42,
+            severity="medium",
+            recommendation="caution",
+            top_risk="prod/network/plan.json still needs review.",
+            findings=[
+                Finding(
+                    finding_id="finding-shared",
+                    analysis_id=0,
+                    title="MEDIUM: prod/network/plan.json",
+                    description="Security group ingress is broader than expected.",
+                    severity="medium",
+                    category="networking/ingress",
+                    deterministic=True,
+                    confidence=1.0,
+                    uncertainty_note=None,
+                    evidence_refs=["ev-shared"],
+                    skill_id=None,
+                )
+            ],
+            evidence_items=[
+                EvidenceItem(
+                    evidence_id="ev-shared",
+                    analysis_id=0,
+                    finding_id="pending:shared",
+                    source_type="artifact",
+                    source_ref="terraform://prod/network/plan.json#L14",
+                    summary="Ingress stays open to the VPC.",
+                    severity_hint="medium",
+                    deterministic=True,
+                    confidence=1.0,
+                    related_change_ids=["change-1"],
+                )
+            ],
+        )
+        current = self._persist_comparison_report(
+            score=71,
+            severity="critical",
+            recommendation="no-go",
+            top_risk="prod/network/plan.json widened database access.",
+            findings=[
+                Finding(
+                    finding_id="finding-shared",
+                    analysis_id=0,
+                    title="CRITICAL: prod/network/plan.json",
+                    description="Security group ingress is broader than expected.",
+                    severity="critical",
+                    category="networking/ingress",
+                    deterministic=True,
+                    confidence=1.0,
+                    uncertainty_note=None,
+                    evidence_refs=["ev-new"],
+                    skill_id=None,
+                )
+            ],
+            evidence_items=[
+                EvidenceItem(
+                    evidence_id="ev-new",
+                    analysis_id=0,
+                    finding_id="pending:shared",
+                    source_type="artifact",
+                    source_ref="terraform://prod/network/plan.json#L26",
+                    summary="Port 3306 is newly reachable in prod/network/plan.json.",
+                    severity_hint="critical",
+                    deterministic=True,
+                    confidence=1.0,
+                    related_change_ids=["change-2"],
+                )
+            ],
+        )
+        report_service_module.configure_report_share(
+            current["id"],
+            password="review-only",
+            redact_filenames=True,
+        )
+
+        comparison = report_service_module.fetch_shared_report_comparison(
+            current["id"],
+            password="review-only",
+        )
+
+        self.assertIsNotNone(comparison)
+        assert comparison is not None
+        serialized = json.dumps(comparison)
+        self.assertNotIn("prod/network/plan.json", serialized)
+        self.assertIn("Artifact 1", serialized)
+
+    def test_fetch_shared_report_comparison_requires_previous_report_access(
+        self,
+    ) -> None:
+        previous = self._persist_comparison_report(
+            score=42,
+            severity="medium",
+            recommendation="caution",
+            top_risk="Previous report is password protected.",
+            findings=[
+                Finding(
+                    finding_id="finding-shared",
+                    analysis_id=0,
+                    title="MEDIUM: aws_security_group.main",
+                    description="Security group ingress is broader than expected.",
+                    severity="medium",
+                    category="networking/ingress",
+                    deterministic=True,
+                    confidence=1.0,
+                    uncertainty_note=None,
+                    evidence_refs=["ev-shared"],
+                    skill_id=None,
+                )
+            ],
+            evidence_items=[
+                EvidenceItem(
+                    evidence_id="ev-shared",
+                    analysis_id=0,
+                    finding_id="pending:shared",
+                    source_type="artifact",
+                    source_ref="terraform://prod/network/plan.json#L14",
+                    summary="Ingress stays open to the VPC.",
+                    severity_hint="medium",
+                    deterministic=True,
+                    confidence=1.0,
+                    related_change_ids=["change-1"],
+                )
+            ],
+        )
+        current = self._persist_comparison_report(
+            score=71,
+            severity="critical",
+            recommendation="no-go",
+            top_risk="Current report is shared without a password.",
+            findings=[
+                Finding(
+                    finding_id="finding-shared",
+                    analysis_id=0,
+                    title="CRITICAL: aws_security_group.main",
+                    description="Security group ingress is broader than expected.",
+                    severity="critical",
+                    category="networking/ingress",
+                    deterministic=True,
+                    confidence=1.0,
+                    uncertainty_note=None,
+                    evidence_refs=["ev-shared"],
+                    skill_id=None,
+                )
+            ],
+            evidence_items=[
+                EvidenceItem(
+                    evidence_id="ev-shared",
+                    analysis_id=0,
+                    finding_id="pending:shared",
+                    source_type="artifact",
+                    source_ref="terraform://prod/network/plan.json#L14",
+                    summary="Ingress stays open to the VPC.",
+                    severity_hint="critical",
+                    deterministic=True,
+                    confidence=1.0,
+                    related_change_ids=["change-1"],
+                )
+            ],
+        )
+        report_service_module.configure_report_share(
+            previous["id"],
+            password="previous-only",
+            redact_filenames=False,
+        )
+
+        self.assertIsNone(
+            report_service_module.fetch_shared_report_comparison(current["id"])
+        )
+        self.assertIsNone(
+            report_service_module.fetch_shared_report_comparison(
+                current["id"],
+                password="wrong-pass",
+            )
+        )
+        self.assertIsNotNone(
+            report_service_module.fetch_shared_report_comparison(
+                current["id"],
+                password="previous-only",
             )
         )
 

--- a/tests/test_ui/test_history_page.py
+++ b/tests/test_ui/test_history_page.py
@@ -72,6 +72,7 @@ class HistoryPageRenderingTests(unittest.TestCase):
         recommendation: str = "no-go",
         top_risk: str = "Security group exposure risk",
         opening_sentence: str = "Ingress widens access to production resources.",
+        finding_description: str = "Security group exposure risk",
     ) -> None:
         parse_batch = ParseBatchResult(
             files=[
@@ -148,9 +149,9 @@ class HistoryPageRenderingTests(unittest.TestCase):
                 Finding(
                     finding_id="finding-001",
                     analysis_id=0,
-                    title="CRITICAL: aws_security_group.main",
-                    description="Security group exposure risk",
-                    severity="critical",
+                    title=f"{severity.upper()}: aws_security_group.main",
+                    description=finding_description,
+                    severity=severity,
                     category="networking/ingress",
                     deterministic=True,
                     confidence=1.0,
@@ -161,6 +162,104 @@ class HistoryPageRenderingTests(unittest.TestCase):
             ],
             audit_context={"source_interface": "ui"},
         )
+
+    def test_public_report_route_shows_compare_button_and_diff_view(self) -> None:
+        self._persist_report(
+            score=42,
+            severity="medium",
+            recommendation="caution",
+            top_risk="Initial security group review",
+            opening_sentence="Initial review of the security group change.",
+            finding_description="Security group exposure risk",
+        )
+        self._persist_report(
+            score=88,
+            severity="critical",
+            recommendation="no-go",
+            top_risk="Security group exposure risk",
+            opening_sentence="Ingress widens access to production resources.",
+            finding_description="Security group exposure risk",
+        )
+
+        overview_response = self.client.get("/reports/2")
+        self.assertEqual(overview_response.status_code, 200)
+        self.assertIn("Compare with previous", overview_response.text)
+
+        compare_response = self.client.get("/reports/2?compare=previous")
+
+        self.assertEqual(compare_response.status_code, 200)
+        self.assertIn("Comparison with report #1", compare_response.text)
+        self.assertIn("Risk score delta", compare_response.text)
+        self.assertIn("+46", compare_response.text)
+        self.assertIn("MEDIUM → CRITICAL", compare_response.text)
+
+    def test_history_detail_route_shows_compare_button_and_diff_view(self) -> None:
+        self._persist_report(
+            score=42,
+            severity="medium",
+            recommendation="caution",
+            top_risk="Initial security group review",
+            opening_sentence="Initial review of the security group change.",
+            finding_description="Security group exposure risk",
+        )
+        self._persist_report(
+            score=88,
+            severity="critical",
+            recommendation="no-go",
+            top_risk="Security group exposure risk",
+            opening_sentence="Ingress widens access to production resources.",
+            finding_description="Security group exposure risk",
+        )
+
+        overview_response = self.client.get("/history/2")
+        self.assertEqual(overview_response.status_code, 200)
+        self.assertIn("Compare with previous", overview_response.text)
+
+        compare_response = self.client.get("/history/2/compare")
+
+        self.assertEqual(compare_response.status_code, 200)
+        self.assertIn("Comparison with report #1", compare_response.text)
+        self.assertIn("Risk score delta", compare_response.text)
+        self.assertIn("+46", compare_response.text)
+        self.assertIn("MEDIUM → CRITICAL", compare_response.text)
+
+    def test_public_report_route_blocks_compare_view_when_previous_report_is_protected(
+        self,
+    ) -> None:
+        self._persist_report(
+            score=42,
+            severity="medium",
+            recommendation="caution",
+            top_risk="Initial security group review",
+            opening_sentence="Initial review of the security group change.",
+            finding_description="Security group exposure risk",
+        )
+        report_service_module.configure_report_share(
+            1,
+            password="previous-only",
+            redact_filenames=False,
+        )
+        self._persist_report(
+            score=88,
+            severity="critical",
+            recommendation="no-go",
+            top_risk="Security group exposure risk",
+            opening_sentence="Ingress widens access to production resources.",
+            finding_description="Security group exposure risk",
+        )
+
+        overview_response = self.client.get("/reports/2")
+        self.assertEqual(overview_response.status_code, 200)
+        self.assertIn("Compare with previous", overview_response.text)
+
+        compare_response = self.client.get("/reports/2?compare=previous")
+
+        self.assertEqual(compare_response.status_code, 200)
+        self.assertIn(
+            "The previous comparable report is not available in this shared context.",
+            compare_response.text,
+        )
+        self.assertNotIn("Comparison with report #1", compare_response.text)
 
     def test_history_page_renders_toolbar_and_report_actions(self) -> None:
         self._persist_report()

--- a/ui/routes/dashboard.py
+++ b/ui/routes/dashboard.py
@@ -226,6 +226,11 @@ def history_detail_page(report_id: int) -> None:
     build_history_detail_page(report_id)
 
 
+@ui.page("/history/{report_id}/compare")
+def history_detail_compare_page(report_id: int) -> None:
+    build_history_detail_page(report_id, show_comparison=True)
+
+
 @ui.page("/settings")
 def settings_page() -> None:
     build_settings_page()

--- a/ui/routes/history.py
+++ b/ui/routes/history.py
@@ -9,6 +9,7 @@ from nicegui import ui
 from services.report_service import (
     fetch_analysis_report,
     fetch_filtered_analysis_history_page,
+    fetch_report_comparison,
     fetch_risk_trends,
     remove_analysis_report,
     remove_analysis_reports,
@@ -262,11 +263,147 @@ def build_history_page() -> None:
         render_actions()
 
 
-def build_history_detail_page(report_id: int) -> None:
+def _render_history_comparison_items(
+    heading: str,
+    items: list[dict[str, Any]],
+    *,
+    empty_message: str,
+) -> None:
+    with ui.column().classes("gap-3"):
+        ui.label(heading).classes("text-lg font-medium dw-text")
+        if not items:
+            ui.label(empty_message).classes("text-sm dw-muted")
+            return
+        for item in items:
+            with ui.card().classes("w-full dw-panel-soft shadow-none"):
+                with ui.column().classes("gap-2 p-4"):
+                    title = str(item.get("title") or item.get("source_type") or "")
+                    ui.label(title).classes("text-sm font-semibold dw-text")
+                    if item.get("finding_title"):
+                        ui.label(str(item["finding_title"])).classes("text-xs dw-muted")
+                    description = str(
+                        item.get("description") or item.get("summary") or ""
+                    )
+                    if description:
+                        ui.label(description).classes("text-sm dw-muted leading-6")
+                    if item.get("source_ref"):
+                        ui.label(str(item["source_ref"])).classes(
+                            "text-xs dw-muted break-all"
+                        )
+
+
+def _render_history_report_comparison(
+    report_id: int,
+    comparison: dict[str, Any] | None,
+) -> None:
+    with ui.card().classes("w-full dw-panel shadow-none p-5") as compare_card:
+        decorate_modal_card(compare_card, label="Report comparison")
+        with ui.row().classes("w-full items-center justify-between gap-3 flex-wrap"):
+            ui.label("Report comparison").classes("text-lg font-medium dw-text")
+            ui.button(
+                "Back to report overview",
+                on_click=lambda: ui.navigate.to(f"/history/{report_id}"),
+            ).props("flat no-caps").classes("dw-theme-button")
+        if comparison is None:
+            ui.label(
+                "No previous comparable report was found for this analysis yet."
+            ).classes("text-sm dw-muted")
+            return
+
+        score_delta = int(comparison.get("risk_score_delta") or 0)
+        score_prefix = "+" if score_delta > 0 else ""
+        score_class = (
+            "dw-danger-text"
+            if score_delta > 0
+            else "dw-success-text"
+            if score_delta < 0
+            else "dw-muted"
+        )
+        with ui.row().classes("w-full items-start justify-between gap-4 flex-wrap"):
+            with ui.column().classes("gap-1 min-w-0 flex-1"):
+                ui.label(
+                    f"Comparison with report #{int(comparison['previous_report']['id'])}"
+                ).classes("text-xl font-semibold dw-text")
+                ui.label(
+                    "Side-by-side changes against the previous saved scan of the same analyzed artifacts."
+                ).classes("text-sm dw-muted leading-6")
+            with ui.column().classes("gap-1 shrink-0"):
+                ui.label("Risk score delta").classes(
+                    "text-[11px] font-semibold uppercase tracking-[0.08em] dw-muted"
+                )
+                ui.label(f"{score_prefix}{score_delta}").classes(
+                    f"text-3xl font-semibold {score_class}"
+                )
+                ui.label(
+                    f"{int(comparison['previous_report']['risk_score'])} -> {int(comparison['current_report']['risk_score'])}"
+                ).classes("text-xs dw-muted")
+        with ui.row().classes("w-full gap-4 flex-wrap mt-2"):
+            with ui.card().classes("dw-panel-soft shadow-none min-w-[260px] flex-1"):
+                with ui.column().classes("gap-2 p-4"):
+                    ui.label("Previous report").classes("text-sm font-semibold dw-text")
+                    ui.label(
+                        f"#{int(comparison['previous_report']['id'])} · "
+                        f"{str(comparison['previous_report']['severity']).upper()} · "
+                        f"{str(comparison['previous_report']['recommendation']).upper()}"
+                    ).classes("text-xs dw-muted")
+                    _render_history_comparison_items(
+                        "Findings removed",
+                        comparison["findings"]["removed"],
+                        empty_message="No findings were removed.",
+                    )
+                    _render_history_comparison_items(
+                        "Evidence removed",
+                        comparison["evidence"]["removed"],
+                        empty_message="No evidence was removed.",
+                    )
+            with ui.card().classes("dw-panel-soft shadow-none min-w-[260px] flex-1"):
+                with ui.column().classes("gap-2 p-4"):
+                    ui.label("Current report").classes("text-sm font-semibold dw-text")
+                    ui.label(
+                        f"#{int(comparison['current_report']['id'])} · "
+                        f"{str(comparison['current_report']['severity']).upper()} · "
+                        f"{str(comparison['current_report']['recommendation']).upper()}"
+                    ).classes("text-xs dw-muted")
+                    _render_history_comparison_items(
+                        "Findings added",
+                        comparison["findings"]["added"],
+                        empty_message="No findings were added.",
+                    )
+                    _render_history_comparison_items(
+                        "Evidence added",
+                        comparison["evidence"]["added"],
+                        empty_message="No evidence was added.",
+                    )
+        with ui.card().classes("w-full dw-panel-soft shadow-none mt-4"):
+            with ui.column().classes("gap-3 p-4"):
+                ui.label("Severity changes").classes("text-sm font-semibold dw-text")
+                changes = comparison["findings"]["severity_changed"]
+                if not changes:
+                    ui.label("No finding severity changed.").classes("text-sm dw-muted")
+                else:
+                    for item in changes:
+                        with ui.row().classes(
+                            "w-full items-start justify-between gap-3 flex-wrap"
+                        ):
+                            with ui.column().classes("min-w-0 flex-1 gap-1"):
+                                ui.label(
+                                    str(item.get("title") or "Untitled finding")
+                                ).classes("text-sm font-semibold dw-text")
+                                ui.label(str(item.get("description") or "")).classes(
+                                    "text-sm dw-muted leading-6"
+                                )
+                            ui.label(
+                                f"{str(item.get('previous_severity') or 'unknown').upper()} → "
+                                f"{str(item.get('current_severity') or 'unknown').upper()}"
+                            ).classes("text-sm font-semibold dw-text")
+
+
+def build_history_detail_page(report_id: int, *, show_comparison: bool = False) -> None:
     """Render one persisted report on a dedicated detail page."""
     apply_theme()
     build_navigation_shell("history")
     report = fetch_analysis_report(report_id)
+    comparison = fetch_report_comparison(report_id) if show_comparison else None
 
     with ui.column().classes("dw-main-content dw-shell gap-5"):
         with ui.card().classes("w-full dw-panel dw-page-header shadow-none"):
@@ -292,4 +429,20 @@ def build_history_detail_page(report_id: int) -> None:
                     "This report is unavailable. Return to history and choose another saved analysis."
                 ).classes("text-sm dw-muted")
             return
+        with ui.card().classes("w-full dw-panel shadow-none p-4"):
+            if show_comparison:
+                _render_history_report_comparison(report_id, comparison)
+            else:
+                with ui.row().classes(
+                    "w-full items-center justify-between gap-3 flex-wrap"
+                ):
+                    ui.label(
+                        "Open a persisted diff against the previous comparable report."
+                    ).classes("text-sm dw-muted")
+                    ui.button(
+                        "Compare with previous",
+                        on_click=lambda: ui.navigate.to(
+                            f"/history/{report_id}/compare#report-comparison"
+                        ),
+                    ).props("flat no-caps").classes("dw-theme-button")
         render_report_detail_page(report)


### PR DESCRIPTION
Story 3.5 now exposes comparison from both shared and in-app report pages while preserving advisory-first sharing boundaries.


## What does this PR do?


The comparison path now enforces previous-report share access, avoids eager shared-overview comparison work, and stabilizes duplicate-finding pairing with evidence-derived ordering so persisted diffs do not depend on ORM row order.

Constraint: Story 3.5 had to reuse persisted report/share contracts instead of adding a new comparison store or PR-specific model
Rejected: Compare duplicate findings by raw relationship iteration order | unstable across unordered ORM loads and produced noisy evidence diffs
Confidence: high
Scope-risk: moderate
Reversibility: clean
Directive: Keep comparison access checks aligned with both current and previous report share policy whenever shared views traverse history
Tested: ./ .venv/bin/ruff check .
Tested: ./.venv/bin/ruff format --check .
Tested: ./.venv/bin/python -m unittest discover -q
Tested: bash scripts/ci-local.sh
Not-tested: Local Bandit scan (bandit not installed)



## Related issue
Closes #