### PR TITLE
Expose a stable canonical skills registry API

### DIFF
--- a/api/routes/skills.py
+++ b/api/routes/skills.py
@@ -1,0 +1,141 @@
+"""Skills registry API routes."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Query
+
+from api.errors import ApiError, ApiRoute
+from api.schemas import (
+    ErrorResponse,
+    SkillRegistryData,
+    SkillRegistryDetailResponse,
+    SkillRegistryListMetaPayload,
+    SkillRegistryListResponse,
+    SkillRegistryResourceMetaPayload,
+    SkillRegistryVersionData,
+    SkillRegistryVersionsResponse,
+)
+from config import settings
+from services.skill_registry_service import (
+    fetch_skill_registry_entry,
+    fetch_skill_registry_page,
+    fetch_skill_registry_versions,
+)
+
+router = APIRouter(prefix="/api/v1/skills", tags=["skills"], route_class=ApiRoute)
+
+
+@router.get(
+    "",
+    response_model=SkillRegistryListResponse,
+    responses={422: {"model": ErrorResponse}, 500: {"model": ErrorResponse}},
+)
+def list_skills(
+    tool: str | None = Query(
+        default=None,
+        description="Filter by primary tool family, such as terraform or kubernetes.",
+    ),
+    tag: str | None = Query(
+        default=None,
+        description="Filter by a single tag from the skill metadata.",
+    ),
+    author: str | None = Query(
+        default=None,
+        description="Filter by author or owner label.",
+    ),
+    search: str | None = Query(
+        default=None,
+        description="Case-insensitive keyword search across name, description, tags, and triggers.",
+    ),
+    page: int = Query(default=1, ge=1, description="1-based results page."),
+    page_size: int = Query(
+        default=50,
+        ge=1,
+        le=100,
+        description="Maximum number of results to return per page.",
+    ),
+) -> SkillRegistryListResponse:
+    page_payload = fetch_skill_registry_page(
+        tool=tool,
+        tag=tag,
+        author=author,
+        search=search,
+        page=page,
+        page_size=page_size,
+    )
+    filters = {
+        key: value
+        for key, value in {
+            "tool": tool,
+            "tag": tag,
+            "author": author,
+            "search": search,
+        }.items()
+        if value
+    }
+    return SkillRegistryListResponse(
+        data=[SkillRegistryData(**item.model_dump()) for item in page_payload.items],
+        meta=SkillRegistryListMetaPayload(
+            app=settings.app_name,
+            version=settings.app_version,
+            count=len(page_payload.items),
+            total_count=page_payload.total_count,
+            page=page_payload.page,
+            page_size=page_payload.page_size,
+            filters=filters,
+        ),
+    )
+
+
+@router.get(
+    "/{skill_id}",
+    response_model=SkillRegistryDetailResponse,
+    responses={
+        404: {"model": ErrorResponse},
+        422: {"model": ErrorResponse},
+        500: {"model": ErrorResponse},
+    },
+)
+def get_skill(skill_id: str) -> SkillRegistryDetailResponse:
+    skill = fetch_skill_registry_entry(skill_id)
+    if skill is None:
+        raise ApiError(
+            status_code=404,
+            code="skill_not_found",
+            message="Skill not found.",
+        )
+    return SkillRegistryDetailResponse(
+        data=SkillRegistryData(**skill.model_dump()),
+        meta=SkillRegistryResourceMetaPayload(
+            app=settings.app_name,
+            version=settings.app_version,
+            id=skill.id,
+        ),
+    )
+
+
+@router.get(
+    "/{skill_id}/versions",
+    response_model=SkillRegistryVersionsResponse,
+    responses={
+        404: {"model": ErrorResponse},
+        422: {"model": ErrorResponse},
+        500: {"model": ErrorResponse},
+    },
+)
+def get_skill_versions(skill_id: str) -> SkillRegistryVersionsResponse:
+    versions = fetch_skill_registry_versions(skill_id)
+    if not versions:
+        raise ApiError(
+            status_code=404,
+            code="skill_not_found",
+            message="Skill not found.",
+        )
+    return SkillRegistryVersionsResponse(
+        data=[SkillRegistryVersionData(**version.model_dump()) for version in versions],
+        meta=SkillRegistryResourceMetaPayload(
+            app=settings.app_name,
+            version=settings.app_version,
+            id=skill_id.strip().lower(),
+        ),
+    )

--- a/api/schemas.py
+++ b/api/schemas.py
@@ -619,6 +619,72 @@ class AnalysisShareConfigResponse(BaseModel):
     meta: ResourceMetaPayload
 
 
+SkillRegistrySource = Literal["built-in", "custom-override", "custom-new"]
+
+
+class SkillRegistryData(BaseModel):
+    id: str = Field(..., description="Stable skill identifier")
+    name: str = Field(..., description="Human-readable skill name")
+    version: str = Field(..., description="Current effective version")
+    source: SkillRegistrySource = Field(
+        ..., description="Where the skill definition currently resolves from"
+    )
+    author: str = Field(..., description="Skill author or owner label")
+    license: str | None = Field(default=None, description="Declared skill license")
+    description: str = Field(..., description="Skill summary")
+    tool: str = Field(..., description="Primary tool family for the skill")
+    tags: list[str] = Field(default_factory=list, description="Searchable skill tags")
+    token_budget: int | None = Field(
+        default=None, description="Suggested token budget for the skill"
+    )
+    triggers: list[str] = Field(
+        default_factory=list, description="Filename or extension triggers"
+    )
+    trigger_content_patterns: list[str] = Field(
+        default_factory=list, description="Content markers used for matching"
+    )
+    updated_at: str = Field(..., description="Last local update timestamp")
+    available_versions: int = Field(
+        ..., description="Number of versions discoverable for this skill id"
+    )
+
+
+class SkillRegistryVersionData(SkillRegistryData):
+    is_current: bool = Field(
+        ..., description="Whether this version is the current effective version"
+    )
+
+
+class SkillRegistryListMetaPayload(MetaPayload):
+    count: int = Field(..., description="Count of returned items")
+    total_count: int = Field(..., description="Total number of matching skills")
+    page: int = Field(..., description="Current results page")
+    page_size: int = Field(..., description="Current results page size")
+    filters: dict[str, str] = Field(
+        default_factory=dict,
+        description="Filters applied to the current registry query",
+    )
+
+
+class SkillRegistryResourceMetaPayload(MetaPayload):
+    id: str = Field(..., description="Stable skill identifier")
+
+
+class SkillRegistryListResponse(BaseModel):
+    data: list[SkillRegistryData]
+    meta: SkillRegistryListMetaPayload
+
+
+class SkillRegistryDetailResponse(BaseModel):
+    data: SkillRegistryData
+    meta: SkillRegistryResourceMetaPayload
+
+
+class SkillRegistryVersionsResponse(BaseModel):
+    data: list[SkillRegistryVersionData]
+    meta: SkillRegistryResourceMetaPayload
+
+
 PersistedReportData.model_rebuild()
 
 

--- a/app.py
+++ b/app.py
@@ -25,6 +25,7 @@ from api.errors import (
 from api.routes.analyses import router as analyses_router
 from api.routes.github_app import router as github_app_router
 from api.routes.health import router as health_router
+from api.routes.skills import router as skills_router
 from config import settings
 from logging_config import configure_logging
 from models.database import init_db
@@ -75,6 +76,7 @@ fastapi_app.add_exception_handler(StarletteHTTPException, http_error_envelope_ha
 fastapi_app.include_router(health_router)
 fastapi_app.include_router(analyses_router)
 fastapi_app.include_router(github_app_router)
+fastapi_app.include_router(skills_router)
 
 
 _original_lifespan = fastapi_app.router.lifespan_context

--- a/docs/skills/registry-api.md
+++ b/docs/skills/registry-api.md
@@ -1,0 +1,29 @@
+# Skills Registry API
+
+Story 4.1 introduces a read-only registry surface under `/api/v1/skills` that
+normalizes the existing markdown-backed skills catalog into a stable API
+contract.
+
+## Endpoints
+
+- `GET /api/v1/skills`
+  Returns the current effective skill inventory with pagination plus optional
+  `tool`, `tag`, `author`, and `search` filters.
+- `GET /api/v1/skills/{id}`
+  Returns the current effective record for a single skill id.
+- `GET /api/v1/skills/{id}/versions`
+  Returns the discoverable bundled-catalog version history for a single skill
+  id.
+
+## Notes
+
+- The current implementation serves the bundled canonical catalog from
+  `skills/*.md`.
+- Installed or team-local cache files under `skills/custom/*.md` are excluded
+  from this API so the browser and installer surfaces do not drift per
+  instance.
+- Skills with invalid YAML frontmatter are skipped instead of failing the
+  registry endpoints.
+- The API contract is intentionally manifest-shaped so later stories can add the
+  formal manifest schema, installer, validator, and public browser without
+  rewriting the read surface.

--- a/services/skill_registry_service.py
+++ b/services/skill_registry_service.py
@@ -1,0 +1,412 @@
+"""Shared skill registry retrieval and normalization."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+import re
+from typing import Any, Literal
+
+from pydantic import BaseModel, Field
+import yaml
+from yaml import YAMLError
+
+
+SKILLS_DIR = Path(__file__).resolve().parents[1] / "skills"
+CUSTOM_DIR = SKILLS_DIR / "custom"
+SkillSource = Literal["built-in", "custom-override", "custom-new"]
+
+
+class SkillRegistryEntry(BaseModel):
+    """Normalized current skill metadata for external surfaces."""
+
+    id: str = Field(..., description="Stable skill identifier")
+    name: str = Field(..., description="Human-readable skill name")
+    version: str = Field(..., description="Current effective version")
+    source: SkillSource = Field(..., description="Where the skill was resolved from")
+    author: str = Field(..., description="Skill author or owner label")
+    license: str | None = Field(default=None, description="Declared skill license")
+    description: str = Field(..., description="Skill summary")
+    tool: str = Field(..., description="Primary tool family for the skill")
+    tags: list[str] = Field(default_factory=list, description="Searchable skill tags")
+    token_budget: int | None = Field(
+        default=None, description="Suggested token budget for the skill"
+    )
+    triggers: list[str] = Field(
+        default_factory=list, description="Filename or extension triggers"
+    )
+    trigger_content_patterns: list[str] = Field(
+        default_factory=list, description="Content markers used for matching"
+    )
+    updated_at: str = Field(..., description="Last local update timestamp")
+    available_versions: int = Field(
+        ..., description="Number of versions discoverable for this skill id"
+    )
+
+
+class SkillRegistryVersionEntry(SkillRegistryEntry):
+    """Version history entry for a skill."""
+
+    is_current: bool = Field(
+        ..., description="Whether this version is the effective current version"
+    )
+
+
+class SkillRegistryPage(BaseModel):
+    """Paginated page of current registry entries."""
+
+    items: list[SkillRegistryEntry] = Field(default_factory=list)
+    total_count: int = Field(..., description="Total number of matching skills")
+    page: int = Field(..., description="Current result page")
+    page_size: int = Field(..., description="Current result page size")
+
+
+class _SkillRecord(BaseModel):
+    id: str
+    name: str
+    version: str
+    source: SkillSource
+    author: str
+    license: str | None = None
+    description: str
+    tool: str
+    tags: list[str] = Field(default_factory=list)
+    token_budget: int | None = None
+    triggers: list[str] = Field(default_factory=list)
+    trigger_content_patterns: list[str] = Field(default_factory=list)
+    updated_at: str
+    updated_at_epoch: float
+
+
+class _ParsedSkillFile(BaseModel):
+    metadata: dict[str, Any] = Field(default_factory=dict)
+    content: str = Field(..., description="Markdown body without frontmatter")
+
+
+def _split_frontmatter(content: str) -> _ParsedSkillFile | None:
+    stripped = content.strip()
+    if stripped.startswith("---"):
+        parts = stripped.split("---", 2)
+        if len(parts) == 3:
+            try:
+                frontmatter = yaml.safe_load(parts[1]) or {}
+            except YAMLError:
+                return None
+            if not isinstance(frontmatter, dict):
+                frontmatter = {}
+            return _ParsedSkillFile(metadata=frontmatter, content=parts[2].strip())
+    return _ParsedSkillFile(metadata={}, content=stripped)
+
+
+def _iter_skill_files(directory: Path) -> list[Path]:
+    if not directory.exists():
+        return []
+    return sorted(
+        path
+        for path in directory.glob("*.md")
+        if path.is_file() and path.name.lower() != "readme.md"
+    )
+
+
+def _normalize_skill_id(raw_value: str | None, path: Path) -> str:
+    candidate = str(raw_value or path.stem).strip().lower()
+    normalized = re.sub(r"[^a-z0-9]+", "-", candidate).strip("-")
+    return normalized or path.stem.strip().lower()
+
+
+def _normalize_string_list(raw_value: Any) -> list[str]:
+    if raw_value is None:
+        return []
+    items = raw_value if isinstance(raw_value, list) else [raw_value]
+    normalized: list[str] = []
+    seen: set[str] = set()
+    for item in items:
+        value = str(item).strip()
+        if not value:
+            continue
+        key = value.lower()
+        if key in seen:
+            continue
+        seen.add(key)
+        normalized.append(value)
+    return normalized
+
+
+def _normalize_token_budget(raw_value: Any) -> int | None:
+    if raw_value in {None, ""}:
+        return None
+    try:
+        return int(raw_value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _extract_description(metadata: dict[str, Any], content: str) -> str:
+    description = str(metadata.get("description") or "").strip()
+    if description:
+        return description
+    for line in content.splitlines():
+        candidate = line.strip()
+        if not candidate or candidate.startswith("#"):
+            continue
+        return candidate
+    return "No description provided."
+
+
+def _default_author(source: SkillSource) -> str:
+    if source == "built-in":
+        return "DeployWhisper"
+    return "Local custom skill"
+
+
+def _default_tool(metadata: dict[str, Any], skill_id: str) -> str:
+    for key in ("tool_type", "tool"):
+        value = str(metadata.get(key) or "").strip().lower()
+        if value:
+            return value
+    return skill_id
+
+
+def _display_name(metadata: dict[str, Any], skill_id: str) -> str:
+    explicit = str(metadata.get("name") or "").strip()
+    if explicit:
+        return explicit
+    return skill_id.replace("-", " ").title()
+
+
+def _updated_at(path: Path) -> tuple[str, float]:
+    updated_epoch = path.stat().st_mtime
+    updated_at = datetime.fromtimestamp(updated_epoch, tz=UTC).isoformat()
+    return updated_at.replace("+00:00", "Z"), updated_epoch
+
+
+def _version_key(version: str) -> tuple[Any, ...]:
+    parts = re.split(r"[^0-9A-Za-z]+", version)
+    key: list[Any] = []
+    for part in parts:
+        if not part:
+            continue
+        key.append(int(part) if part.isdigit() else part.lower())
+    return tuple(key)
+
+
+def _source_priority(source: SkillSource) -> int:
+    return {
+        "built-in": 1,
+        "custom-override": 2,
+        "custom-new": 3,
+    }[source]
+
+
+def _record_to_entry(
+    record: _SkillRecord,
+    *,
+    available_versions: int,
+    is_current: bool | None = None,
+) -> SkillRegistryEntry | SkillRegistryVersionEntry:
+    payload = {
+        "id": record.id,
+        "name": record.name,
+        "version": record.version,
+        "source": record.source,
+        "author": record.author,
+        "license": record.license,
+        "description": record.description,
+        "tool": record.tool,
+        "tags": list(record.tags),
+        "token_budget": record.token_budget,
+        "triggers": list(record.triggers),
+        "trigger_content_patterns": list(record.trigger_content_patterns),
+        "updated_at": record.updated_at,
+        "available_versions": available_versions,
+    }
+    if is_current is None:
+        return SkillRegistryEntry(**payload)
+    return SkillRegistryVersionEntry(**payload, is_current=is_current)
+
+
+def _load_skill_record(path: Path, *, source: SkillSource) -> _SkillRecord | None:
+    raw_content = path.read_text(encoding="utf-8")
+    parsed = _split_frontmatter(raw_content)
+    if parsed is None or not parsed.content:
+        return None
+
+    skill_id = _normalize_skill_id(
+        parsed.metadata.get("skill") or parsed.metadata.get("name"),
+        path,
+    )
+    updated_at, updated_epoch = _updated_at(path)
+    return _SkillRecord(
+        id=skill_id,
+        name=_display_name(parsed.metadata, skill_id),
+        version=str(parsed.metadata.get("version") or "1.0"),
+        source=source,
+        author=str(parsed.metadata.get("author") or _default_author(source)),
+        license=str(parsed.metadata.get("license")).strip() or None
+        if parsed.metadata.get("license") is not None
+        else None,
+        description=_extract_description(parsed.metadata, parsed.content),
+        tool=_default_tool(parsed.metadata, skill_id),
+        tags=_normalize_string_list(parsed.metadata.get("tags")),
+        token_budget=_normalize_token_budget(parsed.metadata.get("token_budget")),
+        triggers=_normalize_string_list(parsed.metadata.get("triggers")),
+        trigger_content_patterns=_normalize_string_list(
+            parsed.metadata.get("trigger_content_patterns")
+        ),
+        updated_at=updated_at,
+        updated_at_epoch=updated_epoch,
+    )
+
+
+def _load_versions_by_skill(*, include_custom: bool) -> dict[str, list[_SkillRecord]]:
+    versions_by_skill: dict[str, list[_SkillRecord]] = {}
+
+    for path in _iter_skill_files(SKILLS_DIR):
+        if path.parent != SKILLS_DIR:
+            continue
+        record = _load_skill_record(path, source="built-in")
+        if record is None:
+            continue
+        versions_by_skill.setdefault(record.id, []).append(record)
+
+    if include_custom:
+        built_in_ids = {
+            _normalize_skill_id(None, path)
+            for path in _iter_skill_files(SKILLS_DIR)
+            if path.parent == SKILLS_DIR
+        }
+
+        for path in _iter_skill_files(CUSTOM_DIR):
+            inferred_id = _normalize_skill_id(None, path)
+            source: SkillSource = (
+                "custom-override" if inferred_id in built_in_ids else "custom-new"
+            )
+            record = _load_skill_record(path, source=source)
+            if record is None:
+                continue
+            versions_by_skill.setdefault(record.id, []).append(record)
+
+    return versions_by_skill
+
+
+def _current_record(records: list[_SkillRecord]) -> _SkillRecord:
+    return max(
+        records,
+        key=lambda record: (
+            _source_priority(record.source),
+            _version_key(record.version),
+            record.updated_at_epoch,
+        ),
+    )
+
+
+def _sorted_versions(records: list[_SkillRecord]) -> list[_SkillRecord]:
+    return sorted(
+        records,
+        key=lambda record: (
+            _source_priority(record.source),
+            _version_key(record.version),
+            record.updated_at_epoch,
+        ),
+        reverse=True,
+    )
+
+
+def _matches_query(
+    record: _SkillRecord,
+    *,
+    tool: str | None,
+    tag: str | None,
+    author: str | None,
+    search: str | None,
+) -> bool:
+    if tool and record.tool.lower() != tool.strip().lower():
+        return False
+    if tag and tag.strip().lower() not in {item.lower() for item in record.tags}:
+        return False
+    if author and record.author.lower() != author.strip().lower():
+        return False
+    if search:
+        needle = search.strip().lower()
+        haystack = " ".join(
+            [
+                record.id,
+                record.name,
+                record.version,
+                record.author,
+                record.tool,
+                record.description,
+                *record.tags,
+                *record.triggers,
+                *record.trigger_content_patterns,
+            ]
+        ).lower()
+        if needle not in haystack:
+            return False
+    return True
+
+
+def fetch_skill_registry_page(
+    *,
+    tool: str | None = None,
+    tag: str | None = None,
+    author: str | None = None,
+    search: str | None = None,
+    page: int = 1,
+    page_size: int = 50,
+) -> SkillRegistryPage:
+    versions_by_skill = _load_versions_by_skill(include_custom=False)
+    current_items = [
+        _record_to_entry(
+            _current_record(records),
+            available_versions=len(records),
+        )
+        for records in versions_by_skill.values()
+    ]
+    filtered = [
+        item
+        for item in sorted(current_items, key=lambda current: current.id)
+        if _matches_query(
+            _SkillRecord(**item.model_dump(), updated_at_epoch=0),
+            tool=tool,
+            tag=tag,
+            author=author,
+            search=search,
+        )
+    ]
+    total_count = len(filtered)
+    start = (page - 1) * page_size
+    end = start + page_size
+    return SkillRegistryPage(
+        items=filtered[start:end],
+        total_count=total_count,
+        page=page,
+        page_size=page_size,
+    )
+
+
+def fetch_skill_registry_entry(skill_id: str) -> SkillRegistryEntry | None:
+    versions_by_skill = _load_versions_by_skill(include_custom=False)
+    records = versions_by_skill.get(skill_id.strip().lower())
+    if not records:
+        return None
+    return _record_to_entry(_current_record(records), available_versions=len(records))
+
+
+def fetch_skill_registry_versions(skill_id: str) -> list[SkillRegistryVersionEntry]:
+    versions_by_skill = _load_versions_by_skill(include_custom=False)
+    records = versions_by_skill.get(skill_id.strip().lower())
+    if not records:
+        return []
+    current = _current_record(records)
+    available_versions = len(records)
+    return [
+        _record_to_entry(
+            record,
+            available_versions=available_versions,
+            is_current=(
+                record.source == current.source and record.version == current.version
+            ),
+        )
+        for record in _sorted_versions(records)
+    ]

--- a/tests/test_api/test_skills.py
+++ b/tests/test_api/test_skills.py
@@ -1,0 +1,232 @@
+"""Tests for skills registry API routes."""
+
+from __future__ import annotations
+
+import os
+import tempfile
+import unittest
+from importlib import reload
+from pathlib import Path
+from unittest.mock import patch
+
+import config as config_module
+import models.database as database_module
+import models.tables as tables_module
+import services.skill_registry_service as skill_registry_service_module
+from app import create_app
+from fastapi.testclient import TestClient
+
+
+class SkillsApiTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tempdir = tempfile.TemporaryDirectory()
+        self.db_path = Path(self.tempdir.name) / "skills.db"
+        self.skills_dir = Path(self.tempdir.name) / "skills"
+        self.custom_dir = self.skills_dir / "custom"
+        self.skills_dir.mkdir(parents=True, exist_ok=True)
+        self.custom_dir.mkdir(parents=True, exist_ok=True)
+        os.environ["DATABASE_URL"] = f"sqlite:///{self.db_path}"
+        reload(config_module)
+        reload(tables_module)
+        reload(database_module)
+        reload(skill_registry_service_module)
+        database_module.init_db()
+        self.client = TestClient(create_app())
+
+    def tearDown(self) -> None:
+        database_module.engine.dispose()
+        os.environ.pop("DATABASE_URL", None)
+        self.tempdir.cleanup()
+
+    def test_list_skills_returns_paginated_filtered_metadata(self) -> None:
+        (self.skills_dir / "terraform.md").write_text(
+            "---\n"
+            "skill: terraform\n"
+            "version: 1.0.0\n"
+            "author: DeployWhisper\n"
+            "tool_type: terraform\n"
+            "tags: [iac, security]\n"
+            "description: Terraform registry skill.\n"
+            "triggers: [.tf]\n"
+            "---\n"
+            "# Terraform\nDetails\n",
+            encoding="utf-8",
+        )
+        (self.skills_dir / "kubernetes.md").write_text(
+            "---\n"
+            "skill: kubernetes\n"
+            "version: 2.0.0\n"
+            "author: Platform Team\n"
+            "tool_type: kubernetes\n"
+            "tags: [cluster]\n"
+            "description: Kubernetes rollout checks.\n"
+            "---\n"
+            "# Kubernetes\nDetails\n",
+            encoding="utf-8",
+        )
+
+        with (
+            patch(
+                "services.skill_registry_service.SKILLS_DIR",
+                self.skills_dir,
+            ),
+            patch(
+                "services.skill_registry_service.CUSTOM_DIR",
+                self.custom_dir,
+            ),
+        ):
+            response = self.client.get(
+                "/api/v1/skills",
+                params={
+                    "tool": "terraform",
+                    "tag": "iac",
+                    "author": "DeployWhisper",
+                    "search": "registry",
+                    "page": 1,
+                    "page_size": 25,
+                },
+            )
+
+        self.assertEqual(response.status_code, 200)
+        payload = response.json()
+        self.assertEqual(payload["meta"]["count"], 1)
+        self.assertEqual(payload["meta"]["total_count"], 1)
+        self.assertEqual(payload["meta"]["filters"]["tool"], "terraform")
+        self.assertEqual(payload["data"][0]["id"], "terraform")
+        self.assertEqual(payload["data"][0]["tool"], "terraform")
+        self.assertEqual(payload["data"][0]["triggers"], [".tf"])
+
+    def test_get_skill_and_versions_return_effective_skill_and_history(self) -> None:
+        (self.skills_dir / "terraform.md").write_text(
+            "---\n"
+            "skill: terraform\n"
+            "version: 1.0.0\n"
+            "author: DeployWhisper\n"
+            "tool_type: terraform\n"
+            "description: Built-in terraform checks.\n"
+            "---\n"
+            "# Terraform\nBuilt-in guidance.\n",
+            encoding="utf-8",
+        )
+        (self.custom_dir / "terraform.md").write_text(
+            "---\n"
+            "skill: terraform\n"
+            "version: 1.3.0\n"
+            "author: Team Ops\n"
+            "tool_type: terraform\n"
+            "tags: [private]\n"
+            "description: Team override.\n"
+            "---\n"
+            "# Terraform\nCustom guidance.\n",
+            encoding="utf-8",
+        )
+
+        with (
+            patch(
+                "services.skill_registry_service.SKILLS_DIR",
+                self.skills_dir,
+            ),
+            patch(
+                "services.skill_registry_service.CUSTOM_DIR",
+                self.custom_dir,
+            ),
+        ):
+            detail_response = self.client.get("/api/v1/skills/terraform")
+            versions_response = self.client.get("/api/v1/skills/terraform/versions")
+
+        self.assertEqual(detail_response.status_code, 200)
+        detail_payload = detail_response.json()
+        self.assertEqual(detail_payload["data"]["source"], "built-in")
+        self.assertEqual(detail_payload["data"]["available_versions"], 1)
+        self.assertEqual(detail_payload["meta"]["id"], "terraform")
+
+        self.assertEqual(versions_response.status_code, 200)
+        versions_payload = versions_response.json()
+        self.assertEqual(len(versions_payload["data"]), 1)
+        self.assertEqual(versions_payload["data"][0]["version"], "1.0.0")
+        self.assertTrue(versions_payload["data"][0]["is_current"])
+        self.assertEqual(versions_payload["data"][0]["source"], "built-in")
+
+    def test_registry_api_ignores_local_custom_cache_entries(self) -> None:
+        (self.skills_dir / "terraform.md").write_text(
+            "---\n"
+            "skill: terraform\n"
+            "version: 1.0.0\n"
+            "author: DeployWhisper\n"
+            "tool_type: terraform\n"
+            "description: Built-in terraform checks.\n"
+            "---\n"
+            "# Terraform\nBuilt-in guidance.\n",
+            encoding="utf-8",
+        )
+        (self.custom_dir / "terraform.md").write_text(
+            "---\n"
+            "skill: terraform\n"
+            "version: 9.9.9\n"
+            "author: Team Ops\n"
+            "tool_type: terraform\n"
+            "description: Local install cache override.\n"
+            "---\n"
+            "# Terraform\nCustom guidance.\n",
+            encoding="utf-8",
+        )
+
+        with (
+            patch("services.skill_registry_service.SKILLS_DIR", self.skills_dir),
+            patch("services.skill_registry_service.CUSTOM_DIR", self.custom_dir),
+        ):
+            detail_response = self.client.get("/api/v1/skills/terraform")
+            versions_response = self.client.get("/api/v1/skills/terraform/versions")
+
+        self.assertEqual(detail_response.status_code, 200)
+        self.assertEqual(detail_response.json()["data"]["source"], "built-in")
+        self.assertEqual(detail_response.json()["data"]["version"], "1.0.0")
+        self.assertEqual(versions_response.status_code, 200)
+        self.assertEqual(len(versions_response.json()["data"]), 1)
+
+    def test_registry_api_skips_invalid_frontmatter_instead_of_failing(self) -> None:
+        (self.skills_dir / "terraform.md").write_text(
+            "---\n: broken\n---\n# Terraform\nBroken frontmatter.\n",
+            encoding="utf-8",
+        )
+
+        with (
+            patch("services.skill_registry_service.SKILLS_DIR", self.skills_dir),
+            patch("services.skill_registry_service.CUSTOM_DIR", self.custom_dir),
+        ):
+            list_response = self.client.get("/api/v1/skills")
+            detail_response = self.client.get("/api/v1/skills/terraform")
+
+        self.assertEqual(list_response.status_code, 200)
+        self.assertEqual(list_response.json()["data"], [])
+        self.assertEqual(detail_response.status_code, 404)
+
+    def test_missing_skill_returns_api_error(self) -> None:
+        with (
+            patch(
+                "services.skill_registry_service.SKILLS_DIR",
+                self.skills_dir,
+            ),
+            patch(
+                "services.skill_registry_service.CUSTOM_DIR",
+                self.custom_dir,
+            ),
+        ):
+            response = self.client.get("/api/v1/skills/missing-skill")
+
+        self.assertEqual(response.status_code, 404)
+        payload = response.json()
+        self.assertEqual(payload["error"]["code"], "skill_not_found")
+
+    def test_openapi_includes_skills_registry_routes(self) -> None:
+        response = self.client.get("/api/v1/openapi.json")
+
+        self.assertEqual(response.status_code, 200)
+        payload = response.json()
+        self.assertIn("/api/v1/skills", payload["paths"])
+        self.assertIn("/api/v1/skills/{skill_id}", payload["paths"])
+        self.assertIn("/api/v1/skills/{skill_id}/versions", payload["paths"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_services/test_skill_registry_service.py
+++ b/tests/test_services/test_skill_registry_service.py
@@ -1,0 +1,215 @@
+"""Tests for the shared skills registry service."""
+
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from services.skill_registry_service import (
+    fetch_skill_registry_entry,
+    fetch_skill_registry_page,
+    fetch_skill_registry_versions,
+)
+
+
+class SkillRegistryServiceTests(unittest.TestCase):
+    def test_registry_page_applies_filters_search_and_pagination(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            skills_dir = Path(tmpdir) / "skills"
+            custom_dir = skills_dir / "custom"
+            skills_dir.mkdir(parents=True, exist_ok=True)
+            custom_dir.mkdir(parents=True, exist_ok=True)
+            (skills_dir / "terraform.md").write_text(
+                "---\n"
+                "skill: terraform\n"
+                "version: 1.0.0\n"
+                "author: DeployWhisper\n"
+                "tool_type: terraform\n"
+                "tags: [iac, security]\n"
+                "description: Terraform registry skill.\n"
+                "triggers: [.tf]\n"
+                "---\n"
+                "# Terraform\nDetails\n",
+                encoding="utf-8",
+            )
+            (skills_dir / "kubernetes.md").write_text(
+                "---\n"
+                "skill: kubernetes\n"
+                "version: 2.0.0\n"
+                "author: Platform Team\n"
+                "tool_type: kubernetes\n"
+                "tags: [cluster]\n"
+                "description: Kubernetes rollout checks.\n"
+                "---\n"
+                "# Kubernetes\nDetails\n",
+                encoding="utf-8",
+            )
+
+            with (
+                patch(
+                    "services.skill_registry_service.SKILLS_DIR",
+                    skills_dir,
+                ),
+                patch(
+                    "services.skill_registry_service.CUSTOM_DIR",
+                    custom_dir,
+                ),
+            ):
+                page = fetch_skill_registry_page(
+                    tool="terraform",
+                    tag="iac",
+                    author="DeployWhisper",
+                    search="registry",
+                    page=1,
+                    page_size=10,
+                )
+                paged = fetch_skill_registry_page(page=2, page_size=1)
+
+        self.assertEqual(page.total_count, 1)
+        self.assertEqual(len(page.items), 1)
+        self.assertEqual(page.items[0].id, "terraform")
+        self.assertEqual(paged.total_count, 2)
+        self.assertEqual(len(paged.items), 1)
+        self.assertEqual(paged.items[0].id, "terraform")
+
+    def test_registry_entry_returns_bundled_catalog_version_only(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            skills_dir = Path(tmpdir) / "skills"
+            custom_dir = skills_dir / "custom"
+            skills_dir.mkdir(parents=True, exist_ok=True)
+            custom_dir.mkdir(parents=True, exist_ok=True)
+            (skills_dir / "terraform.md").write_text(
+                "---\n"
+                "skill: terraform\n"
+                "version: 1.0.0\n"
+                "author: DeployWhisper\n"
+                "tool_type: terraform\n"
+                "description: Built-in terraform checks.\n"
+                "---\n"
+                "# Terraform\nBuilt-in guidance.\n",
+                encoding="utf-8",
+            )
+            (custom_dir / "terraform.md").write_text(
+                "---\n"
+                "skill: terraform\n"
+                "version: 1.2.0\n"
+                "author: Team Ops\n"
+                "tool_type: terraform\n"
+                "tags: [private]\n"
+                "description: Team override.\n"
+                "---\n"
+                "# Terraform\nCustom guidance.\n",
+                encoding="utf-8",
+            )
+            (custom_dir / "README.md").write_text(
+                "# Ignore\nRegistry docs only.\n",
+                encoding="utf-8",
+            )
+
+            with (
+                patch(
+                    "services.skill_registry_service.SKILLS_DIR",
+                    skills_dir,
+                ),
+                patch(
+                    "services.skill_registry_service.CUSTOM_DIR",
+                    custom_dir,
+                ),
+            ):
+                entry = fetch_skill_registry_entry("terraform")
+                versions = fetch_skill_registry_versions("terraform")
+
+        assert entry is not None
+        self.assertEqual(entry.source, "built-in")
+        self.assertEqual(entry.version, "1.0.0")
+        self.assertEqual(entry.available_versions, 1)
+        self.assertEqual([version.version for version in versions], ["1.0.0"])
+        self.assertTrue(versions[0].is_current)
+        self.assertEqual(versions[0].author, "DeployWhisper")
+        self.assertEqual(versions[0].source, "built-in")
+
+    def test_registry_page_ignores_local_custom_cache_for_canonical_results(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            skills_dir = Path(tmpdir) / "skills"
+            custom_dir = skills_dir / "custom"
+            skills_dir.mkdir(parents=True, exist_ok=True)
+            custom_dir.mkdir(parents=True, exist_ok=True)
+            (skills_dir / "terraform.md").write_text(
+                "---\n"
+                "skill: terraform\n"
+                "version: 1.0.0\n"
+                "author: DeployWhisper\n"
+                "tool_type: terraform\n"
+                "description: Built-in terraform checks.\n"
+                "---\n"
+                "# Terraform\nBuilt-in guidance.\n",
+                encoding="utf-8",
+            )
+            (custom_dir / "terraform.md").write_text(
+                "---\n"
+                "skill: terraform\n"
+                "version: 9.9.9\n"
+                "author: Team Ops\n"
+                "tool_type: terraform\n"
+                "description: Local install cache override.\n"
+                "---\n"
+                "# Terraform\nCustom guidance.\n",
+                encoding="utf-8",
+            )
+
+            with (
+                patch("services.skill_registry_service.SKILLS_DIR", skills_dir),
+                patch("services.skill_registry_service.CUSTOM_DIR", custom_dir),
+            ):
+                page = fetch_skill_registry_page()
+                entry = fetch_skill_registry_entry("terraform")
+                versions = fetch_skill_registry_versions("terraform")
+
+        self.assertEqual(page.total_count, 1)
+        self.assertEqual(page.items[0].source, "built-in")
+        assert entry is not None
+        self.assertEqual(entry.source, "built-in")
+        self.assertEqual(entry.version, "1.0.0")
+        self.assertEqual([version.version for version in versions], ["1.0.0"])
+
+    def test_registry_skips_files_with_invalid_frontmatter(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            skills_dir = Path(tmpdir) / "skills"
+            custom_dir = skills_dir / "custom"
+            skills_dir.mkdir(parents=True, exist_ok=True)
+            custom_dir.mkdir(parents=True, exist_ok=True)
+            (skills_dir / "terraform.md").write_text(
+                "---\n: broken\n---\n# Terraform\nBroken frontmatter.\n",
+                encoding="utf-8",
+            )
+            (skills_dir / "kubernetes.md").write_text(
+                "---\n"
+                "skill: kubernetes\n"
+                "version: 1.0.0\n"
+                "tool_type: kubernetes\n"
+                "description: Healthy skill.\n"
+                "---\n"
+                "# Kubernetes\nHealthy guidance.\n",
+                encoding="utf-8",
+            )
+
+            with (
+                patch("services.skill_registry_service.SKILLS_DIR", skills_dir),
+                patch("services.skill_registry_service.CUSTOM_DIR", custom_dir),
+            ):
+                page = fetch_skill_registry_page()
+                missing = fetch_skill_registry_entry("terraform")
+                versions = fetch_skill_registry_versions("terraform")
+
+        self.assertEqual(page.total_count, 1)
+        self.assertEqual(page.items[0].id, "kubernetes")
+        self.assertIsNone(missing)
+        self.assertEqual(versions, [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Story 4.1 adds a shared skills registry service plus read-only API routes for list, detail, and version history. The registry now serves the bundled catalog as the canonical source, skips malformed frontmatter safely, and documents the resulting contract for follow-on marketplace work.

Constraint: Registry API must remain canonical and not reflect instance-local skills/custom cache state
Constraint: Malformed skill frontmatter must not turn registry reads into 500 responses
Rejected: Include skills/custom in registry responses | would make browser and installer behavior instance-specific
Confidence: high
Scope-risk: narrow
Reversibility: clean
Directive: Keep registry read surfaces aligned with canonical catalog semantics until dedicated registry storage lands
Tested: ./ .venv/bin/ruff check .; ./.venv/bin/ruff format --check .; ./.venv/bin/python -m unittest discover -q; bash scripts/ci-local.sh; ./.venv/bin/python -m unittest tests.test_services.test_skill_registry_service tests.test_api.test_skills -q
Not-tested: Local Bandit scan (tool unavailable)

## What does this PR do?

<!-- Brief description of changes -->

## Type of change
- [ ] Feature (new functionality)
- [ ] Bugfix (non-breaking fix)
- [ ] Release preparation
- [ ] Hotfix (critical production fix)
- [ ] Docs / refactor / chore

## Checklist
- [ ] I have followed the branch naming convention
- [ ] Tests pass locally (`pytest tests/ -v`)
- [ ] Linting passes (`ruff check .`)
- [ ] Docker build succeeds
- [ ] I have updated docs if needed
- [ ] No secrets or .env values committed

## Related issue
Closes #