### PR TITLE
Expose the skills catalog as a browsable product surface

### DIFF
--- a/app.py
+++ b/app.py
@@ -37,6 +37,7 @@ from services.report_service import (
 )
 from services.skill_manifest_service import build_skill_manifest_v1_schema
 from ui.routes.dashboard import build_dashboard
+import ui.routes.skills as skills_ui_routes  # noqa: F401
 
 configure_logging()
 

--- a/docs/skills/browser-ui.md
+++ b/docs/skills/browser-ui.md
@@ -1,0 +1,39 @@
+# Skills Browser UI
+
+Story 4.5 adds a public browser experience for the shared skills catalog on the
+same NiceGUI runtime:
+
+- `/skills` for the searchable catalog
+- `/skills/{id}` for the skill detail view
+
+## Browser behavior
+
+- Search filters across the shared registry metadata already used by the skills
+  registry and installer surfaces.
+- Tool and author filters use the same canonical metadata returned by the shared
+  registry service.
+- Sorting supports:
+  - `popularity` using the seeded browser download/star snapshot in the shared
+    registry service
+  - `recency` using the manifest file update timestamp already exposed by the
+    registry
+
+## Detail page content
+
+Each skill detail page surfaces:
+
+- description
+- install command
+- latest harness summary
+- version history
+- author
+- contributors
+- download count
+- star count
+- last updated timestamp
+
+## Analytics note
+
+The current browser page uses seeded preview download/star counts from the
+shared registry service so the public UI can present sort and comparison
+signals before Story 4.8 introduces live daily-updated analytics.

--- a/services/skill_registry_service.py
+++ b/services/skill_registry_service.py
@@ -19,6 +19,45 @@ from services.skill_test_harness_service import (
 SKILLS_DIR = Path(__file__).resolve().parents[1] / "skills"
 CUSTOM_DIR = SKILLS_DIR / "custom"
 SkillSource = Literal["built-in", "custom-override", "custom-new"]
+SkillRegistrySort = Literal["popularity", "recency"]
+
+_SKILL_BROWSER_METADATA: dict[str, dict[str, object]] = {
+    "terraform": {
+        "download_count": 1842,
+        "star_count": 418,
+        "contributors": ["DeployWhisper"],
+    },
+    "kubernetes": {
+        "download_count": 1765,
+        "star_count": 403,
+        "contributors": ["DeployWhisper"],
+    },
+    "docker": {
+        "download_count": 1448,
+        "star_count": 332,
+        "contributors": ["DeployWhisper"],
+    },
+    "ansible": {
+        "download_count": 1320,
+        "star_count": 286,
+        "contributors": ["DeployWhisper"],
+    },
+    "git": {
+        "download_count": 1186,
+        "star_count": 267,
+        "contributors": ["DeployWhisper"],
+    },
+    "jenkins": {
+        "download_count": 1094,
+        "star_count": 241,
+        "contributors": ["DeployWhisper"],
+    },
+    "cloudformation": {
+        "download_count": 962,
+        "star_count": 228,
+        "contributors": ["DeployWhisper"],
+    },
+}
 
 
 class SkillRegistryEntry(BaseModel):
@@ -47,6 +86,18 @@ class SkillRegistryEntry(BaseModel):
     )
     trigger_content_patterns: list[str] = Field(
         default_factory=list, description="Content markers used for matching"
+    )
+    contributors: list[str] = Field(
+        default_factory=list, description="Visible contributor names for browser UI."
+    )
+    download_count: int = Field(
+        default=0, description="Current catalog download count or seeded preview value."
+    )
+    star_count: int = Field(
+        default=0, description="Current catalog star count or seeded preview value."
+    )
+    install_command: str = Field(
+        ..., description="Copy-pasteable installer command for this skill."
     )
     updated_at: str = Field(..., description="Last local update timestamp")
     available_versions: int = Field(
@@ -95,6 +146,9 @@ class _SkillRecord(BaseModel):
     test_results: SkillTestSummary | None = None
     triggers: list[str] = Field(default_factory=list)
     trigger_content_patterns: list[str] = Field(default_factory=list)
+    contributors: list[str] = Field(default_factory=list)
+    download_count: int = 0
+    star_count: int = 0
     updated_at: str
     updated_at_epoch: float
     path: Path
@@ -130,6 +184,25 @@ def _default_tool(tool: str | None, skill_id: str) -> str:
 
 def _display_name(skill_id: str) -> str:
     return skill_id.replace("-", " ").title()
+
+
+def _contributors_for(skill_id: str, author: str) -> list[str]:
+    seeded = _SKILL_BROWSER_METADATA.get(skill_id, {}).get("contributors")
+    if isinstance(seeded, list):
+        contributors = [str(item).strip() for item in seeded if str(item).strip()]
+        if contributors:
+            return contributors
+    return [author]
+
+
+def _download_count_for(skill_id: str) -> int:
+    seeded = _SKILL_BROWSER_METADATA.get(skill_id, {}).get("download_count")
+    return int(seeded) if isinstance(seeded, int) else 0
+
+
+def _star_count_for(skill_id: str) -> int:
+    seeded = _SKILL_BROWSER_METADATA.get(skill_id, {}).get("star_count")
+    return int(seeded) if isinstance(seeded, int) else 0
 
 
 def _updated_at(path: Path) -> tuple[str, float]:
@@ -177,6 +250,10 @@ def _record_to_entry(
         "test_results": record.test_results,
         "triggers": list(record.triggers),
         "trigger_content_patterns": list(record.trigger_content_patterns),
+        "contributors": list(record.contributors),
+        "download_count": record.download_count,
+        "star_count": record.star_count,
+        "install_command": f"deploywhisper skill install {record.id}",
         "updated_at": record.updated_at,
         "available_versions": available_versions,
     }
@@ -218,6 +295,12 @@ def _load_skill_record(path: Path, *, source: SkillSource) -> _SkillRecord | Non
         test_results=summarize_skill_test_suite(skill_id),
         triggers=list(parsed.manifest.triggers),
         trigger_content_patterns=list(parsed.manifest.trigger_content_patterns),
+        contributors=_contributors_for(
+            skill_id,
+            parsed.manifest.author or _default_author(source),
+        ),
+        download_count=_download_count_for(skill_id),
+        star_count=_star_count_for(skill_id),
         updated_at=updated_at,
         updated_at_epoch=updated_epoch,
         path=path,
@@ -318,6 +401,7 @@ def fetch_skill_registry_page(
     tag: str | None = None,
     author: str | None = None,
     search: str | None = None,
+    sort: SkillRegistrySort = "popularity",
     page: int = 1,
     page_size: int = 50,
 ) -> SkillRegistryPage:
@@ -331,7 +415,19 @@ def fetch_skill_registry_page(
     ]
     filtered = [
         item
-        for item in sorted(current_items, key=lambda current: current.id)
+        for item in sorted(
+            current_items,
+            key=lambda current: (
+                (
+                    -current.download_count,
+                    -current.star_count,
+                    current.id,
+                )
+                if sort == "popularity"
+                else (current.updated_at, current.id)
+            ),
+            reverse=(sort == "recency"),
+        )
         if _matches_query(
             _SkillRecord(**item.model_dump(), updated_at_epoch=0, path=Path(".")),
             tool=tool,

--- a/tests/test_services/test_skill_registry_service.py
+++ b/tests/test_services/test_skill_registry_service.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 import tempfile
 import unittest
 from pathlib import Path
@@ -77,9 +78,15 @@ class SkillRegistryServiceTests(unittest.TestCase):
         self.assertEqual(page.items[0].id, "terraform")
         self.assertEqual(page.items[0].name, "Terraform")
         self.assertEqual(page.items[0].test_suite_path, "tests/skill-tests/terraform")
+        self.assertEqual(
+            page.items[0].install_command, "deploywhisper skill install terraform"
+        )
+        self.assertGreater(page.items[0].download_count, 0)
+        self.assertGreater(page.items[0].star_count, 0)
+        self.assertEqual(page.items[0].contributors, ["DeployWhisper"])
         self.assertEqual(paged.total_count, 2)
         self.assertEqual(len(paged.items), 1)
-        self.assertEqual(paged.items[0].id, "terraform")
+        self.assertEqual(paged.items[0].id, "kubernetes")
 
     def test_registry_entry_returns_bundled_catalog_version_only(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -140,6 +147,8 @@ class SkillRegistryServiceTests(unittest.TestCase):
         self.assertEqual(entry.version, "1.0.0")
         self.assertEqual(entry.name, "Terraform")
         self.assertEqual(entry.available_versions, 1)
+        self.assertEqual(entry.install_command, "deploywhisper skill install terraform")
+        self.assertEqual(entry.contributors, ["DeployWhisper"])
         self.assertEqual([version.version for version in versions], ["1.0.0"])
         self.assertTrue(versions[0].is_current)
         self.assertEqual(versions[0].author, "DeployWhisper")
@@ -280,6 +289,55 @@ class SkillRegistryServiceTests(unittest.TestCase):
         assert page.items[0].test_results is not None
         self.assertEqual(page.items[0].test_results.status, "failing")
         self.assertEqual(page.items[0].test_results.failed_scenarios, 1)
+
+    def test_registry_page_supports_recency_sort(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            skills_dir = Path(tmpdir) / "skills"
+            custom_dir = skills_dir / "custom"
+            skills_dir.mkdir(parents=True, exist_ok=True)
+            custom_dir.mkdir(parents=True, exist_ok=True)
+            terraform_path = skills_dir / "terraform.md"
+            kubernetes_path = skills_dir / "kubernetes.md"
+            terraform_path.write_text(
+                "---\n"
+                "name: terraform\n"
+                "version: 1.0.0\n"
+                "author: DeployWhisper\n"
+                "license: MIT\n"
+                "description: Built-in terraform checks.\n"
+                "test_suite_path: tests/skill-tests/terraform\n"
+                "token_budget: 1200\n"
+                "triggers: [.tf]\n"
+                "tags: [iac]\n"
+                "---\n"
+                "# Terraform\nBuilt-in guidance.\n",
+                encoding="utf-8",
+            )
+            kubernetes_path.write_text(
+                "---\n"
+                "name: kubernetes\n"
+                "version: 1.0.0\n"
+                "author: DeployWhisper\n"
+                "license: MIT\n"
+                "description: Built-in kubernetes checks.\n"
+                "test_suite_path: tests/skill-tests/kubernetes\n"
+                "token_budget: 900\n"
+                "triggers: [.yaml]\n"
+                "tags: [cluster]\n"
+                "---\n"
+                "# Kubernetes\nBuilt-in guidance.\n",
+                encoding="utf-8",
+            )
+            os.utime(terraform_path, (1000, 1000))
+            os.utime(kubernetes_path, (2000, 2000))
+
+            with (
+                patch("services.skill_registry_service.SKILLS_DIR", skills_dir),
+                patch("services.skill_registry_service.CUSTOM_DIR", custom_dir),
+            ):
+                page = fetch_skill_registry_page(sort="recency")
+
+        self.assertEqual([item.id for item in page.items], ["kubernetes", "terraform"])
 
 
 if __name__ == "__main__":

--- a/tests/test_ui/test_skills_browser.py
+++ b/tests/test_ui/test_skills_browser.py
@@ -1,0 +1,178 @@
+"""UI tests for the public skills browser."""
+
+from __future__ import annotations
+
+import os
+import tempfile
+import unittest
+from importlib import reload
+from pathlib import Path
+from unittest.mock import patch
+
+import app as app_module
+import config as config_module
+import models.database as database_module
+import models.tables as tables_module
+import services.skill_registry_service as skill_registry_service_module
+from fastapi.testclient import TestClient
+
+
+class SkillsBrowserPageTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tempdir = tempfile.TemporaryDirectory()
+        self.db_path = Path(self.tempdir.name) / "skills-ui.db"
+        self.skills_dir = Path(self.tempdir.name) / "skills"
+        self.custom_dir = self.skills_dir / "custom"
+        self.skills_dir.mkdir(parents=True, exist_ok=True)
+        self.custom_dir.mkdir(parents=True, exist_ok=True)
+        os.environ["DATABASE_URL"] = f"sqlite:///{self.db_path}"
+        reload(config_module)
+        reload(tables_module)
+        reload(database_module)
+        reload(skill_registry_service_module)
+        reload(app_module)
+        database_module.init_db()
+        self.client = TestClient(app_module.create_app())
+
+    def tearDown(self) -> None:
+        database_module.engine.dispose()
+        os.environ.pop("DATABASE_URL", None)
+        self.tempdir.cleanup()
+
+    def _write_skill(
+        self,
+        skill_id: str,
+        *,
+        author: str,
+        description: str,
+        triggers: str,
+        tags: str,
+        suite_path: str,
+    ) -> None:
+        (self.skills_dir / f"{skill_id}.md").write_text(
+            "---\n"
+            f"name: {skill_id}\n"
+            "version: 1.0.0\n"
+            f"author: {author}\n"
+            "license: MIT\n"
+            f"description: {description}\n"
+            f"test_suite_path: {suite_path}\n"
+            "token_budget: 1200\n"
+            f"triggers: [{triggers}]\n"
+            f"tags: [{tags}]\n"
+            "---\n"
+            f"# {skill_id.title()}\nGuidance.\n",
+            encoding="utf-8",
+        )
+
+    def test_skills_browser_page_renders_catalog_and_metrics(self) -> None:
+        self._write_skill(
+            "terraform",
+            author="DeployWhisper",
+            description="Terraform registry skill.",
+            triggers=".tf",
+            tags="iac, security",
+            suite_path="tests/skill-tests/terraform",
+        )
+        self._write_skill(
+            "kubernetes",
+            author="Platform Team",
+            description="Kubernetes rollout checks.",
+            triggers=".yaml",
+            tags="cluster",
+            suite_path="tests/skill-tests/kubernetes",
+        )
+
+        with (
+            patch("services.skill_registry_service.SKILLS_DIR", self.skills_dir),
+            patch("services.skill_registry_service.CUSTOM_DIR", self.custom_dir),
+        ):
+            response = self.client.get("/skills")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("DeployWhisper", response.text)
+        self.assertIn("skills atlas", response.text)
+        self.assertIn("Search the current skills registry", response.text)
+        self.assertIn("Preview downloads", response.text)
+        self.assertIn("deploywhisper skill install terraform", response.text)
+        self.assertIn("Terraform", response.text)
+        self.assertIn("Kubernetes", response.text)
+
+    def test_skills_browser_page_applies_query_filters(self) -> None:
+        self._write_skill(
+            "terraform",
+            author="DeployWhisper",
+            description="Terraform registry skill.",
+            triggers=".tf",
+            tags="iac, security",
+            suite_path="tests/skill-tests/terraform",
+        )
+        self._write_skill(
+            "kubernetes",
+            author="Platform Team",
+            description="Kubernetes rollout checks.",
+            triggers=".yaml",
+            tags="cluster",
+            suite_path="tests/skill-tests/kubernetes",
+        )
+
+        with (
+            patch("services.skill_registry_service.SKILLS_DIR", self.skills_dir),
+            patch("services.skill_registry_service.CUSTOM_DIR", self.custom_dir),
+        ):
+            response = self.client.get("/skills?tool=kubernetes&author=Platform+Team")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("Kubernetes", response.text)
+        self.assertNotIn("Terraform registry skill.", response.text)
+
+    def test_skill_detail_page_shows_install_command_versions_and_contributors(
+        self,
+    ) -> None:
+        self._write_skill(
+            "terraform",
+            author="DeployWhisper",
+            description="Terraform registry skill.",
+            triggers=".tf",
+            tags="iac, security",
+            suite_path="tests/skill-tests/terraform",
+        )
+
+        with (
+            patch("services.skill_registry_service.SKILLS_DIR", self.skills_dir),
+            patch("services.skill_registry_service.CUSTOM_DIR", self.custom_dir),
+        ):
+            response = self.client.get("/skills/terraform")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("deploywhisper skill install terraform", response.text)
+        self.assertIn("Version history", response.text)
+        self.assertIn("Contributors", response.text)
+        self.assertIn("Downloads", response.text)
+        self.assertIn("Stars", response.text)
+        self.assertIn("DeployWhisper", response.text)
+
+    def test_skills_browser_page_includes_items_beyond_first_catalog_page(self) -> None:
+        for index in range(205):
+            self._write_skill(
+                f"skill-{index:03d}",
+                author="DeployWhisper" if index < 204 else "Late Author",
+                description=f"Catalog skill {index}.",
+                triggers=".tf",
+                tags="iac",
+                suite_path="tests/skill-tests/terraform",
+            )
+
+        with (
+            patch("services.skill_registry_service.SKILLS_DIR", self.skills_dir),
+            patch("services.skill_registry_service.CUSTOM_DIR", self.custom_dir),
+        ):
+            response = self.client.get("/skills?author=Late+Author")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("Catalog skill 204.", response.text)
+        self.assertIn("Late Author", response.text)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/ui/routes/skills.py
+++ b/ui/routes/skills.py
@@ -1,0 +1,575 @@
+"""Public skills browser pages."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from urllib.parse import urlencode
+
+from fastapi import Request
+from nicegui import ui
+from starlette.exceptions import HTTPException as StarletteHTTPException
+
+from services.skill_registry_service import (
+    SkillRegistryEntry,
+    SkillRegistrySort,
+    fetch_skill_registry_entry,
+    fetch_skill_registry_page,
+    fetch_skill_registry_versions,
+)
+from ui.theme import apply_theme, build_navigation_shell, build_page_header
+
+_BROWSER_CSS = """
+<style>
+.dw-skills-shell {
+  display: grid;
+  gap: 22px;
+}
+
+.dw-skills-hero {
+  padding: 34px;
+  display: grid;
+  gap: 22px;
+  background:
+    radial-gradient(circle at 85% 18%, rgba(217, 107, 61, 0.18), transparent 30%),
+    linear-gradient(140deg, color-mix(in srgb, var(--dw-surface-strong) 92%, transparent), color-mix(in srgb, var(--dw-surface) 88%, transparent));
+}
+
+.dw-skills-hero-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1.6fr) minmax(280px, 0.9fr);
+  gap: 24px;
+  align-items: end;
+}
+
+.dw-skills-display {
+  font-size: clamp(2.7rem, 6vw, 4.8rem);
+  line-height: 0.94;
+  font-weight: 800;
+  letter-spacing: -0.06em;
+  color: var(--dw-text);
+  max-width: 8ch;
+}
+
+.dw-skills-display span {
+  color: var(--dw-accent);
+}
+
+.dw-skills-body {
+  color: var(--dw-muted);
+  font-size: 15px;
+  line-height: 1.8;
+  max-width: 52ch;
+}
+
+.dw-skills-hero-stats {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 14px;
+}
+
+.dw-skills-stat {
+  border: 1px solid var(--dw-line);
+  border-radius: 18px;
+  padding: 16px;
+  background: color-mix(in srgb, var(--dw-surface-soft) 88%, transparent);
+}
+
+.dw-skills-stat-value {
+  font-size: 28px;
+  font-weight: 700;
+  color: var(--dw-text);
+}
+
+.dw-skills-stat-label {
+  margin-top: 4px;
+  font-size: 11px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--dw-muted);
+}
+
+.dw-skills-controls {
+  display: grid;
+  grid-template-columns: minmax(0, 2fr) repeat(3, minmax(180px, 1fr));
+  gap: 14px;
+  align-items: end;
+}
+
+.dw-skills-catalog {
+  display: grid;
+  gap: 14px;
+}
+
+.dw-skill-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1.45fr) minmax(0, 0.85fr) auto;
+  gap: 20px;
+  align-items: center;
+  padding: 20px 24px;
+  border: 1px solid var(--dw-line);
+  border-radius: 22px;
+  background: linear-gradient(180deg, var(--dw-surface), var(--dw-surface-strong));
+  box-shadow: var(--dw-shadow);
+  transition: transform 180ms ease, border-color 180ms ease;
+}
+
+.dw-skill-row:hover {
+  transform: translateY(-2px);
+  border-color: var(--dw-accent-line);
+}
+
+.dw-skill-row-title {
+  font-size: 24px;
+  font-weight: 700;
+  letter-spacing: -0.04em;
+  color: var(--dw-text);
+}
+
+.dw-skill-row-meta {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+  margin-top: 10px;
+  color: var(--dw-muted);
+  font-size: 12px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.dw-skill-tags {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+  margin-top: 14px;
+}
+
+.dw-skill-tag {
+  display: inline-flex;
+  align-items: center;
+  border: 1px solid var(--dw-line);
+  border-radius: 999px;
+  padding: 5px 9px;
+  font-size: 11px;
+  color: var(--dw-muted);
+  background: var(--dw-pill-bg);
+}
+
+.dw-skill-metrics {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 12px;
+}
+
+.dw-skill-metric-value {
+  font-size: 20px;
+  font-weight: 700;
+  color: var(--dw-text);
+}
+
+.dw-skill-metric-label {
+  margin-top: 2px;
+  font-size: 11px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--dw-muted);
+}
+
+.dw-skill-command {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  border: 1px solid var(--dw-line);
+  border-radius: 16px;
+  padding: 12px 14px;
+  background: var(--dw-pill-bg);
+  color: var(--dw-text);
+  font-family: "IBM Plex Mono", monospace;
+  font-size: 13px;
+}
+
+.dw-skill-detail-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1.4fr) minmax(280px, 0.9fr);
+  gap: 22px;
+}
+
+.dw-skill-detail-stack {
+  display: grid;
+  gap: 18px;
+}
+
+.dw-skill-section {
+  padding: 24px;
+}
+
+.dw-skill-version-list {
+  display: grid;
+  gap: 10px;
+}
+
+.dw-skill-version-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  border-bottom: 1px solid var(--dw-line);
+  padding-bottom: 10px;
+}
+
+.dw-skill-version-row:last-child {
+  border-bottom: none;
+  padding-bottom: 0;
+}
+
+.dw-skill-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  border-radius: 999px;
+  padding: 6px 12px;
+  background: var(--dw-accent-soft);
+  color: var(--dw-accent-contrast);
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.dw-empty-note {
+  padding: 24px;
+  border: 1px dashed var(--dw-line-strong);
+  border-radius: 22px;
+  color: var(--dw-muted);
+  background: var(--dw-surface-soft);
+}
+
+@media (max-width: 900px) {
+  .dw-skills-hero-grid,
+  .dw-skills-controls,
+  .dw-skill-row,
+  .dw-skill-detail-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 640px) {
+  .dw-skills-hero,
+  .dw-skill-section,
+  .dw-skill-row {
+    padding: 20px;
+  }
+
+  .dw-skill-metrics,
+  .dw-skills-hero-stats {
+    grid-template-columns: 1fr;
+  }
+}
+</style>
+"""
+
+
+def _format_updated_at(value: str) -> str:
+    parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    return parsed.strftime("%b %d, %Y")
+
+
+def _query_value(request: Request, key: str) -> str | None:
+    value = str(request.query_params.get(key) or "").strip()
+    return value or None
+
+
+def _fetch_catalog(
+    *,
+    search: str | None = None,
+    tool: str | None = None,
+    author: str | None = None,
+    sort: SkillRegistrySort = "popularity",
+) -> list[SkillRegistryEntry]:
+    items: list[SkillRegistryEntry] = []
+    page_number = 1
+    page_size = 100
+    total_count = 0
+
+    while True:
+        page = fetch_skill_registry_page(
+            search=search,
+            tool=tool,
+            author=author,
+            sort=sort,
+            page=page_number,
+            page_size=page_size,
+        )
+        if page_number == 1:
+            total_count = page.total_count
+        items.extend(page.items)
+        if len(items) >= total_count or not page.items:
+            return items
+        page_number += 1
+
+
+def _browser_options() -> tuple[list[str], list[str]]:
+    catalog = _fetch_catalog(sort="popularity")
+    tools = sorted({item.tool for item in catalog})
+    authors = sorted({item.author for item in catalog})
+    return tools, authors
+
+
+def _navigate_with_filters(
+    *,
+    search: str,
+    tool: str,
+    author: str,
+    sort: str,
+) -> None:
+    params: list[tuple[str, str]] = []
+    if search.strip():
+        params.append(("search", search.strip()))
+    if tool.strip():
+        params.append(("tool", tool.strip()))
+    if author.strip():
+        params.append(("author", author.strip()))
+    if sort.strip():
+        params.append(("sort", sort.strip()))
+    query = f"?{urlencode(params)}" if params else ""
+    ui.navigate.to(f"/skills{query}")
+
+
+def _render_skill_row(skill: SkillRegistryEntry) -> None:
+    with ui.element("a").props(f"href=/skills/{skill.id}").classes("no-underline"):
+        with ui.element("article").classes("dw-skill-row"):
+            with ui.column().classes("gap-0 min-w-0"):
+                ui.label(skill.name).classes("dw-skill-row-title")
+                ui.label(skill.description).classes("dw-skills-body")
+                with ui.element("div").classes("dw-skill-row-meta"):
+                    ui.label(skill.tool)
+                    ui.label(skill.author)
+                    ui.label(f"Updated {_format_updated_at(skill.updated_at)}")
+                    ui.label(
+                        f"{skill.available_versions} version{'s' if skill.available_versions != 1 else ''}"
+                    )
+                with ui.element("div").classes("dw-skill-tags"):
+                    for tag in skill.tags[:4]:
+                        ui.label(tag).classes("dw-skill-tag")
+            with ui.element("div").classes("dw-skill-metrics"):
+                for value, label in (
+                    (str(skill.download_count), "Downloads"),
+                    (str(skill.star_count), "Stars"),
+                    (
+                        skill.test_results.display_text
+                        if skill.test_results
+                        else "No tests",
+                        "Harness",
+                    ),
+                ):
+                    with ui.column().classes("gap-0"):
+                        ui.label(value).classes("dw-skill-metric-value")
+                        ui.label(label).classes("dw-skill-metric-label")
+            with ui.column().classes("items-start gap-3"):
+                ui.label("Install ready").classes("dw-skill-chip")
+                ui.label(skill.install_command).classes("dw-skill-command")
+
+
+@ui.page("/skills")
+def skills_browser_page(request: Request) -> None:
+    apply_theme()
+    ui.add_head_html(_BROWSER_CSS)
+    build_navigation_shell("skills")
+
+    tools, authors = _browser_options()
+    search = _query_value(request, "search") or ""
+    tool = _query_value(request, "tool") or ""
+    author = _query_value(request, "author") or ""
+    sort = (_query_value(request, "sort") or "popularity").lower()
+    sort_value: SkillRegistrySort = "recency" if sort == "recency" else "popularity"
+
+    catalog = _fetch_catalog(
+        search=search or None,
+        tool=tool or None,
+        author=author or None,
+        sort=sort_value,
+    )
+
+    with ui.column().classes("dw-main-content dw-shell dw-skills-shell"):
+        with ui.card().classes("dw-panel shadow-none dw-skills-hero"):
+            with ui.element("div").classes("dw-skills-hero-grid"):
+                with ui.column().classes("gap-5"):
+                    ui.label("Marketplace").classes("dw-eyebrow")
+                    ui.html(
+                        '<div class="dw-skills-display">DeployWhisper <span>skills atlas</span></div>'
+                    )
+                    ui.label(
+                        "Browse the registry before you install anything. Search by domain, filter by owner, and compare readiness signals from the same catalog the CLI consumes."
+                    ).classes("dw-skills-body")
+                with ui.element("div").classes("dw-skills-hero-stats"):
+                    for value, label in (
+                        (str(len(catalog)), "Visible skills"),
+                        (
+                            str(sum(item.download_count for item in catalog)),
+                            "Preview downloads",
+                        ),
+                        (
+                            str(sum(item.star_count for item in catalog)),
+                            "Preview stars",
+                        ),
+                        (
+                            str(
+                                sum(
+                                    1
+                                    for item in catalog
+                                    if item.test_results
+                                    and item.test_results.status == "passing"
+                                )
+                            ),
+                            "Passing harnesses",
+                        ),
+                    ):
+                        with ui.element("div").classes("dw-skills-stat"):
+                            ui.label(value).classes("dw-skills-stat-value")
+                            ui.label(label).classes("dw-skills-stat-label")
+
+            with ui.element("div").classes("dw-skills-controls"):
+                search_input = (
+                    ui.input(
+                        value=search, placeholder="Search skills, tags, or triggers"
+                    )
+                    .props("outlined dense clearable")
+                    .classes("w-full")
+                )
+                tool_select = (
+                    ui.select(["", *tools], value=tool, label="Tool")
+                    .props("outlined dense")
+                    .classes("w-full")
+                )
+                author_select = (
+                    ui.select(["", *authors], value=author, label="Author")
+                    .props("outlined dense")
+                    .classes("w-full")
+                )
+                sort_select = (
+                    ui.select(
+                        {"popularity": "Popularity", "recency": "Recency"},
+                        value=sort,
+                        label="Sort",
+                    )
+                    .props("outlined dense")
+                    .classes("w-full")
+                )
+
+                def apply_filters() -> None:
+                    _navigate_with_filters(
+                        search=str(search_input.value or ""),
+                        tool=str(tool_select.value or ""),
+                        author=str(author_select.value or ""),
+                        sort=str(sort_select.value or "popularity"),
+                    )
+
+                search_input.on("keydown.enter", lambda _: apply_filters())
+                tool_select.on_value_change(lambda _: apply_filters())
+                author_select.on_value_change(lambda _: apply_filters())
+                sort_select.on_value_change(lambda _: apply_filters())
+
+        with ui.card().classes("dw-panel shadow-none dw-page-header"):
+            build_page_header(
+                eyebrow="Catalog",
+                title="Search the current skills registry",
+                subtitle="Popularity and recency come from the shared registry metadata used by the browser and installer surfaces.",
+            )
+
+        with ui.column().classes("dw-skills-catalog"):
+            if not catalog:
+                ui.label(
+                    "No skills match the current search and filter combination."
+                ).classes("dw-empty-note")
+            for item in catalog:
+                _render_skill_row(item)
+
+
+@ui.page("/skills/{skill_id}")
+def skill_detail_page(skill_id: str) -> None:
+    skill = fetch_skill_registry_entry(skill_id)
+    if skill is None:
+        raise StarletteHTTPException(status_code=404, detail="Skill not found")
+
+    versions = fetch_skill_registry_versions(skill_id)
+
+    apply_theme()
+    ui.add_head_html(_BROWSER_CSS)
+    build_navigation_shell("skills")
+
+    with ui.column().classes("dw-main-content dw-shell dw-skills-shell"):
+        with ui.card().classes("dw-panel shadow-none dw-skills-hero"):
+            build_page_header(
+                eyebrow=skill.tool,
+                title=skill.name,
+                subtitle=skill.description,
+                back_href="/skills",
+                back_label="Back to skills",
+            )
+            with ui.element("div").classes("dw-skill-detail-grid"):
+                with ui.column().classes("dw-skill-detail-stack"):
+                    ui.label(skill.install_command).classes("dw-skill-command")
+                    with ui.element("div").classes("dw-skills-hero-stats"):
+                        for value, label in (
+                            (str(skill.download_count), "Downloads"),
+                            (str(skill.star_count), "Stars"),
+                            (_format_updated_at(skill.updated_at), "Last updated"),
+                            (
+                                skill.test_results.display_text
+                                if skill.test_results
+                                else "No harness",
+                                "Test results",
+                            ),
+                        ):
+                            with ui.element("div").classes("dw-skills-stat"):
+                                ui.label(value).classes("dw-skills-stat-value")
+                                ui.label(label).classes("dw-skills-stat-label")
+
+                with ui.element("div").classes("dw-skills-hero-stats"):
+                    with ui.element("div").classes("dw-skills-stat"):
+                        ui.label(skill.author).classes("dw-skills-stat-value text-lg")
+                        ui.label("Author").classes("dw-skills-stat-label")
+                    with ui.element("div").classes("dw-skills-stat"):
+                        ui.label(str(skill.available_versions)).classes(
+                            "dw-skills-stat-value text-lg"
+                        )
+                        ui.label("Tracked versions").classes("dw-skills-stat-label")
+
+        with ui.element("div").classes("dw-skill-detail-grid"):
+            with ui.column().classes("dw-skill-detail-stack"):
+                with ui.card().classes("dw-panel shadow-none dw-skill-section"):
+                    ui.label("Contributors").classes("dw-eyebrow")
+                    for contributor in skill.contributors:
+                        ui.label(contributor).classes("dw-skills-body")
+
+                with ui.card().classes("dw-panel shadow-none dw-skill-section"):
+                    ui.label("Version history").classes("dw-eyebrow")
+                    with ui.element("div").classes("dw-skill-version-list"):
+                        for version in versions:
+                            with ui.element("div").classes("dw-skill-version-row"):
+                                with ui.column().classes("gap-1"):
+                                    ui.label(version.version).classes(
+                                        "text-lg font-semibold dw-text"
+                                    )
+                                    ui.label(
+                                        f"{version.author} · {_format_updated_at(version.updated_at)}"
+                                    ).classes("dw-muted text-sm")
+                                ui.label(
+                                    "Current" if version.is_current else "Archived"
+                                ).classes("dw-skill-chip")
+
+            with ui.column().classes("dw-skill-detail-stack"):
+                with ui.card().classes("dw-panel shadow-none dw-skill-section"):
+                    ui.label("Ready to install").classes("dw-eyebrow")
+                    ui.label(
+                        "Use the shared CLI installer to pull the exact registry artifact shown here."
+                    ).classes("dw-skills-body")
+                    ui.label(skill.install_command).classes("dw-skill-command")
+                    with ui.element("div").classes("dw-skill-tags"):
+                        for tag in skill.tags:
+                            ui.label(tag).classes("dw-skill-tag")
+
+                with ui.card().classes("dw-panel shadow-none dw-skill-section"):
+                    ui.label("Registry snapshot").classes("dw-eyebrow")
+                    ui.label(
+                        "This page reflects the same source-of-truth metadata and version history used by the shared registry and installer surfaces."
+                    ).classes("dw-skills-body")

--- a/ui/theme.py
+++ b/ui/theme.py
@@ -765,6 +765,7 @@ def build_navigation_shell(active: str) -> None:
     """Render the shared top navigation shell."""
     nav_items = (
         ("Dashboard", "/", "dashboard"),
+        ("Skills", "/skills", "skills"),
         ("History", "/history", "history"),
         ("Settings", "/settings", "settings"),
     )


### PR DESCRIPTION
Story 4.5 turns the shared skills registry into a public browser and detail experience on the existing NiceGUI runtime. The implementation keeps the browser on top of the same metadata model used by the installer and registry routes so discovery, install commands, version history, and trust signals do not drift.

The browser now renders a public /skills catalog, per-skill detail pages, shared popularity/recency ordering, and seeded preview metrics while the catalog remains small. A follow-up hardening pass removed the first-page-only cap so the browser and filter controls page through the full shared registry instead of truncating discovery once the marketplace grows.

Constraint: The browser must reuse the shared registry metadata and stay inside the existing NiceGUI + FastAPI runtime rather than creating a parallel frontend or duplicate catalog model
Rejected: Build a standalone marketing microsite outside the app runtime | would duplicate registry logic and drift from installer-facing metadata
Rejected: Keep a hard 200-item browser cap | silently hides skills and breaks discovery/filter accuracy as the marketplace grows
Confidence: high
Scope-risk: moderate
Reversibility: clean
Directive: Treat the browser metrics fields as temporary seeded preview data until Story 4.8 introduces live analytics; do not fork a second popularity model in the UI
Tested: Focused Story 4.5 UI/service/API unittest bundle; repo-wide Ruff check and format check; full unittest discover; scripts/ci-local.sh
Not-tested: Bandit local scan (tool unavailable in this environment)

## What does this PR do?

<!-- Brief description of changes -->

## Type of change
- [ ] Feature (new functionality)
- [ ] Bugfix (non-breaking fix)
- [ ] Release preparation
- [ ] Hotfix (critical production fix)
- [ ] Docs / refactor / chore

## Checklist
- [ ] I have followed the branch naming convention
- [ ] Tests pass locally (`pytest tests/ -v`)
- [ ] Linting passes (`ruff check .`)
- [ ] Docker build succeeds
- [ ] I have updated docs if needed
- [ ] No secrets or .env values committed

## Related issue
Closes #