### PR TITLE
Formalize skill manifests so authors can validate portable skill pack…

### DIFF
--- a/api/schemas.py
+++ b/api/schemas.py
@@ -637,6 +637,10 @@ class SkillRegistryData(BaseModel):
     token_budget: int | None = Field(
         default=None, description="Suggested token budget for the skill"
     )
+    test_suite_path: str | None = Field(
+        default=None,
+        description="Repository path to the skill validation suite, when declared.",
+    )
     triggers: list[str] = Field(
         default_factory=list, description="Filename or extension triggers"
     )

--- a/app.py
+++ b/app.py
@@ -35,6 +35,7 @@ from services.report_service import (
     fetch_shared_analysis_report,
     fetch_shared_report_comparison,
 )
+from services.skill_manifest_service import build_skill_manifest_v1_schema
 from ui.routes.dashboard import build_dashboard
 
 configure_logging()
@@ -127,6 +128,15 @@ def versioned_redoc_ui() -> HTMLResponse:
 def openapi_document() -> JSONResponse:
     """Expose the generated OpenAPI document for compatibility consumers."""
     return JSONResponse(content=fastapi_app.openapi())
+
+
+@fastapi_app.get("/schemas/skill-manifest-v1.json", include_in_schema=False)
+def skill_manifest_schema_document() -> JSONResponse:
+    """Publish the versioned skill manifest schema for author tooling."""
+    return JSONResponse(
+        content=build_skill_manifest_v1_schema(),
+        media_type="application/schema+json",
+    )
 
 
 def _shared_report_prompt_html(report_id: int, *, invalid_password: bool) -> str:

--- a/cli/analyze.py
+++ b/cli/analyze.py
@@ -18,6 +18,10 @@ from integrations.github.init_service import (
     run_github_init,
 )
 import llm.skill_context as skill_context_module
+from services.skill_manifest_service import (
+    SkillManifestValidationError,
+    load_skill_document,
+)
 from services.analysis_service import (
     analyze_uploaded_files,
     build_advisory_summary,
@@ -79,6 +83,33 @@ def _run_skills() -> int:
         mode_text = "override" if status.mode == "override" else "new"
         state_text = "detected" if status.active else "ignored"
         print(f"{status.name}: {mode_text} ({state_text})")
+    return 0
+
+
+def _run_skill_lint(path_arg: str) -> int:
+    path = Path(path_arg)
+    project_root = Path.cwd().resolve()
+    try:
+        document = load_skill_document(
+            path,
+            strict_manifest=True,
+            allow_legacy_name=False,
+            project_root=project_root,
+        )
+    except FileNotFoundError:
+        sys.stderr.write(f"Skill file not found: {path}\n")
+        return 2
+    except SkillManifestValidationError as exc:
+        sys.stderr.write(f"{path}: invalid skill manifest v1\n")
+        for issue in exc.issues:
+            sys.stderr.write(f"- {issue}\n")
+        return 2
+
+    assert document.manifest is not None
+    print(
+        f"{path}: valid skill manifest v1 "
+        f"({document.manifest.name}@{document.manifest.version})"
+    )
     return 0
 
 
@@ -199,6 +230,14 @@ def build_parser() -> argparse.ArgumentParser:
     subparsers = parser.add_subparsers(dest="command")
 
     subparsers.add_parser("skills", help="List built-in and custom AI skill statuses.")
+    skill_parser = subparsers.add_parser(
+        "skill", help="Authoring and package actions for individual skills."
+    )
+    skill_subparsers = skill_parser.add_subparsers(dest="skill_command")
+    skill_lint_parser = skill_subparsers.add_parser(
+        "lint", help="Validate a skill markdown file against manifest v1."
+    )
+    skill_lint_parser.add_argument("path", help="Skill markdown path to validate.")
 
     analyze_parser = subparsers.add_parser(
         "analyze", help="Run headless advisory analysis for one or more artifacts."
@@ -267,6 +306,8 @@ def main() -> None:
 
     if args.command == "skills":
         raise SystemExit(_run_skills())
+    if args.command == "skill" and args.skill_command == "lint":
+        raise SystemExit(_run_skill_lint(args.path))
     if args.command == "analyze":
         raise SystemExit(_run_analyze(args.paths))
     if args.command == "github" and args.github_command == "init":

--- a/docs/skills/authoring-guide.md
+++ b/docs/skills/authoring-guide.md
@@ -1,0 +1,85 @@
+# Skills Authoring Guide
+
+Story 4.2 formalizes the DeployWhisper skill manifest into a versioned v1
+contract. New community or local skills should use the v1 frontmatter shape even
+though the analysis runtime still tolerates older lightweight markdown files for
+backward compatibility.
+
+## Manifest v1
+
+Publish the schema at:
+
+- Filesystem: `schemas/skill-manifest-v1.json`
+- Runtime URL: `/schemas/skill-manifest-v1.json`
+
+Required frontmatter fields:
+
+- `name`: lowercase skill id. It must match the markdown filename stem.
+- `version`: semantic version such as `1.0.0`.
+- `author`: person, team, or organization that owns the skill.
+- `license`: distribution license identifier such as `MIT`.
+- `triggers`: filenames or extensions that activate the skill.
+- `token_budget`: positive integer budget for narrator context assembly.
+- `tags`: search/filter tags used by the registry and browser experiences.
+- `description`: short summary shown in registry and authoring surfaces.
+- `test_suite_path`: repo-relative path for the skill harness introduced by the
+  next story.
+
+Optional extension fields supported today:
+
+- `always_load`: include the skill even without trigger matches.
+- `tool`: explicit tool family for registry filtering when it differs from
+  `name`.
+- `trigger_content_patterns`: content markers for disambiguating shared
+  extensions such as `.yaml`.
+
+## Example
+
+```md
+---
+name: terraform
+version: 1.0.0
+author: DeployWhisper
+license: MIT
+triggers: [.tf, terraform-plan.json]
+token_budget: 1800
+tags: [terraform, iac, infrastructure]
+description: Deep Terraform risk knowledge for stateful infrastructure changes.
+test_suite_path: tests/skill-tests/terraform
+---
+
+## Critical risk patterns
+
+- RDS instance without deletion protection = CRITICAL
+- IAM policy with wildcard action/resource = CRITICAL
+```
+
+## Validation
+
+Use the CLI authoring check before opening a PR or copying a local skill into
+`skills/custom/`:
+
+```bash
+deploywhisper skill lint path/to/my-skill.md
+```
+
+Validation fails when:
+
+- required manifest fields are missing
+- the markdown body is empty after frontmatter stripping
+- `name` does not match the filename stem
+- `version` is not semantic version format
+- `token_budget` is not a positive integer
+- `test_suite_path` is absolute or escapes the repo with `..`
+- `test_suite_path` does not exist under the current repository root
+
+## Authoring rules
+
+- Keep the skill body focused on deterministic review guidance, not executable
+  steps.
+- Prefer explicit severity signals and concrete risk patterns over vague prose.
+- Keep sensitive examples synthetic; do not embed real credentials, internal
+  account ids, or production hostnames.
+- Treat `skills/custom/` as a local cache/override surface. Registry-facing
+  manifests should use the same v1 schema even if runtime loading can still read
+  older markdown.

--- a/llm/skill_context.py
+++ b/llm/skill_context.py
@@ -4,12 +4,16 @@ from __future__ import annotations
 
 from pathlib import Path
 import re
-from typing import Any, Literal
+from typing import Literal
 
 from pydantic import BaseModel, Field
-import yaml
 
 from analysis.risk_scorer import RiskAssessment
+from services.skill_manifest_service import (
+    SkillManifestValidationError,
+    load_skill_document,
+    parse_skill_document,
+)
 
 
 SKILLS_DIR = Path(__file__).resolve().parents[1] / "skills"
@@ -57,16 +61,21 @@ class CustomSkillStatus(BaseModel):
     )
 
 
-def _split_frontmatter(content: str) -> tuple[dict[str, Any], str]:
-    content = content.strip()
-    if content.startswith("---"):
-        parts = content.split("---", 2)
-        if len(parts) == 3:
-            frontmatter = yaml.safe_load(parts[1]) or {}
-            if not isinstance(frontmatter, dict):
-                frontmatter = {}
-            return frontmatter, parts[2].strip()
-    return {}, content.strip()
+def _metadata_list(raw_metadata: dict[str, object], key: str) -> list[str]:
+    raw_value = raw_metadata.get(key)
+    if raw_value is None:
+        return []
+    values = raw_value if isinstance(raw_value, list) else [raw_value]
+    normalized: list[str] = []
+    for value in values:
+        candidate = str(value).strip()
+        if candidate:
+            normalized.append(candidate)
+    return normalized
+
+
+def _metadata_bool(raw_metadata: dict[str, object], key: str) -> bool:
+    return bool(raw_metadata.get(key, False))
 
 
 def _skill_name_from_path(path: Path) -> str | None:
@@ -79,17 +88,15 @@ def _skill_name_from_path(path: Path) -> str | None:
 def _read_skill_file(path: Path) -> str | None:
     if not path.exists():
         return None
-    _, content = _split_frontmatter(path.read_text(encoding="utf-8"))
-    return content or None
-
-
-def _read_skill_definition(path: Path) -> tuple[dict[str, Any], str] | None:
-    if not path.exists():
+    try:
+        document = load_skill_document(
+            path,
+            strict_manifest=False,
+            allow_legacy_name=True,
+        )
+    except SkillManifestValidationError:
         return None
-    metadata, content = _split_frontmatter(path.read_text(encoding="utf-8"))
-    if not content:
-        return None
-    return metadata, content
+    return document.body
 
 
 def _iter_skill_files(directory: Path) -> list[Path]:
@@ -104,51 +111,73 @@ def get_active_skills() -> dict[str, ActiveSkill]:
 
     for path in _iter_skill_files(SKILLS_DIR):
         name = _skill_name_from_path(path)
-        definition = _read_skill_definition(path)
-        if not name or not definition:
+        if not name:
             continue
-        metadata, content = definition
+        try:
+            document = load_skill_document(
+                path,
+                strict_manifest=False,
+                allow_legacy_name=True,
+            )
+        except SkillManifestValidationError:
+            continue
+        metadata = document.manifest
         active[name] = ActiveSkill(
             name=name,
             source="built-in",
             path=str(path),
-            content=content,
-            always_load=bool(metadata.get("always_load", False)),
-            triggers=[
-                str(item).strip()
-                for item in metadata.get("triggers", [])
-                if str(item).strip()
-            ],
-            trigger_content_patterns=[
-                str(item).strip()
-                for item in metadata.get("trigger_content_patterns", [])
-                if str(item).strip()
-            ],
+            content=document.body,
+            always_load=(
+                bool(metadata.always_load)
+                if metadata
+                else _metadata_bool(document.raw_metadata, "always_load")
+            ),
+            triggers=(
+                list(metadata.triggers)
+                if metadata
+                else _metadata_list(document.raw_metadata, "triggers")
+            ),
+            trigger_content_patterns=(
+                list(metadata.trigger_content_patterns)
+                if metadata
+                else _metadata_list(document.raw_metadata, "trigger_content_patterns")
+            ),
         )
 
     for path in _iter_skill_files(CUSTOM_DIR):
         name = _skill_name_from_path(path)
-        definition = _read_skill_definition(path)
-        if not name or not definition:
+        if not name:
             continue
-        metadata, content = definition
+        try:
+            document = load_skill_document(
+                path,
+                strict_manifest=False,
+                allow_legacy_name=True,
+            )
+        except SkillManifestValidationError:
+            continue
+        metadata = document.manifest
         source = "custom-override" if name in active else "custom-new"
         active[name] = ActiveSkill(
             name=name,
             source=source,
             path=str(path),
-            content=content,
-            always_load=bool(metadata.get("always_load", False)),
-            triggers=[
-                str(item).strip()
-                for item in metadata.get("triggers", [])
-                if str(item).strip()
-            ],
-            trigger_content_patterns=[
-                str(item).strip()
-                for item in metadata.get("trigger_content_patterns", [])
-                if str(item).strip()
-            ],
+            content=document.body,
+            always_load=(
+                bool(metadata.always_load)
+                if metadata
+                else _metadata_bool(document.raw_metadata, "always_load")
+            ),
+            triggers=(
+                list(metadata.triggers)
+                if metadata
+                else _metadata_list(document.raw_metadata, "triggers")
+            ),
+            trigger_content_patterns=(
+                list(metadata.trigger_content_patterns)
+                if metadata
+                else _metadata_list(document.raw_metadata, "trigger_content_patterns")
+            ),
         )
 
     return active
@@ -168,16 +197,30 @@ def get_custom_skill_statuses() -> list[CustomSkillStatus]:
         name = _skill_name_from_path(path)
         if not name:
             continue
-        content = _read_skill_file(path)
+        warning = None
+        try:
+            document = load_skill_document(
+                path,
+                strict_manifest=False,
+                allow_legacy_name=True,
+            )
+            content = document.body
+        except SkillManifestValidationError as exc:
+            content = None
+            warning = exc.issues[0]
         statuses.append(
             CustomSkillStatus(
                 name=name,
                 mode="override" if name in built_in_names else "new",
                 active=content is not None,
                 path=str(path),
-                warning=None
-                if content
-                else "Custom skill file is empty after frontmatter stripping.",
+                warning=warning
+                if warning is not None
+                else (
+                    None
+                    if content
+                    else "Custom skill file is empty after frontmatter stripping."
+                ),
             )
         )
     return statuses
@@ -193,8 +236,16 @@ def save_custom_skill(filename: str, raw_text: str) -> CustomSkillStatus:
     if not skill_name:
         raise ValueError("Custom skill filename must include a skill name.")
 
-    _, stripped = _split_frontmatter(raw_text)
-    if not stripped:
+    try:
+        document = parse_skill_document(
+            raw_text,
+            expected_name=skill_name,
+            strict_manifest=False,
+            allow_legacy_name=True,
+        )
+    except SkillManifestValidationError as exc:
+        raise ValueError(str(exc)) from exc
+    if not document.body:
         raise ValueError("Custom skill content cannot be empty.")
 
     CUSTOM_DIR.mkdir(parents=True, exist_ok=True)

--- a/schemas/skill-manifest-v1.json
+++ b/schemas/skill-manifest-v1.json
@@ -1,0 +1,100 @@
+{
+  "$id": "/schemas/skill-manifest-v1.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "description": "Versioned skill manifest contract.",
+  "properties": {
+    "always_load": {
+      "default": false,
+      "description": "Whether the runtime should always include this skill.",
+      "title": "Always Load",
+      "type": "boolean"
+    },
+    "author": {
+      "description": "Skill author or owner.",
+      "title": "Author",
+      "type": "string"
+    },
+    "description": {
+      "description": "Short summary of the skill.",
+      "title": "Description",
+      "type": "string"
+    },
+    "license": {
+      "description": "Distribution license identifier.",
+      "title": "License",
+      "type": "string"
+    },
+    "name": {
+      "description": "Stable lowercase skill identifier.",
+      "title": "Name",
+      "type": "string"
+    },
+    "tags": {
+      "description": "Search and categorization tags.",
+      "items": {
+        "type": "string"
+      },
+      "title": "Tags",
+      "type": "array"
+    },
+    "test_suite_path": {
+      "description": "Repo-relative path to the skill validation suite.",
+      "title": "Test Suite Path",
+      "type": "string"
+    },
+    "token_budget": {
+      "description": "Suggested token budget for this skill.",
+      "minimum": 1,
+      "title": "Token Budget",
+      "type": "integer"
+    },
+    "tool": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "description": "Optional explicit tool family for registry filtering.",
+      "title": "Tool"
+    },
+    "trigger_content_patterns": {
+      "description": "Optional content markers for trigger disambiguation.",
+      "items": {
+        "type": "string"
+      },
+      "title": "Trigger Content Patterns",
+      "type": "array"
+    },
+    "triggers": {
+      "description": "Filename and extension triggers for loading the skill.",
+      "items": {
+        "type": "string"
+      },
+      "title": "Triggers",
+      "type": "array"
+    },
+    "version": {
+      "description": "Semantic version for the skill.",
+      "title": "Version",
+      "type": "string"
+    }
+  },
+  "required": [
+    "name",
+    "version",
+    "author",
+    "license",
+    "triggers",
+    "token_budget",
+    "tags",
+    "description",
+    "test_suite_path"
+  ],
+  "title": "SkillManifestV1",
+  "type": "object"
+}

--- a/services/skill_manifest_service.py
+++ b/services/skill_manifest_service.py
@@ -1,0 +1,284 @@
+"""Shared skill manifest parsing and validation."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import re
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field, ValidationError, field_validator
+import yaml
+from yaml import YAMLError
+
+
+_SKILL_NAME_PATTERN = re.compile(r"^[a-z0-9]+(?:-[a-z0-9]+)*$")
+_SEMVER_PATTERN = re.compile(r"^\d+\.\d+\.\d+$")
+
+
+class SkillManifestValidationError(ValueError):
+    """Raised when skill frontmatter or body validation fails."""
+
+    def __init__(self, issues: list[str]):
+        self.issues = issues
+        super().__init__("\n".join(issues))
+
+
+class SkillManifestV1(BaseModel):
+    """Versioned skill manifest contract."""
+
+    model_config = ConfigDict(extra="forbid", str_strip_whitespace=True)
+
+    name: str = Field(..., description="Stable lowercase skill identifier.")
+    version: str = Field(..., description="Semantic version for the skill.")
+    author: str = Field(..., description="Skill author or owner.")
+    license: str = Field(..., description="Distribution license identifier.")
+    triggers: list[str] = Field(
+        ...,
+        description="Filename and extension triggers for loading the skill.",
+    )
+    token_budget: int = Field(
+        ..., ge=1, description="Suggested token budget for this skill."
+    )
+    tags: list[str] = Field(..., description="Search and categorization tags.")
+    description: str = Field(..., description="Short summary of the skill.")
+    test_suite_path: str = Field(
+        ..., description="Repo-relative path to the skill validation suite."
+    )
+    always_load: bool = Field(
+        default=False,
+        description="Whether the runtime should always include this skill.",
+    )
+    tool: str | None = Field(
+        default=None,
+        description="Optional explicit tool family for registry filtering.",
+    )
+    trigger_content_patterns: list[str] = Field(
+        default_factory=list,
+        description="Optional content markers for trigger disambiguation.",
+    )
+
+    @field_validator("name")
+    @classmethod
+    def _validate_name(cls, value: str) -> str:
+        normalized = value.strip().lower()
+        if not _SKILL_NAME_PATTERN.fullmatch(normalized):
+            raise ValueError("must use lowercase letters, digits, and hyphens only")
+        return normalized
+
+    @field_validator("version")
+    @classmethod
+    def _validate_version(cls, value: str) -> str:
+        normalized = value.strip()
+        if not _SEMVER_PATTERN.fullmatch(normalized):
+            raise ValueError("must use semantic version format (for example 1.0.0)")
+        return normalized
+
+    @field_validator("author", "license", "description", "test_suite_path")
+    @classmethod
+    def _validate_non_empty_string(cls, value: str) -> str:
+        normalized = value.strip()
+        if not normalized:
+            raise ValueError("must not be empty")
+        return normalized
+
+    @field_validator("test_suite_path")
+    @classmethod
+    def _validate_test_suite_path(cls, value: str) -> str:
+        normalized = value.strip()
+        path = Path(normalized)
+        if path.is_absolute():
+            raise ValueError("must be a relative repository path")
+        if ".." in path.parts:
+            raise ValueError("must not traverse outside the repository")
+        return normalized
+
+    @field_validator("triggers", "tags", "trigger_content_patterns")
+    @classmethod
+    def _validate_string_list(cls, value: list[str]) -> list[str]:
+        normalized: list[str] = []
+        seen: set[str] = set()
+        for item in value:
+            candidate = str(item).strip()
+            if not candidate:
+                raise ValueError("must not contain empty values")
+            key = candidate.lower()
+            if key in seen:
+                continue
+            seen.add(key)
+            normalized.append(candidate)
+        return normalized
+
+    @field_validator("triggers")
+    @classmethod
+    def _validate_triggers_not_empty(cls, value: list[str]) -> list[str]:
+        if not value:
+            raise ValueError("must include at least one trigger")
+        return value
+
+    @field_validator("tool")
+    @classmethod
+    def _validate_tool(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
+        normalized = value.strip().lower()
+        return normalized or None
+
+
+class SkillDocument(BaseModel):
+    """Parsed skill document with normalized manifest metadata."""
+
+    manifest: SkillManifestV1 | None = None
+    body: str = Field(..., description="Markdown body without frontmatter.")
+    raw_metadata: dict[str, Any] = Field(default_factory=dict)
+    had_frontmatter: bool = Field(
+        default=False, description="Whether the source file included YAML frontmatter."
+    )
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def build_skill_manifest_v1_schema() -> dict[str, Any]:
+    """Return the published JSON Schema payload for skill manifest v1."""
+
+    schema = SkillManifestV1.model_json_schema()
+    schema["$schema"] = "https://json-schema.org/draft/2020-12/schema"
+    schema["$id"] = "/schemas/skill-manifest-v1.json"
+    return schema
+
+
+def _validate_test_suite_path_exists(
+    value: str,
+    *,
+    project_root: Path | None,
+) -> None:
+    if project_root is None:
+        return
+    candidate = (project_root / value).resolve()
+    try:
+        candidate.relative_to(project_root.resolve())
+    except ValueError as exc:
+        raise SkillManifestValidationError(
+            ["test_suite_path: must resolve inside the repository root"]
+        ) from exc
+    if not candidate.exists():
+        raise SkillManifestValidationError(
+            [f"test_suite_path: path does not exist: {value}"]
+        )
+
+
+def split_frontmatter(raw_text: str) -> tuple[dict[str, Any], str, bool]:
+    """Split YAML frontmatter from markdown content."""
+    stripped = raw_text.strip()
+    if stripped.startswith("---"):
+        parts = stripped.split("---", 2)
+        if len(parts) == 3:
+            try:
+                metadata = yaml.safe_load(parts[1]) or {}
+            except YAMLError as exc:  # noqa: PERF203
+                raise SkillManifestValidationError(
+                    [f"Invalid YAML frontmatter: {exc}"]
+                ) from exc
+            if not isinstance(metadata, dict):
+                raise SkillManifestValidationError(
+                    ["Skill frontmatter must decode to a YAML object."]
+                )
+            return metadata, parts[2].strip(), True
+    return {}, stripped, False
+
+
+def _format_validation_errors(exc: ValidationError) -> list[str]:
+    issues: list[str] = []
+    for error in exc.errors():
+        location = ".".join(str(part) for part in error["loc"])
+        issues.append(f"{location}: {error['msg']}")
+    return issues
+
+
+def parse_skill_document(
+    raw_text: str,
+    *,
+    expected_name: str | None = None,
+    strict_manifest: bool = False,
+    allow_legacy_name: bool = False,
+    project_root: Path | None = None,
+) -> SkillDocument:
+    """Parse a skill markdown document and optionally validate v1 frontmatter."""
+
+    metadata, body, had_frontmatter = split_frontmatter(raw_text)
+    if not body:
+        raise SkillManifestValidationError(
+            ["Skill markdown body must not be empty after frontmatter stripping."]
+        )
+
+    if not had_frontmatter:
+        if strict_manifest:
+            raise SkillManifestValidationError(
+                ["Skill manifest frontmatter is required for manifest v1 validation."]
+            )
+        return SkillDocument(
+            manifest=None,
+            body=body,
+            raw_metadata=metadata,
+            had_frontmatter=False,
+        )
+
+    manifest_payload = dict(metadata)
+    if (
+        allow_legacy_name
+        and "name" not in manifest_payload
+        and "skill" in manifest_payload
+    ):
+        manifest_payload["name"] = manifest_payload["skill"]
+
+    try:
+        manifest = SkillManifestV1.model_validate(manifest_payload)
+    except ValidationError as exc:
+        if strict_manifest:
+            raise SkillManifestValidationError(_format_validation_errors(exc)) from exc
+        return SkillDocument(
+            manifest=None,
+            body=body,
+            raw_metadata=metadata,
+            had_frontmatter=True,
+        )
+
+    if expected_name is not None:
+        normalized_expected = expected_name.strip().lower()
+        if manifest.name != normalized_expected:
+            raise SkillManifestValidationError(
+                [
+                    "name: must match the markdown filename stem "
+                    f"('{normalized_expected}')"
+                ]
+            )
+    if strict_manifest:
+        _validate_test_suite_path_exists(
+            manifest.test_suite_path,
+            project_root=project_root,
+        )
+
+    return SkillDocument(
+        manifest=manifest,
+        body=body,
+        raw_metadata=metadata,
+        had_frontmatter=True,
+    )
+
+
+def load_skill_document(
+    path: Path,
+    *,
+    strict_manifest: bool = False,
+    allow_legacy_name: bool = False,
+    project_root: Path | None = None,
+) -> SkillDocument:
+    """Load and parse a skill markdown file from disk."""
+
+    return parse_skill_document(
+        path.read_text(encoding="utf-8"),
+        expected_name=path.stem.strip().lower(),
+        strict_manifest=strict_manifest,
+        allow_legacy_name=allow_legacy_name,
+        project_root=project_root,
+    )

--- a/services/skill_registry_service.py
+++ b/services/skill_registry_service.py
@@ -8,9 +8,8 @@ import re
 from typing import Any, Literal
 
 from pydantic import BaseModel, Field
-import yaml
-from yaml import YAMLError
 
+from services.skill_manifest_service import REPO_ROOT, load_skill_document
 
 SKILLS_DIR = Path(__file__).resolve().parents[1] / "skills"
 CUSTOM_DIR = SKILLS_DIR / "custom"
@@ -31,6 +30,9 @@ class SkillRegistryEntry(BaseModel):
     tags: list[str] = Field(default_factory=list, description="Searchable skill tags")
     token_budget: int | None = Field(
         default=None, description="Suggested token budget for the skill"
+    )
+    test_suite_path: str | None = Field(
+        default=None, description="Repository path to the skill validation suite"
     )
     triggers: list[str] = Field(
         default_factory=list, description="Filename or extension triggers"
@@ -72,30 +74,11 @@ class _SkillRecord(BaseModel):
     tool: str
     tags: list[str] = Field(default_factory=list)
     token_budget: int | None = None
+    test_suite_path: str | None = None
     triggers: list[str] = Field(default_factory=list)
     trigger_content_patterns: list[str] = Field(default_factory=list)
     updated_at: str
     updated_at_epoch: float
-
-
-class _ParsedSkillFile(BaseModel):
-    metadata: dict[str, Any] = Field(default_factory=dict)
-    content: str = Field(..., description="Markdown body without frontmatter")
-
-
-def _split_frontmatter(content: str) -> _ParsedSkillFile | None:
-    stripped = content.strip()
-    if stripped.startswith("---"):
-        parts = stripped.split("---", 2)
-        if len(parts) == 3:
-            try:
-                frontmatter = yaml.safe_load(parts[1]) or {}
-            except YAMLError:
-                return None
-            if not isinstance(frontmatter, dict):
-                frontmatter = {}
-            return _ParsedSkillFile(metadata=frontmatter, content=parts[2].strip())
-    return _ParsedSkillFile(metadata={}, content=stripped)
 
 
 def _iter_skill_files(directory: Path) -> list[Path]:
@@ -114,63 +97,19 @@ def _normalize_skill_id(raw_value: str | None, path: Path) -> str:
     return normalized or path.stem.strip().lower()
 
 
-def _normalize_string_list(raw_value: Any) -> list[str]:
-    if raw_value is None:
-        return []
-    items = raw_value if isinstance(raw_value, list) else [raw_value]
-    normalized: list[str] = []
-    seen: set[str] = set()
-    for item in items:
-        value = str(item).strip()
-        if not value:
-            continue
-        key = value.lower()
-        if key in seen:
-            continue
-        seen.add(key)
-        normalized.append(value)
-    return normalized
-
-
-def _normalize_token_budget(raw_value: Any) -> int | None:
-    if raw_value in {None, ""}:
-        return None
-    try:
-        return int(raw_value)
-    except (TypeError, ValueError):
-        return None
-
-
-def _extract_description(metadata: dict[str, Any], content: str) -> str:
-    description = str(metadata.get("description") or "").strip()
-    if description:
-        return description
-    for line in content.splitlines():
-        candidate = line.strip()
-        if not candidate or candidate.startswith("#"):
-            continue
-        return candidate
-    return "No description provided."
-
-
 def _default_author(source: SkillSource) -> str:
     if source == "built-in":
         return "DeployWhisper"
     return "Local custom skill"
 
 
-def _default_tool(metadata: dict[str, Any], skill_id: str) -> str:
-    for key in ("tool_type", "tool"):
-        value = str(metadata.get(key) or "").strip().lower()
-        if value:
-            return value
+def _default_tool(tool: str | None, skill_id: str) -> str:
+    if tool:
+        return tool
     return skill_id
 
 
-def _display_name(metadata: dict[str, Any], skill_id: str) -> str:
-    explicit = str(metadata.get("name") or "").strip()
-    if explicit:
-        return explicit
+def _display_name(skill_id: str) -> str:
     return skill_id.replace("-", " ").title()
 
 
@@ -215,6 +154,7 @@ def _record_to_entry(
         "tool": record.tool,
         "tags": list(record.tags),
         "token_budget": record.token_budget,
+        "test_suite_path": record.test_suite_path,
         "triggers": list(record.triggers),
         "trigger_content_patterns": list(record.trigger_content_patterns),
         "updated_at": record.updated_at,
@@ -226,33 +166,37 @@ def _record_to_entry(
 
 
 def _load_skill_record(path: Path, *, source: SkillSource) -> _SkillRecord | None:
-    raw_content = path.read_text(encoding="utf-8")
-    parsed = _split_frontmatter(raw_content)
-    if parsed is None or not parsed.content:
+    try:
+        parsed = load_skill_document(
+            path,
+            strict_manifest=True,
+            allow_legacy_name=False,
+            project_root=REPO_ROOT,
+        )
+    except ValueError:
+        return None
+    if parsed.manifest is None:
         return None
 
     skill_id = _normalize_skill_id(
-        parsed.metadata.get("skill") or parsed.metadata.get("name"),
+        parsed.manifest.name,
         path,
     )
     updated_at, updated_epoch = _updated_at(path)
     return _SkillRecord(
         id=skill_id,
-        name=_display_name(parsed.metadata, skill_id),
-        version=str(parsed.metadata.get("version") or "1.0"),
+        name=_display_name(skill_id),
+        version=parsed.manifest.version,
         source=source,
-        author=str(parsed.metadata.get("author") or _default_author(source)),
-        license=str(parsed.metadata.get("license")).strip() or None
-        if parsed.metadata.get("license") is not None
-        else None,
-        description=_extract_description(parsed.metadata, parsed.content),
-        tool=_default_tool(parsed.metadata, skill_id),
-        tags=_normalize_string_list(parsed.metadata.get("tags")),
-        token_budget=_normalize_token_budget(parsed.metadata.get("token_budget")),
-        triggers=_normalize_string_list(parsed.metadata.get("triggers")),
-        trigger_content_patterns=_normalize_string_list(
-            parsed.metadata.get("trigger_content_patterns")
-        ),
+        author=parsed.manifest.author or _default_author(source),
+        license=parsed.manifest.license or None,
+        description=parsed.manifest.description,
+        tool=_default_tool(parsed.manifest.tool, skill_id),
+        tags=list(parsed.manifest.tags),
+        token_budget=parsed.manifest.token_budget,
+        test_suite_path=parsed.manifest.test_suite_path,
+        triggers=list(parsed.manifest.triggers),
+        trigger_content_patterns=list(parsed.manifest.trigger_content_patterns),
         updated_at=updated_at,
         updated_at_epoch=updated_epoch,
     )

--- a/skills/ansible.md
+++ b/skills/ansible.md
@@ -1,10 +1,14 @@
 ---
-skill: ansible
-version: 1.0
+name: ansible
+version: 1.0.0
+author: DeployWhisper
+license: MIT
 triggers: [.yml, .yaml]
-trigger_content_patterns: [hosts, tasks, roles, become, ansible, playbook, handlers]
 token_budget: 1600
+tags: [ansible, automation, iac]
 description: Deep Ansible operational knowledge covering dangerous module classification, idempotency violations, inventory targeting risks, privilege escalation patterns, and handler ordering pitfalls.
+test_suite_path: tests/skill-tests/ansible
+trigger_content_patterns: [hosts, tasks, roles, become, ansible, playbook, handlers]
 ---
 
 ## Dangerous module classification

--- a/skills/cloudformation.md
+++ b/skills/cloudformation.md
@@ -1,10 +1,14 @@
 ---
-skill: cloudformation
-version: 1.0
+name: cloudformation
+version: 1.0.0
+author: DeployWhisper
+license: MIT
 triggers: [.yaml, .yml, .json, .template]
-trigger_content_patterns: [AWSTemplateFormatVersion, Resources, AWS::, CloudFormation]
 token_budget: 1500
+tags: [cloudformation, aws, iac]
 description: Deep CloudFormation risk intelligence covering resource replacement detection, deletion policies, drift patterns, stack dependencies, IAM resource risks, and service quota awareness.
+test_suite_path: tests/skill-tests/cloudformation
+trigger_content_patterns: [AWSTemplateFormatVersion, Resources, AWS::, CloudFormation]
 ---
 
 ## Resource update behavior

--- a/skills/custom/README.md
+++ b/skills/custom/README.md
@@ -12,10 +12,15 @@ placing a `terraform.md` here will replace the built-in Terraform skill entirely
 # Create a custom skill for your internal modules
 cat > terraform.md << 'EOF'
 ---
-skill: terraform
-version: 1.0
+name: terraform
+version: 1.0.0
+author: Platform Team
+license: Proprietary
 triggers: [.tf, .tfvars]
 token_budget: 500
+tags: [terraform, internal, platform]
+description: Internal Terraform guidance for the platform team.
+test_suite_path: tests/skill-tests/terraform
 ---
 
 ## Internal module patterns
@@ -36,10 +41,15 @@ You can create skills for tools not covered by the built-in set:
 ```bash
 cat > helm.md << 'EOF'
 ---
-skill: helm
-version: 1.0
+name: helm
+version: 1.0.0
+author: Platform Team
+license: Proprietary
 triggers: [Chart.yaml, values.yaml, .tpl]
 token_budget: 800
+tags: [helm, kubernetes, platform]
+description: Helm chart review guidance for team-owned charts.
+test_suite_path: tests/skill-tests/helm
 ---
 
 ## Helm chart risks
@@ -57,10 +67,20 @@ when matching file extensions are detected in the upload.
 
 | Field | Required | Description |
 |-------|----------|-------------|
-| `skill` | Yes | Skill identifier (lowercase, no spaces) |
+| `name` | Yes | Skill identifier (lowercase, filename stem must match) |
 | `version` | Yes | Skill version for tracking changes |
+| `author` | Yes | Owner label for registry and attribution |
+| `license` | Yes | Distribution license identifier |
 | `triggers` | Yes | File extensions or names that activate this skill |
-| `token_budget` | No | Max tokens for this skill (default: 1500) |
-| `description` | No | Human-readable description |
+| `token_budget` | Yes | Max tokens allocated to the skill |
+| `tags` | Yes | Search/filter tags |
+| `description` | Yes | Human-readable description |
+| `test_suite_path` | Yes | Repo-relative path for the skill test suite |
 | `always_load` | No | If true, loads regardless of file detection |
 | `trigger_content_patterns` | No | Strings to look for inside files for disambiguation |
+
+Validate a manifest before sharing it:
+
+```bash
+deploywhisper skill lint skills/custom/terraform.md
+```

--- a/skills/docker.md
+++ b/skills/docker.md
@@ -1,9 +1,13 @@
 ---
-skill: docker
-version: 1.0
+name: docker
+version: 1.0.0
+author: DeployWhisper
+license: MIT
 triggers: [Dockerfile, dockerfile, .dockerfile, docker-compose.yml, docker-compose.yaml, compose.yml, compose.yaml]
 token_budget: 1200
+tags: [docker, containers, supply-chain]
 description: Container image and build risk knowledge covering Dockerfile security patterns, image provenance, multi-stage build risks, compose file analysis, and runtime container security.
+test_suite_path: tests/skill-tests/docker
 ---
 
 ## Dockerfile risk patterns

--- a/skills/git.md
+++ b/skills/git.md
@@ -1,10 +1,14 @@
 ---
-skill: git
-version: 1.0
+name: git
+version: 1.0.0
+author: DeployWhisper
+license: MIT
 triggers: [.diff, .patch, .gitdiff]
-always_load: true
 token_budget: 1200
+tags: [git, diff, review]
 description: Git-based change context intelligence covering commit analysis, sensitive file detection, branch risk signals, author patterns, and co-change analysis. This skill is always loaded because Git context enriches every other tool's analysis.
+test_suite_path: tests/skill-tests/git
+always_load: true
 ---
 
 ## Sensitive file detection

--- a/skills/jenkins.md
+++ b/skills/jenkins.md
@@ -1,10 +1,14 @@
 ---
-skill: jenkins
-version: 1.0
+name: jenkins
+version: 1.0.0
+author: DeployWhisper
+license: MIT
 triggers: [Jenkinsfile, .jenkinsfile, jenkins.groovy]
-trigger_content_patterns: [pipeline, stage, agent, steps, post, input, parallel]
 token_budget: 1400
+tags: [jenkins, ci-cd, pipelines]
 description: Deep Jenkins pipeline safety knowledge covering approval gate analysis, credential exposure patterns, agent security, deployment stage risks, and shared library vulnerabilities.
+test_suite_path: tests/skill-tests/jenkins
+trigger_content_patterns: [pipeline, stage, agent, steps, post, input, parallel]
 ---
 
 ## Approval gate analysis

--- a/skills/kubernetes.md
+++ b/skills/kubernetes.md
@@ -1,10 +1,14 @@
 ---
-skill: kubernetes
-version: 1.0
+name: kubernetes
+version: 1.0.0
+author: DeployWhisper
+license: MIT
 triggers: [.yaml, .yml]
-trigger_content_patterns: [apiVersion, kind, metadata, spec.containers, spec.replicas]
 token_budget: 1800
+tags: [kubernetes, containers, orchestration]
 description: Deep Kubernetes operational knowledge covering workload safety, rolling update risks, RBAC escalation, network policy gaps, and resource management pitfalls.
+test_suite_path: tests/skill-tests/kubernetes
+trigger_content_patterns: [apiVersion, kind, metadata, spec.containers, spec.replicas]
 ---
 
 ## Critical risk patterns

--- a/skills/terraform.md
+++ b/skills/terraform.md
@@ -1,9 +1,13 @@
 ---
-skill: terraform
-version: 1.0
+name: terraform
+version: 1.0.0
+author: DeployWhisper
+license: MIT
 triggers: [.tf, .tfvars, .tfvars.json, terraform-plan.json, tfplan.json]
 token_budget: 1800
+tags: [terraform, iac, infrastructure]
 description: Deep Terraform risk knowledge covering provider-specific patterns, state operations, lifecycle rules, and common failure modes across AWS, GCP, and Azure.
+test_suite_path: tests/skill-tests/terraform
 ---
 
 ## Critical risk patterns

--- a/tests/skill-tests/ansible/README.md
+++ b/tests/skill-tests/ansible/README.md
@@ -1,0 +1,4 @@
+# Ansible Skill Test Placeholder
+
+Story 4.2 reserves this path for the Ansible skill harness cases that will land
+with Story 4.3.

--- a/tests/skill-tests/cloudformation/README.md
+++ b/tests/skill-tests/cloudformation/README.md
@@ -1,0 +1,4 @@
+# CloudFormation Skill Test Placeholder
+
+Story 4.2 reserves this path for the CloudFormation skill harness cases that
+will land with Story 4.3.

--- a/tests/skill-tests/docker/README.md
+++ b/tests/skill-tests/docker/README.md
@@ -1,0 +1,4 @@
+# Docker Skill Test Placeholder
+
+Story 4.2 reserves this path for the Docker skill harness cases that will land
+with Story 4.3.

--- a/tests/skill-tests/git/README.md
+++ b/tests/skill-tests/git/README.md
@@ -1,0 +1,4 @@
+# Git Skill Test Placeholder
+
+Story 4.2 reserves this path for the Git skill harness cases that will land with
+Story 4.3.

--- a/tests/skill-tests/helm/README.md
+++ b/tests/skill-tests/helm/README.md
@@ -1,0 +1,4 @@
+# Helm Skill Test Placeholder
+
+Story 4.2 reserves this path for example and local Helm skill harness cases that
+will land with Story 4.3.

--- a/tests/skill-tests/jenkins/README.md
+++ b/tests/skill-tests/jenkins/README.md
@@ -1,0 +1,4 @@
+# Jenkins Skill Test Placeholder
+
+Story 4.2 reserves this path for the Jenkins skill harness cases that will land
+with Story 4.3.

--- a/tests/skill-tests/kubernetes/README.md
+++ b/tests/skill-tests/kubernetes/README.md
@@ -1,0 +1,4 @@
+# Kubernetes Skill Test Placeholder
+
+Story 4.2 reserves this path for the Kubernetes skill harness cases that will
+land with Story 4.3.

--- a/tests/skill-tests/terraform/README.md
+++ b/tests/skill-tests/terraform/README.md
@@ -1,0 +1,4 @@
+# Terraform Skill Test Placeholder
+
+Story 4.2 reserves this path for the Terraform skill harness cases that will
+land with Story 4.3.

--- a/tests/test_api/test_skills.py
+++ b/tests/test_api/test_skills.py
@@ -41,12 +41,14 @@ class SkillsApiTests(unittest.TestCase):
     def test_list_skills_returns_paginated_filtered_metadata(self) -> None:
         (self.skills_dir / "terraform.md").write_text(
             "---\n"
-            "skill: terraform\n"
+            "name: terraform\n"
             "version: 1.0.0\n"
             "author: DeployWhisper\n"
-            "tool_type: terraform\n"
+            "license: MIT\n"
             "tags: [iac, security]\n"
             "description: Terraform registry skill.\n"
+            "test_suite_path: tests/skill-tests/terraform\n"
+            "token_budget: 1200\n"
             "triggers: [.tf]\n"
             "---\n"
             "# Terraform\nDetails\n",
@@ -54,12 +56,15 @@ class SkillsApiTests(unittest.TestCase):
         )
         (self.skills_dir / "kubernetes.md").write_text(
             "---\n"
-            "skill: kubernetes\n"
+            "name: kubernetes\n"
             "version: 2.0.0\n"
             "author: Platform Team\n"
-            "tool_type: kubernetes\n"
+            "license: MIT\n"
             "tags: [cluster]\n"
             "description: Kubernetes rollout checks.\n"
+            "test_suite_path: tests/skill-tests/kubernetes\n"
+            "token_budget: 900\n"
+            "triggers: [.yaml]\n"
             "---\n"
             "# Kubernetes\nDetails\n",
             encoding="utf-8",
@@ -93,29 +98,40 @@ class SkillsApiTests(unittest.TestCase):
         self.assertEqual(payload["meta"]["total_count"], 1)
         self.assertEqual(payload["meta"]["filters"]["tool"], "terraform")
         self.assertEqual(payload["data"][0]["id"], "terraform")
+        self.assertEqual(payload["data"][0]["name"], "Terraform")
         self.assertEqual(payload["data"][0]["tool"], "terraform")
+        self.assertEqual(
+            payload["data"][0]["test_suite_path"], "tests/skill-tests/terraform"
+        )
         self.assertEqual(payload["data"][0]["triggers"], [".tf"])
 
     def test_get_skill_and_versions_return_effective_skill_and_history(self) -> None:
         (self.skills_dir / "terraform.md").write_text(
             "---\n"
-            "skill: terraform\n"
+            "name: terraform\n"
             "version: 1.0.0\n"
             "author: DeployWhisper\n"
-            "tool_type: terraform\n"
+            "license: MIT\n"
             "description: Built-in terraform checks.\n"
+            "test_suite_path: tests/skill-tests/terraform\n"
+            "token_budget: 1200\n"
+            "triggers: [.tf]\n"
+            "tags: [iac]\n"
             "---\n"
             "# Terraform\nBuilt-in guidance.\n",
             encoding="utf-8",
         )
         (self.custom_dir / "terraform.md").write_text(
             "---\n"
-            "skill: terraform\n"
+            "name: terraform\n"
             "version: 1.3.0\n"
             "author: Team Ops\n"
-            "tool_type: terraform\n"
+            "license: Proprietary\n"
             "tags: [private]\n"
             "description: Team override.\n"
+            "test_suite_path: tests/skill-tests/terraform\n"
+            "token_budget: 1200\n"
+            "triggers: [.tf]\n"
             "---\n"
             "# Terraform\nCustom guidance.\n",
             encoding="utf-8",
@@ -137,6 +153,7 @@ class SkillsApiTests(unittest.TestCase):
         self.assertEqual(detail_response.status_code, 200)
         detail_payload = detail_response.json()
         self.assertEqual(detail_payload["data"]["source"], "built-in")
+        self.assertEqual(detail_payload["data"]["name"], "Terraform")
         self.assertEqual(detail_payload["data"]["available_versions"], 1)
         self.assertEqual(detail_payload["meta"]["id"], "terraform")
 
@@ -150,22 +167,30 @@ class SkillsApiTests(unittest.TestCase):
     def test_registry_api_ignores_local_custom_cache_entries(self) -> None:
         (self.skills_dir / "terraform.md").write_text(
             "---\n"
-            "skill: terraform\n"
+            "name: terraform\n"
             "version: 1.0.0\n"
             "author: DeployWhisper\n"
-            "tool_type: terraform\n"
+            "license: MIT\n"
             "description: Built-in terraform checks.\n"
+            "test_suite_path: tests/skill-tests/terraform\n"
+            "token_budget: 1200\n"
+            "triggers: [.tf]\n"
+            "tags: [iac]\n"
             "---\n"
             "# Terraform\nBuilt-in guidance.\n",
             encoding="utf-8",
         )
         (self.custom_dir / "terraform.md").write_text(
             "---\n"
-            "skill: terraform\n"
+            "name: terraform\n"
             "version: 9.9.9\n"
             "author: Team Ops\n"
-            "tool_type: terraform\n"
+            "license: Proprietary\n"
             "description: Local install cache override.\n"
+            "test_suite_path: tests/skill-tests/terraform\n"
+            "token_budget: 1200\n"
+            "triggers: [.tf]\n"
+            "tags: [private]\n"
             "---\n"
             "# Terraform\nCustom guidance.\n",
             encoding="utf-8",
@@ -226,6 +251,16 @@ class SkillsApiTests(unittest.TestCase):
         self.assertIn("/api/v1/skills", payload["paths"])
         self.assertIn("/api/v1/skills/{skill_id}", payload["paths"])
         self.assertIn("/api/v1/skills/{skill_id}/versions", payload["paths"])
+
+    def test_schema_route_publishes_skill_manifest_v1(self) -> None:
+        response = self.client.get("/schemas/skill-manifest-v1.json")
+
+        self.assertEqual(response.status_code, 200)
+        payload = response.json()
+        self.assertEqual(payload["title"], "SkillManifestV1")
+        self.assertEqual(payload["$id"], "/schemas/skill-manifest-v1.json")
+        self.assertIn("name", payload["required"])
+        self.assertIn("test_suite_path", payload["properties"])
 
 
 if __name__ == "__main__":

--- a/tests/test_cli/test_analyze.py
+++ b/tests/test_cli/test_analyze.py
@@ -69,6 +69,136 @@ class AnalyzeCliTests(unittest.TestCase):
         self.assertEqual(ctx.exception.code, 0)
         self.assertIn("terraform: override (detected)", output.getvalue())
 
+    def test_skill_lint_command_accepts_valid_manifest_v1(self) -> None:
+        skill_path = Path(self.tempdir.name) / "terraform.md"
+        (Path(self.tempdir.name) / "tests/skill-tests/terraform").mkdir(
+            parents=True, exist_ok=True
+        )
+        skill_path.write_text(
+            "---\n"
+            "name: terraform\n"
+            "version: 1.0.0\n"
+            "author: DeployWhisper\n"
+            "license: MIT\n"
+            "triggers: [.tf]\n"
+            "token_budget: 1500\n"
+            "tags: [terraform, iac]\n"
+            "description: Terraform review guidance.\n"
+            "test_suite_path: tests/skill-tests/terraform\n"
+            "---\n"
+            "# Terraform\nGuidance.\n",
+            encoding="utf-8",
+        )
+        output = io.StringIO()
+
+        with (
+            patch("sys.argv", ["deploywhisper", "skill", "lint", str(skill_path)]),
+            patch("pathlib.Path.cwd", return_value=Path(self.tempdir.name)),
+            redirect_stdout(output),
+        ):
+            with self.assertRaises(SystemExit) as ctx:
+                main()
+
+        self.assertEqual(ctx.exception.code, 0)
+        self.assertIn("valid skill manifest v1", output.getvalue())
+
+    def test_skill_lint_command_rejects_missing_required_manifest_fields(self) -> None:
+        skill_path = Path(self.tempdir.name) / "terraform.md"
+        skill_path.write_text(
+            "---\n"
+            "name: terraform\n"
+            "version: 1.0.0\n"
+            "author: DeployWhisper\n"
+            "license: MIT\n"
+            "triggers: [.tf]\n"
+            "token_budget: 1500\n"
+            "tags: [terraform, iac]\n"
+            "description: Terraform review guidance.\n"
+            "---\n"
+            "# Terraform\nGuidance.\n",
+            encoding="utf-8",
+        )
+        stderr = io.StringIO()
+
+        with (
+            patch("sys.argv", ["deploywhisper", "skill", "lint", str(skill_path)]),
+            patch("pathlib.Path.cwd", return_value=Path(self.tempdir.name)),
+            redirect_stderr(stderr),
+        ):
+            with self.assertRaises(SystemExit) as ctx:
+                main()
+
+        self.assertEqual(ctx.exception.code, 2)
+        self.assertIn("invalid skill manifest v1", stderr.getvalue())
+        self.assertIn("test_suite_path", stderr.getvalue())
+
+    def test_skill_lint_command_rejects_nonexistent_test_suite_path(self) -> None:
+        skill_path = Path(self.tempdir.name) / "terraform.md"
+        skill_path.write_text(
+            "---\n"
+            "name: terraform\n"
+            "version: 1.0.0\n"
+            "author: DeployWhisper\n"
+            "license: MIT\n"
+            "triggers: [.tf]\n"
+            "token_budget: 1500\n"
+            "tags: [terraform, iac]\n"
+            "description: Terraform review guidance.\n"
+            "test_suite_path: tests/skill-tests/terraform\n"
+            "---\n"
+            "# Terraform\nGuidance.\n",
+            encoding="utf-8",
+        )
+        stderr = io.StringIO()
+
+        with (
+            patch("sys.argv", ["deploywhisper", "skill", "lint", str(skill_path)]),
+            patch("pathlib.Path.cwd", return_value=Path(self.tempdir.name)),
+            redirect_stderr(stderr),
+        ):
+            with self.assertRaises(SystemExit) as ctx:
+                main()
+
+        self.assertEqual(ctx.exception.code, 2)
+        self.assertIn("path does not exist", stderr.getvalue())
+
+    def test_skill_lint_command_uses_current_working_directory_as_project_root(
+        self,
+    ) -> None:
+        repo_root = Path(self.tempdir.name) / "skill-repo"
+        skill_dir = repo_root / "skills"
+        suite_dir = repo_root / "tests/skill-tests/terraform"
+        suite_dir.mkdir(parents=True, exist_ok=True)
+        skill_dir.mkdir(parents=True, exist_ok=True)
+        skill_path = skill_dir / "terraform.md"
+        skill_path.write_text(
+            "---\n"
+            "name: terraform\n"
+            "version: 1.0.0\n"
+            "author: DeployWhisper\n"
+            "license: MIT\n"
+            "triggers: [.tf]\n"
+            "token_budget: 1500\n"
+            "tags: [terraform, iac]\n"
+            "description: Terraform review guidance.\n"
+            "test_suite_path: tests/skill-tests/terraform\n"
+            "---\n"
+            "# Terraform\nGuidance.\n",
+            encoding="utf-8",
+        )
+        output = io.StringIO()
+
+        with (
+            patch("sys.argv", ["deploywhisper", "skill", "lint", str(skill_path)]),
+            patch("pathlib.Path.cwd", return_value=repo_root),
+            redirect_stdout(output),
+        ):
+            with self.assertRaises(SystemExit) as ctx:
+                main()
+
+        self.assertEqual(ctx.exception.code, 0)
+        self.assertIn("valid skill manifest v1", output.getvalue())
+
     def test_analyze_command_runs_shared_analysis_and_prints_structured_output(
         self,
     ) -> None:

--- a/tests/test_services/test_skill_manifest_service.py
+++ b/tests/test_services/test_skill_manifest_service.py
@@ -1,0 +1,132 @@
+"""Tests for shared skill manifest parsing and validation."""
+
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from services.skill_manifest_service import (
+    build_skill_manifest_v1_schema,
+    SkillManifestValidationError,
+    load_skill_document,
+    parse_skill_document,
+)
+
+
+class SkillManifestServiceTests(unittest.TestCase):
+    def test_strict_manifest_validation_accepts_v1_skill(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            project_root = Path(tmpdir)
+            (project_root / "tests/skill-tests/terraform").mkdir(parents=True)
+            document = parse_skill_document(
+                "---\n"
+                "name: terraform\n"
+                "version: 1.0.0\n"
+                "author: DeployWhisper\n"
+                "license: MIT\n"
+                "triggers: [.tf]\n"
+                "token_budget: 1200\n"
+                "tags: [terraform, iac]\n"
+                "description: Terraform review guidance.\n"
+                "test_suite_path: tests/skill-tests/terraform\n"
+                "---\n"
+                "# Terraform\nGuidance.\n",
+                expected_name="terraform",
+                strict_manifest=True,
+                project_root=project_root,
+            )
+
+        assert document.manifest is not None
+        self.assertEqual(document.manifest.name, "terraform")
+        self.assertEqual(document.manifest.version, "1.0.0")
+        self.assertEqual(document.body, "# Terraform\nGuidance.")
+
+    def test_strict_manifest_validation_rejects_name_filename_mismatch(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            project_root = Path(tmpdir)
+            (project_root / "tests/skill-tests/helm").mkdir(parents=True)
+            with self.assertRaises(SkillManifestValidationError) as ctx:
+                parse_skill_document(
+                    "---\n"
+                    "name: helm\n"
+                    "version: 1.0.0\n"
+                    "author: DeployWhisper\n"
+                    "license: MIT\n"
+                    "triggers: [Chart.yaml]\n"
+                    "token_budget: 900\n"
+                    "tags: [helm]\n"
+                    "description: Helm guidance.\n"
+                    "test_suite_path: tests/skill-tests/helm\n"
+                    "---\n"
+                    "# Helm\nGuidance.\n",
+                    expected_name="terraform",
+                    strict_manifest=True,
+                    project_root=project_root,
+                )
+
+        self.assertIn("filename stem", str(ctx.exception))
+
+    def test_strict_manifest_validation_rejects_missing_test_suite_path(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            project_root = Path(tmpdir)
+            with self.assertRaises(SkillManifestValidationError) as ctx:
+                parse_skill_document(
+                    "---\n"
+                    "name: terraform\n"
+                    "version: 1.0.0\n"
+                    "author: DeployWhisper\n"
+                    "license: MIT\n"
+                    "triggers: [.tf]\n"
+                    "token_budget: 1200\n"
+                    "tags: [terraform, iac]\n"
+                    "description: Terraform review guidance.\n"
+                    "test_suite_path: tests/skill-tests/terraform\n"
+                    "---\n"
+                    "# Terraform\nGuidance.\n",
+                    expected_name="terraform",
+                    strict_manifest=True,
+                    project_root=project_root,
+                )
+
+        self.assertIn("path does not exist", str(ctx.exception))
+
+    def test_non_strict_runtime_mode_keeps_legacy_markdown_compatible(self) -> None:
+        document = parse_skill_document(
+            "---\ntriggers: [docker-compose.yml]\n---\n# Docker\nGuidance.\n",
+            expected_name="docker",
+            strict_manifest=False,
+            allow_legacy_name=True,
+        )
+
+        self.assertIsNone(document.manifest)
+        self.assertEqual(document.body, "# Docker\nGuidance.")
+
+    def test_published_schema_file_matches_public_artifact_shape(self) -> None:
+        schema_path = Path("schemas/skill-manifest-v1.json")
+        payload = json.loads(schema_path.read_text(encoding="utf-8"))
+
+        self.assertEqual(payload, build_skill_manifest_v1_schema())
+        self.assertEqual(payload["$id"], "/schemas/skill-manifest-v1.json")
+        self.assertIn("name", payload["required"])
+        self.assertIn("triggers", payload["required"])
+        self.assertIn("test_suite_path", payload["required"])
+
+    def test_load_skill_document_reads_repo_file_in_strict_mode(self) -> None:
+        document = load_skill_document(
+            Path("skills/terraform.md"),
+            strict_manifest=True,
+            allow_legacy_name=False,
+            project_root=Path.cwd(),
+        )
+
+        assert document.manifest is not None
+        self.assertEqual(document.manifest.name, "terraform")
+        self.assertEqual(
+            document.manifest.test_suite_path, "tests/skill-tests/terraform"
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_services/test_skill_registry_service.py
+++ b/tests/test_services/test_skill_registry_service.py
@@ -23,12 +23,14 @@ class SkillRegistryServiceTests(unittest.TestCase):
             custom_dir.mkdir(parents=True, exist_ok=True)
             (skills_dir / "terraform.md").write_text(
                 "---\n"
-                "skill: terraform\n"
+                "name: terraform\n"
                 "version: 1.0.0\n"
                 "author: DeployWhisper\n"
-                "tool_type: terraform\n"
+                "license: MIT\n"
                 "tags: [iac, security]\n"
                 "description: Terraform registry skill.\n"
+                "test_suite_path: tests/skill-tests/terraform\n"
+                "token_budget: 1200\n"
                 "triggers: [.tf]\n"
                 "---\n"
                 "# Terraform\nDetails\n",
@@ -36,12 +38,15 @@ class SkillRegistryServiceTests(unittest.TestCase):
             )
             (skills_dir / "kubernetes.md").write_text(
                 "---\n"
-                "skill: kubernetes\n"
+                "name: kubernetes\n"
                 "version: 2.0.0\n"
                 "author: Platform Team\n"
-                "tool_type: kubernetes\n"
+                "license: MIT\n"
                 "tags: [cluster]\n"
                 "description: Kubernetes rollout checks.\n"
+                "test_suite_path: tests/skill-tests/kubernetes\n"
+                "token_budget: 900\n"
+                "triggers: [.yaml]\n"
                 "---\n"
                 "# Kubernetes\nDetails\n",
                 encoding="utf-8",
@@ -70,6 +75,8 @@ class SkillRegistryServiceTests(unittest.TestCase):
         self.assertEqual(page.total_count, 1)
         self.assertEqual(len(page.items), 1)
         self.assertEqual(page.items[0].id, "terraform")
+        self.assertEqual(page.items[0].name, "Terraform")
+        self.assertEqual(page.items[0].test_suite_path, "tests/skill-tests/terraform")
         self.assertEqual(paged.total_count, 2)
         self.assertEqual(len(paged.items), 1)
         self.assertEqual(paged.items[0].id, "terraform")
@@ -82,23 +89,30 @@ class SkillRegistryServiceTests(unittest.TestCase):
             custom_dir.mkdir(parents=True, exist_ok=True)
             (skills_dir / "terraform.md").write_text(
                 "---\n"
-                "skill: terraform\n"
+                "name: terraform\n"
                 "version: 1.0.0\n"
                 "author: DeployWhisper\n"
-                "tool_type: terraform\n"
+                "license: MIT\n"
                 "description: Built-in terraform checks.\n"
+                "test_suite_path: tests/skill-tests/terraform\n"
+                "token_budget: 1200\n"
+                "triggers: [.tf]\n"
+                "tags: [iac]\n"
                 "---\n"
                 "# Terraform\nBuilt-in guidance.\n",
                 encoding="utf-8",
             )
             (custom_dir / "terraform.md").write_text(
                 "---\n"
-                "skill: terraform\n"
+                "name: terraform\n"
                 "version: 1.2.0\n"
                 "author: Team Ops\n"
-                "tool_type: terraform\n"
+                "license: Proprietary\n"
                 "tags: [private]\n"
                 "description: Team override.\n"
+                "test_suite_path: tests/skill-tests/terraform\n"
+                "token_budget: 1200\n"
+                "triggers: [.tf]\n"
                 "---\n"
                 "# Terraform\nCustom guidance.\n",
                 encoding="utf-8",
@@ -124,6 +138,7 @@ class SkillRegistryServiceTests(unittest.TestCase):
         assert entry is not None
         self.assertEqual(entry.source, "built-in")
         self.assertEqual(entry.version, "1.0.0")
+        self.assertEqual(entry.name, "Terraform")
         self.assertEqual(entry.available_versions, 1)
         self.assertEqual([version.version for version in versions], ["1.0.0"])
         self.assertTrue(versions[0].is_current)
@@ -140,22 +155,30 @@ class SkillRegistryServiceTests(unittest.TestCase):
             custom_dir.mkdir(parents=True, exist_ok=True)
             (skills_dir / "terraform.md").write_text(
                 "---\n"
-                "skill: terraform\n"
+                "name: terraform\n"
                 "version: 1.0.0\n"
                 "author: DeployWhisper\n"
-                "tool_type: terraform\n"
+                "license: MIT\n"
                 "description: Built-in terraform checks.\n"
+                "test_suite_path: tests/skill-tests/terraform\n"
+                "token_budget: 1200\n"
+                "triggers: [.tf]\n"
+                "tags: [iac]\n"
                 "---\n"
                 "# Terraform\nBuilt-in guidance.\n",
                 encoding="utf-8",
             )
             (custom_dir / "terraform.md").write_text(
                 "---\n"
-                "skill: terraform\n"
+                "name: terraform\n"
                 "version: 9.9.9\n"
                 "author: Team Ops\n"
-                "tool_type: terraform\n"
+                "license: Proprietary\n"
                 "description: Local install cache override.\n"
+                "test_suite_path: tests/skill-tests/terraform\n"
+                "token_budget: 1200\n"
+                "triggers: [.tf]\n"
+                "tags: [private]\n"
                 "---\n"
                 "# Terraform\nCustom guidance.\n",
                 encoding="utf-8",
@@ -188,10 +211,15 @@ class SkillRegistryServiceTests(unittest.TestCase):
             )
             (skills_dir / "kubernetes.md").write_text(
                 "---\n"
-                "skill: kubernetes\n"
+                "name: kubernetes\n"
                 "version: 1.0.0\n"
-                "tool_type: kubernetes\n"
+                "author: DeployWhisper\n"
+                "license: MIT\n"
                 "description: Healthy skill.\n"
+                "test_suite_path: tests/skill-tests/kubernetes\n"
+                "token_budget: 900\n"
+                "triggers: [.yaml]\n"
+                "tags: [cluster]\n"
                 "---\n"
                 "# Kubernetes\nHealthy guidance.\n",
                 encoding="utf-8",


### PR DESCRIPTION
…ages

Story 4.2 introduces a shared manifest contract, generated JSON Schema, and a CLI lint path that validates against the caller's working repository. The implementation keeps runtime skill loading backward-compatible while giving registry and authoring surfaces one normalized metadata model.

Constraint: Story 4.2 requires strict manifest validation without breaking legacy runtime skill loading

Constraint: The schema endpoint must work from installed builds, not only source checkouts

Rejected: Serve /schemas/skill-manifest-v1.json from a packaged top-level file | wheel build does not ship that asset

Rejected: Validate test_suite_path against the DeployWhisper install root | rejects valid external skill repositories

Confidence: high

Scope-risk: moderate

Reversibility: clean

Directive: Keep CLI lint rooted to the caller's working repository; do not rebind test_suite_path validation to the DeployWhisper install root

Tested: Targeted manifest/registry/API/CLI unittest bundles

Tested: ./.venv/bin/ruff check .

Tested: ./.venv/bin/ruff format --check .

Tested: ./.venv/bin/python -m unittest discover -q

Tested: bash scripts/ci-local.sh

Not-tested: Local Bandit scan (bandit not installed)

## What does this PR do?

<!-- Brief description of changes -->

## Type of change
- [ ] Feature (new functionality)
- [ ] Bugfix (non-breaking fix)
- [ ] Release preparation
- [ ] Hotfix (critical production fix)
- [ ] Docs / refactor / chore

## Checklist
- [ ] I have followed the branch naming convention
- [ ] Tests pass locally (`pytest tests/ -v`)
- [ ] Linting passes (`ruff check .`)
- [ ] Docker build succeeds
- [ ] I have updated docs if needed
- [ ] No secrets or .env values committed

## Related issue
Closes #