### PR TITLE
Make skill contributions reviewable and publishable by default

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,3 +6,7 @@
 /llm/           @pramodksahoo
 /analysis/      @pramodksahoo
 /.github/       @pramodksahoo
+/skills/        @pramodksahoo
+/tests/skill-tests/ @pramodksahoo
+/docs/contributing/skills.md @pramodksahoo
+/.github/PULL_REQUEST_TEMPLATE/skill.md @pramodksahoo

--- a/.github/PULL_REQUEST_TEMPLATE/skill.md
+++ b/.github/PULL_REQUEST_TEMPLATE/skill.md
@@ -1,0 +1,32 @@
+## Skill Summary
+
+<!-- What skill or skill update is this PR proposing? -->
+
+## Skill Metadata
+
+- Skill id:
+- Version:
+- Author / owner:
+- Tool family:
+- New skill or update:
+
+## Risk Patterns Added Or Changed
+
+<!-- Summarize the actual guidance or checks this skill introduces. -->
+
+## Validation Evidence
+
+- [ ] `deploywhisper skill lint skills/<skill>.md`
+- [ ] `deploywhisper skill test <skill>`
+- [ ] Added or updated scenarios under `tests/skill-tests/<skill>/`
+
+## Reviewer Notes
+
+<!-- Call out any areas that need domain review, follow-up stories, or curation attention. -->
+
+## Checklist
+
+- [ ] The manifest matches the filename stem and uses manifest v1
+- [ ] Test scenarios cover the new or changed guidance
+- [ ] No real secrets, account ids, or production-only hostnames are included
+- [ ] Related docs were updated when contributor workflow expectations changed

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -244,7 +244,7 @@ jobs:
             test ${PIPESTATUS[0]} -eq 0
           fi
 
-      - name: Run changed skill harnesses
+      - name: Run changed skill lint and harness checks
         env:
           BASE_REF: origin/${{ github.base_ref }}
         run: |
@@ -252,7 +252,7 @@ jobs:
             bash scripts/test-changed-skills.sh 2>&1 | tee changed-skill-harness.log
             test ${PIPESTATUS[0]} -eq 0
           else
-            echo "scripts/test-changed-skills.sh not found — skipping changed skill harness"
+            echo "scripts/test-changed-skills.sh not found — skipping changed skill lint and harness checks"
           fi
 
       - name: Upload changed-test logs

--- a/.github/workflows/publish-skills-registry.yml
+++ b/.github/workflows/publish-skills-registry.yml
@@ -1,0 +1,122 @@
+name: Publish Skills Registry
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "skills/*.md"
+      - "tests/skill-tests/**"
+      - "docs/skills/authoring-guide.md"
+      - "docs/contributing/skills.md"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    name: "Publish changed skills to registry"
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout source repository
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Setup Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+          cache: pip
+          cache-dependency-path: requirements.txt
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Verify registry publish secrets are configured
+        id: config
+        env:
+          REGISTRY_REPO: ${{ secrets.DEPLOYWHISPER_SKILLS_REGISTRY_REPO }}
+          REGISTRY_TOKEN: ${{ secrets.DEPLOYWHISPER_SKILLS_REGISTRY_PUSH_TOKEN }}
+        run: |
+          if [ -z "$REGISTRY_REPO" ] || [ -z "$REGISTRY_TOKEN" ]; then
+            echo "configured=false" >> "$GITHUB_OUTPUT"
+            echo "Skills registry publish secrets are not configured; skipping publish."
+          else
+            echo "configured=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Collect changed skill ids
+        if: steps.config.outputs.configured == 'true'
+        id: changed
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ] || [ "${{ github.event.before }}" = "0000000000000000000000000000000000000000" ]; then
+            python - <<'PY' >> "$GITHUB_OUTPUT"
+from scripts.publish_skills_registry import iter_built_in_skill_ids
+print("skill_ids=" + ",".join(iter_built_in_skill_ids()))
+PY
+            exit 0
+          fi
+
+          python - <<'PY' >> "$GITHUB_OUTPUT"
+from pathlib import Path
+import subprocess
+
+before = "${{ github.event.before }}"
+after = "${{ github.sha }}"
+diff = subprocess.run(
+    ["git", "diff", "--name-only", f"{before}...{after}"],
+    check=True,
+    capture_output=True,
+    text=True,
+).stdout.splitlines()
+skills: set[str] = set()
+for path in diff:
+    normalized = path.strip()
+    if normalized.startswith("skills/") and normalized.endswith(".md"):
+        skills.add(Path(normalized).stem.lower())
+    elif normalized.startswith("tests/skill-tests/"):
+        parts = Path(normalized).parts
+        if len(parts) >= 3:
+            skills.add(parts[2].lower())
+print("skill_ids=" + ",".join(sorted(skills)))
+PY
+
+      - name: Stop when no skill files changed
+        if: steps.config.outputs.configured == 'true' && steps.changed.outputs.skill_ids == ''
+        run: echo "No skill changes detected for publish."
+
+      - name: Checkout registry repository
+        if: steps.config.outputs.configured == 'true' && steps.changed.outputs.skill_ids != ''
+        env:
+          REGISTRY_REPO: ${{ secrets.DEPLOYWHISPER_SKILLS_REGISTRY_REPO }}
+          REGISTRY_TOKEN: ${{ secrets.DEPLOYWHISPER_SKILLS_REGISTRY_PUSH_TOKEN }}
+        run: |
+          git clone "https://x-access-token:${REGISTRY_TOKEN}@github.com/${REGISTRY_REPO}.git" /tmp/skills-registry
+
+      - name: Sync changed skills into registry checkout
+        if: steps.config.outputs.configured == 'true' && steps.changed.outputs.skill_ids != ''
+        env:
+          SKILL_IDS: ${{ steps.changed.outputs.skill_ids }}
+        run: |
+          python scripts/publish_skills_registry.py \
+            --target-repo /tmp/skills-registry \
+            ${SKILL_IDS//,/ }
+
+      - name: Commit and push registry updates
+        if: steps.config.outputs.configured == 'true' && steps.changed.outputs.skill_ids != ''
+        working-directory: /tmp/skills-registry
+        run: |
+          if git diff --quiet; then
+            echo "No registry changes to publish."
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add .
+          git commit -m "Publish skills from deploywhisper"
+          git push

--- a/docs/contributing/skills.md
+++ b/docs/contributing/skills.md
@@ -1,0 +1,81 @@
+# Contributing Skills
+
+Story 4.6 defines the repository workflow for contributing or updating built-in
+skills. The goal is to make skill changes reviewable, deterministic, and
+publishable without requiring contributors to guess the review bar.
+
+## Before you open a PR
+
+1. Create or update the skill markdown file under `skills/<skill>.md`
+2. Add or update deterministic scenarios under `tests/skill-tests/<skill>/`
+3. Validate the manifest:
+
+```bash
+deploywhisper skill lint skills/<skill>.md
+```
+
+4. Run the harness for the changed skill:
+
+```bash
+deploywhisper skill test <skill>
+```
+
+## Pull request workflow
+
+- Use the skill template at `.github/PULL_REQUEST_TEMPLATE/skill.md`
+- Skill PRs should include:
+  - the skill id and version
+  - the risk patterns introduced or changed
+  - the lint and harness commands that were run
+  - notes for domain reviewers or curators when needed
+
+## Automated checks on skill PRs
+
+Pull requests targeting `main` or `develop` already run the normal CI pipeline.
+For skill changes specifically, the changed-skill automation now does both:
+
+- manifest lint for changed `skills/*.md`
+- deterministic harness execution for changed skills and their scenario suites
+
+The changed-skill gate watches:
+
+- `skills/*.md`
+- `tests/skill-tests/<skill>/`
+
+## Reviewer assignment
+
+Skill contribution surfaces are covered explicitly in `.github/CODEOWNERS` so
+GitHub can assign the maintainer review path for:
+
+- `skills/`
+- `tests/skill-tests/`
+- `.github/PULL_REQUEST_TEMPLATE/skill.md`
+- `docs/contributing/skills.md`
+
+## Merge and publish
+
+After a skill change merges to `main`, the `Publish Skills Registry` workflow
+syncs changed skills into the external registry repository when these secrets
+are configured:
+
+- `DEPLOYWHISPER_SKILLS_REGISTRY_REPO`
+- `DEPLOYWHISPER_SKILLS_REGISTRY_PUSH_TOKEN`
+
+The publish job exports each changed built-in skill into the registry checkout
+under `skills/<skill>/` with:
+
+- `skill.md`
+- `manifest.json`
+- `tests/scenarios/`
+
+If the secrets are not configured, the workflow exits cleanly with a notice
+instead of failing unrelated merges.
+
+## Contribution rules
+
+- Keep skill content focused on deterministic review guidance, not executable
+  automation.
+- Use synthetic examples only; never include real secrets, account ids, or
+  production-only hostnames.
+- Keep manifest ids aligned with the markdown filename stem.
+- Update scenarios whenever you change guidance so the harness stays meaningful.

--- a/scripts/publish_skills_registry.py
+++ b/scripts/publish_skills_registry.py
@@ -1,0 +1,78 @@
+"""Sync built-in skills into the external skills registry repository."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+import shutil
+
+from services.skill_manifest_service import load_skill_document
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SKILLS_DIR = REPO_ROOT / "skills"
+SKILL_TESTS_DIR = REPO_ROOT / "tests" / "skill-tests"
+
+
+def iter_built_in_skill_ids() -> list[str]:
+    """Return current built-in skill ids from the source repository."""
+    return sorted(
+        path.stem.strip().lower()
+        for path in SKILLS_DIR.glob("*.md")
+        if path.is_file() and path.name.lower() != "readme.md"
+    )
+
+
+def publish_skill(skill_id: str, *, target_repo: Path) -> None:
+    """Copy one built-in skill and its scenarios into the target registry repo."""
+    source_path = SKILLS_DIR / f"{skill_id}.md"
+    target_dir = target_repo / "skills" / skill_id
+    if not source_path.exists():
+        shutil.rmtree(target_dir, ignore_errors=True)
+        return
+
+    document = load_skill_document(
+        source_path,
+        strict_manifest=True,
+        allow_legacy_name=False,
+        project_root=REPO_ROOT,
+    )
+    assert document.manifest is not None
+
+    target_dir.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(source_path, target_dir / "skill.md")
+    (target_dir / "manifest.json").write_text(
+        json.dumps(document.manifest.model_dump(), indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+    source_suite_dir = REPO_ROOT / document.manifest.test_suite_path
+    target_tests_dir = target_dir / "tests"
+    if target_tests_dir.exists():
+        shutil.rmtree(target_tests_dir)
+    shutil.copytree(source_suite_dir, target_dir / "tests" / "scenarios")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Publish built-in skills to registry.")
+    parser.add_argument(
+        "--target-repo",
+        required=True,
+        help="Filesystem path to the checked out skills registry repository.",
+    )
+    parser.add_argument(
+        "skill_ids",
+        nargs="*",
+        help="Optional skill ids to publish. Defaults to all built-in skills.",
+    )
+    args = parser.parse_args()
+
+    target_repo = Path(args.target_repo).resolve()
+    skill_ids = args.skill_ids or iter_built_in_skill_ids()
+    for skill_id in skill_ids:
+        publish_skill(skill_id.strip().lower(), target_repo=target_repo)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/test-changed-skills.sh
+++ b/scripts/test-changed-skills.sh
@@ -27,12 +27,15 @@ for path in "${CHANGED_PATHS[@]}"; do
 done
 
 if [ "${#SKILLS[@]}" -eq 0 ]; then
-  echo "No changed built-in skill suites detected relative to $BASE_REF."
+  echo "No changed built-in skills detected relative to $BASE_REF."
   exit 0
 fi
 
 mapfile -t UNIQUE_SKILLS < <(printf '%s\n' "${SKILLS[@]}" | sort -u)
 
-echo "Running changed skill harnesses relative to $BASE_REF:"
+echo "Running changed skill lint and harness checks relative to $BASE_REF:"
 printf ' - %s\n' "${UNIQUE_SKILLS[@]}"
+for skill in "${UNIQUE_SKILLS[@]}"; do
+  "$PYTHON_BIN" cli.py skill lint "skills/${skill}.md"
+done
 "$PYTHON_BIN" cli.py skill test "${UNIQUE_SKILLS[@]}"

--- a/tests/test_infra/test_skill_contribution_workflow.py
+++ b/tests/test_infra/test_skill_contribution_workflow.py
@@ -1,0 +1,66 @@
+"""Tests for the skill contribution workflow assets."""
+
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from scripts.publish_skills_registry import publish_skill
+
+
+class SkillContributionWorkflowTests(unittest.TestCase):
+    def test_skill_pr_template_exists_with_validation_sections(self) -> None:
+        template = Path(".github/PULL_REQUEST_TEMPLATE/skill.md").read_text(
+            encoding="utf-8"
+        )
+
+        self.assertIn("## Skill Summary", template)
+        self.assertIn("deploywhisper skill lint", template)
+        self.assertIn("deploywhisper skill test", template)
+
+    def test_codeowners_contains_explicit_skill_contribution_paths(self) -> None:
+        codeowners = Path(".github/CODEOWNERS").read_text(encoding="utf-8")
+
+        self.assertIn("/skills/", codeowners)
+        self.assertIn("/tests/skill-tests/", codeowners)
+        self.assertIn("/.github/PULL_REQUEST_TEMPLATE/skill.md", codeowners)
+        self.assertIn("/docs/contributing/skills.md", codeowners)
+
+    def test_changed_skill_script_runs_lint_before_harness(self) -> None:
+        script = Path("scripts/test-changed-skills.sh").read_text(encoding="utf-8")
+
+        self.assertIn('cli.py skill lint "skills/${skill}.md"', script)
+        self.assertIn('cli.py skill test "${UNIQUE_SKILLS[@]}"', script)
+
+    def test_publish_workflow_exists_and_targets_main_skill_changes(self) -> None:
+        workflow = Path(".github/workflows/publish-skills-registry.yml").read_text(
+            encoding="utf-8"
+        )
+
+        self.assertIn("Publish Skills Registry", workflow)
+        self.assertIn("branches:", workflow)
+        self.assertIn("- main", workflow)
+        self.assertIn("skills/*.md", workflow)
+        self.assertIn("DEPLOYWHISPER_SKILLS_REGISTRY_REPO", workflow)
+        self.assertIn("scripts/publish_skills_registry.py", workflow)
+
+    def test_publish_skill_writes_registry_bundle_and_removes_deleted_skill(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            target_repo = Path(tmpdir) / "registry"
+            target_repo.mkdir(parents=True, exist_ok=True)
+
+            publish_skill("terraform", target_repo=target_repo)
+            exported_dir = target_repo / "skills" / "terraform"
+            self.assertTrue((exported_dir / "skill.md").exists())
+            self.assertTrue((exported_dir / "manifest.json").exists())
+            self.assertTrue((exported_dir / "tests" / "scenarios").exists())
+
+            publish_skill("missing-skill", target_repo=target_repo)
+            self.assertFalse((target_repo / "skills" / "missing-skill").exists())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Story 4.6 turns the skills ecosystem from an internal capability into an external contribution lane with explicit quality gates. Contributors now get a dedicated PR template, maintainer routing, deterministic lint plus harness feedback on changed skills, and a documented merge-to-registry publish path instead of piecing the workflow together from scattered repo conventions.

The implementation keeps the contribution contract aligned with the existing manifest, harness, and registry work. PR-time automation stays on top of the current CLI surfaces, while merge-time publish automation syncs changed built-in skills into the external registry repository only when the required secrets are configured.

Constraint: Skill contribution workflow must reuse existing manifest lint and deterministic harness commands rather than inventing a separate validation path
Rejected: Keep the generic repository PR template only | leaves skill contributors guessing about required manifest/test evidence
Rejected: Manual post-merge registry sync only | weakens the promised merge-to-publish workflow and makes publication easy to forget
Confidence: high
Scope-risk: moderate
Reversibility: clean
Directive: Keep contributor-facing skill checks wired to the shared CLI and harness surfaces so workflow docs, CI, and publish automation do not drift apart
Tested: Focused contribution-workflow infrastructure tests; repo-wide Ruff check and format check; full unittest discover; scripts/ci-local.sh
Not-tested: Live GitHub Actions publish against the external registry repo; Bandit local scan (tool unavailable in this environment)

## What does this PR do?

<!-- Brief description of changes -->

## Type of change
- [ ] Feature (new functionality)
- [ ] Bugfix (non-breaking fix)
- [ ] Release preparation
- [ ] Hotfix (critical production fix)
- [ ] Docs / refactor / chore

## Checklist
- [ ] I have followed the branch naming convention
- [ ] Tests pass locally (`pytest tests/ -v`)
- [ ] Linting passes (`ruff check .`)
- [ ] Docker build succeeds
- [ ] I have updated docs if needed
- [ ] No secrets or .env values committed

## Related issue
Closes #