### PR TITLE
Lock skill publication to the public registry destination

### DIFF
--- a/.github/workflows/publish-skills-registry.yml
+++ b/.github/workflows/publish-skills-registry.yml
@@ -19,6 +19,8 @@ jobs:
     name: "Publish changed skills to registry"
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    env:
+      REGISTRY_REPO: deploywhisper/skills-registry
     steps:
       - name: Checkout source repository
         uses: actions/checkout@v5
@@ -40,12 +42,11 @@ jobs:
       - name: Verify registry publish secrets are configured
         id: config
         env:
-          REGISTRY_REPO: ${{ secrets.DEPLOYWHISPER_SKILLS_REGISTRY_REPO }}
           REGISTRY_TOKEN: ${{ secrets.DEPLOYWHISPER_SKILLS_REGISTRY_PUSH_TOKEN }}
         run: |
-          if [ -z "$REGISTRY_REPO" ] || [ -z "$REGISTRY_TOKEN" ]; then
+          if [ -z "$REGISTRY_TOKEN" ]; then
             echo "configured=false" >> "$GITHUB_OUTPUT"
-            echo "Skills registry publish secrets are not configured; skipping publish."
+            echo "Skills registry push token is not configured; skipping publish."
           else
             echo "configured=true" >> "$GITHUB_OUTPUT"
           fi
@@ -93,7 +94,6 @@ PY
       - name: Checkout registry repository
         if: steps.config.outputs.configured == 'true' && steps.changed.outputs.skill_ids != ''
         env:
-          REGISTRY_REPO: ${{ secrets.DEPLOYWHISPER_SKILLS_REGISTRY_REPO }}
           REGISTRY_TOKEN: ${{ secrets.DEPLOYWHISPER_SKILLS_REGISTRY_PUSH_TOKEN }}
         run: |
           git clone "https://x-access-token:${REGISTRY_TOKEN}@github.com/${REGISTRY_REPO}.git" /tmp/skills-registry

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ DeployWhisper helps platform engineers, DevOps teams, and SREs review deployment
   <img src="https://img.shields.io/badge/runtime-NiceGUI%20%2B%20FastAPI-0f766e?style=flat-square" alt="NiceGUI plus FastAPI"/>
 </p>
 
-**Quick links:** [Quick Start](#quick-start) · [API Endpoints](#api-endpoints) · [Development](#development) · [Contributing](#contributing) · [Open Source](#open-source)
+**Quick links:** [Quick Start](#quick-start) · [Skills Registry](https://deploywhisper.github.io/skills-registry/) · [API Endpoints](#api-endpoints) · [Development](#development) · [Contributing](#contributing) · [Open Source](#open-source)
 
 ## Table of Contents
 
@@ -82,6 +82,7 @@ Artifacts -> Parse -> Normalize -> Score -> Blast Radius -> Rollback -> Narrativ
 - API, CLI, and web entrypoints over one shared analysis pipeline
 - Local-first security model that keeps raw IaC local and avoids persisting API keys
 - Custom AI Skills for team-specific domain guidance
+- Public Skills Registry for published built-in skills: <https://deploywhisper.github.io/skills-registry/>
 - Analysis history and audit metadata for later review
 
 ## Screenshots And Demo
@@ -123,6 +124,7 @@ What is implemented today:
 - Multi-tool parsing and unified analysis pipeline
 - Provider settings, topology management, and custom skill management in the UI
 - Analysis persistence with audit metadata
+- Public Skills Registry site for published built-in skills: <https://deploywhisper.github.io/skills-registry/>
 - GitHub Actions CI for Python quality checks and sharded tests
 
 What is still evolving:

--- a/docs/contributing/skills.md
+++ b/docs/contributing/skills.md
@@ -55,10 +55,9 @@ GitHub can assign the maintainer review path for:
 ## Merge and publish
 
 After a skill change merges to `main`, the `Publish Skills Registry` workflow
-syncs changed skills into the external registry repository when these secrets
-are configured:
+syncs changed skills into `deploywhisper/skills-registry` when this secret is
+configured:
 
-- `DEPLOYWHISPER_SKILLS_REGISTRY_REPO`
 - `DEPLOYWHISPER_SKILLS_REGISTRY_PUSH_TOKEN`
 
 The publish job exports each changed built-in skill into the registry checkout
@@ -68,7 +67,7 @@ under `skills/<skill>/` with:
 - `manifest.json`
 - `tests/scenarios/`
 
-If the secrets are not configured, the workflow exits cleanly with a notice
+If the token is not configured, the workflow exits cleanly with a notice
 instead of failing unrelated merges.
 
 ## Contribution rules

--- a/tests/test_infra/test_skill_contribution_workflow.py
+++ b/tests/test_infra/test_skill_contribution_workflow.py
@@ -42,7 +42,8 @@ class SkillContributionWorkflowTests(unittest.TestCase):
         self.assertIn("branches:", workflow)
         self.assertIn("- main", workflow)
         self.assertIn("skills/*.md", workflow)
-        self.assertIn("DEPLOYWHISPER_SKILLS_REGISTRY_REPO", workflow)
+        self.assertIn("REGISTRY_REPO: deploywhisper/skills-registry", workflow)
+        self.assertIn("DEPLOYWHISPER_SKILLS_REGISTRY_PUSH_TOKEN", workflow)
         self.assertIn("scripts/publish_skills_registry.py", workflow)
 
     def test_publish_skill_writes_registry_bundle_and_removes_deleted_skill(


### PR DESCRIPTION
Now that deploywhisper/skills-registry exists, the contribution workflow no longer needs a second secret to decide where published skills go. The publish workflow now targets the public registry repo directly and contributor documentation plus workflow tests are updated to match that simplified contract.

This keeps Story 4.6 aligned with the actual repository topology that is now live, while reducing setup friction to a single cross-repo push token.

Constraint: Registry publication should require the smallest practical GitHub secret surface once the public registry repo exists
Rejected: Keep the target repository configurable via secret | adds avoidable secret management overhead for a fixed public destination
Confidence: high
Scope-risk: narrow
Reversibility: clean
Directive: If the public registry repo name changes later, update the workflow, docs, and workflow asset tests together
Tested: Focused contribution-workflow infrastructure test
Not-tested: Full repository test suite rerun after this narrow follow-up; live GitHub Actions publish against the external registry repo

## What does this PR do?

<!-- Brief description of changes -->

## Type of change
- [ ] Feature (new functionality)
- [ ] Bugfix (non-breaking fix)
- [ ] Release preparation
- [ ] Hotfix (critical production fix)
- [ ] Docs / refactor / chore

## Checklist
- [ ] I have followed the branch naming convention
- [ ] Tests pass locally (`pytest tests/ -v`)
- [ ] Linting passes (`ruff check .`)
- [ ] Docker build succeeds
- [ ] I have updated docs if needed
- [ ] No secrets or .env values committed

## Related issue
Closes #