### PR TITLE
Harden skill harness review gates before marketplace publish

### DIFF
--- a/cli/analyze.py
+++ b/cli/analyze.py
@@ -154,7 +154,7 @@ def _run_skill_test(skill_ids: list[str], *, emit_json: bool = False) -> int:
                 print(f"  - {scenario.name}: {'; '.join(scenario.failures)}")
     return (
         0
-        if results and all(result.summary.failed_scenarios == 0 for result in results)
+        if results and all(result.summary.status == "passing" for result in results)
         else 1
     )
 

--- a/docs/skills/test-harness.md
+++ b/docs/skills/test-harness.md
@@ -8,6 +8,12 @@ behavior that exists today:
 - trigger-based skills load from representative raw files
 - the emitted skill context contains required guidance snippets
 
+Harness summary states:
+
+- `passing`: every scenario passed
+- `failing`: one or more scenarios failed, including malformed scenario JSON
+- `missing`: the suite path resolved but no scenario files were present; CLI and CI treat this as non-passing
+
 ## Scenario layout
 
 Each built-in skill keeps scenarios under the manifest path declared by

--- a/services/skill_test_harness_service.py
+++ b/services/skill_test_harness_service.py
@@ -6,7 +6,7 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import Literal
 
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, Field, ValidationError, field_validator
 
 from analysis.risk_scorer import RiskAssessment, RiskContributor
 from llm.skill_context import ActiveSkill, build_skill_context_from_active_skills
@@ -97,6 +97,15 @@ class SkillTestSuiteResult(BaseModel):
     scenarios: list[SkillTestScenarioResult] = Field(default_factory=list)
 
 
+class SkillScenarioLoadError(ValueError):
+    """Raised when a scenario definition cannot be loaded safely."""
+
+    def __init__(self, path: Path, message: str) -> None:
+        self.path = path
+        self.message = message
+        super().__init__(message)
+
+
 def _timestamp() -> str:
     return datetime.now(tz=UTC).isoformat().replace("+00:00", "Z")
 
@@ -115,7 +124,7 @@ def _build_summary(
         status = "failing"
     else:
         status = "passing"
-    pass_rate = 1.0 if total == 0 else passed / total
+    pass_rate = 0.0 if total == 0 else passed / total
     return SkillTestSummary(
         skill_id=skill_id,
         total_scenarios=total,
@@ -135,12 +144,17 @@ def _scenario_files(suite_dir: Path) -> list[Path]:
 
 
 def _load_scenarios(suite_dir: Path) -> list[SkillTestScenarioDefinition]:
-    return [
-        SkillTestScenarioDefinition.model_validate_json(
-            path.read_text(encoding="utf-8")
-        )
-        for path in _scenario_files(suite_dir)
-    ]
+    scenarios: list[SkillTestScenarioDefinition] = []
+    for path in _scenario_files(suite_dir):
+        try:
+            scenarios.append(
+                SkillTestScenarioDefinition.model_validate_json(
+                    path.read_text(encoding="utf-8")
+                )
+            )
+        except (OSError, ValidationError, ValueError) as exc:
+            raise SkillScenarioLoadError(path, str(exc)) from exc
+    return scenarios
 
 
 def _load_active_skill(skill_id: str) -> tuple[ActiveSkill, str, Path] | None:
@@ -237,9 +251,26 @@ def run_skill_test_suite(skill_id: str) -> SkillTestSuiteResult | None:
     if loaded is None:
         return None
     active_skill, version, suite_dir = loaded
+    try:
+        loaded_scenarios = _load_scenarios(suite_dir)
+    except SkillScenarioLoadError as exc:
+        scenario_results = [
+            SkillTestScenarioResult(
+                name="suite-load-error",
+                description=f"Failed to load {exc.path.name}.",
+                passed=False,
+                failures=[f"{exc.path.name}: {exc.message}"],
+            )
+        ]
+        return SkillTestSuiteResult(
+            skill_id=skill_id,
+            version=version,
+            summary=_build_summary(skill_id, scenario_results),
+            scenarios=scenario_results,
+        )
+
     scenario_results = [
-        _run_scenario(skill_id, active_skill, scenario)
-        for scenario in _load_scenarios(suite_dir)
+        _run_scenario(skill_id, active_skill, scenario) for scenario in loaded_scenarios
     ]
     return SkillTestSuiteResult(
         skill_id=skill_id,

--- a/tests/test_api/test_skills.py
+++ b/tests/test_api/test_skills.py
@@ -273,6 +273,46 @@ class SkillsApiTests(unittest.TestCase):
         self.assertEqual(payload["data"]["summary"]["status"], "passing")
         self.assertGreaterEqual(len(payload["data"]["scenarios"]), 1)
 
+    def test_skill_test_results_route_reports_invalid_suite_as_failing_not_500(
+        self,
+    ) -> None:
+        (self.skills_dir / "terraform.md").write_text(
+            "---\n"
+            "name: terraform\n"
+            "version: 1.0.0\n"
+            "author: DeployWhisper\n"
+            "license: MIT\n"
+            "description: Built-in terraform checks.\n"
+            "test_suite_path: tests/skill-tests/terraform\n"
+            "token_budget: 1200\n"
+            "triggers: [.tf]\n"
+            "tags: [iac]\n"
+            "---\n"
+            "# Terraform\nBuilt-in guidance.\n",
+            encoding="utf-8",
+        )
+        suite_dir = Path(self.tempdir.name) / "tests" / "skill-tests" / "terraform"
+        suite_dir.mkdir(parents=True, exist_ok=True)
+        (suite_dir / "broken.json").write_text(
+            '{"name": "", "assessment_tool": "terraform"}',
+            encoding="utf-8",
+        )
+
+        with (
+            patch(
+                "services.skill_test_harness_service.REPO_ROOT",
+                Path(self.tempdir.name),
+            ),
+            patch("services.skill_test_harness_service.SKILLS_DIR", self.skills_dir),
+        ):
+            response = self.client.get("/api/v1/skills/terraform/test-results")
+
+        self.assertEqual(response.status_code, 200)
+        payload = response.json()
+        self.assertEqual(payload["data"]["summary"]["status"], "failing")
+        self.assertEqual(payload["data"]["scenarios"][0]["name"], "suite-load-error")
+        self.assertIn("broken.json", payload["data"]["scenarios"][0]["failures"][0])
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_services/test_skill_registry_service.py
+++ b/tests/test_services/test_skill_registry_service.py
@@ -238,6 +238,49 @@ class SkillRegistryServiceTests(unittest.TestCase):
         self.assertIsNone(missing)
         self.assertEqual(versions, [])
 
+    def test_registry_page_reports_invalid_suite_json_as_failing_summary(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            repo_root = Path(tmpdir)
+            skills_dir = repo_root / "skills"
+            custom_dir = skills_dir / "custom"
+            suite_dir = repo_root / "tests" / "skill-tests" / "terraform"
+            skills_dir.mkdir(parents=True, exist_ok=True)
+            custom_dir.mkdir(parents=True, exist_ok=True)
+            suite_dir.mkdir(parents=True, exist_ok=True)
+            (skills_dir / "terraform.md").write_text(
+                "---\n"
+                "name: terraform\n"
+                "version: 1.0.0\n"
+                "author: DeployWhisper\n"
+                "license: MIT\n"
+                "description: Built-in terraform checks.\n"
+                "test_suite_path: tests/skill-tests/terraform\n"
+                "token_budget: 1200\n"
+                "triggers: [.tf]\n"
+                "tags: [iac]\n"
+                "---\n"
+                "# Terraform\nBuilt-in guidance.\n",
+                encoding="utf-8",
+            )
+            (suite_dir / "broken.json").write_text(
+                '{"name": "", "assessment_tool": "terraform"}',
+                encoding="utf-8",
+            )
+
+            with (
+                patch("services.skill_registry_service.SKILLS_DIR", skills_dir),
+                patch("services.skill_registry_service.CUSTOM_DIR", custom_dir),
+                patch("services.skill_test_harness_service.REPO_ROOT", repo_root),
+                patch("services.skill_test_harness_service.SKILLS_DIR", skills_dir),
+            ):
+                page = fetch_skill_registry_page()
+
+        self.assertEqual(page.total_count, 1)
+        self.assertEqual(page.items[0].id, "terraform")
+        assert page.items[0].test_results is not None
+        self.assertEqual(page.items[0].test_results.status, "failing")
+        self.assertEqual(page.items[0].test_results.failed_scenarios, 1)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_services/test_skill_test_harness_service.py
+++ b/tests/test_services/test_skill_test_harness_service.py
@@ -70,6 +70,46 @@ class SkillTestHarnessServiceTests(unittest.TestCase):
         assert result is not None
         self.assertEqual(result.summary.status, "missing")
         self.assertEqual(result.summary.total_scenarios, 0)
+        self.assertEqual(result.summary.pass_rate, 0.0)
+
+    def test_invalid_scenario_json_is_reported_as_failing_suite(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            repo_root = Path(tmpdir)
+            skills_dir = repo_root / "skills"
+            suite_dir = repo_root / "tests" / "skill-tests" / "terraform"
+            skills_dir.mkdir(parents=True, exist_ok=True)
+            suite_dir.mkdir(parents=True, exist_ok=True)
+            (skills_dir / "terraform.md").write_text(
+                "---\n"
+                "name: terraform\n"
+                "version: 1.0.0\n"
+                "author: DeployWhisper\n"
+                "license: MIT\n"
+                "triggers: [.tf]\n"
+                "token_budget: 1500\n"
+                "tags: [terraform]\n"
+                "description: Terraform guidance.\n"
+                "test_suite_path: tests/skill-tests/terraform\n"
+                "---\n"
+                "# Terraform\nGuidance.\n",
+                encoding="utf-8",
+            )
+            (suite_dir / "broken.json").write_text(
+                '{"name": "", "assessment_tool": "terraform"}',
+                encoding="utf-8",
+            )
+
+            with (
+                patch("services.skill_test_harness_service.REPO_ROOT", repo_root),
+                patch("services.skill_test_harness_service.SKILLS_DIR", skills_dir),
+            ):
+                result = run_skill_test_suite("terraform")
+
+        assert result is not None
+        self.assertEqual(result.summary.status, "failing")
+        self.assertEqual(result.summary.failed_scenarios, 1)
+        self.assertEqual(result.scenarios[0].name, "suite-load-error")
+        self.assertIn("broken.json", result.scenarios[0].failures[0])
 
     def test_run_skill_test_suites_defaults_to_all_built_in_skills(self) -> None:
         results = run_skill_test_suites()


### PR DESCRIPTION
The Story 4.3 review surfaced two trust failures in the harness lane: skills with no scenarios could still leave CLI and CI green, and malformed scenario JSON could bubble into registry/test-results surfaces instead of degrading into an explicit suite failure. This commit tightens those semantics so marketplace quality signals stay deterministic and honest.

The harness now reports missing suites as non-passing with a zero pass rate, converts scenario-load errors into failing suite results, and requires an explicit passing summary before the CLI returns success. Supporting tests and docs were updated around the public API and registry summary paths so the failure modes are locked down.

Constraint: Story 4.3 public API/CLI surfaces must remain deterministic and must not crash on malformed skill-suite data
Rejected: Treat invalid scenario files as API 500s | breaks public registry contract and hides per-skill failure context
Rejected: Keep missing suites as zero-failure success | lets untested skills pass CI despite AC1 requiring shipped scenarios
Confidence: high
Scope-risk: narrow
Reversibility: clean
Directive: Keep non-passing harness states (`missing`, malformed suites, failed scenarios) out of successful CLI/CI paths unless the marketplace acceptance criteria change
Tested: Focused Story 4.3 unittest bundle; repo-wide Ruff check and format check; full unittest discover; scripts/ci-local.sh
Not-tested: Bandit local scan (tool unavailable in this environment)

## What does this PR do?

<!-- Brief description of changes -->

## Type of change
- [ ] Feature (new functionality)
- [ ] Bugfix (non-breaking fix)
- [ ] Release preparation
- [ ] Hotfix (critical production fix)
- [ ] Docs / refactor / chore

## Checklist
- [ ] I have followed the branch naming convention
- [ ] Tests pass locally (`pytest tests/ -v`)
- [ ] Linting passes (`ruff check .`)
- [ ] Docker build succeeds
- [ ] I have updated docs if needed
- [ ] No secrets or .env values committed

## Related issue
Closes #