### PR TITLE
Seed the skills marketplace so launch-day browsing is not empty

### DIFF
--- a/docs/skills/launch-catalog.md
+++ b/docs/skills/launch-catalog.md
@@ -1,0 +1,41 @@
+# Launch Skills Catalog
+
+Story 4.7 seeds the public marketplace with 20 DeployWhisper-maintained launch skills so first-time visitors see a usable catalog instead of an empty browser.
+
+## Included skills
+
+- `helm` — Helm chart rollout, hooks, dependency drift, and values-file safety
+- `argocd` — ArgoCD application sync, automation, and ApplicationSet blast radius
+- `pulumi` — Pulumi stack aliases, protection flags, and secret handling
+- `crossplane` — Crossplane compositions, XRD schema drift, and provider config safety
+- `istio` — Istio routing, mTLS, authorization, and mesh policy coordination
+- `nginx-ingress` — Nginx Ingress annotations, TLS, and route precedence
+- `cert-manager` — Cert-Manager issuers, solver settings, and renewal safety
+- `flux` — Flux reconciliation, pruning, HelmRelease config, and interval changes
+- `tekton` — Tekton credentials, finally tasks, and workspace race conditions
+- `opa-gatekeeper` — Gatekeeper deny-policy rollout, scope, and inventory sync
+- `datadog-monitors` — Datadog threshold drift, no-data handling, and alert routing
+- `prometheus-rules` — Prometheus alert timing, recording rules, and cardinality risks
+- `aws-cdk` — AWS CDK logical IDs, removal policies, and synth-time drift
+- `bicep` — Bicep deployment modes, target scope, and secret exposure
+- `pulumi-gcp` — Pulumi GCP IAM authority, project targeting, and secret handling
+- `pulumi-azure` — Pulumi Azure resource-group blast radius, identities, and recovery settings
+- `kustomize` — Kustomize overlays, patch targeting, and namespace drift
+- `helmfile` — Helmfile environment inheritance, release ordering, and shared values
+- `tanka` — Tanka environment fan-out, cluster targeting, and apply semantics
+- `jsonnet` — Jsonnet import graph drift, hidden defaults, and rendered secret leakage
+
+## Launch verification
+
+Every seeded skill ships with:
+
+- a strict manifest v1 frontmatter block in `skills/<id>.md`
+- a deterministic harness suite in `tests/skill-tests/<id>/`
+- at least three scenarios covering tool selection, raw-file trigger selection, and non-match behavior
+- risk-pattern guidance written for advisory-first review flows
+
+Install from the bundled registry with:
+
+```bash
+deploywhisper skill install <skill-id>
+```

--- a/llm/skill_context.py
+++ b/llm/skill_context.py
@@ -304,6 +304,8 @@ def _filename_matches_trigger(filename: str, trigger: str) -> bool:
     normalized_trigger = trigger.lower()
     if normalized_trigger.startswith("."):
         return normalized_filename.endswith(normalized_trigger)
+    if normalized_filename == normalized_trigger:
+        return True
     return Path(normalized_filename).name == normalized_trigger
 
 

--- a/skills/argocd.md
+++ b/skills/argocd.md
@@ -1,0 +1,24 @@
+---
+name: argocd
+version: 1.0.0
+author: DeployWhisper
+license: MIT
+triggers: [argocd-application.yaml, app-of-apps.yaml, argocd-project.yaml]
+token_budget: 1350
+tags: [argocd, gitops, kubernetes]
+description: ArgoCD sync and application-set guidance for GitOps delivery changes across shared clusters.
+test_suite_path: tests/skill-tests/argocd
+trigger_content_patterns: ["argoproj.io/v1alpha1"]
+---
+
+## Critical risk patterns
+
+- `syncPolicy.automated.prune: true` in shared namespaces can delete resources outside the immediate change set = HIGH
+- `selfHeal: true` can instantly revert emergency hotfixes and confuse incident response = MEDIUM
+- ApplicationSet generator changes fan out to every generated application and can widen blast radius cluster-wide = CRITICAL
+- ArgoCD Project repository or destination allowlists widened to `*` remove key deployment guardrails = HIGH
+
+## Review cues
+
+- Check whether ArgoCD automation settings change the blast radius beyond the named application.
+- Prefer deterministic roll-forward or rollback steps over hand-wavy remediation notes.

--- a/skills/aws-cdk.md
+++ b/skills/aws-cdk.md
@@ -1,0 +1,24 @@
+---
+name: aws-cdk
+version: 1.0.0
+author: DeployWhisper
+license: MIT
+triggers: [cdk.json, cdk.context.json]
+token_budget: 1350
+tags: [aws, cdk, iac]
+description: AWS CDK guidance for logical IDs, removal policies, and synth-time environment drift.
+test_suite_path: tests/skill-tests/aws-cdk
+trigger_content_patterns: ["aws-cdk-lib", "PolicyStatement"]
+---
+
+## Critical risk patterns
+
+- Logical ID changes force CloudFormation replacement even when code edits look cosmetic = HIGH
+- `RemovalPolicy.DESTROY` on stateful constructs risks permanent data loss = CRITICAL
+- Context lookups can differ between synth environments and change plans unexpectedly = MEDIUM
+- Broad IAM `PolicyStatement` grants expose entire accounts or regions = HIGH
+
+## Review cues
+
+- Review synthesized logical IDs, removal policies, and IAM grants together for CDK changes.
+- Prefer deterministic roll-forward or rollback steps over hand-wavy remediation notes.

--- a/skills/bicep.md
+++ b/skills/bicep.md
@@ -1,0 +1,23 @@
+---
+name: bicep
+version: 1.0.0
+author: DeployWhisper
+license: MIT
+triggers: [main.bicep, infra.bicep, .bicep]
+token_budget: 1300
+tags: [azure, bicep, iac]
+description: Azure Bicep guidance for deployment modes, secret exposure, and subscription-target drift.
+test_suite_path: tests/skill-tests/bicep
+---
+
+## Critical risk patterns
+
+- Resource or module renames can change deployment identity and trigger destructive replacement = HIGH
+- `existing` resources pointed at the wrong subscription or resource group create broken references = HIGH
+- Key Vault secrets or sensitive outputs emitted as plain strings leak credentials = CRITICAL
+- Complete-mode deployments delete unmanaged resources in the target scope = CRITICAL
+
+## Review cues
+
+- Review Bicep deployment mode, target scope, and secret handling together before approving.
+- Prefer deterministic roll-forward or rollback steps over hand-wavy remediation notes.

--- a/skills/cert-manager.md
+++ b/skills/cert-manager.md
@@ -1,0 +1,24 @@
+---
+name: cert-manager
+version: 1.0.0
+author: DeployWhisper
+license: MIT
+triggers: [cert-manager-certificate.yaml, clusterissuer.yaml, issuer.yaml]
+token_budget: 1250
+tags: [cert-manager, tls, kubernetes]
+description: Cert-Manager issuance and renewal guidance for issuer, solver, and secret-rotation changes.
+test_suite_path: tests/skill-tests/cert-manager
+trigger_content_patterns: ["cert-manager.io/"]
+---
+
+## Critical risk patterns
+
+- Replacing a ClusterIssuer can break renewals for every dependent certificate = CRITICAL
+- DNS01 or HTTP01 solver changes can stall issuance and leave certificates to expire = HIGH
+- Secret name rotation without workload coordination causes immediate TLS outages = HIGH
+- Certificate durations outside issuer policy can trigger noisy renewal loops = MEDIUM
+
+## Review cues
+
+- Review issuer scope, solver reachability, and secret consumers together for cert-manager changes.
+- Prefer deterministic roll-forward or rollback steps over hand-wavy remediation notes.

--- a/skills/crossplane.md
+++ b/skills/crossplane.md
@@ -1,0 +1,24 @@
+---
+name: crossplane
+version: 1.0.0
+author: DeployWhisper
+license: MIT
+triggers: [composition.yaml, xrd.yaml, claim.yaml]
+token_budget: 1450
+tags: [crossplane, platform, kubernetes]
+description: Crossplane composition guidance for control-plane fan-out, provider config, and managed resource safety.
+test_suite_path: tests/skill-tests/crossplane
+trigger_content_patterns: ["apiextensions.crossplane.io", "pkg.crossplane.io"]
+---
+
+## Critical risk patterns
+
+- Composition patch changes on network or database fields can fan out to every bound claim = CRITICAL
+- Removing fields from an XRD schema breaks existing claims and composition compatibility = HIGH
+- ProviderConfig credential-source changes can orphan reconciles or point resources at the wrong account = HIGH
+- `deletionPolicy: Delete` on managed resources means claim removal deletes cloud assets too = CRITICAL
+
+## Review cues
+
+- Review Crossplane changes as control-plane mutations, not just single-resource YAML edits.
+- Prefer deterministic roll-forward or rollback steps over hand-wavy remediation notes.

--- a/skills/datadog-monitors.md
+++ b/skills/datadog-monitors.md
@@ -1,0 +1,23 @@
+---
+name: datadog-monitors
+version: 1.0.0
+author: DeployWhisper
+license: MIT
+triggers: [datadog-monitor.json, datadog-monitor.yaml]
+token_budget: 1200
+tags: [datadog, monitoring, alerts]
+description: Datadog monitor guidance for threshold drift, no-data handling, and alert-routing changes.
+test_suite_path: tests/skill-tests/datadog-monitors
+---
+
+## Critical risk patterns
+
+- Loosening alert thresholds or evaluation windows can suppress paging on real incidents = HIGH
+- Disabling `notify_no_data` on heartbeat-style monitors hides telemetry loss = HIGH
+- Removing renotify behavior on sev1 services lengthens incident response = MEDIUM
+- Composite monitor dependency changes can invert alert logic for multiple downstream teams = HIGH
+
+## Review cues
+
+- Review query logic, no-data handling, and alert routing together for Datadog monitor changes.
+- Prefer deterministic roll-forward or rollback steps over hand-wavy remediation notes.

--- a/skills/flux.md
+++ b/skills/flux.md
@@ -1,0 +1,24 @@
+---
+name: flux
+version: 1.0.0
+author: DeployWhisper
+license: MIT
+triggers: [gotk-sync.yaml, flux-kustomization.yaml, helmrelease.yaml]
+token_budget: 1300
+tags: [flux, gitops, kubernetes]
+description: Flux GitOps guidance for reconciliation, pruning, and source-driven rollout safety.
+test_suite_path: tests/skill-tests/flux
+trigger_content_patterns: ["source.toolkit.fluxcd.io", "helm.toolkit.fluxcd.io", "kustomize.toolkit.fluxcd.io"]
+---
+
+## Critical risk patterns
+
+- Flux Kustomization `prune: true` can delete manually-created but still-needed resources = HIGH
+- Suspending or resuming the wrong source blocks reconciliation across multiple environments = HIGH
+- HelmRelease `valuesFrom` changes can silently swap runtime configuration = MEDIUM
+- Aggressive reconcile interval reductions can thundering-herd the control plane = MEDIUM
+
+## Review cues
+
+- Inspect source objects, reconciliation intervals, and pruning behavior together for Flux changes.
+- Prefer deterministic roll-forward or rollback steps over hand-wavy remediation notes.

--- a/skills/helm.md
+++ b/skills/helm.md
@@ -1,0 +1,24 @@
+---
+name: helm
+version: 1.0.0
+author: DeployWhisper
+license: MIT
+triggers: [Chart.yaml, values.yaml, values-production.yaml]
+token_budget: 1400
+tags: [helm, kubernetes, gitops]
+description: Helm chart rollout guidance covering hooks, chart drift, and value-driven production failures.
+test_suite_path: tests/skill-tests/helm
+trigger_content_patterns: ["apiVersion: v2", "dependencies:"]
+---
+
+## Critical risk patterns
+
+- `post-install` or `pre-upgrade` hooks that mutate shared databases can turn a chart upgrade into a production outage = HIGH
+- Service selector or immutable field changes force resource replacement and can strand live traffic = HIGH
+- Floating chart dependencies or `image.tag: latest` break reproducibility between environments = MEDIUM
+- Scaling critical workloads to zero through values files removes live capacity immediately = HIGH
+
+## Review cues
+
+- Review rendered manifests, hooks, and dependency updates together before approving a Helm rollout.
+- Prefer deterministic roll-forward or rollback steps over hand-wavy remediation notes.

--- a/skills/helmfile.md
+++ b/skills/helmfile.md
@@ -1,0 +1,23 @@
+---
+name: helmfile
+version: 1.0.0
+author: DeployWhisper
+license: MIT
+triggers: [helmfile.yaml, helmfile.yml]
+token_budget: 1300
+tags: [helmfile, helm, gitops]
+description: Helmfile guidance for environment inheritance, release targeting, and shared values safety.
+test_suite_path: tests/skill-tests/helmfile
+---
+
+## Critical risk patterns
+
+- Environment value inheritance can change many releases at once = HIGH
+- `helmDefaults.atomic: false` leaves partial failed rollouts behind = MEDIUM
+- Release selector or ordering changes can affect unintended workloads = HIGH
+- Shared secret or values file path changes break multiple environments together = HIGH
+
+## Review cues
+
+- Review environment inheritance and release targeting together before approving Helmfile changes.
+- Prefer deterministic roll-forward or rollback steps over hand-wavy remediation notes.

--- a/skills/istio.md
+++ b/skills/istio.md
@@ -1,0 +1,24 @@
+---
+name: istio
+version: 1.0.0
+author: DeployWhisper
+license: MIT
+triggers: [virtualservice.yaml, destinationrule.yaml, authorizationpolicy.yaml]
+token_budget: 1350
+tags: [istio, service-mesh, kubernetes]
+description: Istio traffic-management and policy guidance for routing, mTLS, and authorization changes.
+test_suite_path: tests/skill-tests/istio
+trigger_content_patterns: ["networking.istio.io", "security.istio.io"]
+---
+
+## Critical risk patterns
+
+- VirtualService host, match, or gateway rewrites can blackhole traffic across multiple services = CRITICAL
+- DestinationRule TLS mode mismatches commonly surface as cascading 503 errors = HIGH
+- AuthorizationPolicy allow rules with broad principals or namespaces expand lateral access = HIGH
+- PeerAuthentication set to `STRICT` before workloads are mesh-ready can trigger downtime = HIGH
+
+## Review cues
+
+- Review Istio routing and policy changes together because safe config depends on mesh-wide consistency.
+- Prefer deterministic roll-forward or rollback steps over hand-wavy remediation notes.

--- a/skills/jsonnet.md
+++ b/skills/jsonnet.md
@@ -1,0 +1,23 @@
+---
+name: jsonnet
+version: 1.0.0
+author: DeployWhisper
+license: MIT
+triggers: [jsonnetfile.json, config.jsonnet, main.jsonnet, .jsonnet]
+token_budget: 1200
+tags: [jsonnet, templating, kubernetes]
+description: Jsonnet guidance for import-graph drift, hidden defaults, and rendered secret exposure.
+test_suite_path: tests/skill-tests/jsonnet
+---
+
+## Critical risk patterns
+
+- Import graph changes can rewrite many generated manifests indirectly = HIGH
+- Hidden fields or local mixins can mask production-only config drift = MEDIUM
+- Evaluated secret literals leak directly into rendered output and review artifacts = CRITICAL
+- Deleting list elements in generators can remove live permissions or routes = HIGH
+
+## Review cues
+
+- Review rendered output and source-level abstraction changes together for Jsonnet edits.
+- Prefer deterministic roll-forward or rollback steps over hand-wavy remediation notes.

--- a/skills/kustomize.md
+++ b/skills/kustomize.md
@@ -1,0 +1,23 @@
+---
+name: kustomize
+version: 1.0.0
+author: DeployWhisper
+license: MIT
+triggers: [kustomization.yaml, kustomization.yml]
+token_budget: 1250
+tags: [kustomize, kubernetes, gitops]
+description: Kustomize overlay guidance for name transforms, patch targeting, and namespace drift.
+test_suite_path: tests/skill-tests/kustomize
+---
+
+## Critical risk patterns
+
+- NamePrefix or NameSuffix changes rewrite object identities and can break references = HIGH
+- Broad strategic merge or JSON patches can mutate unintended resources = HIGH
+- Image tag swaps without digest pinning reintroduce unreviewed drift = MEDIUM
+- Namespace transformer changes can re-home shared resources unexpectedly = HIGH
+
+## Review cues
+
+- Review Kustomize overlays as graph-wide mutations rather than isolated file edits.
+- Prefer deterministic roll-forward or rollback steps over hand-wavy remediation notes.

--- a/skills/nginx-ingress.md
+++ b/skills/nginx-ingress.md
@@ -1,0 +1,24 @@
+---
+name: nginx-ingress
+version: 1.0.0
+author: DeployWhisper
+license: MIT
+triggers: [nginx-ingress.yaml, ingress-nginx.yaml]
+token_budget: 1250
+tags: [nginx, ingress, kubernetes]
+description: Nginx Ingress controller guidance for routing, annotations, and TLS handling.
+test_suite_path: tests/skill-tests/nginx-ingress
+trigger_content_patterns: ["nginx.ingress.kubernetes.io"]
+---
+
+## Critical risk patterns
+
+- `nginx.ingress.kubernetes.io/configuration-snippet` can inject unsafe directives and bypass shared controls = HIGH
+- Path regex or default-backend rewrites can shadow unrelated routes and break many services = HIGH
+- Missing body-size or timeout tuning on large uploads creates production-only failures = MEDIUM
+- TLS host and secret mismatches cause certificate fallback and immediate client trust errors = HIGH
+
+## Review cues
+
+- Check Nginx annotations and route precedence, not just the host/path diff, before approving.
+- Prefer deterministic roll-forward or rollback steps over hand-wavy remediation notes.

--- a/skills/opa-gatekeeper.md
+++ b/skills/opa-gatekeeper.md
@@ -1,0 +1,24 @@
+---
+name: opa-gatekeeper
+version: 1.0.0
+author: DeployWhisper
+license: MIT
+triggers: [constrainttemplate.yaml, constraint.yaml, gatekeeper-policy.yaml]
+token_budget: 1350
+tags: [opa, gatekeeper, policy]
+description: OPA Gatekeeper policy guidance for deny rollouts, match scope, and inventory sync safety.
+test_suite_path: tests/skill-tests/opa-gatekeeper
+trigger_content_patterns: ["templates.gatekeeper.sh", "constraints.gatekeeper.sh"]
+---
+
+## Critical risk patterns
+
+- ConstraintTemplate or rego errors can remove enforcement when audit failures are ignored = HIGH
+- Broad match exclusions take critical namespaces out of policy coverage = HIGH
+- Rolling out deny policies without dry-run validation can block deployments cluster-wide = CRITICAL
+- Sync config omissions mean policies evaluate stale inventory and create false confidence = MEDIUM
+
+## Review cues
+
+- Review Gatekeeper changes as policy rollouts with cluster-wide blast radius, not isolated YAML edits.
+- Prefer deterministic roll-forward or rollback steps over hand-wavy remediation notes.

--- a/skills/prometheus-rules.md
+++ b/skills/prometheus-rules.md
@@ -1,0 +1,24 @@
+---
+name: prometheus-rules
+version: 1.0.0
+author: DeployWhisper
+license: MIT
+triggers: [prometheus-rules.yaml, alerting-rules.yaml]
+token_budget: 1250
+tags: [prometheus, monitoring, alerts]
+description: Prometheus rule guidance for alert timing, recording rules, and query-cardinality safety.
+test_suite_path: tests/skill-tests/prometheus-rules
+trigger_content_patterns: ["kind: PrometheusRule"]
+---
+
+## Critical risk patterns
+
+- Extending alert `for:` windows delays paging and can hide fast-burning incidents = HIGH
+- Recording rule renames break downstream dashboards, alerts, and SLO calculations = MEDIUM
+- Unbounded joins or label expansions can overload Prometheus and remote-write pipelines = HIGH
+- Severity label downgrades reduce response urgency even when the underlying blast radius is unchanged = HIGH
+
+## Review cues
+
+- Review Prometheus rule semantics, cardinality impact, and downstream consumers before merging.
+- Prefer deterministic roll-forward or rollback steps over hand-wavy remediation notes.

--- a/skills/pulumi-azure.md
+++ b/skills/pulumi-azure.md
@@ -1,0 +1,24 @@
+---
+name: pulumi-azure
+version: 1.0.0
+author: DeployWhisper
+license: MIT
+triggers: [Pulumi.azure.yaml, pulumi-azure.ts]
+token_budget: 1400
+tags: [pulumi, azure, iac]
+description: Pulumi Azure guidance for resource-group blast radius, identities, and recovery settings.
+test_suite_path: tests/skill-tests/pulumi-azure
+trigger_content_patterns: ["@pulumi/azure-native", "pulumi_azure_native"]
+---
+
+## Critical risk patterns
+
+- Resource group replacement cascades to every contained Azure resource = CRITICAL
+- Managed identity or role-assignment drift can break runtime access immediately = HIGH
+- Key Vault soft-delete or purge-protection changes alter recovery guarantees = HIGH
+- Regional SKU changes can require destructive replacement instead of in-place updates = HIGH
+
+## Review cues
+
+- Review resource-group scope, identity changes, and recovery settings together for Pulumi Azure updates.
+- Prefer deterministic roll-forward or rollback steps over hand-wavy remediation notes.

--- a/skills/pulumi-gcp.md
+++ b/skills/pulumi-gcp.md
@@ -1,0 +1,24 @@
+---
+name: pulumi-gcp
+version: 1.0.0
+author: DeployWhisper
+license: MIT
+triggers: [Pulumi.gcp.yaml, pulumi-gcp.ts]
+token_budget: 1400
+tags: [pulumi, gcp, iac]
+description: Pulumi GCP guidance for IAM authority, project targeting, and state exposure risks.
+test_suite_path: tests/skill-tests/pulumi-gcp
+trigger_content_patterns: ["@pulumi/gcp", "pulumi_gcp"]
+---
+
+## Critical risk patterns
+
+- Authoritative IAM bindings can remove required members and lock out workloads or operators = HIGH
+- Cloud SQL or GKE replacements from region or name drift introduce avoidable downtime = HIGH
+- Project or folder target changes move blast radius to the wrong tenant = CRITICAL
+- Decrypting secrets into plain config or logs exposes sensitive state = CRITICAL
+
+## Review cues
+
+- Review project targeting, IAM authority, and replacement indicators together for Pulumi GCP changes.
+- Prefer deterministic roll-forward or rollback steps over hand-wavy remediation notes.

--- a/skills/pulumi.md
+++ b/skills/pulumi.md
@@ -1,0 +1,24 @@
+---
+name: pulumi
+version: 1.0.0
+author: DeployWhisper
+license: MIT
+triggers: [Pulumi.yaml, Pulumi.dev.yaml, Pulumi.prod.yaml]
+token_budget: 1400
+tags: [pulumi, iac, cloud]
+description: Pulumi stack guidance for aliasing, protection, and stateful replacement risks.
+test_suite_path: tests/skill-tests/pulumi
+trigger_content_patterns: ["pulumi config", "@pulumi/"]
+---
+
+## Critical risk patterns
+
+- Resource renames without aliases force replacements and can recreate live infrastructure unexpectedly = HIGH
+- Turning `protect` off on databases, buckets, or queues removes a key deletion backstop = HIGH
+- Promoting secret config into plain-text stack values leaks sensitive data into state and logs = CRITICAL
+- Preview output can miss provider-computed replacements, so review replacement plans conservatively = MEDIUM
+
+## Review cues
+
+- Look for alias coverage, stack-secret handling, and protection changes before approving Pulumi updates.
+- Prefer deterministic roll-forward or rollback steps over hand-wavy remediation notes.

--- a/skills/tanka.md
+++ b/skills/tanka.md
@@ -1,0 +1,24 @@
+---
+name: tanka
+version: 1.0.0
+author: DeployWhisper
+license: MIT
+triggers: [spec.json, environments/default/main.jsonnet]
+token_budget: 1300
+tags: [tanka, jsonnet, kubernetes]
+description: Tanka guidance for environment fan-out, cluster targeting, and Jsonnet-driven drift.
+test_suite_path: tests/skill-tests/tanka
+trigger_content_patterns: ["tanka.dev/v1alpha1", "tk.libsonnet"]
+---
+
+## Critical risk patterns
+
+- Environment-level library changes fan out to every rendered object = HIGH
+- Server-side apply or force behavior can overwrite fields owned by other controllers = HIGH
+- Namespace or environment target drift deploys to the wrong cluster = CRITICAL
+- Hidden Jsonnet defaults make destructive deletions hard to spot in review = MEDIUM
+
+## Review cues
+
+- Review Tanka environment targets and rendered diff shape together before merge.
+- Prefer deterministic roll-forward or rollback steps over hand-wavy remediation notes.

--- a/skills/tekton.md
+++ b/skills/tekton.md
@@ -1,0 +1,24 @@
+---
+name: tekton
+version: 1.0.0
+author: DeployWhisper
+license: MIT
+triggers: [pipeline.yaml, pipelinerun.yaml, task.yaml]
+token_budget: 1250
+tags: [tekton, ci-cd, kubernetes]
+description: Tekton pipeline guidance for credentials, finally tasks, and shared-workspace safety.
+test_suite_path: tests/skill-tests/tekton
+trigger_content_patterns: ["tekton.dev/"]
+---
+
+## Critical risk patterns
+
+- Mounting shared credentials into every task leaks secrets far beyond the intended build step = HIGH
+- Changes to `finally` tasks can skip cleanup, approval, or promotion gates = HIGH
+- Shared PVC workspaces across concurrent runs create artifact races and nondeterministic builds = MEDIUM
+- Floating task image tags change pipeline behavior outside code review = HIGH
+
+## Review cues
+
+- Review credential scope, shared workspace usage, and finally-task behavior together for Tekton changes.
+- Prefer deterministic roll-forward or rollback steps over hand-wavy remediation notes.

--- a/tests/skill-tests/argocd/non-match.json
+++ b/tests/skill-tests/argocd/non-match.json
@@ -1,0 +1,13 @@
+{
+  "name": "argocd-non-match",
+  "description": "Does not load the ArgoCD skill for unrelated files.",
+  "assessment_tool": "terraform",
+  "contributor_summary": "Plain Terraform change with no related skill artifacts.",
+  "raw_files": {
+    "main.tf": "resource \"aws_s3_bucket\" \"logs\" {}\n"
+  },
+  "expect_selected": false,
+  "expected_absent_substrings": [
+    "`syncPolicy.automated.prune: true` in shared namespaces can delete resources outside the immediate change set = HIGH"
+  ]
+}

--- a/tests/skill-tests/argocd/tool-selection.json
+++ b/tests/skill-tests/argocd/tool-selection.json
@@ -1,0 +1,13 @@
+{
+  "name": "argocd-tool-selection",
+  "description": "Loads the ArgoCD skill from the contributor tool.",
+  "assessment_tool": "kubernetes",
+  "contributor_summary": "ArgoCD application automation is being expanded for a shared cluster.",
+  "raw_files": {
+    "argocd-application.yaml": "apiVersion: argoproj.io/v1alpha1\nkind: Application\n"
+  },
+  "expected_substrings": [
+    "`syncPolicy.automated.prune: true` in shared namespaces can delete resources outside the immediate change set = HIGH",
+    "`selfHeal: true` can instantly revert emergency hotfixes and confuse incident response = MEDIUM"
+  ]
+}

--- a/tests/skill-tests/argocd/trigger-selection.json
+++ b/tests/skill-tests/argocd/trigger-selection.json
@@ -1,0 +1,13 @@
+{
+  "name": "argocd-trigger-selection",
+  "description": "Loads the ArgoCD skill from raw file triggers.",
+  "assessment_tool": "terraform",
+  "contributor_summary": "Terraform change also updates ArgoCD application definitions.",
+  "raw_files": {
+    "app-of-apps.yaml": "apiVersion: argoproj.io/v1alpha1\nkind: ApplicationSet\n"
+  },
+  "expected_substrings": [
+    "`selfHeal: true` can instantly revert emergency hotfixes and confuse incident response = MEDIUM",
+    "ApplicationSet generator changes fan out to every generated application and can widen blast radius cluster-wide = CRITICAL"
+  ]
+}

--- a/tests/skill-tests/aws-cdk/non-match.json
+++ b/tests/skill-tests/aws-cdk/non-match.json
@@ -1,0 +1,13 @@
+{
+  "name": "aws-cdk-non-match",
+  "description": "Does not load the AWS CDK skill for unrelated files.",
+  "assessment_tool": "terraform",
+  "contributor_summary": "Plain Terraform change with no related skill artifacts.",
+  "raw_files": {
+    "main.tf": "resource \"aws_s3_bucket\" \"logs\" {}\n"
+  },
+  "expect_selected": false,
+  "expected_absent_substrings": [
+    "Logical ID changes force CloudFormation replacement even when code edits look cosmetic = HIGH"
+  ]
+}

--- a/tests/skill-tests/aws-cdk/tool-selection.json
+++ b/tests/skill-tests/aws-cdk/tool-selection.json
@@ -1,0 +1,13 @@
+{
+  "name": "aws-cdk-tool-selection",
+  "description": "Loads the AWS CDK skill from the contributor tool.",
+  "assessment_tool": "terraform",
+  "contributor_summary": "AWS CDK change updates synthesized resources and removal policy behavior.",
+  "raw_files": {
+    "cdk.json": "{\"app\": \"npx ts-node bin/app.ts\"}\n"
+  },
+  "expected_substrings": [
+    "Logical ID changes force CloudFormation replacement even when code edits look cosmetic = HIGH",
+    "`RemovalPolicy.DESTROY` on stateful constructs risks permanent data loss = CRITICAL"
+  ]
+}

--- a/tests/skill-tests/aws-cdk/trigger-selection.json
+++ b/tests/skill-tests/aws-cdk/trigger-selection.json
@@ -1,0 +1,13 @@
+{
+  "name": "aws-cdk-trigger-selection",
+  "description": "Loads the AWS CDK skill from raw file triggers.",
+  "assessment_tool": "terraform",
+  "contributor_summary": "Terraform change also updates AWS CDK synth context.",
+  "raw_files": {
+    "cdk.context.json": "{\"availability-zones:account=123:region=us-east-1\": [\"us-east-1a\"]}\n"
+  },
+  "expected_substrings": [
+    "`RemovalPolicy.DESTROY` on stateful constructs risks permanent data loss = CRITICAL",
+    "Context lookups can differ between synth environments and change plans unexpectedly = MEDIUM"
+  ]
+}

--- a/tests/skill-tests/bicep/non-match.json
+++ b/tests/skill-tests/bicep/non-match.json
@@ -1,0 +1,13 @@
+{
+  "name": "bicep-non-match",
+  "description": "Does not load the Bicep skill for unrelated files.",
+  "assessment_tool": "terraform",
+  "contributor_summary": "Plain Terraform change with no related skill artifacts.",
+  "raw_files": {
+    "main.tf": "resource \"aws_s3_bucket\" \"logs\" {}\n"
+  },
+  "expect_selected": false,
+  "expected_absent_substrings": [
+    "Resource or module renames can change deployment identity and trigger destructive replacement = HIGH"
+  ]
+}

--- a/tests/skill-tests/bicep/tool-selection.json
+++ b/tests/skill-tests/bicep/tool-selection.json
@@ -1,0 +1,13 @@
+{
+  "name": "bicep-tool-selection",
+  "description": "Loads the Bicep skill from the contributor tool.",
+  "assessment_tool": "terraform",
+  "contributor_summary": "Bicep deployment changes target scope and resource identity.",
+  "raw_files": {
+    "main.bicep": "targetScope = \"resourceGroup\"\nresource stg \"Microsoft.Storage/storageAccounts@2023-01-01\" = {}\n"
+  },
+  "expected_substrings": [
+    "Resource or module renames can change deployment identity and trigger destructive replacement = HIGH",
+    "`existing` resources pointed at the wrong subscription or resource group create broken references = HIGH"
+  ]
+}

--- a/tests/skill-tests/bicep/trigger-selection.json
+++ b/tests/skill-tests/bicep/trigger-selection.json
@@ -1,0 +1,13 @@
+{
+  "name": "bicep-trigger-selection",
+  "description": "Loads the Bicep skill from raw file triggers.",
+  "assessment_tool": "terraform",
+  "contributor_summary": "Terraform change also updates Bicep deployment files.",
+  "raw_files": {
+    "infra.bicep": "output connectionString string = \"secret\"\n"
+  },
+  "expected_substrings": [
+    "`existing` resources pointed at the wrong subscription or resource group create broken references = HIGH",
+    "Key Vault secrets or sensitive outputs emitted as plain strings leak credentials = CRITICAL"
+  ]
+}

--- a/tests/skill-tests/cert-manager/non-match.json
+++ b/tests/skill-tests/cert-manager/non-match.json
@@ -1,0 +1,13 @@
+{
+  "name": "cert-manager-non-match",
+  "description": "Does not load the Cert-Manager skill for unrelated files.",
+  "assessment_tool": "terraform",
+  "contributor_summary": "Plain Terraform change with no related skill artifacts.",
+  "raw_files": {
+    "main.tf": "resource \"aws_s3_bucket\" \"logs\" {}\n"
+  },
+  "expect_selected": false,
+  "expected_absent_substrings": [
+    "Replacing a ClusterIssuer can break renewals for every dependent certificate = CRITICAL"
+  ]
+}

--- a/tests/skill-tests/cert-manager/tool-selection.json
+++ b/tests/skill-tests/cert-manager/tool-selection.json
@@ -1,0 +1,13 @@
+{
+  "name": "cert-manager-tool-selection",
+  "description": "Loads the Cert-Manager skill from the contributor tool.",
+  "assessment_tool": "kubernetes",
+  "contributor_summary": "Cert-manager update rotates issuers and challenge solver settings.",
+  "raw_files": {
+    "clusterissuer.yaml": "apiVersion: cert-manager.io/v1\nkind: ClusterIssuer\n"
+  },
+  "expected_substrings": [
+    "Replacing a ClusterIssuer can break renewals for every dependent certificate = CRITICAL",
+    "DNS01 or HTTP01 solver changes can stall issuance and leave certificates to expire = HIGH"
+  ]
+}

--- a/tests/skill-tests/cert-manager/trigger-selection.json
+++ b/tests/skill-tests/cert-manager/trigger-selection.json
@@ -1,0 +1,13 @@
+{
+  "name": "cert-manager-trigger-selection",
+  "description": "Loads the Cert-Manager skill from raw file triggers.",
+  "assessment_tool": "terraform",
+  "contributor_summary": "Terraform change also updates cert-manager certificate resources.",
+  "raw_files": {
+    "cert-manager-certificate.yaml": "apiVersion: cert-manager.io/v1\nkind: Certificate\n"
+  },
+  "expected_substrings": [
+    "DNS01 or HTTP01 solver changes can stall issuance and leave certificates to expire = HIGH",
+    "Secret name rotation without workload coordination causes immediate TLS outages = HIGH"
+  ]
+}

--- a/tests/skill-tests/crossplane/non-match.json
+++ b/tests/skill-tests/crossplane/non-match.json
@@ -1,0 +1,13 @@
+{
+  "name": "crossplane-non-match",
+  "description": "Does not load the Crossplane skill for unrelated files.",
+  "assessment_tool": "terraform",
+  "contributor_summary": "Plain Terraform change with no related skill artifacts.",
+  "raw_files": {
+    "main.tf": "resource \"aws_s3_bucket\" \"logs\" {}\n"
+  },
+  "expect_selected": false,
+  "expected_absent_substrings": [
+    "Composition patch changes on network or database fields can fan out to every bound claim = CRITICAL"
+  ]
+}

--- a/tests/skill-tests/crossplane/tool-selection.json
+++ b/tests/skill-tests/crossplane/tool-selection.json
@@ -1,0 +1,13 @@
+{
+  "name": "crossplane-tool-selection",
+  "description": "Loads the Crossplane skill from the contributor tool.",
+  "assessment_tool": "kubernetes",
+  "contributor_summary": "Crossplane composition changes touch shared database and networking patches.",
+  "raw_files": {
+    "composition.yaml": "apiVersion: apiextensions.crossplane.io/v1\nkind: Composition\n"
+  },
+  "expected_substrings": [
+    "Composition patch changes on network or database fields can fan out to every bound claim = CRITICAL",
+    "Removing fields from an XRD schema breaks existing claims and composition compatibility = HIGH"
+  ]
+}

--- a/tests/skill-tests/crossplane/trigger-selection.json
+++ b/tests/skill-tests/crossplane/trigger-selection.json
@@ -1,0 +1,13 @@
+{
+  "name": "crossplane-trigger-selection",
+  "description": "Loads the Crossplane skill from raw file triggers.",
+  "assessment_tool": "terraform",
+  "contributor_summary": "Terraform change also updates Crossplane platform definitions.",
+  "raw_files": {
+    "xrd.yaml": "apiVersion: apiextensions.crossplane.io/v1\nkind: CompositeResourceDefinition\n"
+  },
+  "expected_substrings": [
+    "Removing fields from an XRD schema breaks existing claims and composition compatibility = HIGH",
+    "ProviderConfig credential-source changes can orphan reconciles or point resources at the wrong account = HIGH"
+  ]
+}

--- a/tests/skill-tests/datadog-monitors/non-match.json
+++ b/tests/skill-tests/datadog-monitors/non-match.json
@@ -1,0 +1,13 @@
+{
+  "name": "datadog-monitors-non-match",
+  "description": "Does not load the Datadog monitors skill for unrelated files.",
+  "assessment_tool": "terraform",
+  "contributor_summary": "Plain Terraform change with no related skill artifacts.",
+  "raw_files": {
+    "main.tf": "resource \"aws_s3_bucket\" \"logs\" {}\n"
+  },
+  "expect_selected": false,
+  "expected_absent_substrings": [
+    "Loosening alert thresholds or evaluation windows can suppress paging on real incidents = HIGH"
+  ]
+}

--- a/tests/skill-tests/datadog-monitors/tool-selection.json
+++ b/tests/skill-tests/datadog-monitors/tool-selection.json
@@ -1,0 +1,13 @@
+{
+  "name": "datadog-monitors-tool-selection",
+  "description": "Loads the Datadog monitors skill from the contributor tool.",
+  "assessment_tool": "terraform",
+  "contributor_summary": "Datadog monitor update changes thresholds and paging behavior.",
+  "raw_files": {
+    "datadog-monitor.json": "{\"name\": \"api latency\", \"notify_no_data\": true}\n"
+  },
+  "expected_substrings": [
+    "Loosening alert thresholds or evaluation windows can suppress paging on real incidents = HIGH",
+    "Disabling `notify_no_data` on heartbeat-style monitors hides telemetry loss = HIGH"
+  ]
+}

--- a/tests/skill-tests/datadog-monitors/trigger-selection.json
+++ b/tests/skill-tests/datadog-monitors/trigger-selection.json
@@ -1,0 +1,13 @@
+{
+  "name": "datadog-monitors-trigger-selection",
+  "description": "Loads the Datadog monitors skill from raw file triggers.",
+  "assessment_tool": "terraform",
+  "contributor_summary": "Terraform change also updates Datadog monitor definitions.",
+  "raw_files": {
+    "datadog-monitor.yaml": "name: api latency\nnotify_no_data: false\nrenotify_interval: 0\n"
+  },
+  "expected_substrings": [
+    "Disabling `notify_no_data` on heartbeat-style monitors hides telemetry loss = HIGH",
+    "Removing renotify behavior on sev1 services lengthens incident response = MEDIUM"
+  ]
+}

--- a/tests/skill-tests/flux/non-match.json
+++ b/tests/skill-tests/flux/non-match.json
@@ -1,0 +1,13 @@
+{
+  "name": "flux-non-match",
+  "description": "Does not load the Flux skill for unrelated files.",
+  "assessment_tool": "terraform",
+  "contributor_summary": "Plain Terraform change with no related skill artifacts.",
+  "raw_files": {
+    "main.tf": "resource \"aws_s3_bucket\" \"logs\" {}\n"
+  },
+  "expect_selected": false,
+  "expected_absent_substrings": [
+    "Flux Kustomization `prune: true` can delete manually-created but still-needed resources = HIGH"
+  ]
+}

--- a/tests/skill-tests/flux/tool-selection.json
+++ b/tests/skill-tests/flux/tool-selection.json
@@ -1,0 +1,13 @@
+{
+  "name": "flux-tool-selection",
+  "description": "Loads the Flux skill from the contributor tool.",
+  "assessment_tool": "kubernetes",
+  "contributor_summary": "Flux sync settings change reconciliation and pruning behavior.",
+  "raw_files": {
+    "gotk-sync.yaml": "apiVersion: source.toolkit.fluxcd.io/v1\nkind: GitRepository\n"
+  },
+  "expected_substrings": [
+    "Flux Kustomization `prune: true` can delete manually-created but still-needed resources = HIGH",
+    "Suspending or resuming the wrong source blocks reconciliation across multiple environments = HIGH"
+  ]
+}

--- a/tests/skill-tests/flux/trigger-selection.json
+++ b/tests/skill-tests/flux/trigger-selection.json
@@ -1,0 +1,13 @@
+{
+  "name": "flux-trigger-selection",
+  "description": "Loads the Flux skill from raw file triggers.",
+  "assessment_tool": "terraform",
+  "contributor_summary": "Terraform change also updates Flux-managed Helm releases.",
+  "raw_files": {
+    "helmrelease.yaml": "apiVersion: helm.toolkit.fluxcd.io/v2\nkind: HelmRelease\n"
+  },
+  "expected_substrings": [
+    "Suspending or resuming the wrong source blocks reconciliation across multiple environments = HIGH",
+    "HelmRelease `valuesFrom` changes can silently swap runtime configuration = MEDIUM"
+  ]
+}

--- a/tests/skill-tests/helm/non-match.json
+++ b/tests/skill-tests/helm/non-match.json
@@ -1,0 +1,13 @@
+{
+  "name": "helm-non-match",
+  "description": "Does not load the Helm skill for unrelated files.",
+  "assessment_tool": "terraform",
+  "contributor_summary": "Plain Terraform change with no related skill artifacts.",
+  "raw_files": {
+    "main.tf": "resource \"aws_s3_bucket\" \"logs\" {}\n"
+  },
+  "expect_selected": false,
+  "expected_absent_substrings": [
+    "`post-install` or `pre-upgrade` hooks that mutate shared databases can turn a chart upgrade into a production outage = HIGH"
+  ]
+}

--- a/tests/skill-tests/helm/tool-selection.json
+++ b/tests/skill-tests/helm/tool-selection.json
@@ -1,0 +1,13 @@
+{
+  "name": "helm-tool-selection",
+  "description": "Loads the Helm skill from the contributor tool.",
+  "assessment_tool": "kubernetes",
+  "contributor_summary": "Helm release updates the api chart and production values.",
+  "raw_files": {
+    "Chart.yaml": "apiVersion: v2\nname: api\ndependencies:\n  - name: redis\n"
+  },
+  "expected_substrings": [
+    "`post-install` or `pre-upgrade` hooks that mutate shared databases can turn a chart upgrade into a production outage = HIGH",
+    "Service selector or immutable field changes force resource replacement and can strand live traffic = HIGH"
+  ]
+}

--- a/tests/skill-tests/helm/trigger-selection.json
+++ b/tests/skill-tests/helm/trigger-selection.json
@@ -1,0 +1,13 @@
+{
+  "name": "helm-trigger-selection",
+  "description": "Loads the Helm skill from raw file triggers.",
+  "assessment_tool": "terraform",
+  "contributor_summary": "Terraform change also updates Helm production values.",
+  "raw_files": {
+    "values-production.yaml": "image:\n  tag: latest\nreplicaCount: 0\n"
+  },
+  "expected_substrings": [
+    "Service selector or immutable field changes force resource replacement and can strand live traffic = HIGH",
+    "Floating chart dependencies or `image.tag: latest` break reproducibility between environments = MEDIUM"
+  ]
+}

--- a/tests/skill-tests/helmfile/non-match.json
+++ b/tests/skill-tests/helmfile/non-match.json
@@ -1,0 +1,13 @@
+{
+  "name": "helmfile-non-match",
+  "description": "Does not load the Helmfile skill for unrelated files.",
+  "assessment_tool": "terraform",
+  "contributor_summary": "Plain Terraform change with no related skill artifacts.",
+  "raw_files": {
+    "main.tf": "resource \"aws_s3_bucket\" \"logs\" {}\n"
+  },
+  "expect_selected": false,
+  "expected_absent_substrings": [
+    "Environment value inheritance can change many releases at once = HIGH"
+  ]
+}

--- a/tests/skill-tests/helmfile/tool-selection.json
+++ b/tests/skill-tests/helmfile/tool-selection.json
@@ -1,0 +1,13 @@
+{
+  "name": "helmfile-tool-selection",
+  "description": "Loads the Helmfile skill from the contributor tool.",
+  "assessment_tool": "kubernetes",
+  "contributor_summary": "Helmfile update changes environment inheritance and release selection.",
+  "raw_files": {
+    "helmfile.yaml": "environments:\n  prod: {}\nreleases: []\n"
+  },
+  "expected_substrings": [
+    "Environment value inheritance can change many releases at once = HIGH",
+    "`helmDefaults.atomic: false` leaves partial failed rollouts behind = MEDIUM"
+  ]
+}

--- a/tests/skill-tests/helmfile/trigger-selection.json
+++ b/tests/skill-tests/helmfile/trigger-selection.json
@@ -1,0 +1,13 @@
+{
+  "name": "helmfile-trigger-selection",
+  "description": "Loads the Helmfile skill from raw file triggers.",
+  "assessment_tool": "terraform",
+  "contributor_summary": "Terraform change also updates Helmfile rollout definitions.",
+  "raw_files": {
+    "helmfile.yml": "helmDefaults:\n  atomic: false\n"
+  },
+  "expected_substrings": [
+    "`helmDefaults.atomic: false` leaves partial failed rollouts behind = MEDIUM",
+    "Release selector or ordering changes can affect unintended workloads = HIGH"
+  ]
+}

--- a/tests/skill-tests/istio/non-match.json
+++ b/tests/skill-tests/istio/non-match.json
@@ -1,0 +1,13 @@
+{
+  "name": "istio-non-match",
+  "description": "Does not load the Istio skill for unrelated files.",
+  "assessment_tool": "terraform",
+  "contributor_summary": "Plain Terraform change with no related skill artifacts.",
+  "raw_files": {
+    "main.tf": "resource \"aws_s3_bucket\" \"logs\" {}\n"
+  },
+  "expect_selected": false,
+  "expected_absent_substrings": [
+    "VirtualService host, match, or gateway rewrites can blackhole traffic across multiple services = CRITICAL"
+  ]
+}

--- a/tests/skill-tests/istio/tool-selection.json
+++ b/tests/skill-tests/istio/tool-selection.json
@@ -1,0 +1,13 @@
+{
+  "name": "istio-tool-selection",
+  "description": "Loads the Istio skill from the contributor tool.",
+  "assessment_tool": "kubernetes",
+  "contributor_summary": "Istio rollout updates mesh routing and mTLS policy.",
+  "raw_files": {
+    "virtualservice.yaml": "apiVersion: networking.istio.io/v1beta1\nkind: VirtualService\n"
+  },
+  "expected_substrings": [
+    "VirtualService host, match, or gateway rewrites can blackhole traffic across multiple services = CRITICAL",
+    "DestinationRule TLS mode mismatches commonly surface as cascading 503 errors = HIGH"
+  ]
+}

--- a/tests/skill-tests/istio/trigger-selection.json
+++ b/tests/skill-tests/istio/trigger-selection.json
@@ -1,0 +1,13 @@
+{
+  "name": "istio-trigger-selection",
+  "description": "Loads the Istio skill from raw file triggers.",
+  "assessment_tool": "terraform",
+  "contributor_summary": "Terraform change also updates Istio access policy manifests.",
+  "raw_files": {
+    "authorizationpolicy.yaml": "apiVersion: security.istio.io/v1beta1\nkind: AuthorizationPolicy\n"
+  },
+  "expected_substrings": [
+    "DestinationRule TLS mode mismatches commonly surface as cascading 503 errors = HIGH",
+    "AuthorizationPolicy allow rules with broad principals or namespaces expand lateral access = HIGH"
+  ]
+}

--- a/tests/skill-tests/jsonnet/non-match.json
+++ b/tests/skill-tests/jsonnet/non-match.json
@@ -1,0 +1,13 @@
+{
+  "name": "jsonnet-non-match",
+  "description": "Does not load the Jsonnet skill for unrelated files.",
+  "assessment_tool": "terraform",
+  "contributor_summary": "Plain Terraform change with no related skill artifacts.",
+  "raw_files": {
+    "main.tf": "resource \"aws_s3_bucket\" \"logs\" {}\n"
+  },
+  "expect_selected": false,
+  "expected_absent_substrings": [
+    "Import graph changes can rewrite many generated manifests indirectly = HIGH"
+  ]
+}

--- a/tests/skill-tests/jsonnet/tool-selection.json
+++ b/tests/skill-tests/jsonnet/tool-selection.json
@@ -1,0 +1,13 @@
+{
+  "name": "jsonnet-tool-selection",
+  "description": "Loads the Jsonnet skill from the contributor tool.",
+  "assessment_tool": "kubernetes",
+  "contributor_summary": "Jsonnet template update changes imports and generated manifests.",
+  "raw_files": {
+    "config.jsonnet": "local app = { name: \"api\" };\napp\n"
+  },
+  "expected_substrings": [
+    "Import graph changes can rewrite many generated manifests indirectly = HIGH",
+    "Hidden fields or local mixins can mask production-only config drift = MEDIUM"
+  ]
+}

--- a/tests/skill-tests/jsonnet/trigger-selection.json
+++ b/tests/skill-tests/jsonnet/trigger-selection.json
@@ -1,0 +1,13 @@
+{
+  "name": "jsonnet-trigger-selection",
+  "description": "Loads the Jsonnet skill from raw file triggers.",
+  "assessment_tool": "terraform",
+  "contributor_summary": "Terraform change also updates Jsonnet dependency definitions.",
+  "raw_files": {
+    "jsonnetfile.json": "{\"dependencies\": []}\n"
+  },
+  "expected_substrings": [
+    "Hidden fields or local mixins can mask production-only config drift = MEDIUM",
+    "Evaluated secret literals leak directly into rendered output and review artifacts = CRITICAL"
+  ]
+}

--- a/tests/skill-tests/kustomize/non-match.json
+++ b/tests/skill-tests/kustomize/non-match.json
@@ -1,0 +1,13 @@
+{
+  "name": "kustomize-non-match",
+  "description": "Does not load the Kustomize skill for unrelated files.",
+  "assessment_tool": "terraform",
+  "contributor_summary": "Plain Terraform change with no related skill artifacts.",
+  "raw_files": {
+    "main.tf": "resource \"aws_s3_bucket\" \"logs\" {}\n"
+  },
+  "expect_selected": false,
+  "expected_absent_substrings": [
+    "NamePrefix or NameSuffix changes rewrite object identities and can break references = HIGH"
+  ]
+}

--- a/tests/skill-tests/kustomize/tool-selection.json
+++ b/tests/skill-tests/kustomize/tool-selection.json
@@ -1,0 +1,13 @@
+{
+  "name": "kustomize-tool-selection",
+  "description": "Loads the Kustomize skill from the contributor tool.",
+  "assessment_tool": "kubernetes",
+  "contributor_summary": "Kustomize overlay change updates image tags and name transforms.",
+  "raw_files": {
+    "kustomization.yaml": "resources:\n  - deployment.yaml\nimages: []\n"
+  },
+  "expected_substrings": [
+    "NamePrefix or NameSuffix changes rewrite object identities and can break references = HIGH",
+    "Broad strategic merge or JSON patches can mutate unintended resources = HIGH"
+  ]
+}

--- a/tests/skill-tests/kustomize/trigger-selection.json
+++ b/tests/skill-tests/kustomize/trigger-selection.json
@@ -1,0 +1,13 @@
+{
+  "name": "kustomize-trigger-selection",
+  "description": "Loads the Kustomize skill from raw file triggers.",
+  "assessment_tool": "terraform",
+  "contributor_summary": "Terraform change also updates Kustomize overlay files.",
+  "raw_files": {
+    "kustomization.yml": "namespace: platform\npatches: []\n"
+  },
+  "expected_substrings": [
+    "Broad strategic merge or JSON patches can mutate unintended resources = HIGH",
+    "Image tag swaps without digest pinning reintroduce unreviewed drift = MEDIUM"
+  ]
+}

--- a/tests/skill-tests/nginx-ingress/non-match.json
+++ b/tests/skill-tests/nginx-ingress/non-match.json
@@ -1,0 +1,13 @@
+{
+  "name": "nginx-ingress-non-match",
+  "description": "Does not load the Nginx Ingress skill for unrelated files.",
+  "assessment_tool": "terraform",
+  "contributor_summary": "Plain Terraform change with no related skill artifacts.",
+  "raw_files": {
+    "main.tf": "resource \"aws_s3_bucket\" \"logs\" {}\n"
+  },
+  "expect_selected": false,
+  "expected_absent_substrings": [
+    "`nginx.ingress.kubernetes.io/configuration-snippet` can inject unsafe directives and bypass shared controls = HIGH"
+  ]
+}

--- a/tests/skill-tests/nginx-ingress/tool-selection.json
+++ b/tests/skill-tests/nginx-ingress/tool-selection.json
@@ -1,0 +1,13 @@
+{
+  "name": "nginx-ingress-tool-selection",
+  "description": "Loads the Nginx Ingress skill from the contributor tool.",
+  "assessment_tool": "kubernetes",
+  "contributor_summary": "Nginx ingress change updates annotations and route handling.",
+  "raw_files": {
+    "nginx-ingress.yaml": "metadata:\n  annotations:\n    nginx.ingress.kubernetes.io/rewrite-target: /\n"
+  },
+  "expected_substrings": [
+    "`nginx.ingress.kubernetes.io/configuration-snippet` can inject unsafe directives and bypass shared controls = HIGH",
+    "Path regex or default-backend rewrites can shadow unrelated routes and break many services = HIGH"
+  ]
+}

--- a/tests/skill-tests/nginx-ingress/trigger-selection.json
+++ b/tests/skill-tests/nginx-ingress/trigger-selection.json
@@ -1,0 +1,13 @@
+{
+  "name": "nginx-ingress-trigger-selection",
+  "description": "Loads the Nginx Ingress skill from raw file triggers.",
+  "assessment_tool": "terraform",
+  "contributor_summary": "Terraform change also updates ingress controller annotations.",
+  "raw_files": {
+    "ingress-nginx.yaml": "metadata:\n  annotations:\n    nginx.ingress.kubernetes.io/configuration-snippet: more_set_headers\n"
+  },
+  "expected_substrings": [
+    "Path regex or default-backend rewrites can shadow unrelated routes and break many services = HIGH",
+    "Missing body-size or timeout tuning on large uploads creates production-only failures = MEDIUM"
+  ]
+}

--- a/tests/skill-tests/opa-gatekeeper/non-match.json
+++ b/tests/skill-tests/opa-gatekeeper/non-match.json
@@ -1,0 +1,13 @@
+{
+  "name": "opa-gatekeeper-non-match",
+  "description": "Does not load the OPA Gatekeeper skill for unrelated files.",
+  "assessment_tool": "terraform",
+  "contributor_summary": "Plain Terraform change with no related skill artifacts.",
+  "raw_files": {
+    "main.tf": "resource \"aws_s3_bucket\" \"logs\" {}\n"
+  },
+  "expect_selected": false,
+  "expected_absent_substrings": [
+    "ConstraintTemplate or rego errors can remove enforcement when audit failures are ignored = HIGH"
+  ]
+}

--- a/tests/skill-tests/opa-gatekeeper/tool-selection.json
+++ b/tests/skill-tests/opa-gatekeeper/tool-selection.json
@@ -1,0 +1,13 @@
+{
+  "name": "opa-gatekeeper-tool-selection",
+  "description": "Loads the OPA Gatekeeper skill from the contributor tool.",
+  "assessment_tool": "kubernetes",
+  "contributor_summary": "OPA Gatekeeper policy update changes deny logic and match scope.",
+  "raw_files": {
+    "constrainttemplate.yaml": "apiVersion: templates.gatekeeper.sh/v1\nkind: ConstraintTemplate\n"
+  },
+  "expected_substrings": [
+    "ConstraintTemplate or rego errors can remove enforcement when audit failures are ignored = HIGH",
+    "Broad match exclusions take critical namespaces out of policy coverage = HIGH"
+  ]
+}

--- a/tests/skill-tests/opa-gatekeeper/trigger-selection.json
+++ b/tests/skill-tests/opa-gatekeeper/trigger-selection.json
@@ -1,0 +1,13 @@
+{
+  "name": "opa-gatekeeper-trigger-selection",
+  "description": "Loads the OPA Gatekeeper skill from raw file triggers.",
+  "assessment_tool": "terraform",
+  "contributor_summary": "Terraform change also updates Gatekeeper constraint policy.",
+  "raw_files": {
+    "gatekeeper-policy.yaml": "apiVersion: constraints.gatekeeper.sh/v1beta1\nkind: K8sRequiredLabels\n"
+  },
+  "expected_substrings": [
+    "Broad match exclusions take critical namespaces out of policy coverage = HIGH",
+    "Rolling out deny policies without dry-run validation can block deployments cluster-wide = CRITICAL"
+  ]
+}

--- a/tests/skill-tests/prometheus-rules/non-match.json
+++ b/tests/skill-tests/prometheus-rules/non-match.json
@@ -1,0 +1,13 @@
+{
+  "name": "prometheus-rules-non-match",
+  "description": "Does not load the Prometheus rules skill for unrelated files.",
+  "assessment_tool": "terraform",
+  "contributor_summary": "Plain Terraform change with no related skill artifacts.",
+  "raw_files": {
+    "main.tf": "resource \"aws_s3_bucket\" \"logs\" {}\n"
+  },
+  "expect_selected": false,
+  "expected_absent_substrings": [
+    "Extending alert `for:` windows delays paging and can hide fast-burning incidents = HIGH"
+  ]
+}

--- a/tests/skill-tests/prometheus-rules/tool-selection.json
+++ b/tests/skill-tests/prometheus-rules/tool-selection.json
@@ -1,0 +1,13 @@
+{
+  "name": "prometheus-rules-tool-selection",
+  "description": "Loads the Prometheus rules skill from the contributor tool.",
+  "assessment_tool": "kubernetes",
+  "contributor_summary": "Prometheus rules update changes alert windows and recording names.",
+  "raw_files": {
+    "prometheus-rules.yaml": "kind: PrometheusRule\nspec:\n  groups: []\n"
+  },
+  "expected_substrings": [
+    "Extending alert `for:` windows delays paging and can hide fast-burning incidents = HIGH",
+    "Recording rule renames break downstream dashboards, alerts, and SLO calculations = MEDIUM"
+  ]
+}

--- a/tests/skill-tests/prometheus-rules/trigger-selection.json
+++ b/tests/skill-tests/prometheus-rules/trigger-selection.json
@@ -1,0 +1,13 @@
+{
+  "name": "prometheus-rules-trigger-selection",
+  "description": "Loads the Prometheus rules skill from raw file triggers.",
+  "assessment_tool": "terraform",
+  "contributor_summary": "Terraform change also updates Prometheus alert rules.",
+  "raw_files": {
+    "alerting-rules.yaml": "kind: PrometheusRule\nspec:\n  groups:\n    - name: api\n"
+  },
+  "expected_substrings": [
+    "Recording rule renames break downstream dashboards, alerts, and SLO calculations = MEDIUM",
+    "Unbounded joins or label expansions can overload Prometheus and remote-write pipelines = HIGH"
+  ]
+}

--- a/tests/skill-tests/pulumi-azure/non-match.json
+++ b/tests/skill-tests/pulumi-azure/non-match.json
@@ -1,0 +1,13 @@
+{
+  "name": "pulumi-azure-non-match",
+  "description": "Does not load the Pulumi Azure skill for unrelated files.",
+  "assessment_tool": "terraform",
+  "contributor_summary": "Plain Terraform change with no related skill artifacts.",
+  "raw_files": {
+    "main.tf": "resource \"aws_s3_bucket\" \"logs\" {}\n"
+  },
+  "expect_selected": false,
+  "expected_absent_substrings": [
+    "Resource group replacement cascades to every contained Azure resource = CRITICAL"
+  ]
+}

--- a/tests/skill-tests/pulumi-azure/tool-selection.json
+++ b/tests/skill-tests/pulumi-azure/tool-selection.json
@@ -1,0 +1,13 @@
+{
+  "name": "pulumi-azure-tool-selection",
+  "description": "Loads the Pulumi Azure skill from the contributor tool.",
+  "assessment_tool": "terraform",
+  "contributor_summary": "Pulumi Azure stack update changes identity and regional deployment settings.",
+  "raw_files": {
+    "Pulumi.azure.yaml": "config:\n  azure-native:location: eastus\n"
+  },
+  "expected_substrings": [
+    "Resource group replacement cascades to every contained Azure resource = CRITICAL",
+    "Managed identity or role-assignment drift can break runtime access immediately = HIGH"
+  ]
+}

--- a/tests/skill-tests/pulumi-azure/trigger-selection.json
+++ b/tests/skill-tests/pulumi-azure/trigger-selection.json
@@ -1,0 +1,13 @@
+{
+  "name": "pulumi-azure-trigger-selection",
+  "description": "Loads the Pulumi Azure skill from raw file triggers.",
+  "assessment_tool": "terraform",
+  "contributor_summary": "Terraform change also updates Pulumi Azure program code.",
+  "raw_files": {
+    "pulumi-azure.ts": "import * as azure from \"@pulumi/azure-native\";\n"
+  },
+  "expected_substrings": [
+    "Managed identity or role-assignment drift can break runtime access immediately = HIGH",
+    "Key Vault soft-delete or purge-protection changes alter recovery guarantees = HIGH"
+  ]
+}

--- a/tests/skill-tests/pulumi-gcp/non-match.json
+++ b/tests/skill-tests/pulumi-gcp/non-match.json
@@ -1,0 +1,13 @@
+{
+  "name": "pulumi-gcp-non-match",
+  "description": "Does not load the Pulumi GCP skill for unrelated files.",
+  "assessment_tool": "terraform",
+  "contributor_summary": "Plain Terraform change with no related skill artifacts.",
+  "raw_files": {
+    "main.tf": "resource \"aws_s3_bucket\" \"logs\" {}\n"
+  },
+  "expect_selected": false,
+  "expected_absent_substrings": [
+    "Authoritative IAM bindings can remove required members and lock out workloads or operators = HIGH"
+  ]
+}

--- a/tests/skill-tests/pulumi-gcp/tool-selection.json
+++ b/tests/skill-tests/pulumi-gcp/tool-selection.json
@@ -1,0 +1,13 @@
+{
+  "name": "pulumi-gcp-tool-selection",
+  "description": "Loads the Pulumi GCP skill from the contributor tool.",
+  "assessment_tool": "terraform",
+  "contributor_summary": "Pulumi GCP stack update changes IAM and project targeting.",
+  "raw_files": {
+    "Pulumi.gcp.yaml": "config:\n  gcp:project: prod-platform\n"
+  },
+  "expected_substrings": [
+    "Authoritative IAM bindings can remove required members and lock out workloads or operators = HIGH",
+    "Cloud SQL or GKE replacements from region or name drift introduce avoidable downtime = HIGH"
+  ]
+}

--- a/tests/skill-tests/pulumi-gcp/trigger-selection.json
+++ b/tests/skill-tests/pulumi-gcp/trigger-selection.json
@@ -1,0 +1,13 @@
+{
+  "name": "pulumi-gcp-trigger-selection",
+  "description": "Loads the Pulumi GCP skill from raw file triggers.",
+  "assessment_tool": "terraform",
+  "contributor_summary": "Terraform change also updates Pulumi GCP program code.",
+  "raw_files": {
+    "pulumi-gcp.ts": "import * as gcp from \"@pulumi/gcp\";\n"
+  },
+  "expected_substrings": [
+    "Cloud SQL or GKE replacements from region or name drift introduce avoidable downtime = HIGH",
+    "Project or folder target changes move blast radius to the wrong tenant = CRITICAL"
+  ]
+}

--- a/tests/skill-tests/pulumi/non-match.json
+++ b/tests/skill-tests/pulumi/non-match.json
@@ -1,0 +1,13 @@
+{
+  "name": "pulumi-non-match",
+  "description": "Does not load the Pulumi skill for unrelated files.",
+  "assessment_tool": "terraform",
+  "contributor_summary": "Plain Terraform change with no related skill artifacts.",
+  "raw_files": {
+    "main.tf": "resource \"aws_s3_bucket\" \"logs\" {}\n"
+  },
+  "expect_selected": false,
+  "expected_absent_substrings": [
+    "Resource renames without aliases force replacements and can recreate live infrastructure unexpectedly = HIGH"
+  ]
+}

--- a/tests/skill-tests/pulumi/tool-selection.json
+++ b/tests/skill-tests/pulumi/tool-selection.json
@@ -1,0 +1,13 @@
+{
+  "name": "pulumi-tool-selection",
+  "description": "Loads the Pulumi skill from the contributor tool.",
+  "assessment_tool": "terraform",
+  "contributor_summary": "Pulumi stack update renames resources and changes protection settings.",
+  "raw_files": {
+    "Pulumi.yaml": "name: platform\nruntime: nodejs\n"
+  },
+  "expected_substrings": [
+    "Resource renames without aliases force replacements and can recreate live infrastructure unexpectedly = HIGH",
+    "Turning `protect` off on databases, buckets, or queues removes a key deletion backstop = HIGH"
+  ]
+}

--- a/tests/skill-tests/pulumi/trigger-selection.json
+++ b/tests/skill-tests/pulumi/trigger-selection.json
@@ -1,0 +1,13 @@
+{
+  "name": "pulumi-trigger-selection",
+  "description": "Loads the Pulumi skill from raw file triggers.",
+  "assessment_tool": "terraform",
+  "contributor_summary": "Terraform change also touches a Pulumi stack definition.",
+  "raw_files": {
+    "Pulumi.dev.yaml": "config:\n  app:domain: api.internal\n"
+  },
+  "expected_substrings": [
+    "Turning `protect` off on databases, buckets, or queues removes a key deletion backstop = HIGH",
+    "Promoting secret config into plain-text stack values leaks sensitive data into state and logs = CRITICAL"
+  ]
+}

--- a/tests/skill-tests/tanka/non-match.json
+++ b/tests/skill-tests/tanka/non-match.json
@@ -1,0 +1,13 @@
+{
+  "name": "tanka-non-match",
+  "description": "Does not load the Tanka skill for unrelated files.",
+  "assessment_tool": "terraform",
+  "contributor_summary": "Plain Terraform change with no related skill artifacts.",
+  "raw_files": {
+    "main.tf": "resource \"aws_s3_bucket\" \"logs\" {}\n"
+  },
+  "expect_selected": false,
+  "expected_absent_substrings": [
+    "Environment-level library changes fan out to every rendered object = HIGH"
+  ]
+}

--- a/tests/skill-tests/tanka/tool-selection.json
+++ b/tests/skill-tests/tanka/tool-selection.json
@@ -1,0 +1,13 @@
+{
+  "name": "tanka-tool-selection",
+  "description": "Loads the Tanka skill from the contributor tool.",
+  "assessment_tool": "kubernetes",
+  "contributor_summary": "Tanka environment update changes render targets and apply behavior.",
+  "raw_files": {
+    "spec.json": "{\"apiVersion\": \"tanka.dev/v1alpha1\"}\n"
+  },
+  "expected_substrings": [
+    "Environment-level library changes fan out to every rendered object = HIGH",
+    "Server-side apply or force behavior can overwrite fields owned by other controllers = HIGH"
+  ]
+}

--- a/tests/skill-tests/tanka/trigger-selection.json
+++ b/tests/skill-tests/tanka/trigger-selection.json
@@ -1,0 +1,13 @@
+{
+  "name": "tanka-trigger-selection",
+  "description": "Loads the Tanka skill from raw file triggers.",
+  "assessment_tool": "terraform",
+  "contributor_summary": "Terraform change also updates Tanka Jsonnet environments.",
+  "raw_files": {
+    "main.jsonnet": "local env = import \"tk.libsonnet\";\n"
+  },
+  "expected_substrings": [
+    "Server-side apply or force behavior can overwrite fields owned by other controllers = HIGH",
+    "Namespace or environment target drift deploys to the wrong cluster = CRITICAL"
+  ]
+}

--- a/tests/skill-tests/tekton/non-match.json
+++ b/tests/skill-tests/tekton/non-match.json
@@ -1,0 +1,13 @@
+{
+  "name": "tekton-non-match",
+  "description": "Does not load the Tekton skill for unrelated files.",
+  "assessment_tool": "terraform",
+  "contributor_summary": "Plain Terraform change with no related skill artifacts.",
+  "raw_files": {
+    "main.tf": "resource \"aws_s3_bucket\" \"logs\" {}\n"
+  },
+  "expect_selected": false,
+  "expected_absent_substrings": [
+    "Mounting shared credentials into every task leaks secrets far beyond the intended build step = HIGH"
+  ]
+}

--- a/tests/skill-tests/tekton/tool-selection.json
+++ b/tests/skill-tests/tekton/tool-selection.json
@@ -1,0 +1,13 @@
+{
+  "name": "tekton-tool-selection",
+  "description": "Loads the Tekton skill from the contributor tool.",
+  "assessment_tool": "kubernetes",
+  "contributor_summary": "Tekton pipeline update changes cleanup and credential behavior.",
+  "raw_files": {
+    "pipeline.yaml": "apiVersion: tekton.dev/v1\nkind: Pipeline\n"
+  },
+  "expected_substrings": [
+    "Mounting shared credentials into every task leaks secrets far beyond the intended build step = HIGH",
+    "Changes to `finally` tasks can skip cleanup, approval, or promotion gates = HIGH"
+  ]
+}

--- a/tests/skill-tests/tekton/trigger-selection.json
+++ b/tests/skill-tests/tekton/trigger-selection.json
@@ -1,0 +1,13 @@
+{
+  "name": "tekton-trigger-selection",
+  "description": "Loads the Tekton skill from raw file triggers.",
+  "assessment_tool": "terraform",
+  "contributor_summary": "Terraform change also updates Tekton task definitions.",
+  "raw_files": {
+    "task.yaml": "apiVersion: tekton.dev/v1\nkind: Task\n"
+  },
+  "expected_substrings": [
+    "Changes to `finally` tasks can skip cleanup, approval, or promotion gates = HIGH",
+    "Shared PVC workspaces across concurrent runs create artifact races and nondeterministic builds = MEDIUM"
+  ]
+}

--- a/tests/test_infra/test_seeded_community_skills.py
+++ b/tests/test_infra/test_seeded_community_skills.py
@@ -1,0 +1,102 @@
+"""Regression tests for the seeded launch-day skills catalog."""
+
+from __future__ import annotations
+
+import json
+import unittest
+
+from services.skill_manifest_service import REPO_ROOT, load_skill_document
+from services.skill_test_harness_service import run_skill_test_suites
+
+
+LAUNCH_SKILL_IDS = {
+    "helm",
+    "argocd",
+    "pulumi",
+    "crossplane",
+    "istio",
+    "nginx-ingress",
+    "cert-manager",
+    "flux",
+    "tekton",
+    "opa-gatekeeper",
+    "datadog-monitors",
+    "prometheus-rules",
+    "aws-cdk",
+    "bicep",
+    "pulumi-gcp",
+    "pulumi-azure",
+    "kustomize",
+    "helmfile",
+    "tanka",
+    "jsonnet",
+}
+SUPPORTED_RUNTIME_TOOLS = {
+    "terraform",
+    "kubernetes",
+    "ansible",
+    "jenkins",
+    "cloudformation",
+}
+
+
+class SeededCommunitySkillsTests(unittest.TestCase):
+    def test_launch_catalog_contains_expected_first_party_skills(self) -> None:
+        skill_paths = {path.stem for path in (REPO_ROOT / "skills").glob("*.md")}
+
+        self.assertTrue(
+            LAUNCH_SKILL_IDS.issubset(skill_paths),
+            f"Missing launch skills: {sorted(LAUNCH_SKILL_IDS - skill_paths)}",
+        )
+
+        for skill_id in sorted(LAUNCH_SKILL_IDS):
+            document = load_skill_document(
+                REPO_ROOT / "skills" / f"{skill_id}.md",
+                strict_manifest=True,
+                allow_legacy_name=False,
+                project_root=REPO_ROOT,
+            )
+
+            assert document.manifest is not None
+            self.assertEqual(document.manifest.author, "DeployWhisper")
+            self.assertEqual(
+                document.manifest.test_suite_path,
+                f"tests/skill-tests/{skill_id}",
+            )
+            self.assertIn("## Critical risk patterns", document.body)
+
+    def test_launch_catalog_suites_have_three_passing_scenarios(self) -> None:
+        for skill_id in sorted(LAUNCH_SKILL_IDS):
+            suite_files = list(
+                (REPO_ROOT / "tests" / "skill-tests" / skill_id).glob("*.json")
+            )
+            self.assertGreaterEqual(
+                len(suite_files),
+                3,
+                f"{skill_id} must ship at least 3 deterministic scenarios.",
+            )
+            scenario = json.loads(
+                (
+                    REPO_ROOT
+                    / "tests"
+                    / "skill-tests"
+                    / skill_id
+                    / "tool-selection.json"
+                ).read_text(encoding="utf-8")
+            )
+            self.assertIn(
+                scenario["assessment_tool"],
+                SUPPORTED_RUNTIME_TOOLS,
+                f"{skill_id} tool-selection scenario must use a runtime-supported contributor tool.",
+            )
+
+        results = run_skill_test_suites(sorted(LAUNCH_SKILL_IDS))
+
+        self.assertEqual({result.skill_id for result in results}, LAUNCH_SKILL_IDS)
+        for result in results:
+            self.assertEqual(result.summary.status, "passing", result.skill_id)
+            self.assertGreaterEqual(result.summary.total_scenarios, 3)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_llm/test_skill_context.py
+++ b/tests/test_llm/test_skill_context.py
@@ -11,6 +11,7 @@ from analysis.risk_scorer import RiskAssessment, RiskContributor
 from llm.skill_context import (
     build_skill_context,
     get_custom_skill_statuses,
+    resolve_skills,
     save_custom_skill,
 )
 
@@ -211,6 +212,68 @@ class SkillContextTests(unittest.TestCase):
         self.assertIn("Kubernetes guidance.", skill_context)
         self.assertNotIn("Ansible guidance.", skill_context)
         self.assertNotIn("CloudFormation guidance.", skill_context)
+
+    def test_seeded_jsonnet_skill_does_not_match_generic_python_tokens(self) -> None:
+        selected = resolve_skills(
+            self._assessment("terraform"),
+            raw_files={"app.py": b"import os\nlocal = 1\n"},
+        )
+
+        self.assertNotIn("jsonnet", [skill.name for skill in selected])
+
+    def test_seeded_prometheus_skill_does_not_match_generic_yaml_groups(self) -> None:
+        selected = resolve_skills(
+            self._assessment("terraform"),
+            raw_files={
+                "deployment.yaml": (
+                    b"apiVersion: v1\nkind: ConfigMap\nmetadata:\n"
+                    b"  name: test\nspec:\n  groups:\n    - default\n"
+                )
+            },
+        )
+
+        self.assertNotIn("prometheus-rules", [skill.name for skill in selected])
+
+    def test_seeded_kustomize_skill_does_not_match_generic_yaml_patch_words(
+        self,
+    ) -> None:
+        selected = resolve_skills(
+            self._assessment("terraform"),
+            raw_files={"config.yaml": b"images:\n  - name: app\npatches: []\n"},
+        )
+
+        self.assertNotIn("kustomize", [skill.name for skill in selected])
+
+    def test_seeded_helmfile_skill_does_not_match_generic_yaml_environment_key(
+        self,
+    ) -> None:
+        selected = resolve_skills(
+            self._assessment("terraform"),
+            raw_files={"config.yaml": b"environments:\n  prod:\n    values: []\n"},
+        )
+
+        self.assertNotIn("helmfile", [skill.name for skill in selected])
+
+    def test_seeded_bicep_skill_matches_bicep_extension(self) -> None:
+        selected = resolve_skills(
+            self._assessment("terraform"),
+            raw_files={
+                "service.bicep": (
+                    b"param location string\nresource app "
+                    b'"Microsoft.Web/sites@2023-01-01" = {}\n'
+                )
+            },
+        )
+
+        self.assertIn("bicep", [skill.name for skill in selected])
+
+    def test_seeded_jsonnet_skill_matches_jsonnet_extension(self) -> None:
+        selected = resolve_skills(
+            self._assessment("terraform"),
+            raw_files={"dashboard.jsonnet": b"local app = { name: 'api' };\napp\n"},
+        )
+
+        self.assertIn("jsonnet", [skill.name for skill in selected])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Story 4.7 seeds the registry with 20 first-party skills, launch-catalog docs, and deterministic harness suites so the marketplace is usable on day one instead of presenting an empty catalog.

The follow-up review pass tightened runtime trigger matching and replaced synthetic tool-selection scenarios with runtime-supported contributor tools so the seeded content matches the existing skill resolver and harness contracts.

Constraint: Seeded skills had to fit the existing manifest v1, registry, installer, and deterministic harness contracts without adding dependencies
Rejected: Keep generic substring trigger_content_patterns | caused unrelated skill activation in runtime probes
Rejected: Use synthetic tool ids in tool-selection suites | overstated working-installation coverage versus current runtime outputs
Confidence: high
Scope-risk: moderate
Directive: Keep future seeded skills aligned with runtime-supported tools and probe new trigger patterns for false positives before publishing
Tested: ./ .venv/bin/ruff check .; ./.venv/bin/ruff format --check .; ./.venv/bin/python -m unittest tests.test_llm.test_skill_context tests.test_infra.test_seeded_community_skills -q; ./.venv/bin/python -m unittest discover -q; bash scripts/ci-local.sh
Not-tested: Local Bandit parity because Bandit is not installed in this environment

## What does this PR do?

<!-- Brief description of changes -->

## Type of change
- [ ] Feature (new functionality)
- [ ] Bugfix (non-breaking fix)
- [ ] Release preparation
- [ ] Hotfix (critical production fix)
- [ ] Docs / refactor / chore

## Checklist
- [ ] I have followed the branch naming convention
- [ ] Tests pass locally (`pytest tests/ -v`)
- [ ] Linting passes (`ruff check .`)
- [ ] Docker build succeeds
- [ ] I have updated docs if needed
- [ ] No secrets or .env values committed

## Related issue
Closes #