### PR TITLE
Make skill installs safe and recoverable from the CLI

### DIFF
--- a/api/routes/skills.py
+++ b/api/routes/skills.py
@@ -7,6 +7,8 @@ from fastapi import APIRouter, Query
 from api.errors import ApiError, ApiRoute
 from api.schemas import (
     ErrorResponse,
+    SkillRegistryContentData,
+    SkillRegistryContentResponse,
     SkillRegistryData,
     SkillRegistryDetailResponse,
     SkillRegistryListMetaPayload,
@@ -19,6 +21,7 @@ from api.schemas import (
 )
 from config import settings
 from services.skill_registry_service import (
+    fetch_skill_registry_content,
     fetch_skill_registry_entry,
     fetch_skill_registry_page,
     fetch_skill_registry_versions,
@@ -140,6 +143,39 @@ def get_skill_versions(skill_id: str) -> SkillRegistryVersionsResponse:
             app=settings.app_name,
             version=settings.app_version,
             id=skill_id.strip().lower(),
+        ),
+    )
+
+
+@router.get(
+    "/{skill_id}/content",
+    response_model=SkillRegistryContentResponse,
+    responses={
+        404: {"model": ErrorResponse},
+        422: {"model": ErrorResponse},
+        500: {"model": ErrorResponse},
+    },
+)
+def get_skill_content(
+    skill_id: str,
+    version: str | None = Query(
+        default=None,
+        description="Optional exact version selector for install payload retrieval.",
+    ),
+) -> SkillRegistryContentResponse:
+    skill_content = fetch_skill_registry_content(skill_id, version=version)
+    if skill_content is None:
+        raise ApiError(
+            status_code=404,
+            code="skill_not_found",
+            message="Skill not found.",
+        )
+    return SkillRegistryContentResponse(
+        data=SkillRegistryContentData(**skill_content.model_dump()),
+        meta=SkillRegistryResourceMetaPayload(
+            app=settings.app_name,
+            version=settings.app_version,
+            id=skill_content.id,
         ),
     )
 

--- a/api/schemas.py
+++ b/api/schemas.py
@@ -695,6 +695,16 @@ class SkillRegistryVersionData(SkillRegistryData):
     )
 
 
+class SkillRegistryContentData(BaseModel):
+    id: str = Field(..., description="Stable skill identifier")
+    version: str = Field(..., description="Registry version for the returned skill")
+    content: str = Field(
+        ...,
+        description="Raw markdown payload including frontmatter for installation.",
+    )
+    sha256: str = Field(..., description="SHA-256 checksum for the payload")
+
+
 class SkillRegistryListMetaPayload(MetaPayload):
     count: int = Field(..., description="Count of returned items")
     total_count: int = Field(..., description="Total number of matching skills")
@@ -722,6 +732,11 @@ class SkillRegistryDetailResponse(BaseModel):
 
 class SkillRegistryVersionsResponse(BaseModel):
     data: list[SkillRegistryVersionData]
+    meta: SkillRegistryResourceMetaPayload
+
+
+class SkillRegistryContentResponse(BaseModel):
+    data: SkillRegistryContentData
     meta: SkillRegistryResourceMetaPayload
 
 

--- a/cli/analyze.py
+++ b/cli/analyze.py
@@ -22,6 +22,13 @@ from services.skill_manifest_service import (
     SkillManifestValidationError,
     load_skill_document,
 )
+from services.skill_installer_service import (
+    SkillInstallerError,
+    install_skill,
+    list_installed_skills,
+    remove_skill,
+    update_skill,
+)
 from services.skill_test_harness_service import run_skill_test_suites
 from services.skill_test_harness_service import iter_built_in_skill_ids
 from services.analysis_service import (
@@ -159,6 +166,64 @@ def _run_skill_test(skill_ids: list[str], *, emit_json: bool = False) -> int:
     )
 
 
+def _run_skill_install(skill_id: str) -> int:
+    try:
+        result = install_skill(skill_id)
+    except SkillInstallerError as exc:
+        sys.stderr.write(f"{exc.message}\n")
+        return 2
+    print(
+        f"Installed {result.skill_id}@{result.version} "
+        f"to {result.destination} [{result.mode}]"
+    )
+    return 0
+
+
+def _run_skill_list() -> int:
+    installed = list_installed_skills()
+    if not installed:
+        print("No installed custom skills found.")
+        return 0
+    for item in installed:
+        version_text = item.version or "unknown"
+        state_text = "active" if item.active else "ignored"
+        line = f"{item.id}@{version_text} [{item.mode}, {state_text}]"
+        if item.warning:
+            line += f" - {item.warning}"
+        print(line)
+    return 0
+
+
+def _run_skill_update(skill_id: str) -> int:
+    try:
+        result = update_skill(skill_id)
+    except SkillInstallerError as exc:
+        sys.stderr.write(f"{exc.message}\n")
+        return 2
+    if result.action == "unchanged":
+        print(
+            f"{result.skill_id} is already up to date "
+            f"at {result.version} ({result.destination})"
+        )
+        return 0
+    print(
+        f"Updated {result.skill_id} "
+        f"{result.previous_version or 'unknown'} -> {result.version} "
+        f"at {result.destination}"
+    )
+    return 0
+
+
+def _run_skill_remove(skill_id: str) -> int:
+    try:
+        result = remove_skill(skill_id)
+    except SkillInstallerError as exc:
+        sys.stderr.write(f"{exc.message}\n")
+        return 2
+    print(f"Removed {result.skill_id} from {result.destination}")
+    return 0
+
+
 def _run_analyze(paths: list[str]) -> int:
     if not paths:
         _emit_json(
@@ -280,6 +345,13 @@ def build_parser() -> argparse.ArgumentParser:
         "skill", help="Authoring and package actions for individual skills."
     )
     skill_subparsers = skill_parser.add_subparsers(dest="skill_command")
+    skill_install_parser = skill_subparsers.add_parser(
+        "install", help="Fetch and install a registry skill into skills/custom."
+    )
+    skill_install_parser.add_argument("skill_id", help="Skill id to install.")
+    skill_subparsers.add_parser(
+        "list", help="List installed custom skills from skills/custom."
+    )
     skill_lint_parser = skill_subparsers.add_parser(
         "lint", help="Validate a skill markdown file against manifest v1."
     )
@@ -297,6 +369,14 @@ def build_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="Emit machine-readable JSON instead of human-readable output.",
     )
+    skill_update_parser = skill_subparsers.add_parser(
+        "update", help="Refresh an installed skill to the latest registry version."
+    )
+    skill_update_parser.add_argument("skill_id", help="Installed skill id to update.")
+    skill_remove_parser = skill_subparsers.add_parser(
+        "remove", help="Uninstall a custom skill from skills/custom."
+    )
+    skill_remove_parser.add_argument("skill_id", help="Installed skill id to remove.")
 
     analyze_parser = subparsers.add_parser(
         "analyze", help="Run headless advisory analysis for one or more artifacts."
@@ -365,10 +445,18 @@ def main() -> None:
 
     if args.command == "skills":
         raise SystemExit(_run_skills())
+    if args.command == "skill" and args.skill_command == "install":
+        raise SystemExit(_run_skill_install(args.skill_id))
+    if args.command == "skill" and args.skill_command == "list":
+        raise SystemExit(_run_skill_list())
     if args.command == "skill" and args.skill_command == "lint":
         raise SystemExit(_run_skill_lint(args.path))
     if args.command == "skill" and args.skill_command == "test":
         raise SystemExit(_run_skill_test(args.skill_ids, emit_json=args.json))
+    if args.command == "skill" and args.skill_command == "update":
+        raise SystemExit(_run_skill_update(args.skill_id))
+    if args.command == "skill" and args.skill_command == "remove":
+        raise SystemExit(_run_skill_remove(args.skill_id))
     if args.command == "analyze":
         raise SystemExit(_run_analyze(args.paths))
     if args.command == "github" and args.github_command == "init":

--- a/config.py
+++ b/config.py
@@ -48,6 +48,12 @@ class Settings:
     github_app_private_key_path: str | None = (
         os.getenv("DEPLOYWHISPER_GITHUB_APP_PRIVATE_KEY_PATH") or None
     )
+    skills_registry_base_url: str | None = (
+        os.getenv("DEPLOYWHISPER_SKILLS_REGISTRY_URL")
+        or os.getenv("APP_BASE_URL")
+        or os.getenv("PUBLIC_APP_URL")
+        or None
+    )
     github_app_api_base_url: str = os.getenv(
         "DEPLOYWHISPER_GITHUB_APP_API_BASE_URL",
         "https://api.github.com",

--- a/docs/skills/installer-cli.md
+++ b/docs/skills/installer-cli.md
@@ -1,0 +1,63 @@
+# Skills Installer CLI
+
+Story 4.4 adds registry-backed install lifecycle commands under
+`deploywhisper skill ...` so users can manage local skill cache files without
+copying markdown by hand.
+
+## Commands
+
+Install the latest published version of a skill into `skills/custom/`:
+
+```bash
+deploywhisper skill install helm
+```
+
+List currently installed custom skills:
+
+```bash
+deploywhisper skill list
+```
+
+Update an installed custom skill to the latest registry version:
+
+```bash
+deploywhisper skill update helm
+```
+
+Remove an installed custom skill:
+
+```bash
+deploywhisper skill remove helm
+```
+
+## Registry URL resolution
+
+The installer fetches metadata and raw markdown from the configured Skills
+Registry API. It resolves the base URL in this order:
+
+1. `DEPLOYWHISPER_SKILLS_REGISTRY_URL`
+2. `APP_BASE_URL`
+3. `PUBLIC_APP_URL`
+
+If none of those are configured, install and update commands fail with a clear
+configuration error instead of guessing a remote endpoint.
+
+## Install location and precedence
+
+- Installed skills are written to `skills/custom/<skill>.md`
+- Files in `skills/custom/` override bundled `skills/<skill>.md` entries with
+  the same filename
+- Skill ids must use lowercase letters, digits, and hyphens only
+- `deploywhisper skill install` refuses to overwrite an existing custom file;
+  use `deploywhisper skill update` when you intentionally want the latest
+  registry version
+- `deploywhisper skill update` also restores the canonical registry copy when
+  the installed file has drifted locally but still reports the same version
+
+## Validation behavior
+
+- Registry payloads are validated against manifest v1 before being written to
+  disk
+- The installer verifies the registry-provided SHA-256 checksum before saving
+- `deploywhisper skill list` reports both active installed skills and ignored
+  files when a custom manifest is invalid

--- a/docs/skills/registry-api.md
+++ b/docs/skills/registry-api.md
@@ -11,6 +11,9 @@ contract.
   `tool`, `tag`, `author`, and `search` filters.
 - `GET /api/v1/skills/{id}`
   Returns the current effective record for a single skill id.
+- `GET /api/v1/skills/{id}/content`
+  Returns the raw markdown payload, manifest version, and SHA-256 checksum used
+  by the installer CLI.
 - `GET /api/v1/skills/{id}/versions`
   Returns the discoverable bundled-catalog version history for a single skill
   id.
@@ -22,6 +25,9 @@ contract.
 - Installed or team-local cache files under `skills/custom/*.md` are excluded
   from this API so the browser and installer surfaces do not drift per
   instance.
+- The content endpoint returns the exact markdown payload with frontmatter so
+  installer clients can validate and cache the same artifact the registry
+  publishes.
 - Skills with invalid YAML frontmatter are skipped instead of failing the
   registry endpoints.
 - The API contract is intentionally manifest-shaped so later stories can add the

--- a/services/skill_installer_service.py
+++ b/services/skill_installer_service.py
@@ -1,0 +1,391 @@
+"""Registry-backed installer operations for custom skills."""
+
+from __future__ import annotations
+
+from hashlib import sha256
+import json
+from pathlib import Path
+import re
+from typing import Literal
+from urllib import error, parse, request
+
+from pydantic import BaseModel, Field
+
+from config import settings
+from services.skill_manifest_service import (
+    SkillManifestValidationError,
+    load_skill_document,
+    parse_skill_document,
+)
+
+SKILLS_DIR = Path(__file__).resolve().parents[1] / "skills"
+CUSTOM_DIR = SKILLS_DIR / "custom"
+SkillInstallMode = Literal["override", "new"]
+_SKILL_ID_PATTERN = re.compile(r"^[a-z0-9]+(?:-[a-z0-9]+)*$")
+
+
+class SkillInstallerError(ValueError):
+    """Raised when installer actions fail."""
+
+    def __init__(
+        self,
+        code: str,
+        message: str,
+        details: dict[str, str] | None = None,
+    ) -> None:
+        self.code = code
+        self.message = message
+        self.details = details or {}
+        super().__init__(message)
+
+
+class InstalledSkillEntry(BaseModel):
+    """Normalized installed-skill summary for CLI output."""
+
+    id: str = Field(..., description="Stable skill identifier.")
+    version: str | None = Field(
+        default=None, description="Installed manifest version when available."
+    )
+    mode: SkillInstallMode = Field(
+        ..., description="Whether the local install overrides a bundled skill."
+    )
+    active: bool = Field(..., description="Whether the installed file parses cleanly.")
+    path: str = Field(..., description="Filesystem location of the installed skill.")
+    description: str | None = Field(
+        default=None, description="Installed manifest description when available."
+    )
+    warning: str | None = Field(
+        default=None, description="Parsing warning for invalid installed files."
+    )
+
+
+class SkillRemoteContent(BaseModel):
+    """Registry-delivered markdown payload for an installable skill."""
+
+    id: str = Field(..., description="Stable skill identifier.")
+    version: str = Field(..., description="Registry version for the returned skill.")
+    content: str = Field(..., description="Raw markdown content including frontmatter.")
+    sha256: str = Field(..., description="SHA-256 checksum of the registry payload.")
+    source_url: str = Field(..., description="Registry endpoint used for retrieval.")
+
+
+class SkillInstallResult(BaseModel):
+    """Outcome details for install/update/remove operations."""
+
+    action: Literal["installed", "updated", "removed", "unchanged"] = Field(
+        ..., description="Lifecycle action that completed."
+    )
+    skill_id: str = Field(..., description="Stable skill identifier.")
+    version: str | None = Field(
+        default=None, description="Version after the action completes."
+    )
+    previous_version: str | None = Field(
+        default=None, description="Version before the action completes."
+    )
+    destination: str = Field(..., description="Local skill file path.")
+    mode: SkillInstallMode = Field(
+        ..., description="Whether the installed skill is a new file or override."
+    )
+    sha256: str | None = Field(
+        default=None, description="Checksum for the written registry payload."
+    )
+    source_url: str | None = Field(
+        default=None, description="Registry URL used for install or update."
+    )
+
+
+def _normalize_skill_id(skill_id: str) -> str:
+    normalized = skill_id.strip().lower()
+    if not normalized:
+        raise SkillInstallerError(
+            "invalid_skill_id",
+            "Skill id must not be empty.",
+        )
+    if not _SKILL_ID_PATTERN.fullmatch(normalized):
+        raise SkillInstallerError(
+            "invalid_skill_id",
+            "Skill id must use lowercase letters, digits, and hyphens only.",
+            {"skill_id": normalized},
+        )
+    return normalized
+
+
+def _skill_destination(skill_id: str) -> Path:
+    return CUSTOM_DIR / f"{skill_id}.md"
+
+
+def _install_mode(skill_id: str) -> SkillInstallMode:
+    return "override" if (SKILLS_DIR / f"{skill_id}.md").exists() else "new"
+
+
+def _current_version(path: Path) -> str | None:
+    try:
+        document = load_skill_document(
+            path,
+            strict_manifest=False,
+            allow_legacy_name=True,
+        )
+    except (FileNotFoundError, SkillManifestValidationError):
+        return None
+    return document.manifest.version if document.manifest else None
+
+
+def _current_checksum(path: Path) -> str | None:
+    try:
+        return sha256(path.read_bytes()).hexdigest()
+    except OSError:
+        return None
+
+
+def _registry_base_url() -> str:
+    configured = (settings.skills_registry_base_url or "").strip()
+    if configured:
+        return configured.rstrip("/")
+    raise SkillInstallerError(
+        "skills_registry_unconfigured",
+        "Skill registry URL is not configured. Set DEPLOYWHISPER_SKILLS_REGISTRY_URL or APP_BASE_URL.",
+    )
+
+
+def _load_json(url: str) -> dict:
+    req = request.Request(
+        url,
+        headers={
+            "Accept": "application/json",
+            "User-Agent": "DeployWhisper/skill-installer",
+        },
+    )
+    try:
+        with request.urlopen(req, timeout=15) as response:
+            payload = response.read().decode("utf-8")
+    except error.HTTPError as exc:
+        try:
+            payload = json.loads(exc.read().decode("utf-8"))
+        except (OSError, UnicodeDecodeError, json.JSONDecodeError):
+            payload = {}
+        error_payload = dict(payload.get("error") or {})
+        raise SkillInstallerError(
+            str(error_payload.get("code") or "skills_registry_request_failed"),
+            str(
+                error_payload.get("message") or f"Skill registry request failed: {exc}"
+            ),
+            {
+                key: str(value)
+                for key, value in dict(error_payload.get("details") or {}).items()
+            },
+        ) from exc
+    except error.URLError as exc:
+        raise SkillInstallerError(
+            "skills_registry_unreachable",
+            "Skill registry could not be reached.",
+            {"reason": str(exc.reason)},
+        ) from exc
+
+    try:
+        return json.loads(payload)
+    except json.JSONDecodeError as exc:
+        raise SkillInstallerError(
+            "skills_registry_invalid_response",
+            "Skill registry returned invalid JSON.",
+            {"url": url},
+        ) from exc
+
+
+def fetch_registry_skill_content(
+    skill_id: str,
+    *,
+    version: str | None = None,
+) -> SkillRemoteContent:
+    """Fetch a registry skill markdown payload and validate it locally."""
+
+    normalized_id = _normalize_skill_id(skill_id)
+    query = ""
+    if version:
+        query = "?" + parse.urlencode({"version": version.strip()})
+    url = (
+        f"{_registry_base_url()}/api/v1/skills/"
+        f"{parse.quote(normalized_id)}/content{query}"
+    )
+    payload = _load_json(url)
+    data = dict(payload.get("data") or {})
+    content = str(data.get("content") or "")
+    if not content:
+        raise SkillInstallerError(
+            "skills_registry_invalid_response",
+            "Skill registry response did not include skill content.",
+            {"url": url},
+        )
+
+    try:
+        document = parse_skill_document(
+            content,
+            expected_name=normalized_id,
+            strict_manifest=True,
+            project_root=None,
+        )
+    except SkillManifestValidationError as exc:
+        raise SkillInstallerError(
+            "invalid_skill_manifest",
+            "Fetched skill manifest failed validation.",
+            {"issues": "; ".join(exc.issues)},
+        ) from exc
+
+    assert document.manifest is not None
+    checksum = sha256(content.encode("utf-8")).hexdigest()
+    advertised_checksum = str(data.get("sha256") or "").strip()
+    if advertised_checksum and advertised_checksum != checksum:
+        raise SkillInstallerError(
+            "skill_checksum_mismatch",
+            "Fetched skill checksum did not match the registry metadata.",
+            {"skill_id": normalized_id},
+        )
+
+    return SkillRemoteContent(
+        id=normalized_id,
+        version=document.manifest.version,
+        content=content,
+        sha256=checksum,
+        source_url=url,
+    )
+
+
+def list_installed_skills() -> list[InstalledSkillEntry]:
+    """Return installed custom skills from the local cache directory."""
+
+    if not CUSTOM_DIR.exists():
+        return []
+
+    built_in_ids = {
+        path.stem.strip().lower()
+        for path in SKILLS_DIR.glob("*.md")
+        if path.is_file() and path.name.lower() != "readme.md"
+    }
+    entries: list[InstalledSkillEntry] = []
+    for path in sorted(
+        item
+        for item in CUSTOM_DIR.glob("*.md")
+        if item.is_file() and item.name.lower() != "readme.md"
+    ):
+        skill_id = path.stem.strip().lower()
+        mode: SkillInstallMode = "override" if skill_id in built_in_ids else "new"
+        try:
+            document = load_skill_document(
+                path,
+                strict_manifest=False,
+                allow_legacy_name=True,
+            )
+            manifest = document.manifest
+            entries.append(
+                InstalledSkillEntry(
+                    id=skill_id,
+                    version=manifest.version if manifest else None,
+                    mode=mode,
+                    active=True,
+                    path=str(path),
+                    description=manifest.description if manifest else None,
+                )
+            )
+        except SkillManifestValidationError as exc:
+            entries.append(
+                InstalledSkillEntry(
+                    id=skill_id,
+                    version=None,
+                    mode=mode,
+                    active=False,
+                    path=str(path),
+                    warning=exc.issues[0]
+                    if exc.issues
+                    else "Skill manifest is invalid.",
+                )
+            )
+    return entries
+
+
+def install_skill(skill_id: str) -> SkillInstallResult:
+    """Install a skill from the configured registry into skills/custom."""
+
+    normalized_id = _normalize_skill_id(skill_id)
+    destination = _skill_destination(normalized_id)
+    if destination.exists():
+        raise SkillInstallerError(
+            "skill_already_installed",
+            "Skill is already installed. Use `deploywhisper skill update` to refresh it.",
+            {"skill_id": normalized_id, "path": str(destination)},
+        )
+
+    remote = fetch_registry_skill_content(normalized_id)
+    CUSTOM_DIR.mkdir(parents=True, exist_ok=True)
+    destination.write_text(remote.content, encoding="utf-8")
+    return SkillInstallResult(
+        action="installed",
+        skill_id=normalized_id,
+        version=remote.version,
+        destination=str(destination),
+        mode=_install_mode(normalized_id),
+        sha256=remote.sha256,
+        source_url=remote.source_url,
+    )
+
+
+def update_skill(skill_id: str) -> SkillInstallResult:
+    """Refresh an installed skill to the latest registry version."""
+
+    normalized_id = _normalize_skill_id(skill_id)
+    destination = _skill_destination(normalized_id)
+    if not destination.exists():
+        raise SkillInstallerError(
+            "skill_not_installed",
+            "Skill is not installed. Use `deploywhisper skill install` first.",
+            {"skill_id": normalized_id, "path": str(destination)},
+        )
+
+    previous_version = _current_version(destination)
+    previous_checksum = _current_checksum(destination)
+    remote = fetch_registry_skill_content(normalized_id)
+    if previous_version == remote.version and previous_checksum == remote.sha256:
+        return SkillInstallResult(
+            action="unchanged",
+            skill_id=normalized_id,
+            version=remote.version,
+            previous_version=previous_version,
+            destination=str(destination),
+            mode=_install_mode(normalized_id),
+            sha256=remote.sha256,
+            source_url=remote.source_url,
+        )
+
+    destination.write_text(remote.content, encoding="utf-8")
+    return SkillInstallResult(
+        action="updated",
+        skill_id=normalized_id,
+        version=remote.version,
+        previous_version=previous_version,
+        destination=str(destination),
+        mode=_install_mode(normalized_id),
+        sha256=remote.sha256,
+        source_url=remote.source_url,
+    )
+
+
+def remove_skill(skill_id: str) -> SkillInstallResult:
+    """Remove an installed custom skill from the local cache."""
+
+    normalized_id = _normalize_skill_id(skill_id)
+    destination = _skill_destination(normalized_id)
+    if not destination.exists():
+        raise SkillInstallerError(
+            "skill_not_installed",
+            "Skill is not installed.",
+            {"skill_id": normalized_id, "path": str(destination)},
+        )
+
+    previous_version = _current_version(destination)
+    destination.unlink()
+    return SkillInstallResult(
+        action="removed",
+        skill_id=normalized_id,
+        version=None,
+        previous_version=previous_version,
+        destination=str(destination),
+        mode=_install_mode(normalized_id),
+    )

--- a/services/skill_registry_service.py
+++ b/services/skill_registry_service.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from datetime import UTC, datetime
+from hashlib import sha256
 from pathlib import Path
 import re
 from typing import Any, Literal
@@ -70,6 +71,15 @@ class SkillRegistryPage(BaseModel):
     page_size: int = Field(..., description="Current result page size")
 
 
+class SkillRegistryContent(BaseModel):
+    """Raw markdown payload for an installable registry skill."""
+
+    id: str = Field(..., description="Stable skill identifier")
+    version: str = Field(..., description="Registry version for this skill")
+    content: str = Field(..., description="Raw markdown content with frontmatter")
+    sha256: str = Field(..., description="SHA-256 checksum of the content")
+
+
 class _SkillRecord(BaseModel):
     id: str
     name: str
@@ -87,6 +97,7 @@ class _SkillRecord(BaseModel):
     trigger_content_patterns: list[str] = Field(default_factory=list)
     updated_at: str
     updated_at_epoch: float
+    path: Path
 
 
 def _iter_skill_files(directory: Path) -> list[Path]:
@@ -209,6 +220,7 @@ def _load_skill_record(path: Path, *, source: SkillSource) -> _SkillRecord | Non
         trigger_content_patterns=list(parsed.manifest.trigger_content_patterns),
         updated_at=updated_at,
         updated_at_epoch=updated_epoch,
+        path=path,
     )
 
 
@@ -321,7 +333,7 @@ def fetch_skill_registry_page(
         item
         for item in sorted(current_items, key=lambda current: current.id)
         if _matches_query(
-            _SkillRecord(**item.model_dump(), updated_at_epoch=0),
+            _SkillRecord(**item.model_dump(), updated_at_epoch=0, path=Path(".")),
             tool=tool,
             tag=tag,
             author=author,
@@ -364,3 +376,34 @@ def fetch_skill_registry_versions(skill_id: str) -> list[SkillRegistryVersionEnt
         )
         for record in _sorted_versions(records)
     ]
+
+
+def fetch_skill_registry_content(
+    skill_id: str,
+    *,
+    version: str | None = None,
+) -> SkillRegistryContent | None:
+    """Return raw markdown content for a registry skill version."""
+
+    versions_by_skill = _load_versions_by_skill(include_custom=False)
+    records = versions_by_skill.get(skill_id.strip().lower())
+    if not records:
+        return None
+
+    selected = _current_record(records)
+    if version is not None:
+        normalized_version = version.strip()
+        matching = [
+            record for record in records if record.version == normalized_version
+        ]
+        if not matching:
+            return None
+        selected = _sorted_versions(matching)[0]
+
+    content = selected.path.read_text(encoding="utf-8")
+    return SkillRegistryContent(
+        id=selected.id,
+        version=selected.version,
+        content=content,
+        sha256=sha256(content.encode("utf-8")).hexdigest(),
+    )

--- a/tests/test_api/test_skills.py
+++ b/tests/test_api/test_skills.py
@@ -166,6 +166,36 @@ class SkillsApiTests(unittest.TestCase):
         self.assertTrue(versions_payload["data"][0]["is_current"])
         self.assertEqual(versions_payload["data"][0]["source"], "built-in")
 
+    def test_get_skill_content_returns_raw_markdown_payload(self) -> None:
+        content = (
+            "---\n"
+            "name: terraform\n"
+            "version: 1.0.0\n"
+            "author: DeployWhisper\n"
+            "license: MIT\n"
+            "description: Built-in terraform checks.\n"
+            "test_suite_path: tests/skill-tests/terraform\n"
+            "token_budget: 1200\n"
+            "triggers: [.tf]\n"
+            "tags: [iac]\n"
+            "---\n"
+            "# Terraform\nBuilt-in guidance.\n"
+        )
+        (self.skills_dir / "terraform.md").write_text(content, encoding="utf-8")
+
+        with (
+            patch("services.skill_registry_service.SKILLS_DIR", self.skills_dir),
+            patch("services.skill_registry_service.CUSTOM_DIR", self.custom_dir),
+        ):
+            response = self.client.get("/api/v1/skills/terraform/content")
+
+        self.assertEqual(response.status_code, 200)
+        payload = response.json()
+        self.assertEqual(payload["data"]["id"], "terraform")
+        self.assertEqual(payload["data"]["version"], "1.0.0")
+        self.assertEqual(payload["data"]["content"], content)
+        self.assertEqual(len(payload["data"]["sha256"]), 64)
+
     def test_registry_api_ignores_local_custom_cache_entries(self) -> None:
         (self.skills_dir / "terraform.md").write_text(
             "---\n"
@@ -252,6 +282,7 @@ class SkillsApiTests(unittest.TestCase):
         payload = response.json()
         self.assertIn("/api/v1/skills", payload["paths"])
         self.assertIn("/api/v1/skills/{skill_id}", payload["paths"])
+        self.assertIn("/api/v1/skills/{skill_id}/content", payload["paths"])
         self.assertIn("/api/v1/skills/{skill_id}/versions", payload["paths"])
 
     def test_schema_route_publishes_skill_manifest_v1(self) -> None:

--- a/tests/test_cli/test_analyze.py
+++ b/tests/test_cli/test_analyze.py
@@ -23,6 +23,12 @@ from cli.analyze import main
 from importlib import reload
 from integrations.github.init_service import GitHubInitOptions, GitHubInitResult
 from llm.narrator import NarrativeResult
+from services.skill_installer_service import InstalledSkillEntry, SkillInstallResult
+from services.skill_test_harness_service import (
+    SkillTestScenarioResult,
+    SkillTestSuiteResult,
+    SkillTestSummary,
+)
 
 
 class AnalyzeCliTests(unittest.TestCase):
@@ -266,6 +272,151 @@ class AnalyzeCliTests(unittest.TestCase):
         payload = json.loads(stderr.getvalue())
         self.assertEqual(payload["error"]["code"], "skill_not_found")
         self.assertEqual(payload["error"]["details"]["skill_ids"], ["missing-skill"])
+
+    def test_skill_test_command_returns_nonzero_for_missing_suite_status(self) -> None:
+        output = io.StringIO()
+        missing_result = SkillTestSuiteResult(
+            skill_id="terraform",
+            version="1.0.0",
+            summary=SkillTestSummary(
+                skill_id="terraform",
+                total_scenarios=0,
+                passed_scenarios=0,
+                failed_scenarios=0,
+                pass_rate=0.0,
+                status="missing",
+                display_text="0/0 scenarios passing",
+                generated_at="2026-04-24T00:00:00Z",
+            ),
+            scenarios=[SkillTestScenarioResult(name="suite-missing", passed=False)],
+        )
+
+        with (
+            patch("cli.analyze.run_skill_test_suites", return_value=[missing_result]),
+            patch("sys.argv", ["deploywhisper", "skill", "test", "terraform"]),
+            redirect_stdout(output),
+        ):
+            with self.assertRaises(SystemExit) as ctx:
+                main()
+
+        self.assertEqual(ctx.exception.code, 1)
+        self.assertIn("[missing]", output.getvalue())
+
+    def test_skill_install_command_reports_install_location(self) -> None:
+        output = io.StringIO()
+
+        with (
+            patch(
+                "cli.analyze.install_skill",
+                return_value=SkillInstallResult(
+                    action="installed",
+                    skill_id="helm",
+                    version="1.2.0",
+                    previous_version=None,
+                    destination="skills/custom/helm.md",
+                    mode="new",
+                    sha256="abc",
+                    source_url="https://registry.example.com/api/v1/skills/helm/content",
+                ),
+            ),
+            patch("sys.argv", ["deploywhisper", "skill", "install", "helm"]),
+            redirect_stdout(output),
+        ):
+            with self.assertRaises(SystemExit) as ctx:
+                main()
+
+        self.assertEqual(ctx.exception.code, 0)
+        self.assertIn("Installed helm@1.2.0", output.getvalue())
+        self.assertIn("skills/custom/helm.md", output.getvalue())
+
+    def test_skill_list_command_prints_installed_skill_inventory(self) -> None:
+        output = io.StringIO()
+
+        with (
+            patch(
+                "cli.analyze.list_installed_skills",
+                return_value=[
+                    InstalledSkillEntry(
+                        id="helm",
+                        version="1.2.0",
+                        mode="new",
+                        active=True,
+                        path="skills/custom/helm.md",
+                        description="Helm rollout checks.",
+                    ),
+                    InstalledSkillEntry(
+                        id="terraform",
+                        version="2.0.0",
+                        mode="override",
+                        active=False,
+                        path="skills/custom/terraform.md",
+                        warning="invalid frontmatter",
+                    ),
+                ],
+            ),
+            patch("sys.argv", ["deploywhisper", "skill", "list"]),
+            redirect_stdout(output),
+        ):
+            with self.assertRaises(SystemExit) as ctx:
+                main()
+
+        self.assertEqual(ctx.exception.code, 0)
+        self.assertIn("helm@1.2.0 [new, active]", output.getvalue())
+        self.assertIn("terraform@2.0.0 [override, ignored]", output.getvalue())
+
+    def test_skill_update_command_reports_noop_when_latest_version_is_installed(
+        self,
+    ) -> None:
+        output = io.StringIO()
+
+        with (
+            patch(
+                "cli.analyze.update_skill",
+                return_value=SkillInstallResult(
+                    action="unchanged",
+                    skill_id="helm",
+                    version="1.2.0",
+                    previous_version="1.2.0",
+                    destination="skills/custom/helm.md",
+                    mode="new",
+                    sha256="abc",
+                    source_url="https://registry.example.com/api/v1/skills/helm/content",
+                ),
+            ),
+            patch("sys.argv", ["deploywhisper", "skill", "update", "helm"]),
+            redirect_stdout(output),
+        ):
+            with self.assertRaises(SystemExit) as ctx:
+                main()
+
+        self.assertEqual(ctx.exception.code, 0)
+        self.assertIn("already up to date", output.getvalue())
+        self.assertIn("1.2.0", output.getvalue())
+
+    def test_skill_remove_command_reports_deleted_custom_skill(self) -> None:
+        output = io.StringIO()
+
+        with (
+            patch(
+                "cli.analyze.remove_skill",
+                return_value=SkillInstallResult(
+                    action="removed",
+                    skill_id="helm",
+                    version=None,
+                    previous_version="1.2.0",
+                    destination="skills/custom/helm.md",
+                    mode="new",
+                ),
+            ),
+            patch("sys.argv", ["deploywhisper", "skill", "remove", "helm"]),
+            redirect_stdout(output),
+        ):
+            with self.assertRaises(SystemExit) as ctx:
+                main()
+
+        self.assertEqual(ctx.exception.code, 0)
+        self.assertIn("Removed helm", output.getvalue())
+        self.assertIn("skills/custom/helm.md", output.getvalue())
 
     def test_analyze_command_runs_shared_analysis_and_prints_structured_output(
         self,

--- a/tests/test_services/test_skill_installer_service.py
+++ b/tests/test_services/test_skill_installer_service.py
@@ -1,0 +1,334 @@
+"""Tests for registry-backed skill installer operations."""
+
+from __future__ import annotations
+
+from hashlib import sha256
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from services.skill_installer_service import (
+    SkillInstallerError,
+    install_skill,
+    list_installed_skills,
+    remove_skill,
+    update_skill,
+)
+
+
+class _FakeHttpResponse:
+    def __init__(self, payload: dict) -> None:
+        self._payload = json.dumps(payload).encode("utf-8")
+
+    def read(self) -> bytes:
+        return self._payload
+
+    def __enter__(self) -> _FakeHttpResponse:
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> bool:
+        return False
+
+
+class SkillInstallerServiceTests(unittest.TestCase):
+    def test_install_skill_fetches_registry_content_into_custom_dir(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            repo_root = Path(tmpdir)
+            skills_dir = repo_root / "skills"
+            custom_dir = skills_dir / "custom"
+            skills_dir.mkdir(parents=True, exist_ok=True)
+            custom_dir.mkdir(parents=True, exist_ok=True)
+            content = (
+                "---\n"
+                "name: helm\n"
+                "version: 1.2.0\n"
+                "author: Community\n"
+                "license: MIT\n"
+                "triggers: [Chart.yaml]\n"
+                "token_budget: 900\n"
+                "tags: [helm]\n"
+                "description: Helm rollout checks.\n"
+                "test_suite_path: tests/skill-tests/helm\n"
+                "---\n"
+                "# Helm\nCommunity guidance.\n"
+            )
+            response_payload = {
+                "data": {
+                    "id": "helm",
+                    "version": "1.2.0",
+                    "content": content,
+                    "sha256": sha256(content.encode("utf-8")).hexdigest(),
+                }
+            }
+
+            with (
+                patch("services.skill_installer_service.SKILLS_DIR", skills_dir),
+                patch("services.skill_installer_service.CUSTOM_DIR", custom_dir),
+                patch(
+                    "services.skill_installer_service.settings",
+                    SimpleNamespace(
+                        skills_registry_base_url="https://registry.example.com"
+                    ),
+                ),
+                patch(
+                    "services.skill_installer_service.request.urlopen",
+                    return_value=_FakeHttpResponse(response_payload),
+                ) as mocked_urlopen,
+            ):
+                result = install_skill("helm")
+                self.assertEqual(result.action, "installed")
+                self.assertEqual(result.skill_id, "helm")
+                self.assertEqual(result.version, "1.2.0")
+                self.assertEqual(result.mode, "new")
+                installed_path = Path(result.destination)
+                self.assertTrue(installed_path.exists())
+                self.assertEqual(installed_path.read_text(encoding="utf-8"), content)
+                request_url = mocked_urlopen.call_args.args[0].full_url
+                self.assertEqual(
+                    request_url,
+                    "https://registry.example.com/api/v1/skills/helm/content",
+                )
+
+    def test_update_skill_replaces_existing_custom_file_with_latest_version(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            repo_root = Path(tmpdir)
+            skills_dir = repo_root / "skills"
+            custom_dir = skills_dir / "custom"
+            skills_dir.mkdir(parents=True, exist_ok=True)
+            custom_dir.mkdir(parents=True, exist_ok=True)
+            (custom_dir / "helm.md").write_text(
+                "---\n"
+                "name: helm\n"
+                "version: 1.0.0\n"
+                "author: Community\n"
+                "license: MIT\n"
+                "triggers: [Chart.yaml]\n"
+                "token_budget: 900\n"
+                "tags: [helm]\n"
+                "description: Helm rollout checks.\n"
+                "test_suite_path: tests/skill-tests/helm\n"
+                "---\n"
+                "# Helm\nOld guidance.\n",
+                encoding="utf-8",
+            )
+            content = (
+                "---\n"
+                "name: helm\n"
+                "version: 1.2.0\n"
+                "author: Community\n"
+                "license: MIT\n"
+                "triggers: [Chart.yaml]\n"
+                "token_budget: 900\n"
+                "tags: [helm]\n"
+                "description: Helm rollout checks.\n"
+                "test_suite_path: tests/skill-tests/helm\n"
+                "---\n"
+                "# Helm\nNew guidance.\n"
+            )
+            response_payload = {
+                "data": {
+                    "id": "helm",
+                    "version": "1.2.0",
+                    "content": content,
+                    "sha256": sha256(content.encode("utf-8")).hexdigest(),
+                }
+            }
+
+            with (
+                patch("services.skill_installer_service.SKILLS_DIR", skills_dir),
+                patch("services.skill_installer_service.CUSTOM_DIR", custom_dir),
+                patch(
+                    "services.skill_installer_service.settings",
+                    SimpleNamespace(
+                        skills_registry_base_url="https://registry.example.com"
+                    ),
+                ),
+                patch(
+                    "services.skill_installer_service.request.urlopen",
+                    return_value=_FakeHttpResponse(response_payload),
+                ),
+            ):
+                result = update_skill("helm")
+
+            updated_path = custom_dir / "helm.md"
+            self.assertEqual(result.action, "updated")
+            self.assertEqual(result.previous_version, "1.0.0")
+            self.assertEqual(result.version, "1.2.0")
+            self.assertEqual(updated_path.read_text(encoding="utf-8"), content)
+
+    def test_update_skill_rewrites_drifted_file_even_when_version_matches(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            repo_root = Path(tmpdir)
+            skills_dir = repo_root / "skills"
+            custom_dir = skills_dir / "custom"
+            skills_dir.mkdir(parents=True, exist_ok=True)
+            custom_dir.mkdir(parents=True, exist_ok=True)
+            installed_path = custom_dir / "helm.md"
+            installed_path.write_text(
+                "---\n"
+                "name: helm\n"
+                "version: 1.2.0\n"
+                "author: Community\n"
+                "license: MIT\n"
+                "triggers: [Chart.yaml]\n"
+                "token_budget: 900\n"
+                "tags: [helm]\n"
+                "description: Helm rollout checks.\n"
+                "test_suite_path: tests/skill-tests/helm\n"
+                "---\n"
+                "# Helm\nLocally drifted guidance.\n",
+                encoding="utf-8",
+            )
+            registry_content = (
+                "---\n"
+                "name: helm\n"
+                "version: 1.2.0\n"
+                "author: Community\n"
+                "license: MIT\n"
+                "triggers: [Chart.yaml]\n"
+                "token_budget: 900\n"
+                "tags: [helm]\n"
+                "description: Helm rollout checks.\n"
+                "test_suite_path: tests/skill-tests/helm\n"
+                "---\n"
+                "# Helm\nCanonical registry guidance.\n"
+            )
+            response_payload = {
+                "data": {
+                    "id": "helm",
+                    "version": "1.2.0",
+                    "content": registry_content,
+                    "sha256": sha256(registry_content.encode("utf-8")).hexdigest(),
+                }
+            }
+
+            with (
+                patch("services.skill_installer_service.SKILLS_DIR", skills_dir),
+                patch("services.skill_installer_service.CUSTOM_DIR", custom_dir),
+                patch(
+                    "services.skill_installer_service.settings",
+                    SimpleNamespace(
+                        skills_registry_base_url="https://registry.example.com"
+                    ),
+                ),
+                patch(
+                    "services.skill_installer_service.request.urlopen",
+                    return_value=_FakeHttpResponse(response_payload),
+                ),
+            ):
+                result = update_skill("helm")
+
+            self.assertEqual(result.action, "updated")
+            self.assertEqual(result.previous_version, "1.2.0")
+            self.assertEqual(result.version, "1.2.0")
+            self.assertEqual(
+                installed_path.read_text(encoding="utf-8"), registry_content
+            )
+
+    def test_remove_skill_deletes_installed_custom_file(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            repo_root = Path(tmpdir)
+            skills_dir = repo_root / "skills"
+            custom_dir = skills_dir / "custom"
+            skills_dir.mkdir(parents=True, exist_ok=True)
+            custom_dir.mkdir(parents=True, exist_ok=True)
+            installed_path = custom_dir / "helm.md"
+            installed_path.write_text(
+                "---\n"
+                "name: helm\n"
+                "version: 1.1.0\n"
+                "author: Community\n"
+                "license: MIT\n"
+                "triggers: [Chart.yaml]\n"
+                "token_budget: 900\n"
+                "tags: [helm]\n"
+                "description: Helm rollout checks.\n"
+                "test_suite_path: tests/skill-tests/helm\n"
+                "---\n"
+                "# Helm\nGuidance.\n",
+                encoding="utf-8",
+            )
+
+            with (
+                patch("services.skill_installer_service.SKILLS_DIR", skills_dir),
+                patch("services.skill_installer_service.CUSTOM_DIR", custom_dir),
+            ):
+                result = remove_skill("helm")
+
+        self.assertEqual(result.action, "removed")
+        self.assertEqual(result.previous_version, "1.1.0")
+        self.assertFalse(Path(result.destination).exists())
+
+    def test_list_installed_skills_reports_override_and_invalid_entries(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            repo_root = Path(tmpdir)
+            skills_dir = repo_root / "skills"
+            custom_dir = skills_dir / "custom"
+            skills_dir.mkdir(parents=True, exist_ok=True)
+            custom_dir.mkdir(parents=True, exist_ok=True)
+            (skills_dir / "terraform.md").write_text(
+                "# Built-in\nTerraform guidance.\n",
+                encoding="utf-8",
+            )
+            (custom_dir / "terraform.md").write_text(
+                "---\n"
+                "name: terraform\n"
+                "version: 3.0.0\n"
+                "author: Team Ops\n"
+                "license: Proprietary\n"
+                "triggers: [.tf]\n"
+                "token_budget: 500\n"
+                "tags: [terraform]\n"
+                "description: Team terraform guidance.\n"
+                "test_suite_path: tests/skill-tests/terraform\n"
+                "---\n"
+                "# Terraform\nOverride guidance.\n",
+                encoding="utf-8",
+            )
+            (custom_dir / "broken.md").write_text(
+                "---\ninvalid: [\n---\n", encoding="utf-8"
+            )
+
+            with (
+                patch("services.skill_installer_service.SKILLS_DIR", skills_dir),
+                patch("services.skill_installer_service.CUSTOM_DIR", custom_dir),
+            ):
+                entries = list_installed_skills()
+
+        self.assertEqual([entry.id for entry in entries], ["broken", "terraform"])
+        self.assertFalse(entries[0].active)
+        self.assertEqual(entries[1].mode, "override")
+        self.assertEqual(entries[1].version, "3.0.0")
+
+    def test_install_skill_rejects_existing_destination(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            repo_root = Path(tmpdir)
+            skills_dir = repo_root / "skills"
+            custom_dir = skills_dir / "custom"
+            skills_dir.mkdir(parents=True, exist_ok=True)
+            custom_dir.mkdir(parents=True, exist_ok=True)
+            (custom_dir / "helm.md").write_text("# Existing\n", encoding="utf-8")
+
+            with (
+                patch("services.skill_installer_service.SKILLS_DIR", skills_dir),
+                patch("services.skill_installer_service.CUSTOM_DIR", custom_dir),
+            ):
+                with self.assertRaises(SkillInstallerError) as ctx:
+                    install_skill("helm")
+
+        self.assertEqual(ctx.exception.code, "skill_already_installed")
+
+    def test_install_skill_rejects_invalid_skill_id(self) -> None:
+        with self.assertRaises(SkillInstallerError) as ctx:
+            install_skill("../helm")
+
+        self.assertEqual(ctx.exception.code, "invalid_skill_id")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Story 4.4 adds registry-backed install, list, update, and remove commands on top of the existing skills surfaces. The follow-up review tightened the implementation so installer operations stay inside the intended custom-skill cache and so update can restore the canonical registry payload when a local file has drifted without a version bump.

The resulting path keeps one shared installer service for filesystem writes, registry fetches, checksum verification, and manifest validation, while the CLI and API remain thin adapters over that shared behavior.

Constraint: Installer operations must write only to the local custom-skill cache and must not trust registry or local file state blindly
Rejected: Accept arbitrary skill ids and rely on path joining | allows path traversal outside skills/custom
Rejected: Treat matching version strings as sufficient for update noop | leaves drifted or corrupted installs unrepaired
Confidence: high
Scope-risk: moderate
Reversibility: clean
Directive: Keep installer id validation aligned with manifest-safe skill ids and preserve checksum-based repair behavior unless the registry contract changes
Tested: Focused Story 4.4 unittest bundle; repo-wide Ruff check and format check; full unittest discover; scripts/ci-local.sh
Not-tested: Bandit local scan (tool unavailable in this environment)

## What does this PR do?

<!-- Brief description of changes -->

## Type of change
- [ ] Feature (new functionality)
- [ ] Bugfix (non-breaking fix)
- [ ] Release preparation
- [ ] Hotfix (critical production fix)
- [ ] Docs / refactor / chore

## Checklist
- [ ] I have followed the branch naming convention
- [ ] Tests pass locally (`pytest tests/ -v`)
- [ ] Linting passes (`ruff check .`)
- [ ] Docker build succeeds
- [ ] I have updated docs if needed
- [ ] No secrets or .env values committed

## Related issue
Closes #