### PR TITLE
Reduce GitHub setup friction without breaking the intended merge path

### DIFF
--- a/README.md
+++ b/README.md
@@ -550,6 +550,13 @@ organization and point it at your own DeployWhisper instance. See
 Keep the `DeployWhisper / Risk Analysis` check advisory-only in GitHub branch
 protection; do not add it as a required status check.
 
+To scaffold this setup into another repository with a workflow file, README
+update, and optional self-hosted GitHub App notes, run:
+
+```bash
+deploywhisper github init
+```
+
 Example:
 
 ```bash

--- a/cli/analyze.py
+++ b/cli/analyze.py
@@ -12,6 +12,11 @@ from pathlib import Path
 
 from api.errors import build_error
 from api.schemas import build_analysis_run_data, build_meta
+from integrations.github.init_service import (
+    GitHubInitError,
+    collect_github_init_options,
+    run_github_init,
+)
 import llm.skill_context as skill_context_module
 from services.analysis_service import (
     analyze_uploaded_files,
@@ -152,6 +157,43 @@ def _run_analyze(paths: list[str]) -> int:
     return 0
 
 
+def _run_github_init(args: argparse.Namespace) -> int:
+    try:
+        options = collect_github_init_options(
+            repo_path=args.repo,
+            workflow_path=args.workflow_path,
+            api_endpoint=args.api_endpoint,
+            enable_github_app=args.github_app,
+            base_branch=args.base_branch,
+            github_owner=args.github_owner,
+            github_app_name=args.github_app_name,
+            github_app_slug=args.github_app_slug,
+            public_base_url=args.public_base_url,
+            branch_name=args.branch_name,
+        )
+        result = run_github_init(options)
+    except GitHubInitError as exc:
+        _emit_json(
+            build_error(
+                code="github_init_failed",
+                message="GitHub initialization wizard failed.",
+                details={"reason": str(exc)},
+            ),
+            stream=sys.stderr,
+        )
+        return 1
+
+    print(f"Updated workflow: {result.workflow_path}")
+    print(f"Updated README: {result.readme_path}")
+    if result.github_app_notes_path:
+        print(f"Added self-hosted GitHub App notes: {result.github_app_notes_path}")
+    print(f"Created branch: {result.branch_name}")
+    print(f"Base branch: {result.base_branch}")
+    print(f"Commit: {result.commit_sha}")
+    print(f"Pull request: {result.pr_url}")
+    return 0
+
+
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description="DeployWhisper CLI")
     subparsers = parser.add_subparsers(dest="command")
@@ -165,6 +207,57 @@ def build_parser() -> argparse.ArgumentParser:
         "paths", nargs="*", help="Artifact file paths to analyze."
     )
 
+    github_parser = subparsers.add_parser(
+        "github", help="GitHub workflow setup helpers."
+    )
+    github_subparsers = github_parser.add_subparsers(dest="github_command")
+    github_init_parser = github_subparsers.add_parser(
+        "init",
+        help="Scaffold the DeployWhisper GitHub workflow, commit it, and open a PR.",
+    )
+    github_init_parser.add_argument(
+        "--repo",
+        help="Target repository checkout path. Defaults to the current directory.",
+    )
+    github_init_parser.add_argument(
+        "--workflow-path",
+        help="Workflow file path relative to the target repository.",
+    )
+    github_init_parser.add_argument(
+        "--api-endpoint",
+        help="DeployWhisper analyses API endpoint for the generated workflow.",
+    )
+    github_init_parser.add_argument(
+        "--base-branch",
+        help="Base branch that should receive the generated PR.",
+    )
+    github_init_parser.add_argument(
+        "--github-app",
+        action="store_true",
+        default=None,
+        help="Include advanced self-hosted GitHub App setup notes.",
+    )
+    github_init_parser.add_argument(
+        "--github-owner",
+        help="GitHub owner or account for the self-hosted GitHub App path.",
+    )
+    github_init_parser.add_argument(
+        "--github-app-name",
+        help="GitHub App display name for the self-hosted GitHub App path.",
+    )
+    github_init_parser.add_argument(
+        "--github-app-slug",
+        help="GitHub App slug for the self-hosted GitHub App path.",
+    )
+    github_init_parser.add_argument(
+        "--public-base-url",
+        help="Public DeployWhisper base URL for the self-hosted GitHub App path.",
+    )
+    github_init_parser.add_argument(
+        "--branch-name",
+        help="Optional branch name to use in the target repository.",
+    )
+
     return parser
 
 
@@ -176,6 +269,8 @@ def main() -> None:
         raise SystemExit(_run_skills())
     if args.command == "analyze":
         raise SystemExit(_run_analyze(args.paths))
+    if args.command == "github" and args.github_command == "init":
+        raise SystemExit(_run_github_init(args))
 
     print("DeployWhisper CLI ready: foundation-check")
 

--- a/integrations/github/init_service.py
+++ b/integrations/github/init_service.py
@@ -1,0 +1,576 @@
+"""Interactive GitHub setup wizard for installing DeployWhisper into a repo."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import os
+from pathlib import Path
+import shutil
+import subprocess
+from textwrap import dedent
+from urllib.parse import urlparse
+
+DEFAULT_WORKFLOW_PATH = ".github/workflows/deploywhisper.yml"
+DEFAULT_APP_NOTES_PATH = ".github/deploywhisper-self-hosted-github-app.md"
+DEFAULT_BRANCH_NAME = "feature/deploywhisper-github-init"
+README_SECTION_START = "<!-- deploywhisper:start -->"
+README_SECTION_END = "<!-- deploywhisper:end -->"
+OPERATOR_DOCS_URL = (
+    "https://github.com/deploywhisper/deploywhisper/blob/develop/"
+    "docs/github-app-self-hosted-setup.md"
+)
+
+
+class GitHubInitError(RuntimeError):
+    """Raised when the GitHub init wizard cannot complete."""
+
+
+@dataclass(frozen=True)
+class GitHubInitOptions:
+    repo_path: str
+    workflow_path: str
+    api_endpoint: str
+    enable_github_app: bool
+    base_branch: str
+    github_owner: str | None = None
+    github_app_name: str | None = None
+    github_app_slug: str | None = None
+    public_base_url: str | None = None
+    branch_name: str | None = None
+
+
+@dataclass(frozen=True)
+class GitHubInitResult:
+    repo_path: str
+    workflow_path: str
+    readme_path: str
+    github_app_notes_path: str | None
+    branch_name: str
+    base_branch: str
+    commit_sha: str
+    pr_url: str
+
+
+def collect_github_init_options(
+    *,
+    repo_path: str | None,
+    workflow_path: str | None,
+    api_endpoint: str | None,
+    enable_github_app: bool | None,
+    github_owner: str | None,
+    github_app_name: str | None,
+    github_app_slug: str | None,
+    public_base_url: str | None,
+    base_branch: str | None,
+    branch_name: str | None,
+    input_fn=input,
+) -> GitHubInitOptions:
+    """Collect or confirm wizard answers for repo installation."""
+
+    repo_value = _prompt_required(
+        "Repo checkout path",
+        default=(repo_path or "."),
+        input_fn=input_fn,
+    )
+    workflow_value = _prompt_required(
+        "Workflow path",
+        default=(workflow_path or DEFAULT_WORKFLOW_PATH),
+        input_fn=input_fn,
+    )
+    api_value = _prompt_required(
+        "DeployWhisper API endpoint",
+        default=(api_endpoint or _default_api_endpoint()),
+        input_fn=input_fn,
+    )
+    base_branch_value = _prompt_required(
+        "Base branch for the pull request",
+        default=(base_branch or _infer_base_branch(repo_value)),
+        input_fn=input_fn,
+    )
+
+    advanced_requested = bool(enable_github_app) or any(
+        [github_owner, github_app_name, github_app_slug, public_base_url]
+    )
+    if enable_github_app is None and not advanced_requested:
+        advanced_requested = _prompt_yes_no(
+            "Add advanced self-hosted GitHub App setup notes?",
+            default=False,
+            input_fn=input_fn,
+        )
+
+    owner_value = github_owner
+    app_name_value = github_app_name
+    app_slug_value = github_app_slug
+    public_base_value = public_base_url
+    if advanced_requested:
+        owner_value = _prompt_required(
+            "GitHub owner or account",
+            default=(github_owner or ""),
+            input_fn=input_fn,
+        )
+        app_name_value = _prompt_required(
+            "GitHub App name",
+            default=(github_app_name or "DeployWhisper"),
+            input_fn=input_fn,
+        )
+        app_slug_value = _prompt_required(
+            "GitHub App slug",
+            default=(github_app_slug or "deploywhisper"),
+            input_fn=input_fn,
+        )
+        public_base_value = _prompt_required(
+            "Public DeployWhisper base URL",
+            default=(public_base_url or _default_public_base_url()),
+            input_fn=input_fn,
+        )
+
+    options = GitHubInitOptions(
+        repo_path=repo_value,
+        workflow_path=workflow_value,
+        api_endpoint=api_value,
+        enable_github_app=advanced_requested,
+        base_branch=base_branch_value,
+        github_owner=owner_value,
+        github_app_name=app_name_value,
+        github_app_slug=app_slug_value,
+        public_base_url=public_base_value,
+        branch_name=branch_name,
+    )
+    _validate_options(options)
+    return options
+
+
+def run_github_init(options: GitHubInitOptions) -> GitHubInitResult:
+    """Apply the GitHub init wizard to a target repository and open a PR."""
+
+    repo_root = Path(options.repo_path).expanduser().resolve()
+    if not repo_root.exists():
+        raise GitHubInitError(f"Repository path does not exist: {repo_root}")
+    if not repo_root.is_dir():
+        raise GitHubInitError(f"Repository path is not a directory: {repo_root}")
+    _require_binary("git")
+    _require_binary("gh")
+
+    _ensure_git_repo(repo_root)
+    _ensure_clean_worktree(repo_root)
+    _ensure_origin_remote(repo_root)
+
+    base_branch = _checkout_base_branch(repo_root, options.base_branch)
+
+    branch_name = _resolve_branch_name(repo_root, options.branch_name)
+    _run_command(repo_root, "git", "checkout", "-b", branch_name)
+
+    workflow_rel_path = options.workflow_path.strip().replace("\\", "/")
+    workflow_path = repo_root / workflow_rel_path
+    workflow_path.parent.mkdir(parents=True, exist_ok=True)
+    workflow_path.write_text(_render_workflow(options), encoding="utf-8")
+
+    readme_path = repo_root / "README.md"
+    existing_readme = (
+        readme_path.read_text(encoding="utf-8")
+        if readme_path.exists()
+        else f"# {repo_root.name}\n\n"
+    )
+    github_app_notes_path: str | None = None
+    notes_rel_path = None
+    if options.enable_github_app:
+        notes_rel_path = DEFAULT_APP_NOTES_PATH
+        notes_path = repo_root / notes_rel_path
+        notes_path.parent.mkdir(parents=True, exist_ok=True)
+        notes_path.write_text(
+            _render_github_app_notes(options),
+            encoding="utf-8",
+        )
+        github_app_notes_path = notes_rel_path
+    readme_path.write_text(
+        _upsert_readme_section(
+            existing_readme,
+            _render_readme_section(
+                options,
+                workflow_path=workflow_rel_path,
+                notes_path=notes_rel_path,
+            ),
+        ),
+        encoding="utf-8",
+    )
+
+    files_to_add = [workflow_rel_path, "README.md"]
+    if github_app_notes_path:
+        files_to_add.append(github_app_notes_path)
+
+    _run_command(repo_root, "git", "add", *files_to_add)
+    _run_command(
+        repo_root,
+        "git",
+        "commit",
+        "-m",
+        "Add DeployWhisper GitHub review workflow",
+    )
+    commit_sha = _git_stdout(repo_root, "rev-parse", "HEAD")
+    _run_command(repo_root, "git", "push", "-u", "origin", branch_name)
+    pr_url = _gh_create_pr(
+        repo_root,
+        base_branch=base_branch,
+        head_branch=branch_name,
+        title="Add DeployWhisper GitHub review workflow",
+        body=_render_pr_body(options, workflow_path=workflow_rel_path),
+    )
+
+    return GitHubInitResult(
+        repo_path=str(repo_root),
+        workflow_path=workflow_rel_path,
+        readme_path="README.md",
+        github_app_notes_path=github_app_notes_path,
+        branch_name=branch_name,
+        base_branch=base_branch,
+        commit_sha=commit_sha,
+        pr_url=pr_url,
+    )
+
+
+def _render_workflow(options: GitHubInitOptions) -> str:
+    api_endpoint = options.api_endpoint.strip()
+    return dedent(
+        f"""\
+        name: DeployWhisper
+
+        on:
+          pull_request:
+            types: [opened, synchronize, reopened]
+
+        permissions:
+          contents: read
+          pull-requests: write
+
+        jobs:
+          deploywhisper:
+            runs-on: ubuntu-latest
+            env:
+              DEPLOYWHISPER_API_URL: {api_endpoint}
+            steps:
+              - uses: actions/checkout@v4
+                with:
+                  fetch-depth: 0
+              - uses: deploywhisper/analyze-action@v1
+                with:
+                  api-url: ${{{{ env.DEPLOYWHISPER_API_URL }}}}
+                  api-token: ${{{{ secrets.DEPLOYWHISPER_API_TOKEN }}}}
+        """
+    )
+
+
+def _render_readme_section(
+    options: GitHubInitOptions,
+    *,
+    workflow_path: str,
+    notes_path: str | None,
+) -> str:
+    lines = [
+        "## DeployWhisper",
+        "",
+        "This repository uses DeployWhisper for advisory-only deployment risk review in pull requests.",
+        "",
+        "### GitHub workflow",
+        "",
+        f"- Workflow file: `{workflow_path}`",
+        f"- Configured API endpoint: `{options.api_endpoint}`",
+        "- Optional secret: `DEPLOYWHISPER_API_TOKEN` for protected DeployWhisper APIs",
+        "- The `DeployWhisper / Risk Analysis` check is advisory-only and should not be configured as a required status check",
+        "",
+        "### Configuration example",
+        "",
+        "Set these in your repository before merging the PR:",
+        "",
+        f"- `DEPLOYWHISPER_API_URL={options.api_endpoint}`",
+        "- `DEPLOYWHISPER_API_TOKEN=<optional bearer token>`",
+    ]
+    if options.enable_github_app:
+        lines.extend(
+            [
+                "",
+                "### Advanced self-hosted GitHub App",
+                "",
+                "- This setup keeps the Action-first workflow and adds self-hosted GitHub App guidance as an advanced path.",
+                f"- GitHub owner/account: `{options.github_owner}`",
+                f"- GitHub App name: `{options.github_app_name}`",
+                f"- GitHub App slug: `{options.github_app_slug}`",
+                f"- Public DeployWhisper base URL: `{options.public_base_url}`",
+                f"- Operator guide: {OPERATOR_DOCS_URL}",
+            ]
+        )
+        if notes_path:
+            lines.append(f"- Repo-local setup notes: `{notes_path}`")
+    return "\n".join(lines).strip()
+
+
+def _render_github_app_notes(options: GitHubInitOptions) -> str:
+    return dedent(
+        f"""\
+        # Advanced Self-Hosted DeployWhisper GitHub App
+
+        This repository selected the advanced self-hosted GitHub App path in addition
+        to the default Action-first workflow.
+
+        ## Selected values
+
+        - GitHub owner/account: `{options.github_owner}`
+        - GitHub App name: `{options.github_app_name}`
+        - GitHub App slug: `{options.github_app_slug}`
+        - Public DeployWhisper base URL: `{options.public_base_url}`
+
+        ## Next steps
+
+        1. Keep the Action-first workflow in `{options.workflow_path}` for PR-triggered analysis.
+        2. Create the self-hosted GitHub App in your own GitHub account or organization.
+        3. Point the webhook and callback URLs at `{options.public_base_url}`.
+        4. Follow the operator guide: {OPERATOR_DOCS_URL}
+        5. Keep `DeployWhisper / Risk Analysis` advisory-only in branch protection.
+        """
+    )
+
+
+def _render_pr_body(options: GitHubInitOptions, *, workflow_path: str) -> str:
+    lines = [
+        "## Summary",
+        "",
+        "- add the DeployWhisper GitHub workflow",
+        "- document the API endpoint and advisory-only check behavior",
+    ]
+    if options.enable_github_app:
+        lines.append("- add advanced self-hosted GitHub App setup notes")
+    lines.extend(
+        [
+            "",
+            "## Files",
+            "",
+            f"- `{workflow_path}`",
+            "- `README.md`",
+        ]
+    )
+    if options.enable_github_app:
+        lines.append(f"- `{DEFAULT_APP_NOTES_PATH}`")
+    return "\n".join(lines)
+
+
+def _upsert_readme_section(existing: str, section: str) -> str:
+    rendered_section = f"{README_SECTION_START}\n{section}\n{README_SECTION_END}\n"
+    if README_SECTION_START in existing and README_SECTION_END in existing:
+        before, _, remainder = existing.partition(README_SECTION_START)
+        _, _, after = remainder.partition(README_SECTION_END)
+        prefix = before.rstrip()
+        suffix = after.lstrip("\n")
+        blocks = [prefix, rendered_section.rstrip()]
+        if suffix:
+            blocks.append(suffix.rstrip())
+        return "\n\n".join(block for block in blocks if block) + "\n"
+    stripped = existing.rstrip()
+    if stripped:
+        return f"{stripped}\n\n{rendered_section}"
+    return rendered_section
+
+
+def _default_api_endpoint() -> str:
+    base_url = _default_public_base_url()
+    if not base_url:
+        return "http://127.0.0.1:8080/api/v1/analyses"
+    return f"{base_url.rstrip('/')}/api/v1/analyses"
+
+
+def _default_public_base_url() -> str:
+    return (
+        os.getenv("APP_BASE_URL")
+        or os.getenv("PUBLIC_APP_URL")
+        or "https://deploywhisper.example.com"
+    )
+
+
+def _prompt_required(prompt: str, *, default: str, input_fn) -> str:
+    raw = input_fn(f"{prompt} [{default}]: ").strip()
+    return raw or default
+
+
+def _prompt_yes_no(prompt: str, *, default: bool, input_fn) -> bool:
+    suffix = "Y/n" if default else "y/N"
+    raw = input_fn(f"{prompt} [{suffix}]: ").strip().lower()
+    if not raw:
+        return default
+    if raw in {"y", "yes"}:
+        return True
+    if raw in {"n", "no"}:
+        return False
+    raise GitHubInitError(f"Expected yes or no answer for: {prompt}")
+
+
+def _validate_options(options: GitHubInitOptions) -> None:
+    if not options.workflow_path.strip():
+        raise GitHubInitError("Workflow path is required.")
+    if not options.base_branch.strip():
+        raise GitHubInitError("Base branch is required.")
+    _validate_url(options.api_endpoint, field_name="API endpoint")
+    if options.enable_github_app:
+        if not options.github_owner:
+            raise GitHubInitError(
+                "GitHub owner/account is required for GitHub App setup."
+            )
+        if not options.github_app_name:
+            raise GitHubInitError("GitHub App name is required for GitHub App setup.")
+        if not options.github_app_slug:
+            raise GitHubInitError("GitHub App slug is required for GitHub App setup.")
+        _validate_url(
+            options.public_base_url or "",
+            field_name="public DeployWhisper base URL",
+        )
+
+
+def _validate_url(value: str, *, field_name: str) -> None:
+    parsed = urlparse(value)
+    if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+        raise GitHubInitError(f"{field_name} must be an absolute http(s) URL.")
+
+
+def _require_binary(name: str) -> None:
+    if shutil.which(name) is None:
+        raise GitHubInitError(f"Required command not found on PATH: {name}")
+
+
+def _ensure_git_repo(repo_root: Path) -> None:
+    marker = _git_stdout(repo_root, "rev-parse", "--is-inside-work-tree")
+    if marker != "true":
+        raise GitHubInitError(f"Target path is not a git repository: {repo_root}")
+
+
+def _ensure_clean_worktree(repo_root: Path) -> None:
+    status = _git_stdout(repo_root, "status", "--porcelain")
+    if status:
+        raise GitHubInitError(
+            "Target repository has uncommitted changes. Commit or stash them before running deploywhisper github init."
+        )
+
+
+def _ensure_origin_remote(repo_root: Path) -> None:
+    remote = _git_stdout(repo_root, "remote", "get-url", "origin")
+    if not remote:
+        raise GitHubInitError(
+            "Target repository does not have an origin remote configured."
+        )
+
+
+def _infer_base_branch(repo_path: str) -> str:
+    repo_root = Path(repo_path).expanduser().resolve()
+    if not repo_root.exists() or shutil.which("git") is None:
+        return "main"
+    if _git_ref_exists(repo_root, "refs/heads/develop") or _git_ref_exists(
+        repo_root,
+        "refs/remotes/origin/develop",
+    ):
+        return "develop"
+    completed = _run_command(
+        repo_root,
+        "git",
+        "symbolic-ref",
+        "refs/remotes/origin/HEAD",
+        check=False,
+    )
+    if completed.returncode == 0:
+        ref = completed.stdout.strip()
+        prefix = "refs/remotes/origin/"
+        if ref.startswith(prefix):
+            branch_name = ref.removeprefix(prefix).strip()
+            if branch_name:
+                return branch_name
+    return "main"
+
+
+def _checkout_base_branch(repo_root: Path, branch_name: str) -> str:
+    cleaned = branch_name.strip()
+    if _git_ref_exists(repo_root, f"refs/heads/{cleaned}"):
+        _run_command(repo_root, "git", "checkout", cleaned)
+        return cleaned
+    if _git_ref_exists(repo_root, f"refs/remotes/origin/{cleaned}"):
+        _run_command(
+            repo_root,
+            "git",
+            "checkout",
+            "-b",
+            cleaned,
+            f"origin/{cleaned}",
+        )
+        return cleaned
+    raise GitHubInitError(f"Base branch does not exist locally or on origin: {cleaned}")
+
+
+def _resolve_branch_name(repo_root: Path, requested: str | None) -> str:
+    candidate = (requested or DEFAULT_BRANCH_NAME).strip() or DEFAULT_BRANCH_NAME
+    if not _branch_exists(repo_root, candidate):
+        return candidate
+    suffix = 2
+    while _branch_exists(repo_root, f"{candidate}-{suffix}"):
+        suffix += 1
+    return f"{candidate}-{suffix}"
+
+
+def _branch_exists(repo_root: Path, branch_name: str) -> bool:
+    return _git_ref_exists(repo_root, f"refs/heads/{branch_name}")
+
+
+def _git_ref_exists(repo_root: Path, ref_name: str) -> bool:
+    completed = _run_command(
+        repo_root,
+        "git",
+        "show-ref",
+        "--verify",
+        "--quiet",
+        ref_name,
+        check=False,
+    )
+    return completed.returncode == 0
+
+
+def _gh_create_pr(
+    repo_root: Path,
+    *,
+    base_branch: str,
+    head_branch: str,
+    title: str,
+    body: str,
+) -> str:
+    completed = _run_command(
+        repo_root,
+        "gh",
+        "pr",
+        "create",
+        "--base",
+        base_branch,
+        "--head",
+        head_branch,
+        "--title",
+        title,
+        "--body",
+        body,
+    )
+    return completed.stdout.strip()
+
+
+def _git_stdout(repo_root: Path, *args: str) -> str:
+    completed = _run_command(repo_root, "git", *args)
+    return completed.stdout.strip()
+
+
+def _run_command(
+    repo_root: Path,
+    *args: str,
+    check: bool = True,
+) -> subprocess.CompletedProcess[str]:
+    completed = subprocess.run(
+        args,
+        cwd=repo_root,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if check and completed.returncode != 0:
+        stderr = (
+            completed.stderr.strip() or completed.stdout.strip() or "unknown failure"
+        )
+        raise GitHubInitError(f"Command failed ({' '.join(args)}): {stderr}")
+    return completed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,9 @@ dependencies = [
   "python-dotenv==1.2.2",
 ]
 
+[project.scripts]
+deploywhisper = "cli.analyze:main"
+
 [tool.hatch.build.targets.wheel]
 packages = [
   "api",

--- a/tests/test_cli/test_analyze.py
+++ b/tests/test_cli/test_analyze.py
@@ -21,6 +21,7 @@ import services.analysis_service as analysis_service_module
 from analysis.risk_scorer import RiskAssessment, RiskContributor
 from cli.analyze import main
 from importlib import reload
+from integrations.github.init_service import GitHubInitOptions, GitHubInitResult
 from llm.narrator import NarrativeResult
 
 
@@ -451,6 +452,69 @@ class AnalyzeCliTests(unittest.TestCase):
         self.assertEqual(stderr.getvalue(), "")
         payload = json.loads(stdout.getvalue())
         self.assertEqual(payload["meta"]["interface"], "cli")
+
+    @patch("cli.analyze.run_github_init")
+    @patch("cli.analyze.collect_github_init_options")
+    def test_github_init_command_uses_shared_init_service(
+        self,
+        collect_github_init_options,
+        run_github_init,
+    ) -> None:
+        collect_github_init_options.return_value = GitHubInitOptions(
+            repo_path="/tmp/example-repo",
+            workflow_path=".github/workflows/deploywhisper.yml",
+            api_endpoint="https://deploywhisper.example.com/api/v1/analyses",
+            enable_github_app=False,
+            base_branch="develop",
+        )
+        run_github_init.return_value = GitHubInitResult(
+            repo_path="/tmp/example-repo",
+            workflow_path=".github/workflows/deploywhisper.yml",
+            readme_path="README.md",
+            github_app_notes_path=None,
+            branch_name="feature/deploywhisper-github-init",
+            base_branch="main",
+            commit_sha="abc123",
+            pr_url="https://github.com/example/repo/pull/7",
+        )
+        output = io.StringIO()
+
+        with (
+            patch(
+                "sys.argv",
+                [
+                    "deploywhisper",
+                    "github",
+                    "init",
+                    "--repo",
+                    "/tmp/example-repo",
+                ],
+            ),
+            redirect_stdout(output),
+        ):
+            with self.assertRaises(SystemExit) as ctx:
+                main()
+
+        self.assertEqual(ctx.exception.code, 0)
+        collect_github_init_options.assert_called_once_with(
+            repo_path="/tmp/example-repo",
+            workflow_path=None,
+            api_endpoint=None,
+            enable_github_app=None,
+            base_branch=None,
+            github_owner=None,
+            github_app_name=None,
+            github_app_slug=None,
+            public_base_url=None,
+            branch_name=None,
+        )
+        run_github_init.assert_called_once()
+        self.assertIn(
+            "Updated workflow: .github/workflows/deploywhisper.yml", output.getvalue()
+        )
+        self.assertIn(
+            "Pull request: https://github.com/example/repo/pull/7", output.getvalue()
+        )
 
 
 if __name__ == "__main__":

--- a/tests/test_services/test_github_init_service.py
+++ b/tests/test_services/test_github_init_service.py
@@ -1,0 +1,260 @@
+"""Tests for the GitHub installation wizard service."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+import subprocess
+import tempfile
+import unittest
+from unittest.mock import patch
+
+from integrations.github import init_service
+
+
+class GitHubInitServiceTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.original_app_base_url = os.environ.get("APP_BASE_URL")
+        os.environ["APP_BASE_URL"] = "https://deploywhisper.example.com"
+
+    def tearDown(self) -> None:
+        if self.original_app_base_url is None:
+            os.environ.pop("APP_BASE_URL", None)
+        else:
+            os.environ["APP_BASE_URL"] = self.original_app_base_url
+
+    def test_collect_github_init_options_defaults_to_action_first_answers(self) -> None:
+        responses = iter(
+            [
+                "/tmp/example-repo",
+                "",
+                "",
+                "",
+                "n",
+            ]
+        )
+
+        options = init_service.collect_github_init_options(
+            repo_path=None,
+            workflow_path=None,
+            api_endpoint=None,
+            enable_github_app=None,
+            base_branch=None,
+            github_owner=None,
+            github_app_name=None,
+            github_app_slug=None,
+            public_base_url=None,
+            branch_name=None,
+            input_fn=lambda _: next(responses),
+        )
+
+        self.assertEqual(options.repo_path, "/tmp/example-repo")
+        self.assertEqual(options.workflow_path, init_service.DEFAULT_WORKFLOW_PATH)
+        self.assertEqual(
+            options.api_endpoint,
+            "https://deploywhisper.example.com/api/v1/analyses",
+        )
+        self.assertEqual(options.base_branch, "main")
+        self.assertFalse(options.enable_github_app)
+
+    def test_collect_github_init_options_prompts_for_self_hosted_app_fields(
+        self,
+    ) -> None:
+        responses = iter(
+            [
+                "/tmp/example-repo",
+                "",
+                "",
+                "",
+                "y",
+                "acme",
+                "DeployWhisper Acme",
+                "deploywhisper-acme",
+                "https://deploywhisper.acme.example.com",
+            ]
+        )
+
+        options = init_service.collect_github_init_options(
+            repo_path=None,
+            workflow_path=None,
+            api_endpoint=None,
+            enable_github_app=None,
+            base_branch=None,
+            github_owner=None,
+            github_app_name=None,
+            github_app_slug=None,
+            public_base_url=None,
+            branch_name=None,
+            input_fn=lambda _: next(responses),
+        )
+
+        self.assertTrue(options.enable_github_app)
+        self.assertEqual(options.base_branch, "main")
+        self.assertEqual(options.github_owner, "acme")
+        self.assertEqual(options.github_app_name, "DeployWhisper Acme")
+        self.assertEqual(options.github_app_slug, "deploywhisper-acme")
+        self.assertEqual(
+            options.public_base_url, "https://deploywhisper.acme.example.com"
+        )
+
+    @patch("integrations.github.init_service._require_binary")
+    @patch("integrations.github.init_service._run_command")
+    def test_run_github_init_writes_files_and_opens_pr(
+        self,
+        run_command,
+        require_binary,
+    ) -> None:
+        require_binary.return_value = None
+        command_log: list[tuple[str, ...]] = []
+
+        def fake_run_command(repo_root: Path, *args: str, check: bool = True):
+            command_log.append(args)
+            if args[:3] == ("git", "rev-parse", "--is-inside-work-tree"):
+                return subprocess.CompletedProcess(args, 0, "true\n", "")
+            if args[:3] == ("git", "status", "--porcelain"):
+                return subprocess.CompletedProcess(args, 0, "", "")
+            if args[:4] == ("git", "remote", "get-url", "origin"):
+                return subprocess.CompletedProcess(
+                    args,
+                    0,
+                    "git@github.com:acme/example-repo.git\n",
+                    "",
+                )
+            if args[:3] == ("git", "branch", "--show-current"):
+                return subprocess.CompletedProcess(args, 0, "feature/existing\n", "")
+            if args[:4] == ("git", "show-ref", "--verify", "--quiet"):
+                if args[4] == "refs/heads/develop":
+                    return subprocess.CompletedProcess(args, 0, "", "")
+                if args[4] == "refs/heads/feature/deploywhisper-github-init":
+                    return subprocess.CompletedProcess(args, 1, "", "")
+                return subprocess.CompletedProcess(args, 1, "", "")
+            if args[:3] == ("git", "rev-parse", "HEAD"):
+                return subprocess.CompletedProcess(args, 0, "abc123\n", "")
+            if args[:3] == ("gh", "pr", "create"):
+                return subprocess.CompletedProcess(
+                    args,
+                    0,
+                    "https://github.com/acme/example-repo/pull/7\n",
+                    "",
+                )
+            return subprocess.CompletedProcess(args, 0, "", "")
+
+        run_command.side_effect = fake_run_command
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            repo_root = Path(tmpdir)
+            (repo_root / "README.md").write_text("# Example Repo\n", encoding="utf-8")
+
+            result = init_service.run_github_init(
+                init_service.GitHubInitOptions(
+                    repo_path=str(repo_root),
+                    workflow_path=".github/workflows/deploywhisper.yml",
+                    api_endpoint="https://deploywhisper.example.com/api/v1/analyses",
+                    enable_github_app=True,
+                    base_branch="develop",
+                    github_owner="acme",
+                    github_app_name="DeployWhisper Acme",
+                    github_app_slug="deploywhisper-acme",
+                    public_base_url="https://deploywhisper.acme.example.com",
+                )
+            )
+
+            workflow_text = (
+                repo_root / ".github/workflows/deploywhisper.yml"
+            ).read_text(encoding="utf-8")
+            readme_text = (repo_root / "README.md").read_text(encoding="utf-8")
+            notes_text = (
+                repo_root / ".github/deploywhisper-self-hosted-github-app.md"
+            ).read_text(encoding="utf-8")
+
+        self.assertEqual(result.base_branch, "develop")
+        self.assertEqual(result.branch_name, "feature/deploywhisper-github-init")
+        self.assertEqual(result.commit_sha, "abc123")
+        self.assertEqual(result.pr_url, "https://github.com/acme/example-repo/pull/7")
+        self.assertIn("deploywhisper/analyze-action@v1", workflow_text)
+        self.assertIn(
+            "DEPLOYWHISPER_API_URL: https://deploywhisper.example.com/api/v1/analyses",
+            workflow_text,
+        )
+        self.assertIn(init_service.README_SECTION_START, readme_text)
+        self.assertIn("Advanced self-hosted GitHub App", readme_text)
+        self.assertIn("DeployWhisper Acme", notes_text)
+        self.assertIn(
+            ("git", "checkout", "develop"),
+            command_log,
+        )
+        self.assertIn(
+            ("git", "checkout", "-b", "feature/deploywhisper-github-init"), command_log
+        )
+        self.assertIn(
+            ("git", "push", "-u", "origin", "feature/deploywhisper-github-init"),
+            command_log,
+        )
+        self.assertTrue(
+            any(command[:3] == ("gh", "pr", "create") for command in command_log)
+        )
+
+    @patch("integrations.github.init_service._require_binary")
+    @patch("integrations.github.init_service._run_command")
+    def test_run_github_init_requires_clean_target_repo(
+        self,
+        run_command,
+        require_binary,
+    ) -> None:
+        require_binary.return_value = None
+
+        def fake_run_command(repo_root: Path, *args: str, check: bool = True):
+            if args[:3] == ("git", "rev-parse", "--is-inside-work-tree"):
+                return subprocess.CompletedProcess(args, 0, "true\n", "")
+            if args[:3] == ("git", "status", "--porcelain"):
+                return subprocess.CompletedProcess(args, 0, " M README.md\n", "")
+            if args[:4] == ("git", "remote", "get-url", "origin"):
+                return subprocess.CompletedProcess(
+                    args,
+                    0,
+                    "git@github.com:acme/example-repo.git\n",
+                    "",
+                )
+            return subprocess.CompletedProcess(args, 0, "", "")
+
+        run_command.side_effect = fake_run_command
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            repo_root = Path(tmpdir)
+            with self.assertRaisesRegex(
+                init_service.GitHubInitError,
+                "uncommitted changes",
+            ):
+                init_service.run_github_init(
+                    init_service.GitHubInitOptions(
+                        repo_path=str(repo_root),
+                        workflow_path=".github/workflows/deploywhisper.yml",
+                        api_endpoint="https://deploywhisper.example.com/api/v1/analyses",
+                        enable_github_app=False,
+                        base_branch="main",
+                    )
+                )
+
+    @patch("integrations.github.init_service._git_ref_exists")
+    @patch("integrations.github.init_service._run_command")
+    def test_infer_base_branch_prefers_develop_when_present(
+        self,
+        run_command,
+        git_ref_exists,
+    ) -> None:
+        git_ref_exists.side_effect = lambda _repo_root, ref_name: (
+            ref_name
+            in {
+                "refs/heads/develop",
+                "refs/remotes/origin/develop",
+            }
+        )
+
+        inferred = init_service._infer_base_branch(".")
+
+        self.assertEqual(inferred, "develop")
+        run_command.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Story 3.8 adds an interactive deploywhisper github init workflow that scaffolds the Action-first install path, documents optional self-hosted GitHub App notes, and automates target-repo branch, commit, push, and PR creation through the existing CLI surface. The follow-up review fix hardens the wizard so it targets an explicit inferred base branch instead of whichever branch happened to be checked out in the target repo.

Constraint: The install flow must stay Action-first and must not imply a public hosted GitHub App
Rejected: Infer the PR base from the current checked-out branch | creates PRs against unrelated feature branches
Confidence: high
Scope-risk: moderate
Reversibility: clean
Directive: Keep the wizard branch creation and PR target tied to an explicit base branch, not ambient checkout state
Tested: ./.venv/bin/python -m unittest tests.test_cli.test_analyze tests.test_services.test_github_init_service -q; ./.venv/bin/ruff check cli/analyze.py integrations/github/init_service.py tests/test_cli/test_analyze.py tests/test_services/test_github_init_service.py; ./.venv/bin/ruff check .; ./.venv/bin/ruff format --check .; ./.venv/bin/python -m unittest discover -q; bash scripts/ci-local.sh
Not-tested: Bandit security scan not installed locally; live gh or git PR creation against a real external repository
Related: Story 3.8 installation wizard

## What does this PR do?

<!-- Brief description of changes -->

## Type of change
- [ ] Feature (new functionality)
- [ ] Bugfix (non-breaking fix)
- [ ] Release preparation
- [ ] Hotfix (critical production fix)
- [ ] Docs / refactor / chore

## Checklist
- [ ] I have followed the branch naming convention
- [ ] Tests pass locally (`pytest tests/ -v`)
- [ ] Linting passes (`ruff check .`)
- [ ] Docker build succeeds
- [ ] I have updated docs if needed
- [ ] No secrets or .env values committed

## Related issue
Closes #