### PR TITLE
Protect marketplace quality by making skill behavior testable and vis…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -244,12 +244,25 @@ jobs:
             test ${PIPESTATUS[0]} -eq 0
           fi
 
+      - name: Run changed skill harnesses
+        env:
+          BASE_REF: origin/${{ github.base_ref }}
+        run: |
+          if [ -f scripts/test-changed-skills.sh ]; then
+            bash scripts/test-changed-skills.sh 2>&1 | tee changed-skill-harness.log
+            test ${PIPESTATUS[0]} -eq 0
+          else
+            echo "scripts/test-changed-skills.sh not found — skipping changed skill harness"
+          fi
+
       - name: Upload changed-test logs
         if: failure()
         uses: actions/upload-artifact@v5
         with:
           name: changed-tests-log
-          path: changed-tests.log
+          path: |
+            changed-tests.log
+            changed-skill-harness.log
           retention-days: 14
 
   # ===========================================================================

--- a/api/routes/skills.py
+++ b/api/routes/skills.py
@@ -12,8 +12,10 @@ from api.schemas import (
     SkillRegistryListMetaPayload,
     SkillRegistryListResponse,
     SkillRegistryResourceMetaPayload,
+    SkillRegistryTestResultsResponse,
     SkillRegistryVersionData,
     SkillRegistryVersionsResponse,
+    SkillTestResultsData,
 )
 from config import settings
 from services.skill_registry_service import (
@@ -21,6 +23,7 @@ from services.skill_registry_service import (
     fetch_skill_registry_page,
     fetch_skill_registry_versions,
 )
+from services.skill_test_harness_service import run_skill_test_suite
 
 router = APIRouter(prefix="/api/v1/skills", tags=["skills"], route_class=ApiRoute)
 
@@ -137,5 +140,32 @@ def get_skill_versions(skill_id: str) -> SkillRegistryVersionsResponse:
             app=settings.app_name,
             version=settings.app_version,
             id=skill_id.strip().lower(),
+        ),
+    )
+
+
+@router.get(
+    "/{skill_id}/test-results",
+    response_model=SkillRegistryTestResultsResponse,
+    responses={
+        404: {"model": ErrorResponse},
+        422: {"model": ErrorResponse},
+        500: {"model": ErrorResponse},
+    },
+)
+def get_skill_test_results(skill_id: str) -> SkillRegistryTestResultsResponse:
+    suite_result = run_skill_test_suite(skill_id.strip().lower())
+    if suite_result is None:
+        raise ApiError(
+            status_code=404,
+            code="skill_not_found",
+            message="Skill not found.",
+        )
+    return SkillRegistryTestResultsResponse(
+        data=SkillTestResultsData(**suite_result.model_dump()),
+        meta=SkillRegistryResourceMetaPayload(
+            app=settings.app_name,
+            version=settings.app_version,
+            id=suite_result.skill_id,
         ),
     )

--- a/api/schemas.py
+++ b/api/schemas.py
@@ -620,6 +620,38 @@ class AnalysisShareConfigResponse(BaseModel):
 
 
 SkillRegistrySource = Literal["built-in", "custom-override", "custom-new"]
+SkillHarnessStatus = Literal["passing", "failing", "missing"]
+
+
+class SkillTestResultsSummaryData(BaseModel):
+    total_scenarios: int = Field(..., description="Total number of harness scenarios.")
+    passed_scenarios: int = Field(..., description="Number of passing scenarios.")
+    failed_scenarios: int = Field(..., description="Number of failing scenarios.")
+    pass_rate: float = Field(..., description="Fraction of scenarios that passed.")
+    status: SkillHarnessStatus = Field(
+        ..., description="High-level harness status for the skill."
+    )
+    display_text: str = Field(..., description="Human-readable pass/fail summary.")
+    generated_at: str = Field(..., description="UTC timestamp for this harness run.")
+
+
+class SkillTestScenarioResultData(BaseModel):
+    name: str = Field(..., description="Stable scenario name.")
+    description: str | None = Field(
+        default=None, description="Human-readable description of the scenario."
+    )
+    passed: bool = Field(..., description="Whether the scenario passed.")
+    failures: list[str] = Field(
+        default_factory=list,
+        description="Failure reasons when the scenario did not pass.",
+    )
+
+
+class SkillTestResultsData(BaseModel):
+    skill_id: str = Field(..., description="Stable skill identifier.")
+    version: str = Field(..., description="Skill version under test.")
+    summary: SkillTestResultsSummaryData
+    scenarios: list[SkillTestScenarioResultData] = Field(default_factory=list)
 
 
 class SkillRegistryData(BaseModel):
@@ -640,6 +672,10 @@ class SkillRegistryData(BaseModel):
     test_suite_path: str | None = Field(
         default=None,
         description="Repository path to the skill validation suite, when declared.",
+    )
+    test_results: SkillTestResultsSummaryData | None = Field(
+        default=None,
+        description="Latest deterministic harness summary for the skill.",
     )
     triggers: list[str] = Field(
         default_factory=list, description="Filename or extension triggers"
@@ -686,6 +722,11 @@ class SkillRegistryDetailResponse(BaseModel):
 
 class SkillRegistryVersionsResponse(BaseModel):
     data: list[SkillRegistryVersionData]
+    meta: SkillRegistryResourceMetaPayload
+
+
+class SkillRegistryTestResultsResponse(BaseModel):
+    data: SkillTestResultsData
     meta: SkillRegistryResourceMetaPayload
 
 

--- a/cli/analyze.py
+++ b/cli/analyze.py
@@ -22,6 +22,8 @@ from services.skill_manifest_service import (
     SkillManifestValidationError,
     load_skill_document,
 )
+from services.skill_test_harness_service import run_skill_test_suites
+from services.skill_test_harness_service import iter_built_in_skill_ids
 from services.analysis_service import (
     analyze_uploaded_files,
     build_advisory_summary,
@@ -111,6 +113,50 @@ def _run_skill_lint(path_arg: str) -> int:
         f"({document.manifest.name}@{document.manifest.version})"
     )
     return 0
+
+
+def _run_skill_test(skill_ids: list[str], *, emit_json: bool = False) -> int:
+    normalized_ids = [
+        skill_id.strip().lower() for skill_id in skill_ids if skill_id.strip()
+    ]
+    known_ids = set(iter_built_in_skill_ids())
+    missing_ids = [skill_id for skill_id in normalized_ids if skill_id not in known_ids]
+    if missing_ids:
+        if emit_json:
+            _emit_json(
+                build_error(
+                    code="skill_not_found",
+                    message="One or more skills were not found.",
+                    details={"skill_ids": missing_ids},
+                ),
+                stream=sys.stderr,
+            )
+        else:
+            sys.stderr.write("Unknown skill ids: " + ", ".join(missing_ids) + "\n")
+        return 2
+
+    results = run_skill_test_suites(normalized_ids)
+    if emit_json:
+        _emit_json(
+            {"data": [result.model_dump() for result in results]},
+            stream=sys.stdout,
+        )
+    else:
+        if not results:
+            print("No skill test suites found.")
+            return 1
+        for result in results:
+            summary = result.summary
+            print(f"{result.skill_id}: {summary.display_text} [{summary.status}]")
+            for scenario in result.scenarios:
+                if scenario.passed:
+                    continue
+                print(f"  - {scenario.name}: {'; '.join(scenario.failures)}")
+    return (
+        0
+        if results and all(result.summary.failed_scenarios == 0 for result in results)
+        else 1
+    )
 
 
 def _run_analyze(paths: list[str]) -> int:
@@ -238,6 +284,19 @@ def build_parser() -> argparse.ArgumentParser:
         "lint", help="Validate a skill markdown file against manifest v1."
     )
     skill_lint_parser.add_argument("path", help="Skill markdown path to validate.")
+    skill_test_parser = skill_subparsers.add_parser(
+        "test", help="Run deterministic harness scenarios for one or more skills."
+    )
+    skill_test_parser.add_argument(
+        "skill_ids",
+        nargs="*",
+        help="Optional skill ids to test. Defaults to all built-in skills.",
+    )
+    skill_test_parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit machine-readable JSON instead of human-readable output.",
+    )
 
     analyze_parser = subparsers.add_parser(
         "analyze", help="Run headless advisory analysis for one or more artifacts."
@@ -308,6 +367,8 @@ def main() -> None:
         raise SystemExit(_run_skills())
     if args.command == "skill" and args.skill_command == "lint":
         raise SystemExit(_run_skill_lint(args.path))
+    if args.command == "skill" and args.skill_command == "test":
+        raise SystemExit(_run_skill_test(args.skill_ids, emit_json=args.json))
     if args.command == "analyze":
         raise SystemExit(_run_analyze(args.paths))
     if args.command == "github" and args.github_command == "init":

--- a/docs/skills/authoring-guide.md
+++ b/docs/skills/authoring-guide.md
@@ -63,6 +63,14 @@ Use the CLI authoring check before opening a PR or copying a local skill into
 deploywhisper skill lint path/to/my-skill.md
 ```
 
+Run the deterministic harness for built-in skills with:
+
+```bash
+deploywhisper skill test terraform
+```
+
+Scenario layout and harness behavior are documented in `docs/skills/test-harness.md`.
+
 Validation fails when:
 
 - required manifest fields are missing

--- a/docs/skills/test-harness.md
+++ b/docs/skills/test-harness.md
@@ -1,0 +1,75 @@
+# Skills Test Harness
+
+Story 4.3 adds a deterministic harness for built-in skill suites. The harness
+does not try to execute skill prose. Instead, it validates the real runtime
+behavior that exists today:
+
+- the target skill is selected in isolation
+- trigger-based skills load from representative raw files
+- the emitted skill context contains required guidance snippets
+
+## Scenario layout
+
+Each built-in skill keeps scenarios under the manifest path declared by
+`test_suite_path`, currently `tests/skill-tests/<skill>/`.
+
+Example:
+
+```text
+tests/skill-tests/terraform/
+├── README.md
+└── basic-selection.json
+```
+
+Scenario file shape:
+
+```json
+{
+  "name": "terraform-basic-selection",
+  "description": "Loads the Terraform skill for a Terraform contributor.",
+  "assessment_tool": "terraform",
+  "contributor_summary": "Terraform changes update networking and storage resources.",
+  "raw_files": {
+    "main.tf": "resource \"aws_security_group\" \"db\" {}"
+  },
+  "expect_selected": true,
+  "expected_substrings": [
+    "Security group or firewall rule with `0.0.0.0/0`"
+  ],
+  "expected_absent_substrings": []
+}
+```
+
+## CLI usage
+
+Run all built-in skill suites:
+
+```bash
+deploywhisper skill test
+```
+
+Run selected skills only:
+
+```bash
+deploywhisper skill test terraform docker
+```
+
+Emit machine-readable JSON for automation:
+
+```bash
+deploywhisper skill test terraform --json
+```
+
+## CI integration
+
+- Local CI now runs the full harness through `bash scripts/ci-local.sh`
+- Pull requests run changed skill suites through `scripts/test-changed-skills.sh`
+- Changed-skill detection watches both `skills/*.md` and `tests/skill-tests/<skill>/`
+
+## Public results
+
+The skills API exposes harness status through:
+
+- `GET /api/v1/skills`
+- `GET /api/v1/skills/{id}`
+- `GET /api/v1/skills/{id}/test-results`

--- a/llm/skill_context.py
+++ b/llm/skill_context.py
@@ -327,12 +327,12 @@ def _trigger_matches_raw_files(
     )
 
 
-def resolve_skills(
+def resolve_skills_from_active_skills(
+    active_skills: dict[str, ActiveSkill],
     assessment: RiskAssessment,
     raw_files: dict[str, bytes | None] | None = None,
 ) -> list[ActiveSkill]:
-    """Resolve the effective skills that should be included for this analysis."""
-    active_skills = get_active_skills()
+    """Resolve skills from an explicit active-skill map."""
     seen: set[str] = set()
     selected: list[ActiveSkill] = []
     search_blob = _assessment_search_blob(assessment)
@@ -362,6 +362,18 @@ def resolve_skills(
     return selected
 
 
+def resolve_skills(
+    assessment: RiskAssessment,
+    raw_files: dict[str, bytes | None] | None = None,
+) -> list[ActiveSkill]:
+    """Resolve the effective skills that should be included for this analysis."""
+    return resolve_skills_from_active_skills(
+        get_active_skills(),
+        assessment,
+        raw_files=raw_files,
+    )
+
+
 def build_skill_context(
     assessment: RiskAssessment,
     raw_files: dict[str, bytes | None] | None = None,
@@ -369,5 +381,22 @@ def build_skill_context(
     sections = [
         f"## {skill.name.upper()} SKILL ({skill.source})\n{skill.content}"
         for skill in resolve_skills(assessment, raw_files=raw_files)
+    ]
+    return "\n\n".join(sections)
+
+
+def build_skill_context_from_active_skills(
+    active_skills: dict[str, ActiveSkill],
+    assessment: RiskAssessment,
+    raw_files: dict[str, bytes | None] | None = None,
+) -> str:
+    """Build skill context from an explicit active-skill map."""
+    sections = [
+        f"## {skill.name.upper()} SKILL ({skill.source})\n{skill.content}"
+        for skill in resolve_skills_from_active_skills(
+            active_skills,
+            assessment,
+            raw_files=raw_files,
+        )
     ]
     return "\n\n".join(sections)

--- a/scripts/ci-local.sh
+++ b/scripts/ci-local.sh
@@ -64,6 +64,7 @@ fi
   cli.py \
   config.py \
   logging_config.py
+"$PYTHON_BIN" cli.py skill test
 "$PYTHON_BIN" -m unittest discover -q
 
 if [ "${RUN_UI_A11Y:-0}" = "1" ]; then

--- a/scripts/test-changed-skills.sh
+++ b/scripts/test-changed-skills.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_REF="${BASE_REF:-origin/main}"
+PYTHON_BIN="${PYTHON_BIN:-python}"
+
+if ! git rev-parse --verify "$BASE_REF" >/dev/null 2>&1; then
+  echo "Base ref '$BASE_REF' is unavailable. Skipping changed-skill harness feedback."
+  exit 0
+fi
+
+mapfile -t CHANGED_PATHS < <(git diff --name-only "$BASE_REF"...HEAD || true)
+
+SKILLS=()
+for path in "${CHANGED_PATHS[@]}"; do
+  if [[ "$path" =~ ^skills/([^.]+)\.md$ ]]; then
+    skill="${BASH_REMATCH[1]}"
+  elif [[ "$path" =~ ^tests/skill-tests/([^/]+)/ ]]; then
+    skill="${BASH_REMATCH[1]}"
+  else
+    continue
+  fi
+
+  if [ -f "skills/${skill}.md" ]; then
+    SKILLS+=("$skill")
+  fi
+done
+
+if [ "${#SKILLS[@]}" -eq 0 ]; then
+  echo "No changed built-in skill suites detected relative to $BASE_REF."
+  exit 0
+fi
+
+mapfile -t UNIQUE_SKILLS < <(printf '%s\n' "${SKILLS[@]}" | sort -u)
+
+echo "Running changed skill harnesses relative to $BASE_REF:"
+printf ' - %s\n' "${UNIQUE_SKILLS[@]}"
+"$PYTHON_BIN" cli.py skill test "${UNIQUE_SKILLS[@]}"

--- a/services/skill_registry_service.py
+++ b/services/skill_registry_service.py
@@ -10,6 +10,10 @@ from typing import Any, Literal
 from pydantic import BaseModel, Field
 
 from services.skill_manifest_service import REPO_ROOT, load_skill_document
+from services.skill_test_harness_service import (
+    SkillTestSummary,
+    summarize_skill_test_suite,
+)
 
 SKILLS_DIR = Path(__file__).resolve().parents[1] / "skills"
 CUSTOM_DIR = SKILLS_DIR / "custom"
@@ -33,6 +37,9 @@ class SkillRegistryEntry(BaseModel):
     )
     test_suite_path: str | None = Field(
         default=None, description="Repository path to the skill validation suite"
+    )
+    test_results: SkillTestSummary | None = Field(
+        default=None, description="Latest deterministic harness summary for the skill."
     )
     triggers: list[str] = Field(
         default_factory=list, description="Filename or extension triggers"
@@ -75,6 +82,7 @@ class _SkillRecord(BaseModel):
     tags: list[str] = Field(default_factory=list)
     token_budget: int | None = None
     test_suite_path: str | None = None
+    test_results: SkillTestSummary | None = None
     triggers: list[str] = Field(default_factory=list)
     trigger_content_patterns: list[str] = Field(default_factory=list)
     updated_at: str
@@ -155,6 +163,7 @@ def _record_to_entry(
         "tags": list(record.tags),
         "token_budget": record.token_budget,
         "test_suite_path": record.test_suite_path,
+        "test_results": record.test_results,
         "triggers": list(record.triggers),
         "trigger_content_patterns": list(record.trigger_content_patterns),
         "updated_at": record.updated_at,
@@ -195,6 +204,7 @@ def _load_skill_record(path: Path, *, source: SkillSource) -> _SkillRecord | Non
         tags=list(parsed.manifest.tags),
         token_budget=parsed.manifest.token_budget,
         test_suite_path=parsed.manifest.test_suite_path,
+        test_results=summarize_skill_test_suite(skill_id),
         triggers=list(parsed.manifest.triggers),
         trigger_content_patterns=list(parsed.manifest.trigger_content_patterns),
         updated_at=updated_at,

--- a/services/skill_test_harness_service.py
+++ b/services/skill_test_harness_service.py
@@ -1,0 +1,281 @@
+"""Deterministic skill test harness execution."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Literal
+
+from pydantic import BaseModel, Field, field_validator
+
+from analysis.risk_scorer import RiskAssessment, RiskContributor
+from llm.skill_context import ActiveSkill, build_skill_context_from_active_skills
+from services.skill_manifest_service import REPO_ROOT, load_skill_document
+
+
+SKILLS_DIR = REPO_ROOT / "skills"
+SkillHarnessStatus = Literal["passing", "failing", "missing"]
+
+
+class SkillTestScenarioDefinition(BaseModel):
+    """Deterministic scenario definition for a single skill."""
+
+    name: str = Field(..., description="Stable scenario name.")
+    description: str | None = Field(
+        default=None, description="Human-readable description of the scenario."
+    )
+    assessment_tool: str = Field(
+        ..., description="Contributor tool name used to build assessment context."
+    )
+    contributor_summary: str = Field(
+        default="Exercise skill guidance.",
+        description="Summary used for the single contributor in the scenario.",
+    )
+    raw_files: dict[str, str] = Field(
+        default_factory=dict,
+        description="Filename to text payload map supplied to skill resolution.",
+    )
+    expect_selected: bool = Field(
+        default=True, description="Whether the target skill should be selected."
+    )
+    expected_substrings: list[str] = Field(
+        default_factory=list,
+        description="Substrings that must appear in the emitted skill context.",
+    )
+    expected_absent_substrings: list[str] = Field(
+        default_factory=list,
+        description="Substrings that must not appear in the emitted skill context.",
+    )
+
+    @field_validator("name", "assessment_tool", "contributor_summary")
+    @classmethod
+    def _validate_required_text(cls, value: str) -> str:
+        normalized = value.strip()
+        if not normalized:
+            raise ValueError("must not be empty")
+        return normalized
+
+    @field_validator("expected_substrings", "expected_absent_substrings")
+    @classmethod
+    def _validate_substrings(cls, value: list[str]) -> list[str]:
+        normalized: list[str] = []
+        for item in value:
+            candidate = str(item).strip()
+            if candidate:
+                normalized.append(candidate)
+        return normalized
+
+
+class SkillTestScenarioResult(BaseModel):
+    """Pass/fail result for one harness scenario."""
+
+    name: str
+    description: str | None = None
+    passed: bool
+    failures: list[str] = Field(default_factory=list)
+
+
+class SkillTestSummary(BaseModel):
+    """Aggregate summary for a harness run."""
+
+    skill_id: str
+    total_scenarios: int
+    passed_scenarios: int
+    failed_scenarios: int
+    pass_rate: float = Field(..., ge=0.0, le=1.0)
+    status: SkillHarnessStatus
+    display_text: str
+    generated_at: str
+
+
+class SkillTestSuiteResult(BaseModel):
+    """Complete harness result for one skill."""
+
+    skill_id: str
+    version: str
+    summary: SkillTestSummary
+    scenarios: list[SkillTestScenarioResult] = Field(default_factory=list)
+
+
+def _timestamp() -> str:
+    return datetime.now(tz=UTC).isoformat().replace("+00:00", "Z")
+
+
+def _build_summary(
+    skill_id: str,
+    scenario_results: list[SkillTestScenarioResult],
+) -> SkillTestSummary:
+    total = len(scenario_results)
+    passed = sum(1 for result in scenario_results if result.passed)
+    failed = total - passed
+    status: SkillHarnessStatus
+    if total == 0:
+        status = "missing"
+    elif failed > 0:
+        status = "failing"
+    else:
+        status = "passing"
+    pass_rate = 1.0 if total == 0 else passed / total
+    return SkillTestSummary(
+        skill_id=skill_id,
+        total_scenarios=total,
+        passed_scenarios=passed,
+        failed_scenarios=failed,
+        pass_rate=pass_rate,
+        status=status,
+        display_text=f"{passed}/{total} scenarios passing",
+        generated_at=_timestamp(),
+    )
+
+
+def _scenario_files(suite_dir: Path) -> list[Path]:
+    if not suite_dir.exists():
+        return []
+    return sorted(path for path in suite_dir.glob("*.json") if path.is_file())
+
+
+def _load_scenarios(suite_dir: Path) -> list[SkillTestScenarioDefinition]:
+    return [
+        SkillTestScenarioDefinition.model_validate_json(
+            path.read_text(encoding="utf-8")
+        )
+        for path in _scenario_files(suite_dir)
+    ]
+
+
+def _load_active_skill(skill_id: str) -> tuple[ActiveSkill, str, Path] | None:
+    path = SKILLS_DIR / f"{skill_id}.md"
+    if not path.exists():
+        return None
+    document = load_skill_document(
+        path,
+        strict_manifest=True,
+        allow_legacy_name=False,
+        project_root=REPO_ROOT,
+    )
+    if document.manifest is None:
+        return None
+    return (
+        ActiveSkill(
+            name=skill_id,
+            source="built-in",
+            path=str(path),
+            content=document.body,
+            always_load=document.manifest.always_load,
+            triggers=list(document.manifest.triggers),
+            trigger_content_patterns=list(document.manifest.trigger_content_patterns),
+        ),
+        document.manifest.version,
+        REPO_ROOT / document.manifest.test_suite_path,
+    )
+
+
+def _build_assessment(
+    skill_id: str,
+    scenario: SkillTestScenarioDefinition,
+) -> RiskAssessment:
+    return RiskAssessment(
+        score=20,
+        severity="low",
+        recommendation="go",
+        top_risk=f"Skill harness scenario for {skill_id}.",
+        partial_context=False,
+        warnings=[],
+        contributors=[
+            RiskContributor(
+                source_file=next(
+                    iter(scenario.raw_files.keys()), f"{skill_id}.fixture"
+                ),
+                tool=scenario.assessment_tool,
+                resource_id=f"{skill_id}.scenario",
+                action="modify",
+                contribution=5,
+                summary=scenario.contributor_summary,
+            )
+        ],
+    )
+
+
+def _run_scenario(
+    skill_id: str,
+    active_skill: ActiveSkill,
+    scenario: SkillTestScenarioDefinition,
+) -> SkillTestScenarioResult:
+    raw_files = {
+        filename: content.encode("utf-8")
+        for filename, content in scenario.raw_files.items()
+    }
+    context = build_skill_context_from_active_skills(
+        {skill_id: active_skill},
+        _build_assessment(skill_id, scenario),
+        raw_files=raw_files,
+    )
+    selected = bool(context.strip())
+    failures: list[str] = []
+    if scenario.expect_selected and not selected:
+        failures.append("Skill was not selected for the scenario context.")
+    if not scenario.expect_selected and selected:
+        failures.append("Skill was selected unexpectedly for the scenario context.")
+    for expected in scenario.expected_substrings:
+        if expected not in context:
+            failures.append(f"Missing expected substring: {expected}")
+    for unexpected in scenario.expected_absent_substrings:
+        if unexpected in context:
+            failures.append(f"Unexpected substring present: {unexpected}")
+    return SkillTestScenarioResult(
+        name=scenario.name,
+        description=scenario.description,
+        passed=not failures,
+        failures=failures,
+    )
+
+
+def run_skill_test_suite(skill_id: str) -> SkillTestSuiteResult | None:
+    """Run the deterministic harness for a single built-in skill."""
+
+    loaded = _load_active_skill(skill_id)
+    if loaded is None:
+        return None
+    active_skill, version, suite_dir = loaded
+    scenario_results = [
+        _run_scenario(skill_id, active_skill, scenario)
+        for scenario in _load_scenarios(suite_dir)
+    ]
+    return SkillTestSuiteResult(
+        skill_id=skill_id,
+        version=version,
+        summary=_build_summary(skill_id, scenario_results),
+        scenarios=scenario_results,
+    )
+
+
+def summarize_skill_test_suite(skill_id: str) -> SkillTestSummary | None:
+    """Return only the harness summary for a built-in skill."""
+
+    suite_result = run_skill_test_suite(skill_id)
+    if suite_result is None:
+        return None
+    return suite_result.summary
+
+
+def iter_built_in_skill_ids() -> list[str]:
+    """Return built-in skill ids that participate in the local harness."""
+
+    return sorted(
+        path.stem.lower() for path in SKILLS_DIR.glob("*.md") if path.is_file()
+    )
+
+
+def run_skill_test_suites(
+    skill_ids: list[str] | None = None,
+) -> list[SkillTestSuiteResult]:
+    """Run harness suites for the requested built-in skill ids."""
+
+    requested = skill_ids or iter_built_in_skill_ids()
+    results: list[SkillTestSuiteResult] = []
+    for skill_id in requested:
+        suite = run_skill_test_suite(skill_id)
+        if suite is None:
+            continue
+        results.append(suite)
+    return results

--- a/skills/cloudformation.md
+++ b/skills/cloudformation.md
@@ -8,7 +8,7 @@ token_budget: 1500
 tags: [cloudformation, aws, iac]
 description: Deep CloudFormation risk intelligence covering resource replacement detection, deletion policies, drift patterns, stack dependencies, IAM resource risks, and service quota awareness.
 test_suite_path: tests/skill-tests/cloudformation
-trigger_content_patterns: [AWSTemplateFormatVersion, Resources, AWS::, CloudFormation]
+trigger_content_patterns: [AWSTemplateFormatVersion, Resources, "AWS::", CloudFormation]
 ---
 
 ## Resource update behavior

--- a/tests/skill-tests/ansible/basic-selection.json
+++ b/tests/skill-tests/ansible/basic-selection.json
@@ -1,0 +1,13 @@
+{
+  "name": "ansible-basic-selection",
+  "description": "Loads the Ansible skill for an Ansible contributor.",
+  "assessment_tool": "ansible",
+  "contributor_summary": "Ansible playbook removes old users and services.",
+  "raw_files": {
+    "playbook.yml": "- hosts: app\n  tasks:\n    - name: remove app user\n      user:\n        name: app\n        state: absent\n"
+  },
+  "expected_substrings": [
+    "Destructive modules (CRITICAL)",
+    "`shell` — same as command but through a shell interpreter"
+  ]
+}

--- a/tests/skill-tests/cloudformation/basic-selection.json
+++ b/tests/skill-tests/cloudformation/basic-selection.json
@@ -1,0 +1,13 @@
+{
+  "name": "cloudformation-basic-selection",
+  "description": "Loads the CloudFormation skill for a CloudFormation contributor.",
+  "assessment_tool": "cloudformation",
+  "contributor_summary": "CloudFormation template changes replace stateful infrastructure.",
+  "raw_files": {
+    "stack.yaml": "AWSTemplateFormatVersion: '2010-09-09'\nResources:\n  ApiBucket:\n    Type: AWS::S3::Bucket\n"
+  },
+  "expected_substrings": [
+    "Any resource change that triggers `Replacement` instead of `Update` = CRITICAL",
+    "RDS `MultiAZ` change = triggers brief failover"
+  ]
+}

--- a/tests/skill-tests/docker/basic-trigger.json
+++ b/tests/skill-tests/docker/basic-trigger.json
@@ -1,0 +1,13 @@
+{
+  "name": "docker-trigger-selection",
+  "description": "Loads the Docker skill via raw file triggers.",
+  "assessment_tool": "terraform",
+  "contributor_summary": "Infrastructure change also updates the application Dockerfile.",
+  "raw_files": {
+    "Dockerfile": "FROM python:3.11\nCOPY . .\nRUN pip install -r requirements.txt\n"
+  },
+  "expected_substrings": [
+    "No `USER` instruction in the Dockerfile = CRITICAL",
+    "`COPY . .` or `ADD . .` without `.dockerignore` = HIGH"
+  ]
+}

--- a/tests/skill-tests/git/basic-trigger.json
+++ b/tests/skill-tests/git/basic-trigger.json
@@ -1,0 +1,13 @@
+{
+  "name": "git-trigger-selection",
+  "description": "Loads the Git skill from diff-file triggers.",
+  "assessment_tool": "terraform",
+  "contributor_summary": "Pull request includes a Git diff artifact for review.",
+  "raw_files": {
+    "changes.diff": "diff --git a/main.tf b/main.tf\nindex 1111111..2222222 100644\n--- a/main.tf\n+++ b/main.tf\n@@ -1 +1 @@\n-resource \"aws_s3_bucket\" \"old\" {}\n+resource \"aws_s3_bucket\" \"new\" {}\n"
+  },
+  "expected_substrings": [
+    "These file patterns must NEVER be sent to external LLM providers.",
+    "`.env`, `.env.local`, `.env.production`, `.env.*`"
+  ]
+}

--- a/tests/skill-tests/jenkins/basic-selection.json
+++ b/tests/skill-tests/jenkins/basic-selection.json
@@ -1,0 +1,13 @@
+{
+  "name": "jenkins-basic-selection",
+  "description": "Loads the Jenkins skill for a Jenkins contributor.",
+  "assessment_tool": "jenkins",
+  "contributor_summary": "Jenkins pipeline changes affect deploy approvals.",
+  "raw_files": {
+    "Jenkinsfile": "pipeline {\n  agent any\n  stages {\n    stage('Deploy') {\n      steps {\n        input 'Deploy to production?'\n      }\n    }\n  }\n}\n"
+  },
+  "expected_substrings": [
+    "`input` step removed from before a production deploy stage = CRITICAL",
+    "`when` condition removed entirely from deploy stage = CRITICAL"
+  ]
+}

--- a/tests/skill-tests/kubernetes/basic-selection.json
+++ b/tests/skill-tests/kubernetes/basic-selection.json
@@ -1,0 +1,13 @@
+{
+  "name": "kubernetes-basic-selection",
+  "description": "Loads the Kubernetes skill for a Kubernetes contributor.",
+  "assessment_tool": "kubernetes",
+  "contributor_summary": "Kubernetes deployment rollout updates application pods.",
+  "raw_files": {
+    "deployment.yaml": "apiVersion: apps/v1\nkind: Deployment\nmetadata:\n  name: api\nspec:\n  template:\n    spec:\n      containers:\n        - name: api\n          image: example/api:latest\n"
+  },
+  "expected_substrings": [
+    "Container running as root",
+    "No `resources.limits.memory` set"
+  ]
+}

--- a/tests/skill-tests/terraform/basic-selection.json
+++ b/tests/skill-tests/terraform/basic-selection.json
@@ -1,0 +1,13 @@
+{
+  "name": "terraform-basic-selection",
+  "description": "Loads the Terraform skill for a Terraform contributor.",
+  "assessment_tool": "terraform",
+  "contributor_summary": "Terraform changes update networking and storage resources.",
+  "raw_files": {
+    "main.tf": "resource \"aws_security_group\" \"db\" {}"
+  },
+  "expected_substrings": [
+    "Security group or firewall rule with `0.0.0.0/0`",
+    "Resources with `prevent_destroy = true`"
+  ]
+}

--- a/tests/test_api/test_skills.py
+++ b/tests/test_api/test_skills.py
@@ -103,6 +103,7 @@ class SkillsApiTests(unittest.TestCase):
         self.assertEqual(
             payload["data"][0]["test_suite_path"], "tests/skill-tests/terraform"
         )
+        self.assertEqual(payload["data"][0]["test_results"]["status"], "passing")
         self.assertEqual(payload["data"][0]["triggers"], [".tf"])
 
     def test_get_skill_and_versions_return_effective_skill_and_history(self) -> None:
@@ -155,6 +156,7 @@ class SkillsApiTests(unittest.TestCase):
         self.assertEqual(detail_payload["data"]["source"], "built-in")
         self.assertEqual(detail_payload["data"]["name"], "Terraform")
         self.assertEqual(detail_payload["data"]["available_versions"], 1)
+        self.assertEqual(detail_payload["data"]["test_results"]["status"], "passing")
         self.assertEqual(detail_payload["meta"]["id"], "terraform")
 
         self.assertEqual(versions_response.status_code, 200)
@@ -261,6 +263,15 @@ class SkillsApiTests(unittest.TestCase):
         self.assertEqual(payload["$id"], "/schemas/skill-manifest-v1.json")
         self.assertIn("name", payload["required"])
         self.assertIn("test_suite_path", payload["properties"])
+
+    def test_skill_test_results_route_returns_public_scenario_results(self) -> None:
+        response = self.client.get("/api/v1/skills/terraform/test-results")
+
+        self.assertEqual(response.status_code, 200)
+        payload = response.json()
+        self.assertEqual(payload["data"]["skill_id"], "terraform")
+        self.assertEqual(payload["data"]["summary"]["status"], "passing")
+        self.assertGreaterEqual(len(payload["data"]["scenarios"]), 1)
 
 
 if __name__ == "__main__":

--- a/tests/test_cli/test_analyze.py
+++ b/tests/test_cli/test_analyze.py
@@ -199,6 +199,74 @@ class AnalyzeCliTests(unittest.TestCase):
         self.assertEqual(ctx.exception.code, 0)
         self.assertIn("valid skill manifest v1", output.getvalue())
 
+    def test_skill_test_command_reports_success_for_requested_skill(self) -> None:
+        output = io.StringIO()
+
+        with (
+            patch("sys.argv", ["deploywhisper", "skill", "test", "terraform"]),
+            redirect_stdout(output),
+        ):
+            with self.assertRaises(SystemExit) as ctx:
+                main()
+
+        self.assertEqual(ctx.exception.code, 0)
+        self.assertIn("terraform:", output.getvalue())
+        self.assertIn("scenarios passing", output.getvalue())
+
+    def test_skill_test_command_emits_json(self) -> None:
+        output = io.StringIO()
+
+        with (
+            patch(
+                "sys.argv",
+                ["deploywhisper", "skill", "test", "terraform", "--json"],
+            ),
+            redirect_stdout(output),
+        ):
+            with self.assertRaises(SystemExit) as ctx:
+                main()
+
+        self.assertEqual(ctx.exception.code, 0)
+        payload = json.loads(output.getvalue())
+        self.assertEqual(payload["data"][0]["skill_id"], "terraform")
+        self.assertEqual(payload["data"][0]["summary"]["status"], "passing")
+
+    def test_skill_test_command_rejects_unknown_skill_id(self) -> None:
+        stderr = io.StringIO()
+
+        with (
+            patch("sys.argv", ["deploywhisper", "skill", "test", "missing-skill"]),
+            redirect_stderr(stderr),
+        ):
+            with self.assertRaises(SystemExit) as ctx:
+                main()
+
+        self.assertEqual(ctx.exception.code, 2)
+        self.assertIn("Unknown skill ids: missing-skill", stderr.getvalue())
+
+    def test_skill_test_command_emits_structured_error_for_unknown_skill_in_json_mode(
+        self,
+    ) -> None:
+        stdout = io.StringIO()
+        stderr = io.StringIO()
+
+        with (
+            patch(
+                "sys.argv",
+                ["deploywhisper", "skill", "test", "missing-skill", "--json"],
+            ),
+            redirect_stdout(stdout),
+            redirect_stderr(stderr),
+        ):
+            with self.assertRaises(SystemExit) as ctx:
+                main()
+
+        self.assertEqual(ctx.exception.code, 2)
+        self.assertEqual(stdout.getvalue(), "")
+        payload = json.loads(stderr.getvalue())
+        self.assertEqual(payload["error"]["code"], "skill_not_found")
+        self.assertEqual(payload["error"]["details"]["skill_ids"], ["missing-skill"])
+
     def test_analyze_command_runs_shared_analysis_and_prints_structured_output(
         self,
     ) -> None:

--- a/tests/test_services/test_skill_test_harness_service.py
+++ b/tests/test_services/test_skill_test_harness_service.py
@@ -1,0 +1,84 @@
+"""Tests for the deterministic skill test harness service."""
+
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from services.skill_test_harness_service import (
+    iter_built_in_skill_ids,
+    run_skill_test_suite,
+    run_skill_test_suites,
+    summarize_skill_test_suite,
+)
+
+
+class SkillTestHarnessServiceTests(unittest.TestCase):
+    def test_run_skill_test_suite_reports_passing_summary(self) -> None:
+        result = run_skill_test_suite("terraform")
+
+        assert result is not None
+        self.assertEqual(result.skill_id, "terraform")
+        self.assertEqual(result.summary.status, "passing")
+        self.assertGreaterEqual(result.summary.total_scenarios, 1)
+        self.assertEqual(result.summary.failed_scenarios, 0)
+        self.assertTrue(all(scenario.passed for scenario in result.scenarios))
+
+    def test_summarize_skill_test_suite_returns_public_display_text(self) -> None:
+        summary = summarize_skill_test_suite("docker")
+
+        assert summary is not None
+        self.assertEqual(summary.skill_id, "docker")
+        self.assertEqual(summary.status, "passing")
+        self.assertIn("/", summary.display_text)
+
+    def test_run_skill_test_suite_returns_none_for_missing_skill(self) -> None:
+        self.assertIsNone(run_skill_test_suite("missing-skill"))
+
+    def test_missing_scenario_files_are_reported_as_missing(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            repo_root = Path(tmpdir)
+            skills_dir = repo_root / "skills"
+            skill_tests_dir = repo_root / "tests" / "skill-tests"
+            skills_dir.mkdir(parents=True, exist_ok=True)
+            skill_tests_dir.mkdir(parents=True, exist_ok=True)
+            (skill_tests_dir / "terraform").mkdir(parents=True, exist_ok=True)
+            (skills_dir / "terraform.md").write_text(
+                "---\n"
+                "name: terraform\n"
+                "version: 1.0.0\n"
+                "author: DeployWhisper\n"
+                "license: MIT\n"
+                "triggers: [.tf]\n"
+                "token_budget: 1500\n"
+                "tags: [terraform]\n"
+                "description: Terraform guidance.\n"
+                "test_suite_path: tests/skill-tests/terraform\n"
+                "---\n"
+                "# Terraform\nGuidance.\n",
+                encoding="utf-8",
+            )
+
+            with (
+                patch("services.skill_test_harness_service.REPO_ROOT", repo_root),
+                patch("services.skill_test_harness_service.SKILLS_DIR", skills_dir),
+            ):
+                result = run_skill_test_suite("terraform")
+
+        assert result is not None
+        self.assertEqual(result.summary.status, "missing")
+        self.assertEqual(result.summary.total_scenarios, 0)
+
+    def test_run_skill_test_suites_defaults_to_all_built_in_skills(self) -> None:
+        results = run_skill_test_suites()
+
+        self.assertEqual(
+            {result.skill_id for result in results},
+            set(iter_built_in_skill_ids()),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
…ible

Story 4.3 adds a deterministic skill harness that exercises real skill selection and emitted guidance, then surfaces those results through CLI, API, and CI. The implementation keeps the checks aligned with the current markdown-based runtime instead of inventing a parallel test model.

Constraint: Skills are markdown knowledge assets, not executable plugins, so the harness must validate actual runtime selection/context behavior

Constraint: PR automation must run only the changed built-in skill suites without adding new dependencies

Rejected: Execute arbitrary skill prose as code | violates the current skill model and local-first safety boundary

Rejected: Build a separate harness-specific skill format | would drift from the real runtime contract

Confidence: high

Scope-risk: moderate

Reversibility: clean

Directive: Keep harness scenarios tied to real skill-selection behavior and update CLI/API/CI together when the harness contract changes

Tested: Targeted harness/registry/API/CLI/skill-context unittest bundle

Tested: ./.venv/bin/ruff check .

Tested: ./.venv/bin/ruff format --check .

Tested: ./.venv/bin/python cli.py skill test --json

Tested: ./.venv/bin/python -m unittest discover -q

Tested: bash scripts/ci-local.sh

Not-tested: Local Bandit scan (bandit not installed)

## What does this PR do?

<!-- Brief description of changes -->

## Type of change
- [ ] Feature (new functionality)
- [ ] Bugfix (non-breaking fix)
- [ ] Release preparation
- [ ] Hotfix (critical production fix)
- [ ] Docs / refactor / chore

## Checklist
- [ ] I have followed the branch naming convention
- [ ] Tests pass locally (`pytest tests/ -v`)
- [ ] Linting passes (`ruff check .`)
- [ ] Docker build succeeds
- [ ] I have updated docs if needed
- [ ] No secrets or .env values committed

## Related issue
Closes #