### PR TITLE
Keep GitHub-native setup self-hosted and Action-first

### DIFF
--- a/README.md
+++ b/README.md
@@ -532,6 +532,22 @@ When a prior scan exists for the same analyzed artifact set, the shared report
 page also exposes a `Compare with previous` view with risk-score, findings, and
 evidence deltas.
 
+### GitHub App Mode
+
+DeployWhisper also supports a GitHub App adapter for webhook-driven PR analysis,
+checks API publishing, and OAuth-guided installation handoff. The App adapter is
+documented in [`docs/github-app.md`](./docs/github-app.md) and is designed to
+run in three lanes:
+
+- Action-first: workflow file + Marketplace Action
+- Advanced self-hosted GitHub App: webhook, checks, and OAuth-backed installation flow against your own DeployWhisper server
+- Combined mode: Action for explicit workflow control, self-hosted GitHub App for checks and richer installation UX
+
+The recommended open-source posture is Action-first. If you want GitHub App
+capabilities, create a private/self-hosted GitHub App in your own account or
+organization and point it at your own DeployWhisper instance. See
+[`docs/github-app-self-hosted-setup.md`](./docs/github-app-self-hosted-setup.md).
+
 Example:
 
 ```bash

--- a/_bmad-output/planning-artifacts/architecture.md
+++ b/_bmad-output/planning-artifacts/architecture.md
@@ -655,7 +655,7 @@ Capabilities:
 - Compare old vs new report
 - Link to full report (shareable URL)
 - Check Run integration (advisory-only, never required)
-- GitHub App for richer interactions (checks API, OAuth, installation wizard)
+- Advanced self-hosted GitHub App support for richer interactions (checks API, OAuth, installation wizard)
 
 Adapter pattern:
 - Core analysis pipeline is surface-agnostic
@@ -1023,7 +1023,7 @@ deploywhisper/
 
 ### ADR-11: GitHub adapter uses Action + App in parallel (new)
 **Status:** Accepted
-**Reason:** Action is simpler (works in any workflow) — ship it first. App enables richer interactions (check runs, PR events, OAuth) — add it second. Both are needed for full workflow-native integration.
+**Reason:** Action is simpler and best aligns with the product's open-source local-first posture, so ship it first. Self-hosted GitHub App support enables richer interactions (check runs, PR events, OAuth) for teams that run their own DeployWhisper server. Defer any public hosted Marketplace app until the trust, privacy, and operating model are intentionally defined.
 
 ---
 

--- a/_bmad-output/planning-artifacts/epics.md
+++ b/_bmad-output/planning-artifacts/epics.md
@@ -386,15 +386,15 @@ Ship an official GitHub Action and GitHub App so DeployWhisper reports appear in
 
 #### E3-S6: GitHub App
 **As a** DeployWhisper maintainer,
-**I want** a GitHub App complementing the Action,
+**I want** advanced self-hosted GitHub App support complementing the Action,
 **so that** I can post check runs and richer interactions.
 
 **Acceptance:**
-- GitHub App published to Marketplace
+- Self-hosted GitHub App runtime and operator guide are ready for installation in a team's own GitHub account or organization
 - Supports checks API (passing/neutral/failing, always advisory)
 - Handles PR events for automatic runs (opt-in via config)
 - OAuth flow for team installation
-- Docs covering Action-only, App-only, and combined modes
+- Docs covering Action-first, advanced self-hosted GitHub App mode, and combined modes
 
 #### E3-S7: Check run integration
 **As a** reviewer,

--- a/api/routes/github_app.py
+++ b/api/routes/github_app.py
@@ -1,0 +1,140 @@
+"""GitHub App adapter routes."""
+
+from __future__ import annotations
+
+from html import escape
+
+from fastapi import APIRouter, Query, Request
+from fastapi.responses import HTMLResponse, RedirectResponse
+
+from api.errors import ApiError, ApiRoute
+from config import settings
+from integrations.github.app_service import (
+    GitHubAppConfigurationError,
+    GitHubAppRequestError,
+    build_github_app_oauth_url,
+    complete_github_app_oauth,
+    get_github_app_config,
+    handle_github_app_webhook,
+    verify_github_webhook_signature,
+)
+
+router = APIRouter(
+    prefix="/api/v1/github/app",
+    tags=["github-app"],
+    route_class=ApiRoute,
+)
+
+
+@router.get("/oauth/start", include_in_schema=False)
+def github_app_oauth_start(
+    return_to: str | None = Query(default=None),
+) -> RedirectResponse:
+    try:
+        authorize_url = build_github_app_oauth_url(return_to=return_to)
+    except GitHubAppConfigurationError as exc:
+        raise ApiError(
+            status_code=405,
+            code="github_app_oauth_disabled",
+            message=str(exc),
+        ) from exc
+    return RedirectResponse(url=authorize_url, status_code=302)
+
+
+@router.get("/oauth/callback", include_in_schema=False)
+def github_app_oauth_callback(
+    code: str,
+    state: str,
+) -> HTMLResponse:
+    try:
+        result = complete_github_app_oauth(code=code, state=state)
+    except (GitHubAppConfigurationError, GitHubAppRequestError) as exc:
+        raise ApiError(
+            status_code=400,
+            code="github_app_oauth_failed",
+            message=str(exc),
+        ) from exc
+    install_url = result.install_url or result.marketplace_url or "#"
+    return_to = result.state_return_to or "/"
+    return HTMLResponse(
+        content=(
+            "<!doctype html><html><head><meta charset='utf-8'>"
+            "<title>DeployWhisper GitHub App authorization</title>"
+            "<style>"
+            "body{margin:0;background:#f4efe7;color:#18202b;font-family:ui-sans-serif,system-ui,sans-serif;}"
+            "main{max-width:720px;margin:72px auto;padding:32px;background:#fff;border-radius:20px;box-shadow:0 18px 48px rgba(24,32,43,0.08);}"
+            "h1{margin:0 0 12px;font-size:30px;line-height:1.2;}"
+            "p{margin:0 0 16px;color:#5e697b;line-height:1.7;}"
+            "a.button{display:inline-flex;align-items:center;justify-content:center;padding:12px 16px;border-radius:12px;background:#d96b3d;color:#fff;font-weight:700;text-decoration:none;margin-right:12px;}"
+            "a.secondary{background:#fff;color:#d96b3d;border:1px solid rgba(24,32,43,0.12);}"
+            "</style></head><body><main>"
+            "<h1>GitHub App authorization complete</h1>"
+            "<p>Your DeployWhisper GitHub App authorization succeeded. Continue to the installation step to connect the app to your team or organization.</p>"
+            f"<p>Token type: {escape(result.token_type)}"
+            + (f" · Scope: {escape(result.scope)}" if result.scope else "")
+            + "</p>"
+            f"<a class='button' href='{escape(install_url)}'>Continue to GitHub App installation</a>"
+            f"<a class='button secondary' href='{escape(return_to)}'>Return to DeployWhisper</a>"
+            "</main></body></html>"
+        )
+    )
+
+
+@router.post("/webhook")
+async def github_app_webhook(request: Request) -> dict[str, object]:
+    config = get_github_app_config()
+    payload_bytes = await request.body()
+    signature = request.headers.get("X-Hub-Signature-256")
+    if not verify_github_webhook_signature(payload_bytes, signature, config=config):
+        raise ApiError(
+            status_code=403,
+            code="github_app_webhook_forbidden",
+            message="GitHub App webhook signature verification failed.",
+        )
+    try:
+        payload = await request.json()
+    except Exception as exc:  # noqa: BLE001
+        raise ApiError(
+            status_code=400,
+            code="github_app_webhook_invalid_json",
+            message="GitHub App webhook payload must be valid JSON.",
+        ) from exc
+    event_name = request.headers.get("X-GitHub-Event", "").strip() or "unknown"
+    try:
+        result = handle_github_app_webhook(
+            event_name=event_name,
+            payload=payload,
+            config=config,
+        )
+    except GitHubAppConfigurationError as exc:
+        raise ApiError(
+            status_code=405,
+            code="github_app_unconfigured",
+            message=str(exc),
+        ) from exc
+    except GitHubAppRequestError as exc:
+        raise ApiError(
+            status_code=502,
+            code="github_app_upstream_failed",
+            message=str(exc),
+        ) from exc
+
+    return {
+        "data": {
+            "event": result.event,
+            "action": result.action,
+            "handled": result.handled,
+            "automatic_analysis_triggered": result.automatic_analysis_triggered,
+            "check_run_id": result.check_run_id,
+            "report_id": result.report_id,
+            "report_url": result.report_url,
+            "marketplace_url": config.marketplace_url,
+            "install_url": config.install_url,
+            "advisory_only": True,
+            "note": result.note,
+        },
+        "meta": {
+            "api_version": "v1",
+            "app_name": settings.app_name,
+        },
+    }

--- a/app.py
+++ b/app.py
@@ -23,6 +23,7 @@ from api.errors import (
     validation_error_handler,
 )
 from api.routes.analyses import router as analyses_router
+from api.routes.github_app import router as github_app_router
 from api.routes.health import router as health_router
 from config import settings
 from logging_config import configure_logging
@@ -73,6 +74,7 @@ fastapi_app.add_exception_handler(RequestValidationError, validation_error_handl
 fastapi_app.add_exception_handler(StarletteHTTPException, http_error_envelope_handler)
 fastapi_app.include_router(health_router)
 fastapi_app.include_router(analyses_router)
+fastapi_app.include_router(github_app_router)
 
 
 _original_lifespan = fastapi_app.router.lifespan_context

--- a/config.py
+++ b/config.py
@@ -28,6 +28,45 @@ class Settings:
     share_management_token: str | None = os.getenv(
         "DEPLOYWHISPER_SHARE_TOKEN"
     ) or os.getenv("APP_SHARE_MANAGEMENT_TOKEN")
+    github_app_enabled: bool = (
+        os.getenv("DEPLOYWHISPER_GITHUB_APP_ENABLED", "false").lower() == "true"
+    )
+    github_app_id: str | None = os.getenv("DEPLOYWHISPER_GITHUB_APP_ID") or None
+    github_app_slug: str | None = os.getenv("DEPLOYWHISPER_GITHUB_APP_SLUG") or None
+    github_app_client_id: str | None = (
+        os.getenv("DEPLOYWHISPER_GITHUB_APP_CLIENT_ID") or None
+    )
+    github_app_client_secret: str | None = (
+        os.getenv("DEPLOYWHISPER_GITHUB_APP_CLIENT_SECRET") or None
+    )
+    github_app_webhook_secret: str | None = (
+        os.getenv("DEPLOYWHISPER_GITHUB_APP_WEBHOOK_SECRET") or None
+    )
+    github_app_private_key: str | None = (
+        os.getenv("DEPLOYWHISPER_GITHUB_APP_PRIVATE_KEY") or None
+    )
+    github_app_private_key_path: str | None = (
+        os.getenv("DEPLOYWHISPER_GITHUB_APP_PRIVATE_KEY_PATH") or None
+    )
+    github_app_api_base_url: str = os.getenv(
+        "DEPLOYWHISPER_GITHUB_APP_API_BASE_URL",
+        "https://api.github.com",
+    )
+    github_app_authorize_url: str = os.getenv(
+        "DEPLOYWHISPER_GITHUB_APP_AUTHORIZE_URL",
+        "https://github.com/login/oauth/authorize",
+    )
+    github_app_access_token_url: str = os.getenv(
+        "DEPLOYWHISPER_GITHUB_APP_ACCESS_TOKEN_URL",
+        "https://github.com/login/oauth/access_token",
+    )
+    github_app_pr_events_enabled: bool = (
+        os.getenv("DEPLOYWHISPER_GITHUB_APP_PR_EVENTS_ENABLED", "false").lower()
+        == "true"
+    )
+    github_app_checks_enabled: bool = (
+        os.getenv("DEPLOYWHISPER_GITHUB_APP_CHECKS_ENABLED", "true").lower() == "true"
+    )
     llm_api_key: str | None = (
         os.getenv("LLM_API_KEY")
         or os.getenv("OPENAI_API_KEY")

--- a/docs/github-app-self-hosted-setup.md
+++ b/docs/github-app-self-hosted-setup.md
@@ -1,0 +1,170 @@
+# Self-Hosted GitHub App Setup
+
+This guide shows how a user or team creates a private/self-hosted DeployWhisper GitHub App in their own GitHub account or organization and points it at their own DeployWhisper server.
+
+This is the recommended GitHub App model for the open-source product.
+
+## When to use this
+
+Use this guide if you want:
+
+- Action-first as the default integration mode
+- GitHub check runs, webhook-driven PR analysis, and OAuth-backed install flow
+- your own DeployWhisper server to receive and analyze PR artifacts
+- no dependency on a public hosted DeployWhisper GitHub App
+
+## What this model means
+
+- You create the GitHub App in your own GitHub account or organization
+- GitHub sends webhooks to your own DeployWhisper server
+- Your own DeployWhisper server fetches changed PR artifacts
+- Your own DeployWhisper server creates advisory check runs and report links
+- The app does not need to be public or listed on GitHub Marketplace
+
+## Prerequisites
+
+- A reachable DeployWhisper base URL such as `https://deploywhisper.example.com`
+- A DeployWhisper instance running the Story 3.6 GitHub App adapter code
+- Ability to set environment variables on that DeployWhisper instance
+- Admin access to the GitHub account or organization where the GitHub App will live
+
+## DeployWhisper server settings
+
+Set these on your DeployWhisper server:
+
+- `DEPLOYWHISPER_GITHUB_APP_ENABLED=true`
+- `DEPLOYWHISPER_GITHUB_APP_ID`
+- `DEPLOYWHISPER_GITHUB_APP_SLUG`
+- `DEPLOYWHISPER_GITHUB_APP_CLIENT_ID`
+- `DEPLOYWHISPER_GITHUB_APP_CLIENT_SECRET`
+- `DEPLOYWHISPER_GITHUB_APP_WEBHOOK_SECRET`
+- `DEPLOYWHISPER_GITHUB_APP_PRIVATE_KEY` or `DEPLOYWHISPER_GITHUB_APP_PRIVATE_KEY_PATH`
+- `APP_BASE_URL` or `PUBLIC_APP_URL`
+
+Optional:
+
+- `DEPLOYWHISPER_GITHUB_APP_PR_EVENTS_ENABLED=true`
+- `DEPLOYWHISPER_GITHUB_APP_CHECKS_ENABLED=true`
+- `DEPLOYWHISPER_GITHUB_APP_API_BASE_URL`
+- `DEPLOYWHISPER_GITHUB_APP_AUTHORIZE_URL`
+- `DEPLOYWHISPER_GITHUB_APP_ACCESS_TOKEN_URL`
+
+## GitHub UI steps
+
+### 1. Open GitHub App settings
+
+1. Sign in to GitHub as the account or org admin that will own the app
+2. Open `Settings`
+3. Open `Developer settings`
+4. Click `GitHub Apps`
+5. Click `New GitHub App`
+
+### 2. Fill the basic app fields
+
+Recommended values:
+
+- GitHub App name:
+  `DeployWhisper`
+- Description:
+  `Advisory-only deployment risk analysis for pull requests using your own DeployWhisper server.`
+- Homepage URL:
+  `https://<your-deploywhisper-base-url>`
+- Callback URL:
+  `https://<your-deploywhisper-base-url>/api/v1/github/app/oauth/callback`
+- Setup URL:
+  Leave blank unless you later build a dedicated install UI
+- Webhook URL:
+  `https://<your-deploywhisper-base-url>/api/v1/github/app/webhook`
+- Webhook secret:
+  Use a long random value and store the same value in `DEPLOYWHISPER_GITHUB_APP_WEBHOOK_SECRET`
+
+### 3. Keep the app private to your account or org
+
+- Do not publish the app to GitHub Marketplace
+- Do not depend on a public hosted listing
+- Install it only on repositories or organizations you control
+
+### 4. Configure permissions
+
+Repository permissions:
+
+- `Checks`: `Read and write`
+- `Pull requests`: `Read-only`
+- `Contents`: `Read-only`
+- `Metadata`: default
+
+### 5. Subscribe to webhook events
+
+Enable:
+
+- `Pull request`
+
+### 6. Create app credentials
+
+After creating the app:
+
+1. Copy the GitHub App `App ID`
+2. Copy the `Client ID`
+3. Generate a `Client secret`
+4. Generate a private key and download the `.pem`
+
+Map them into DeployWhisper:
+
+- `DEPLOYWHISPER_GITHUB_APP_ID=<App ID>`
+- `DEPLOYWHISPER_GITHUB_APP_CLIENT_ID=<Client ID>`
+- `DEPLOYWHISPER_GITHUB_APP_CLIENT_SECRET=<Client secret>`
+- `DEPLOYWHISPER_GITHUB_APP_PRIVATE_KEY_PATH=<path to pem>`
+  or
+- `DEPLOYWHISPER_GITHUB_APP_PRIVATE_KEY=<pem contents>`
+
+Also set:
+
+- `DEPLOYWHISPER_GITHUB_APP_SLUG=<your app slug>`
+- `DEPLOYWHISPER_GITHUB_APP_PR_EVENTS_ENABLED=true`
+- `DEPLOYWHISPER_GITHUB_APP_CHECKS_ENABLED=true`
+
+## Installation steps
+
+1. Open the GitHub App settings page
+2. Click `Install App`
+3. Choose your account or organization
+4. Select the repositories you want the app to access
+5. Complete the installation
+
+## Verification checklist
+
+1. Open a PR in an installed repository that changes supported deployment artifacts
+2. Confirm GitHub delivers the webhook successfully
+3. Confirm DeployWhisper receives the webhook
+4. Confirm DeployWhisper downloads the changed files within the shared 50 MB limit
+5. Confirm DeployWhisper persists a report
+6. Confirm a check run named `DeployWhisper / Risk Analysis` appears on the PR
+7. Confirm the check remains advisory-only and does not block merge on its own
+8. Confirm the report link opens your own DeployWhisper server
+
+## Action-first recommendation
+
+For most teams, the recommended rollout order is:
+
+1. Start with the DeployWhisper GitHub Action
+2. Confirm your DeployWhisper instance and report links are working
+3. Add the self-hosted GitHub App only if you want richer GitHub-native checks and install flow
+
+## Combined mode
+
+Combined mode means:
+
+- Action handles explicit workflow execution and PR comments
+- Self-hosted GitHub App handles checks API, webhook automation, and installation UX
+
+Both still point at your own DeployWhisper server.
+
+## What is intentionally deferred
+
+This guide does not cover:
+
+- public hosted GitHub App rollout
+- GitHub Marketplace listing/publication
+- a SaaS trust model where other users send PR data to a third-party hosted DeployWhisper service
+
+Those are separate product decisions and are intentionally deferred from the current open-source self-hosted deployment model.

--- a/docs/github-app.md
+++ b/docs/github-app.md
@@ -1,0 +1,92 @@
+# GitHub App Mode
+
+DeployWhisper now supports an advanced self-hosted GitHub App adapter alongside the Marketplace Action.
+
+## Why this exists
+
+- Action-first mode keeps repository-local workflow ownership simple and best matches the project's local-first trust posture.
+- Advanced self-hosted GitHub App mode adds richer GitHub-native capabilities like checks, webhook-driven PR automation, and OAuth-based team installation.
+- Combined mode lets teams keep the Action for explicit workflow control while enabling their own self-hosted GitHub App for checks and installation UX.
+
+## Modes
+
+### Action-only
+
+- Use `deploywhisper/analyze-action@v1`
+- Best when teams want only workflow-file driven execution
+- No GitHub App registration required
+
+### Advanced self-hosted GitHub App
+
+- Create a private or internal GitHub App in your own GitHub account or organization
+- Point its webhook and OAuth callback URLs at your own DeployWhisper server
+- Enable PR automation with `DEPLOYWHISPER_GITHUB_APP_PR_EVENTS_ENABLED=true`
+- Use `/api/v1/github/app/oauth/start` to begin the user authorization flow
+- Follow the operator guide in [`docs/github-app-self-hosted-setup.md`](./github-app-self-hosted-setup.md)
+
+### Combined mode
+
+- Keep the Action for explicit workflow dispatch and PR comments
+- Install your own self-hosted GitHub App for checks API integration and richer installation/auth flows
+- Both paths still use the same DeployWhisper analysis core and persisted report/share contracts
+
+## Positioning
+
+- Default recommendation: `Action-first`
+- Advanced option: `self-hosted GitHub App`
+- Deferred: public hosted GitHub App / Marketplace SaaS rollout
+
+The current open-source product is intentionally not positioned around a public hosted GitHub App. Teams that want GitHub App behavior should create and run their own app against their own DeployWhisper instance.
+
+## Required environment variables
+
+- `DEPLOYWHISPER_GITHUB_APP_ENABLED=true`
+- `DEPLOYWHISPER_GITHUB_APP_ID`
+- `DEPLOYWHISPER_GITHUB_APP_SLUG`
+- `DEPLOYWHISPER_GITHUB_APP_CLIENT_ID`
+- `DEPLOYWHISPER_GITHUB_APP_CLIENT_SECRET`
+- `DEPLOYWHISPER_GITHUB_APP_WEBHOOK_SECRET`
+- `DEPLOYWHISPER_GITHUB_APP_PRIVATE_KEY` or `DEPLOYWHISPER_GITHUB_APP_PRIVATE_KEY_PATH`
+- `APP_BASE_URL` or `PUBLIC_APP_URL`
+
+Optional:
+
+- `DEPLOYWHISPER_GITHUB_APP_PR_EVENTS_ENABLED=true`
+- `DEPLOYWHISPER_GITHUB_APP_CHECKS_ENABLED=true`
+- `DEPLOYWHISPER_GITHUB_APP_API_BASE_URL`
+- `DEPLOYWHISPER_GITHUB_APP_AUTHORIZE_URL`
+- `DEPLOYWHISPER_GITHUB_APP_ACCESS_TOKEN_URL`
+
+## Runtime behavior
+
+- Webhook verification uses `X-Hub-Signature-256`
+- Pull request webhook actions `opened`, `reopened`, and `synchronize` can trigger automatic advisory analyses when PR automation is enabled
+- Supported changed artifacts are downloaded from GitHub, filtered through the shared intake rules, and sent through the existing parse/assess/persist pipeline
+- Check runs are advisory-only: `success` for `GO`, `neutral` for `CAUTION`, `failure` for `NO-GO`
+- Shared report URLs remain the deep-link target for richer investigation
+
+## OAuth and installation flow
+
+1. Start the user authorization flow at `/api/v1/github/app/oauth/start`
+2. GitHub redirects back to `/api/v1/github/app/oauth/callback`
+3. DeployWhisper exchanges the code for a GitHub App user access token
+4. The callback page hands the maintainer off to the GitHub App installation URL
+
+## Operator guide
+
+Use the detailed operator runbook in [`docs/github-app-self-hosted-setup.md`](./github-app-self-hosted-setup.md) to:
+
+1. Create a private/self-hosted GitHub App in your own account or organization
+2. Configure callback URL(s) to your DeployWhisper instance
+3. Configure webhook URL and secret
+4. Request repository permissions for `checks`, `pull_requests`, and `contents`
+5. Subscribe to `pull_request` webhooks
+6. Install the app only into the repositories or organizations you control
+
+## Deferred hosted mode
+
+Public hosted / Marketplace GitHub App rollout is intentionally deferred. If that changes later, it should be treated as a separate product and trust-boundary decision rather than implied by the current open-source self-hosted mode.
+
+## OpenSSL note
+
+DeployWhisper signs GitHub App JWTs by calling the system `openssl` binary. Ensure OpenSSL is available in the runtime image or host where the app adapter will run.

--- a/integrations/__init__.py
+++ b/integrations/__init__.py
@@ -1,0 +1,1 @@
+"""Integration adapters for external workflow surfaces."""

--- a/integrations/github/__init__.py
+++ b/integrations/github/__init__.py
@@ -1,0 +1,1 @@
+"""GitHub integration adapters."""

--- a/integrations/github/app_service.py
+++ b/integrations/github/app_service.py
@@ -1,0 +1,733 @@
+"""GitHub App adapter services."""
+
+from __future__ import annotations
+
+import base64
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+import hashlib
+import hmac
+import json
+import os
+from pathlib import Path
+import secrets
+import shutil
+import subprocess
+import tempfile
+from typing import Any
+from urllib import error, parse, request
+
+from config import settings
+from services.analysis_service import analyze_uploaded_files
+from services.intake_service import (
+    MAX_TOTAL_UPLOAD_BYTES,
+    build_pending_analysis,
+    total_upload_bytes,
+    uniquify_artifact_names,
+)
+from services.report_service import build_share_report_link
+
+DEFAULT_GITHUB_API_BASE_URL = "https://api.github.com"
+DEFAULT_GITHUB_AUTHORIZE_URL = "https://github.com/login/oauth/authorize"
+DEFAULT_GITHUB_ACCESS_TOKEN_URL = "https://github.com/login/oauth/access_token"
+DEFAULT_CHECK_RUN_NAME = "DeployWhisper / Risk Analysis"
+PULL_REQUEST_TRIGGER_ACTIONS = {"opened", "reopened", "synchronize"}
+_STATE_MAX_AGE_SECONDS = 600
+_UPLOAD_LIMIT_MESSAGE = (
+    "Total artifact payload exceeds the 50 MB analysis-session limit."
+)
+
+
+class GitHubAppConfigurationError(RuntimeError):
+    """Raised when required GitHub App configuration is missing."""
+
+
+class GitHubAppRequestError(RuntimeError):
+    """Raised when a GitHub API request fails."""
+
+
+@dataclass(frozen=True)
+class GitHubAppConfig:
+    enabled: bool
+    app_id: str | None
+    slug: str | None
+    client_id: str | None
+    client_secret: str | None
+    webhook_secret: str | None
+    private_key_pem: str | None
+    api_base_url: str
+    authorize_url: str
+    access_token_url: str
+    app_base_url: str | None
+    automatic_pr_events_enabled: bool
+    checks_enabled: bool
+
+    @property
+    def install_url(self) -> str | None:
+        if not self.slug:
+            return None
+        return f"https://github.com/apps/{self.slug}/installations/new"
+
+    @property
+    def marketplace_url(self) -> str | None:
+        if not self.slug:
+            return None
+        return f"https://github.com/apps/{self.slug}"
+
+    @property
+    def callback_url(self) -> str | None:
+        if not self.app_base_url:
+            return None
+        return self.app_base_url.rstrip("/") + "/api/v1/github/app/oauth/callback"
+
+
+@dataclass(frozen=True)
+class GitHubWebhookResult:
+    event: str
+    action: str | None
+    handled: bool
+    automatic_analysis_triggered: bool
+    check_run_id: int | None
+    report_id: int | None
+    report_url: str | None
+    note: str
+
+
+@dataclass(frozen=True)
+class GitHubOAuthResult:
+    install_url: str | None
+    marketplace_url: str | None
+    user_access_token: str
+    token_type: str
+    scope: str | None
+    state_return_to: str | None
+
+
+def get_github_app_config() -> GitHubAppConfig:
+    inline_key = (os.getenv("DEPLOYWHISPER_GITHUB_APP_PRIVATE_KEY") or "").strip()
+    private_key_path = (
+        os.getenv("DEPLOYWHISPER_GITHUB_APP_PRIVATE_KEY_PATH") or ""
+    ).strip()
+    private_key_pem = inline_key or _load_private_key_from_path(private_key_path)
+    app_base_url = (
+        os.getenv("APP_BASE_URL")
+        or os.getenv("PUBLIC_APP_URL")
+        or settings.app_base_url
+        or ""
+    ).strip() or None
+    return GitHubAppConfig(
+        enabled=os.getenv("DEPLOYWHISPER_GITHUB_APP_ENABLED", "false").lower()
+        == "true",
+        app_id=(os.getenv("DEPLOYWHISPER_GITHUB_APP_ID") or "").strip() or None,
+        slug=(os.getenv("DEPLOYWHISPER_GITHUB_APP_SLUG") or "").strip() or None,
+        client_id=(os.getenv("DEPLOYWHISPER_GITHUB_APP_CLIENT_ID") or "").strip()
+        or None,
+        client_secret=(
+            os.getenv("DEPLOYWHISPER_GITHUB_APP_CLIENT_SECRET") or ""
+        ).strip()
+        or None,
+        webhook_secret=(
+            os.getenv("DEPLOYWHISPER_GITHUB_APP_WEBHOOK_SECRET") or ""
+        ).strip()
+        or None,
+        private_key_pem=private_key_pem,
+        api_base_url=(
+            os.getenv("DEPLOYWHISPER_GITHUB_APP_API_BASE_URL")
+            or DEFAULT_GITHUB_API_BASE_URL
+        ).rstrip("/"),
+        authorize_url=(
+            os.getenv("DEPLOYWHISPER_GITHUB_APP_AUTHORIZE_URL")
+            or DEFAULT_GITHUB_AUTHORIZE_URL
+        ).rstrip("/"),
+        access_token_url=(
+            os.getenv("DEPLOYWHISPER_GITHUB_APP_ACCESS_TOKEN_URL")
+            or DEFAULT_GITHUB_ACCESS_TOKEN_URL
+        ).rstrip("/"),
+        app_base_url=app_base_url,
+        automatic_pr_events_enabled=os.getenv(
+            "DEPLOYWHISPER_GITHUB_APP_PR_EVENTS_ENABLED",
+            "false",
+        ).lower()
+        == "true",
+        checks_enabled=os.getenv(
+            "DEPLOYWHISPER_GITHUB_APP_CHECKS_ENABLED",
+            "true",
+        ).lower()
+        == "true",
+    )
+
+
+def _load_private_key_from_path(path_value: str) -> str | None:
+    if not path_value:
+        return None
+    path = Path(path_value)
+    if not path.exists():
+        return None
+    return path.read_text(encoding="utf-8")
+
+
+def _require_runtime_config(config: GitHubAppConfig) -> None:
+    missing: list[str] = []
+    if not config.enabled:
+        missing.append("DEPLOYWHISPER_GITHUB_APP_ENABLED=true")
+    if not config.app_id:
+        missing.append("DEPLOYWHISPER_GITHUB_APP_ID")
+    if not config.private_key_pem:
+        missing.append(
+            "DEPLOYWHISPER_GITHUB_APP_PRIVATE_KEY or DEPLOYWHISPER_GITHUB_APP_PRIVATE_KEY_PATH"
+        )
+    if not config.webhook_secret:
+        missing.append("DEPLOYWHISPER_GITHUB_APP_WEBHOOK_SECRET")
+    if missing:
+        raise GitHubAppConfigurationError(
+            "GitHub App runtime is not configured: " + ", ".join(missing)
+        )
+
+
+def _require_oauth_config(config: GitHubAppConfig) -> None:
+    missing: list[str] = []
+    if not config.client_id:
+        missing.append("DEPLOYWHISPER_GITHUB_APP_CLIENT_ID")
+    if not config.client_secret:
+        missing.append("DEPLOYWHISPER_GITHUB_APP_CLIENT_SECRET")
+    if not config.callback_url:
+        missing.append("APP_BASE_URL or PUBLIC_APP_URL")
+    if missing:
+        raise GitHubAppConfigurationError(
+            "GitHub App OAuth is not configured: " + ", ".join(missing)
+        )
+
+
+def verify_github_webhook_signature(
+    payload: bytes,
+    signature_header: str | None,
+    *,
+    config: GitHubAppConfig | None = None,
+) -> bool:
+    config = config or get_github_app_config()
+    secret = (config.webhook_secret or "").encode("utf-8")
+    if not secret or not signature_header or not signature_header.startswith("sha256="):
+        return False
+    expected = hmac.new(secret, payload, hashlib.sha256).hexdigest()
+    return hmac.compare_digest(signature_header[7:], expected)
+
+
+def build_github_app_oauth_url(
+    *,
+    return_to: str | None = None,
+    config: GitHubAppConfig | None = None,
+) -> str:
+    config = config or get_github_app_config()
+    _require_oauth_config(config)
+    state = _encode_oauth_state(
+        {"return_to": return_to or "", "nonce": secrets.token_urlsafe(12)},
+        secret=str(config.client_secret),
+    )
+    query = {
+        "client_id": str(config.client_id),
+        "redirect_uri": str(config.callback_url),
+        "state": state,
+        "prompt": "select_account",
+    }
+    return config.authorize_url + "?" + parse.urlencode(query)
+
+
+def complete_github_app_oauth(
+    *,
+    code: str,
+    state: str,
+    config: GitHubAppConfig | None = None,
+) -> GitHubOAuthResult:
+    config = config or get_github_app_config()
+    _require_oauth_config(config)
+    state_payload = _decode_oauth_state(state, secret=str(config.client_secret))
+    payload = _post_form_json(
+        config.access_token_url,
+        {
+            "client_id": str(config.client_id),
+            "client_secret": str(config.client_secret),
+            "code": code,
+            "redirect_uri": str(config.callback_url),
+        },
+    )
+    access_token = str(payload.get("access_token") or "").strip()
+    if not access_token:
+        raise GitHubAppRequestError(
+            "GitHub OAuth callback did not return an access token."
+        )
+    return GitHubOAuthResult(
+        install_url=config.install_url,
+        marketplace_url=config.marketplace_url,
+        user_access_token=access_token,
+        token_type=str(payload.get("token_type") or "bearer"),
+        scope=(str(payload.get("scope") or "").strip() or None),
+        state_return_to=(str(state_payload.get("return_to") or "").strip() or None),
+    )
+
+
+def handle_github_app_webhook(
+    *,
+    event_name: str,
+    payload: dict[str, Any],
+    config: GitHubAppConfig | None = None,
+) -> GitHubWebhookResult:
+    config = config or get_github_app_config()
+    action = str(payload.get("action") or "").strip() or None
+    if event_name != "pull_request":
+        return GitHubWebhookResult(
+            event=event_name,
+            action=action,
+            handled=False,
+            automatic_analysis_triggered=False,
+            check_run_id=None,
+            report_id=None,
+            report_url=None,
+            note="Webhook event ignored because Story 3.6 only wires pull_request automation.",
+        )
+    if not config.automatic_pr_events_enabled:
+        return GitHubWebhookResult(
+            event=event_name,
+            action=action,
+            handled=True,
+            automatic_analysis_triggered=False,
+            check_run_id=None,
+            report_id=None,
+            report_url=None,
+            note="GitHub App pull request automation is disabled by configuration.",
+        )
+    if action not in PULL_REQUEST_TRIGGER_ACTIONS:
+        return GitHubWebhookResult(
+            event=event_name,
+            action=action,
+            handled=True,
+            automatic_analysis_triggered=False,
+            check_run_id=None,
+            report_id=None,
+            report_url=None,
+            note="Pull request action did not require an automatic analysis run.",
+        )
+    _require_runtime_config(config)
+    installation_id = int(payload.get("installation", {}).get("id") or 0)
+    repository = dict(payload.get("repository") or {})
+    pull_request = dict(payload.get("pull_request") or {})
+    owner = str(repository.get("owner", {}).get("login") or "").strip()
+    repo_name = str(repository.get("name") or "").strip()
+    pull_number = int(pull_request.get("number") or payload.get("number") or 0)
+    head_sha = str(pull_request.get("head", {}).get("sha") or "").strip()
+    if (
+        not installation_id
+        or not owner
+        or not repo_name
+        or not pull_number
+        or not head_sha
+    ):
+        raise GitHubAppRequestError(
+            "GitHub pull_request webhook payload is missing installation, repository, PR number, or head SHA."
+        )
+
+    installation_token = _generate_installation_access_token(
+        installation_id,
+        config=config,
+    )
+    raw_files = _load_pull_request_artifacts(
+        owner=owner,
+        repo_name=repo_name,
+        pull_number=pull_number,
+        head_sha=head_sha,
+        installation_token=installation_token,
+        api_base_url=config.api_base_url,
+    )
+    unique_files = uniquify_artifact_names(raw_files)
+    pending = build_pending_analysis(unique_files)
+    accepted_files = [
+        (name, raw_content)
+        for (name, raw_content), item in zip(unique_files, pending.items)
+        if item.status == "ready"
+    ]
+    if not accepted_files:
+        note = "No supported changed artifacts were available from this pull request."
+        check_run_id = (
+            _create_check_run(
+                owner=owner,
+                repo_name=repo_name,
+                head_sha=head_sha,
+                installation_token=installation_token,
+                conclusion="neutral",
+                title=DEFAULT_CHECK_RUN_NAME,
+                summary=note,
+                details_url=None,
+                api_base_url=config.api_base_url,
+            )
+            if config.checks_enabled
+            else None
+        )
+        return GitHubWebhookResult(
+            event=event_name,
+            action=action,
+            handled=True,
+            automatic_analysis_triggered=False,
+            check_run_id=check_run_id,
+            report_id=None,
+            report_url=None,
+            note=note,
+        )
+
+    result = analyze_uploaded_files(
+        accepted_files,
+        audit_context={
+            "source_interface": "github_app",
+            "trigger_type": "github_app_pull_request",
+            "trigger_id": f"{owner}/{repo_name}#PR-{pull_number}",
+        },
+    )
+    report_id = int(result.persisted_report["id"])
+    report_url = build_share_report_link(report_id)
+    check_run_id = None
+    if config.checks_enabled:
+        check_run_id = _create_check_run(
+            owner=owner,
+            repo_name=repo_name,
+            head_sha=head_sha,
+            installation_token=installation_token,
+            conclusion=_check_run_conclusion(result.assessment.recommendation),
+            title=DEFAULT_CHECK_RUN_NAME,
+            summary=_check_run_summary(result.persisted_report),
+            details_url=report_url,
+            api_base_url=config.api_base_url,
+        )
+    return GitHubWebhookResult(
+        event=event_name,
+        action=action,
+        handled=True,
+        automatic_analysis_triggered=True,
+        check_run_id=check_run_id,
+        report_id=report_id,
+        report_url=report_url,
+        note="GitHub App webhook processed and advisory analysis completed.",
+    )
+
+
+def _load_pull_request_artifacts(
+    *,
+    owner: str,
+    repo_name: str,
+    pull_number: int,
+    head_sha: str,
+    installation_token: str,
+    api_base_url: str,
+) -> list[tuple[str, bytes | None]]:
+    artifacts: list[tuple[str, bytes | None]] = []
+    page = 1
+    while True:
+        file_rows = _github_api_json(
+            f"{api_base_url}/repos/{owner}/{repo_name}/pulls/{pull_number}/files?per_page=100&page={page}",
+            token=installation_token,
+        )
+        if not isinstance(file_rows, list) or not file_rows:
+            break
+        for row in file_rows:
+            if not isinstance(row, dict):
+                continue
+            status = str(row.get("status") or "")
+            if status == "removed":
+                continue
+            filename = str(row.get("filename") or "").strip()
+            if not filename:
+                continue
+            raw_content = _download_repo_file(
+                owner=owner,
+                repo_name=repo_name,
+                path=filename,
+                ref=head_sha,
+                installation_token=installation_token,
+                api_base_url=api_base_url,
+            )
+            artifacts.append((filename, raw_content))
+            if total_upload_bytes(artifacts) > MAX_TOTAL_UPLOAD_BYTES:
+                raise GitHubAppRequestError(_UPLOAD_LIMIT_MESSAGE)
+        if len(file_rows) < 100:
+            break
+        page += 1
+    return artifacts
+
+
+def _download_repo_file(
+    *,
+    owner: str,
+    repo_name: str,
+    path: str,
+    ref: str,
+    installation_token: str,
+    api_base_url: str,
+) -> bytes | None:
+    quoted_path = parse.quote(path, safe="/")
+    payload = _github_api_json(
+        f"{api_base_url}/repos/{owner}/{repo_name}/contents/{quoted_path}?ref={parse.quote(ref, safe='')}",
+        token=installation_token,
+    )
+    if isinstance(payload, dict):
+        if payload.get("encoding") == "base64" and payload.get("content"):
+            return base64.b64decode(str(payload["content"]).encode("utf-8"))
+        download_url = str(payload.get("download_url") or "").strip()
+        if download_url:
+            return _github_api_bytes(download_url, token=installation_token)
+    return None
+
+
+def _check_run_conclusion(recommendation: str) -> str:
+    recommendation_value = str(recommendation).strip().lower()
+    if recommendation_value == "go":
+        return "success"
+    if recommendation_value == "caution":
+        return "neutral"
+    return "failure"
+
+
+def _check_run_summary(report: dict[str, Any]) -> str:
+    headline = str(
+        report.get("narrative_opening") or report.get("top_risk") or ""
+    ).strip()
+    if not headline:
+        headline = "DeployWhisper completed an advisory review for this pull request."
+    recommendation = str(report.get("recommendation") or "unknown").upper()
+    severity = str(report.get("severity") or "unknown").upper()
+    score = int(report.get("risk_score") or 0)
+    return (
+        f"{headline}\n\n"
+        f"Severity: {severity}\n"
+        f"Recommendation: {recommendation}\n"
+        f"Risk score: {score}\n"
+        "DeployWhisper remains advisory-only and never blocks merge on its own."
+    )
+
+
+def _create_check_run(
+    *,
+    owner: str,
+    repo_name: str,
+    head_sha: str,
+    installation_token: str,
+    conclusion: str,
+    title: str,
+    summary: str,
+    details_url: str | None,
+    api_base_url: str,
+) -> int | None:
+    payload: dict[str, Any] = {
+        "name": title,
+        "head_sha": head_sha,
+        "status": "completed",
+        "conclusion": conclusion,
+        "completed_at": datetime.now(UTC).isoformat(),
+        "output": {
+            "title": title,
+            "summary": summary[:65535],
+        },
+    }
+    if details_url:
+        payload["details_url"] = details_url
+    response = _github_api_json(
+        f"{api_base_url}/repos/{owner}/{repo_name}/check-runs",
+        token=installation_token,
+        method="POST",
+        body=payload,
+    )
+    if isinstance(response, dict):
+        check_run_id = response.get("id")
+        if isinstance(check_run_id, int):
+            return check_run_id
+    return None
+
+
+def _generate_installation_access_token(
+    installation_id: int,
+    *,
+    config: GitHubAppConfig,
+) -> str:
+    app_jwt = _generate_app_jwt(config)
+    response = _github_api_json(
+        f"{config.api_base_url}/app/installations/{installation_id}/access_tokens",
+        token=app_jwt,
+        method="POST",
+        body={},
+        token_scheme="Bearer",
+    )
+    token = str(response.get("token") or "").strip()
+    if not token:
+        raise GitHubAppRequestError(
+            "GitHub did not return an installation access token for the app."
+        )
+    return token
+
+
+def _generate_app_jwt(config: GitHubAppConfig) -> str:
+    if not config.app_id or not config.private_key_pem:
+        raise GitHubAppConfigurationError(
+            "GitHub App JWT generation requires app ID and private key."
+        )
+    issued_at = int(datetime.now(UTC).timestamp()) - 60
+    expires_at = int((datetime.now(UTC) + timedelta(minutes=9)).timestamp())
+    header = _b64url_json({"alg": "RS256", "typ": "JWT"})
+    payload = _b64url_json(
+        {
+            "iat": issued_at,
+            "exp": expires_at,
+            "iss": config.app_id,
+        }
+    )
+    signing_input = f"{header}.{payload}".encode("utf-8")
+    signature = _sign_with_openssl(signing_input, config.private_key_pem)
+    return f"{header}.{payload}.{_b64url(signature)}"
+
+
+def _sign_with_openssl(message: bytes, private_key_pem: str) -> bytes:
+    openssl_path = shutil.which("openssl")
+    if openssl_path is None:
+        raise GitHubAppConfigurationError(
+            "OpenSSL is required to sign GitHub App JWTs in this runtime."
+        )
+    with tempfile.NamedTemporaryFile("w", encoding="utf-8", delete=False) as handle:
+        handle.write(private_key_pem)
+        key_path = handle.name
+    try:
+        completed = subprocess.run(
+            [openssl_path, "dgst", "-sha256", "-sign", key_path],
+            input=message,
+            capture_output=True,
+            check=True,
+        )
+        return completed.stdout
+    except subprocess.CalledProcessError as exc:  # noqa: PERF203
+        raise GitHubAppConfigurationError(
+            "GitHub App JWT signing failed. Verify the private key format."
+        ) from exc
+    finally:
+        try:
+            Path(key_path).unlink()
+        except FileNotFoundError:
+            pass
+
+
+def _github_api_json(
+    url: str,
+    *,
+    token: str,
+    method: str = "GET",
+    body: dict[str, Any] | None = None,
+    token_scheme: str = "Bearer",
+) -> Any:
+    raw = _github_api_request(
+        url,
+        token=token,
+        method=method,
+        body=body,
+        token_scheme=token_scheme,
+    )
+    if not raw:
+        return {}
+    return json.loads(raw.decode("utf-8"))
+
+
+def _github_api_bytes(url: str, *, token: str) -> bytes:
+    return _github_api_request(url, token=token, method="GET", body=None)
+
+
+def _github_api_request(
+    url: str,
+    *,
+    token: str,
+    method: str,
+    body: dict[str, Any] | None,
+    token_scheme: str = "Bearer",
+) -> bytes:
+    data = None
+    headers = {
+        "Accept": "application/vnd.github+json",
+        "Authorization": f"{token_scheme} {token}",
+        "User-Agent": "DeployWhisper-GitHub-App",
+        "X-GitHub-Api-Version": "2022-11-28",
+    }
+    if body is not None:
+        data = json.dumps(body).encode("utf-8")
+        headers["Content-Type"] = "application/json"
+    req = request.Request(url, data=data, headers=headers, method=method)
+    try:
+        with request.urlopen(req, timeout=15) as response:
+            return response.read()
+    except error.HTTPError as exc:
+        detail = exc.read().decode("utf-8", errors="replace")
+        raise GitHubAppRequestError(
+            f"GitHub API request failed ({exc.code}) for {url}: {detail}"
+        ) from exc
+
+
+def _post_form_json(url: str, form_payload: dict[str, str]) -> dict[str, Any]:
+    data = parse.urlencode(form_payload).encode("utf-8")
+    req = request.Request(
+        url,
+        data=data,
+        method="POST",
+        headers={
+            "Accept": "application/json",
+            "Content-Type": "application/x-www-form-urlencoded",
+            "User-Agent": "DeployWhisper-GitHub-App",
+        },
+    )
+    try:
+        with request.urlopen(req, timeout=15) as response:
+            raw = response.read().decode("utf-8")
+    except error.HTTPError as exc:
+        detail = exc.read().decode("utf-8", errors="replace")
+        raise GitHubAppRequestError(
+            f"GitHub OAuth token exchange failed ({exc.code}): {detail}"
+        ) from exc
+    return json.loads(raw)
+
+
+def _b64url(data: bytes) -> str:
+    return base64.urlsafe_b64encode(data).rstrip(b"=").decode("ascii")
+
+
+def _b64url_json(payload: dict[str, Any]) -> str:
+    return _b64url(
+        json.dumps(payload, separators=(",", ":"), sort_keys=True).encode("utf-8")
+    )
+
+
+def _encode_oauth_state(payload: dict[str, Any], *, secret: str) -> str:
+    body = {
+        **payload,
+        "iat": int(datetime.now(UTC).timestamp()),
+    }
+    encoded_body = _b64url_json(body)
+    signature = hmac.new(
+        secret.encode("utf-8"),
+        encoded_body.encode("utf-8"),
+        hashlib.sha256,
+    ).digest()
+    return f"{encoded_body}.{_b64url(signature)}"
+
+
+def _decode_oauth_state(state: str, *, secret: str) -> dict[str, Any]:
+    encoded_body, _, encoded_signature = state.partition(".")
+    if not encoded_body or not encoded_signature:
+        raise GitHubAppRequestError("GitHub App OAuth state is invalid.")
+    expected_signature = _b64url(
+        hmac.new(
+            secret.encode("utf-8"),
+            encoded_body.encode("utf-8"),
+            hashlib.sha256,
+        ).digest()
+    )
+    if not hmac.compare_digest(expected_signature, encoded_signature):
+        raise GitHubAppRequestError("GitHub App OAuth state could not be verified.")
+    body = json.loads(
+        base64.urlsafe_b64decode(encoded_body + "=" * (-len(encoded_body) % 4))
+    )
+    issued_at = int(body.get("iat") or 0)
+    if (
+        not issued_at
+        or (datetime.now(UTC).timestamp() - issued_at) > _STATE_MAX_AGE_SECONDS
+    ):
+        raise GitHubAppRequestError("GitHub App OAuth state has expired.")
+    return body

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ dependencies = [
 packages = [
   "api",
   "services",
+  "integrations",
   "parsers",
   "analysis",
   "evidence",

--- a/tests/test_api/test_github_app.py
+++ b/tests/test_api/test_github_app.py
@@ -1,0 +1,123 @@
+"""API tests for the GitHub App adapter routes."""
+
+from __future__ import annotations
+
+import hmac
+import hashlib
+import os
+import tempfile
+import unittest
+from importlib import reload
+from unittest.mock import patch
+
+import app as app_module
+import config as config_module
+import models.database as database_module
+import models.tables as tables_module
+from fastapi.testclient import TestClient
+
+
+class GitHubAppRouteTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tempdir = tempfile.TemporaryDirectory()
+        os.environ["DATABASE_URL"] = f"sqlite:///{self.tempdir.name}/github_app.db"
+        os.environ["APP_BASE_URL"] = "https://deploywhisper.example.com"
+        os.environ["DEPLOYWHISPER_GITHUB_APP_ENABLED"] = "true"
+        os.environ["DEPLOYWHISPER_GITHUB_APP_ID"] = "12345"
+        os.environ["DEPLOYWHISPER_GITHUB_APP_SLUG"] = "deploywhisper"
+        os.environ["DEPLOYWHISPER_GITHUB_APP_CLIENT_ID"] = "client-123"
+        os.environ["DEPLOYWHISPER_GITHUB_APP_CLIENT_SECRET"] = "client-secret"
+        os.environ["DEPLOYWHISPER_GITHUB_APP_WEBHOOK_SECRET"] = "webhook-secret"
+        os.environ["DEPLOYWHISPER_GITHUB_APP_PRIVATE_KEY"] = (
+            "-----BEGIN PRIVATE KEY-----\nTEST\n-----END PRIVATE KEY-----"
+        )
+        os.environ["DEPLOYWHISPER_GITHUB_APP_PR_EVENTS_ENABLED"] = "true"
+        reload(config_module)
+        reload(tables_module)
+        reload(database_module)
+        reload(app_module)
+        database_module.init_db()
+        self.client = TestClient(app_module.create_app())
+
+    def tearDown(self) -> None:
+        database_module.engine.dispose()
+        for key in [
+            "DATABASE_URL",
+            "APP_BASE_URL",
+            "DEPLOYWHISPER_GITHUB_APP_ENABLED",
+            "DEPLOYWHISPER_GITHUB_APP_ID",
+            "DEPLOYWHISPER_GITHUB_APP_SLUG",
+            "DEPLOYWHISPER_GITHUB_APP_CLIENT_ID",
+            "DEPLOYWHISPER_GITHUB_APP_CLIENT_SECRET",
+            "DEPLOYWHISPER_GITHUB_APP_WEBHOOK_SECRET",
+            "DEPLOYWHISPER_GITHUB_APP_PRIVATE_KEY",
+            "DEPLOYWHISPER_GITHUB_APP_PR_EVENTS_ENABLED",
+        ]:
+            os.environ.pop(key, None)
+        self.tempdir.cleanup()
+
+    def test_oauth_start_redirects_to_github(self) -> None:
+        response = self.client.get(
+            "/api/v1/github/app/oauth/start",
+            params={"return_to": "/settings"},
+            follow_redirects=False,
+        )
+
+        self.assertEqual(response.status_code, 302)
+        self.assertIn("client_id=client-123", response.headers["location"])
+        self.assertIn("state=", response.headers["location"])
+
+    def test_webhook_rejects_invalid_signature(self) -> None:
+        response = self.client.post(
+            "/api/v1/github/app/webhook",
+            headers={
+                "X-GitHub-Event": "pull_request",
+                "X-Hub-Signature-256": "sha256=bad",
+            },
+            json={"action": "opened"},
+        )
+
+        self.assertEqual(response.status_code, 403)
+        self.assertIn("github_app_webhook_forbidden", response.text)
+
+    @patch("api.routes.github_app.handle_github_app_webhook")
+    def test_webhook_returns_service_payload(self, handle_github_app_webhook) -> None:
+        payload = b'{"action":"opened"}'
+        signature = (
+            "sha256="
+            + hmac.new(
+                b"webhook-secret",
+                payload,
+                hashlib.sha256,
+            ).hexdigest()
+        )
+        handle_github_app_webhook.return_value = type(
+            "Result",
+            (),
+            {
+                "event": "pull_request",
+                "action": "opened",
+                "handled": True,
+                "automatic_analysis_triggered": True,
+                "check_run_id": 7,
+                "report_id": 17,
+                "report_url": "https://deploywhisper.example.com/reports/17",
+                "note": "ok",
+            },
+        )()
+
+        response = self.client.post(
+            "/api/v1/github/app/webhook",
+            headers={
+                "X-GitHub-Event": "pull_request",
+                "X-Hub-Signature-256": signature,
+                "Content-Type": "application/json",
+            },
+            content=payload,
+        )
+
+        self.assertEqual(response.status_code, 200)
+        body = response.json()
+        self.assertTrue(body["data"]["automatic_analysis_triggered"])
+        self.assertEqual(body["data"]["check_run_id"], 7)
+        self.assertEqual(body["data"]["report_id"], 17)

--- a/tests/test_services/test_github_app_service.py
+++ b/tests/test_services/test_github_app_service.py
@@ -1,0 +1,188 @@
+"""Tests for the GitHub App adapter service."""
+
+from __future__ import annotations
+
+import hmac
+import hashlib
+import os
+import unittest
+from unittest.mock import patch
+from urllib.parse import parse_qs, urlparse
+
+from integrations.github import app_service
+
+
+class GitHubAppServiceTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.env_keys = [
+            "APP_BASE_URL",
+            "DEPLOYWHISPER_GITHUB_APP_ENABLED",
+            "DEPLOYWHISPER_GITHUB_APP_ID",
+            "DEPLOYWHISPER_GITHUB_APP_SLUG",
+            "DEPLOYWHISPER_GITHUB_APP_CLIENT_ID",
+            "DEPLOYWHISPER_GITHUB_APP_CLIENT_SECRET",
+            "DEPLOYWHISPER_GITHUB_APP_WEBHOOK_SECRET",
+            "DEPLOYWHISPER_GITHUB_APP_PRIVATE_KEY",
+            "DEPLOYWHISPER_GITHUB_APP_PRIVATE_KEY_PATH",
+            "DEPLOYWHISPER_GITHUB_APP_PR_EVENTS_ENABLED",
+            "DEPLOYWHISPER_GITHUB_APP_CHECKS_ENABLED",
+        ]
+        self.original_env = {key: os.environ.get(key) for key in self.env_keys}
+        os.environ["APP_BASE_URL"] = "https://deploywhisper.example.com"
+        os.environ["DEPLOYWHISPER_GITHUB_APP_ENABLED"] = "true"
+        os.environ["DEPLOYWHISPER_GITHUB_APP_ID"] = "12345"
+        os.environ["DEPLOYWHISPER_GITHUB_APP_SLUG"] = "deploywhisper"
+        os.environ["DEPLOYWHISPER_GITHUB_APP_CLIENT_ID"] = "client-123"
+        os.environ["DEPLOYWHISPER_GITHUB_APP_CLIENT_SECRET"] = "client-secret"
+        os.environ["DEPLOYWHISPER_GITHUB_APP_WEBHOOK_SECRET"] = "webhook-secret"
+        os.environ["DEPLOYWHISPER_GITHUB_APP_PRIVATE_KEY"] = (
+            "-----BEGIN PRIVATE KEY-----\nTEST\n-----END PRIVATE KEY-----"
+        )
+        os.environ["DEPLOYWHISPER_GITHUB_APP_PR_EVENTS_ENABLED"] = "true"
+        os.environ["DEPLOYWHISPER_GITHUB_APP_CHECKS_ENABLED"] = "true"
+
+    def tearDown(self) -> None:
+        for key, value in self.original_env.items():
+            if value is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = value
+
+    def test_verify_github_webhook_signature_accepts_valid_sha256(self) -> None:
+        payload = b'{"zen":"ship it"}'
+        signature = (
+            "sha256="
+            + hmac.new(
+                b"webhook-secret",
+                payload,
+                hashlib.sha256,
+            ).hexdigest()
+        )
+
+        self.assertTrue(app_service.verify_github_webhook_signature(payload, signature))
+        self.assertFalse(
+            app_service.verify_github_webhook_signature(payload, "sha256=bad")
+        )
+
+    def test_build_github_app_oauth_url_includes_signed_state(self) -> None:
+        authorize_url = app_service.build_github_app_oauth_url(return_to="/settings")
+        parsed = urlparse(authorize_url)
+        query = parse_qs(parsed.query)
+
+        self.assertEqual(parsed.scheme, "https")
+        self.assertEqual(query["client_id"], ["client-123"])
+        self.assertEqual(
+            query["redirect_uri"],
+            ["https://deploywhisper.example.com/api/v1/github/app/oauth/callback"],
+        )
+        self.assertIn("state", query)
+        self.assertIn(".", query["state"][0])
+
+    @patch("integrations.github.app_service._post_form_json")
+    def test_complete_github_app_oauth_returns_installation_handoff(
+        self,
+        post_form_json,
+    ) -> None:
+        post_form_json.return_value = {
+            "access_token": "user-token",
+            "token_type": "bearer",
+            "scope": "checks",
+        }
+        state = app_service._encode_oauth_state(
+            {"return_to": "/settings"},
+            secret="client-secret",
+        )
+
+        result = app_service.complete_github_app_oauth(code="abc123", state=state)
+
+        self.assertEqual(result.user_access_token, "user-token")
+        self.assertEqual(
+            result.install_url,
+            "https://github.com/apps/deploywhisper/installations/new",
+        )
+        self.assertEqual(result.state_return_to, "/settings")
+
+    @patch("integrations.github.app_service._create_check_run")
+    @patch("integrations.github.app_service.analyze_uploaded_files")
+    @patch("integrations.github.app_service._load_pull_request_artifacts")
+    @patch("integrations.github.app_service._generate_installation_access_token")
+    def test_handle_github_app_webhook_runs_analysis_and_check_run(
+        self,
+        generate_installation_access_token,
+        load_pull_request_artifacts,
+        analyze_uploaded_files,
+        create_check_run,
+    ) -> None:
+        generate_installation_access_token.return_value = "installation-token"
+        load_pull_request_artifacts.return_value = [("plan.tf", b'resource "x" "y" {}')]
+        analyze_uploaded_files.return_value = type(
+            "Result",
+            (),
+            {
+                "assessment": type("Assessment", (), {"recommendation": "caution"})(),
+                "persisted_report": {"id": 17},
+            },
+        )()
+        create_check_run.return_value = 991
+
+        result = app_service.handle_github_app_webhook(
+            event_name="pull_request",
+            payload={
+                "action": "opened",
+                "number": 3,
+                "installation": {"id": 42},
+                "repository": {
+                    "name": "deploywhisper",
+                    "owner": {"login": "deploywhisper"},
+                },
+                "pull_request": {
+                    "number": 3,
+                    "head": {"sha": "abc123"},
+                },
+            },
+        )
+
+        self.assertTrue(result.automatic_analysis_triggered)
+        self.assertEqual(result.report_id, 17)
+        self.assertEqual(result.check_run_id, 991)
+
+    def test_handle_github_app_webhook_skips_when_pr_automation_disabled(self) -> None:
+        os.environ["DEPLOYWHISPER_GITHUB_APP_PR_EVENTS_ENABLED"] = "false"
+
+        result = app_service.handle_github_app_webhook(
+            event_name="pull_request",
+            payload={"action": "opened"},
+        )
+
+        self.assertTrue(result.handled)
+        self.assertFalse(result.automatic_analysis_triggered)
+
+    @patch("integrations.github.app_service._download_repo_file")
+    @patch("integrations.github.app_service._github_api_json")
+    def test_load_pull_request_artifacts_rejects_payloads_over_session_limit(
+        self,
+        github_api_json,
+        download_repo_file,
+    ) -> None:
+        github_api_json.side_effect = [
+            [
+                {"status": "modified", "filename": "one.tf"},
+                {"status": "modified", "filename": "two.tf"},
+            ],
+            [],
+        ]
+        oversize = b"x" * 25_100_000
+        download_repo_file.side_effect = [oversize, oversize]
+
+        with self.assertRaisesRegex(
+            app_service.GitHubAppRequestError,
+            "50 MB analysis-session limit",
+        ):
+            app_service._load_pull_request_artifacts(
+                owner="deploywhisper",
+                repo_name="deploywhisper",
+                pull_number=7,
+                head_sha="abc123",
+                installation_token="installation-token",
+                api_base_url="https://api.github.com",
+            )


### PR DESCRIPTION
Story 3.6 adds a GitHub App adapter without turning DeployWhisper into a hosted GitHub SaaS. The branch wires webhook, OAuth, and check-run support into the shared runtime, then reframes the docs and Epic 3 planning around Action-first adoption with advanced self-hosted GitHub App support.

The result keeps the richer GitHub integration path available while matching the product's local-first trust posture and avoiding a premature Marketplace-hosted rollout.

Constraint: No new Python dependencies; GitHub App auth had to fit the existing stdlib-first runtime and local-first trust boundary
Rejected: Public hosted Marketplace GitHub App as the default integration path | trust boundary too wide for current open-source/local-first posture
Confidence: high
Scope-risk: moderate
Reversibility: clean
Directive: Keep Action-first as the default recommendation and treat any public hosted GitHub App rollout as a separate product decision
Tested: /Users/psaho01/deploywhisper/.venv/bin/ruff check .
Tested: /Users/psaho01/deploywhisper/.venv/bin/ruff format --check .
Tested: /Users/psaho01/deploywhisper/.venv/bin/python -m unittest discover -q
Tested: env PYTHON_BIN=/Users/psaho01/deploywhisper/.venv/bin/python RUFF_BIN=/Users/psaho01/deploywhisper/.venv/bin/ruff bash scripts/ci-local.sh
Not-tested: Local Bandit scan (bandit not installed)
Not-tested: Live GitHub App creation/install in GitHub UI

## What does this PR do?

<!-- Brief description of changes -->

## Type of change
- [ ] Feature (new functionality)
- [ ] Bugfix (non-breaking fix)
- [ ] Release preparation
- [ ] Hotfix (critical production fix)
- [ ] Docs / refactor / chore

## Checklist
- [ ] I have followed the branch naming convention
- [ ] Tests pass locally (`pytest tests/ -v`)
- [ ] Linting passes (`ruff check .`)
- [ ] Docker build succeeds
- [ ] I have updated docs if needed
- [ ] No secrets or .env values committed

## Related issue
Closes #