### PR TITLE
Expose shared skill analytics so marketplace trust signals are visibl…

### DIFF
--- a/.github/workflows/refresh-skill-analytics.yml
+++ b/.github/workflows/refresh-skill-analytics.yml
@@ -1,0 +1,43 @@
+name: Refresh Skill Analytics
+
+on:
+  schedule:
+    - cron: "17 2 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  issues: read
+
+jobs:
+  refresh:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+      - name: Setup Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+
+      - name: Refresh analytics snapshot
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DEPLOYWHISPER_SKILL_ANALYTICS_URL: ${{ vars.DEPLOYWHISPER_SKILL_ANALYTICS_URL }}
+        run: |
+          python scripts/refresh_skill_analytics.py \
+            --repo "${{ github.repository }}"
+
+      - name: Commit refreshed analytics
+        run: |
+          if git diff --quiet; then
+            echo "No analytics changes to commit."
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add data/skill-analytics.json
+          git commit -m "Refresh skill analytics snapshot"
+          git push

--- a/api/schemas.py
+++ b/api/schemas.py
@@ -683,6 +683,22 @@ class SkillRegistryData(BaseModel):
     trigger_content_patterns: list[str] = Field(
         default_factory=list, description="Content markers used for matching"
     )
+    install_count: int = Field(
+        default=0, description="Current install count from the analytics snapshot"
+    )
+    active_issue_count: int = Field(
+        default=0, description="Current open issue count from the analytics snapshot"
+    )
+    analytics_updated_at: str = Field(
+        ..., description="When the analytics snapshot was last refreshed"
+    )
+    download_count: int = Field(
+        default=0,
+        description="Compatibility popularity metric derived from install counts.",
+    )
+    star_count: int = Field(
+        default=0, description="Current star count from the analytics snapshot"
+    )
     updated_at: str = Field(..., description="Last local update timestamp")
     available_versions: int = Field(
         ..., description="Number of versions discoverable for this skill id"

--- a/cli/analyze.py
+++ b/cli/analyze.py
@@ -29,6 +29,7 @@ from services.skill_installer_service import (
     remove_skill,
     update_skill,
 )
+from services.skill_registry_service import fetch_skill_registry_page
 from services.skill_test_harness_service import run_skill_test_suites
 from services.skill_test_harness_service import iter_built_in_skill_ids
 from services.analysis_service import (
@@ -194,6 +195,40 @@ def _run_skill_list() -> int:
     return 0
 
 
+def _run_skill_catalog_list() -> int:
+    items = []
+    page_number = 1
+    page_size = 100
+    total_count = 0
+
+    while True:
+        page = fetch_skill_registry_page(page=page_number, page_size=page_size)
+        if page_number == 1:
+            total_count = page.total_count
+        items.extend(page.items)
+        if len(items) >= total_count or not page.items:
+            break
+        page_number += 1
+
+    if not items:
+        print("No registry skills found.")
+        return 0
+    for item in items:
+        pass_rate = (
+            f"{round(item.test_results.pass_rate * 100):.0f}%"
+            if item.test_results is not None
+            else "n/a"
+        )
+        print(
+            f"{item.id} installs={item.install_count} "
+            f"pass-rate={pass_rate} "
+            f"active-issues={item.active_issue_count} "
+            f"updated={item.updated_at[:10]} "
+            f"analytics={item.analytics_updated_at[:10]}"
+        )
+    return 0
+
+
 def _run_skill_update(skill_id: str) -> int:
     try:
         result = update_skill(skill_id)
@@ -349,8 +384,13 @@ def build_parser() -> argparse.ArgumentParser:
         "install", help="Fetch and install a registry skill into skills/custom."
     )
     skill_install_parser.add_argument("skill_id", help="Skill id to install.")
-    skill_subparsers.add_parser(
+    skill_list_parser = skill_subparsers.add_parser(
         "list", help="List installed custom skills from skills/custom."
+    )
+    skill_list_parser.add_argument(
+        "--catalog",
+        action="store_true",
+        help="Show registry catalog analytics instead of installed custom skills.",
     )
     skill_lint_parser = skill_subparsers.add_parser(
         "lint", help="Validate a skill markdown file against manifest v1."
@@ -448,7 +488,11 @@ def main() -> None:
     if args.command == "skill" and args.skill_command == "install":
         raise SystemExit(_run_skill_install(args.skill_id))
     if args.command == "skill" and args.skill_command == "list":
-        raise SystemExit(_run_skill_list())
+        raise SystemExit(
+            _run_skill_catalog_list()
+            if getattr(args, "catalog", False)
+            else _run_skill_list()
+        )
     if args.command == "skill" and args.skill_command == "lint":
         raise SystemExit(_run_skill_lint(args.path))
     if args.command == "skill" and args.skill_command == "test":

--- a/data/skill-analytics.json
+++ b/data/skill-analytics.json
@@ -1,0 +1,140 @@
+{
+  "generated_at": "2026-04-25T00:00:00Z",
+  "skills": {
+    "ansible": {
+      "active_issue_count": 2,
+      "install_count": 1320,
+      "star_count": 286
+    },
+    "argocd": {
+      "active_issue_count": 3,
+      "install_count": 921,
+      "star_count": 207
+    },
+    "aws-cdk": {
+      "active_issue_count": 4,
+      "install_count": 748,
+      "star_count": 156
+    },
+    "bicep": {
+      "active_issue_count": 2,
+      "install_count": 734,
+      "star_count": 151
+    },
+    "cert-manager": {
+      "active_issue_count": 1,
+      "install_count": 832,
+      "star_count": 181
+    },
+    "cloudformation": {
+      "active_issue_count": 2,
+      "install_count": 962,
+      "star_count": 228
+    },
+    "crossplane": {
+      "active_issue_count": 2,
+      "install_count": 876,
+      "star_count": 198
+    },
+    "datadog-monitors": {
+      "active_issue_count": 3,
+      "install_count": 775,
+      "star_count": 164
+    },
+    "docker": {
+      "active_issue_count": 1,
+      "install_count": 1448,
+      "star_count": 332
+    },
+    "flux": {
+      "active_issue_count": 2,
+      "install_count": 819,
+      "star_count": 176
+    },
+    "git": {
+      "active_issue_count": 1,
+      "install_count": 1186,
+      "star_count": 267
+    },
+    "helm": {
+      "active_issue_count": 2,
+      "install_count": 938,
+      "star_count": 214
+    },
+    "helmfile": {
+      "active_issue_count": 2,
+      "install_count": 672,
+      "star_count": 135
+    },
+    "istio": {
+      "active_issue_count": 5,
+      "install_count": 861,
+      "star_count": 192
+    },
+    "jenkins": {
+      "active_issue_count": 4,
+      "install_count": 1094,
+      "star_count": 241
+    },
+    "jsonnet": {
+      "active_issue_count": 1,
+      "install_count": 641,
+      "star_count": 128
+    },
+    "kubernetes": {
+      "active_issue_count": 3,
+      "install_count": 1765,
+      "star_count": 403
+    },
+    "kustomize": {
+      "active_issue_count": 1,
+      "install_count": 688,
+      "star_count": 139
+    },
+    "nginx-ingress": {
+      "active_issue_count": 2,
+      "install_count": 846,
+      "star_count": 188
+    },
+    "opa-gatekeeper": {
+      "active_issue_count": 2,
+      "install_count": 789,
+      "star_count": 168
+    },
+    "prometheus-rules": {
+      "active_issue_count": 2,
+      "install_count": 761,
+      "star_count": 159
+    },
+    "pulumi": {
+      "active_issue_count": 4,
+      "install_count": 904,
+      "star_count": 203
+    },
+    "pulumi-azure": {
+      "active_issue_count": 3,
+      "install_count": 703,
+      "star_count": 144
+    },
+    "pulumi-gcp": {
+      "active_issue_count": 3,
+      "install_count": 719,
+      "star_count": 147
+    },
+    "tanka": {
+      "active_issue_count": 2,
+      "install_count": 655,
+      "star_count": 131
+    },
+    "tekton": {
+      "active_issue_count": 3,
+      "install_count": 804,
+      "star_count": 172
+    },
+    "terraform": {
+      "active_issue_count": 2,
+      "install_count": 1842,
+      "star_count": 418
+    }
+  }
+}

--- a/docs/skills/analytics.md
+++ b/docs/skills/analytics.md
@@ -1,0 +1,45 @@
+# Skills Analytics
+
+Story 4.8 adds a shared analytics layer for the skills marketplace so the same
+per-skill signals are available in the API, browser, and CLI.
+
+## Metrics
+
+Each registry skill now exposes:
+
+- `install_count`
+- `test_results.pass_rate`
+- `updated_at`
+- `active_issue_count`
+- `analytics_updated_at`
+
+## Data source
+
+The snapshot lives in `data/skill-analytics.json`.
+
+- `updated_at` still comes from the skill manifest file timestamp
+- `test_results.pass_rate` still comes from the deterministic harness
+- install count, star count, and active issue count come from the committed
+  analytics snapshot
+- `analytics_updated_at` records the snapshot refresh time
+
+## Refresh workflow
+
+Daily refresh is handled by:
+
+- workflow: `.github/workflows/refresh-skill-analytics.yml`
+- script: `scripts/refresh_skill_analytics.py`
+
+The refresh workflow now combines two runtime sources:
+
+- install and star metrics from `DEPLOYWHISPER_SKILL_ANALYTICS_URL`
+- active issue counts from GitHub issue search
+
+The refresh script refuses to run without the metrics URL so the job does not
+silently republish stale install/star values with a fresh timestamp.
+
+## Surfaces
+
+- Browser: `/skills` and `/skills/{id}`
+- API: `/api/v1/skills` and `/api/v1/skills/{id}`
+- CLI: `deploywhisper skill list --catalog`

--- a/docs/skills/browser-ui.md
+++ b/docs/skills/browser-ui.md
@@ -24,16 +24,23 @@ Each skill detail page surfaces:
 
 - description
 - install command
-- latest harness summary
+- latest harness summary and pass rate
 - version history
 - author
 - contributors
-- download count
-- star count
+- install count
+- active issue count
 - last updated timestamp
+- analytics refresh timestamp
 
 ## Analytics note
 
-The current browser page uses seeded preview download/star counts from the
-shared registry service so the public UI can present sort and comparison
-signals before Story 4.8 introduces live daily-updated analytics.
+Story 4.8 upgrades the browser to use the shared analytics snapshot in
+`data/skill-analytics.json`. The browser now shows:
+
+- install counts
+- harness pass rate
+- active issue count
+- the daily snapshot refresh timestamp
+
+The snapshot is refreshed by `.github/workflows/refresh-skill-analytics.yml`.

--- a/docs/skills/installer-cli.md
+++ b/docs/skills/installer-cli.md
@@ -18,6 +18,12 @@ List currently installed custom skills:
 deploywhisper skill list
 ```
 
+List the shared registry catalog with analytics signals:
+
+```bash
+deploywhisper skill list --catalog
+```
+
 Update an installed custom skill to the latest registry version:
 
 ```bash
@@ -61,3 +67,16 @@ configuration error instead of guessing a remote endpoint.
 - The installer verifies the registry-provided SHA-256 checksum before saving
 - `deploywhisper skill list` reports both active installed skills and ignored
   files when a custom manifest is invalid
+- `deploywhisper skill list --catalog` shows registry analytics including
+  install count, harness pass rate, last updated, and active issues using the
+  same shared registry metadata exposed by the browser
+
+## Daily analytics snapshot
+
+- Registry analytics live in `data/skill-analytics.json`
+- `.github/workflows/refresh-skill-analytics.yml` refreshes the snapshot daily
+- `scripts/refresh_skill_analytics.py` refreshes active issue counts from
+  GitHub issue search and requires `DEPLOYWHISPER_SKILL_ANALYTICS_URL` for the
+  install/star popularity feed
+- the refresh job fails explicitly if the popularity feed is missing or omits a
+  built-in skill, rather than silently carrying stale metrics forward

--- a/scripts/refresh_skill_analytics.py
+++ b/scripts/refresh_skill_analytics.py
@@ -1,0 +1,263 @@
+"""Refresh the committed skill analytics snapshot."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from datetime import UTC, datetime
+import os
+from pathlib import Path
+from urllib import error, parse, request
+from urllib.parse import urlparse
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SKILLS_DIR = REPO_ROOT / "skills"
+DEFAULT_OUTPUT = REPO_ROOT / "data" / "skill-analytics.json"
+DEFAULT_REPOSITORY = "deploywhisper/deploywhisper"
+GITHUB_API_BASE = "https://api.github.com"
+
+_SEEDED_ANALYTICS: dict[str, dict[str, int]] = {
+    "terraform": {"install_count": 1842, "star_count": 418, "active_issue_count": 2},
+    "kubernetes": {"install_count": 1765, "star_count": 403, "active_issue_count": 3},
+    "docker": {"install_count": 1448, "star_count": 332, "active_issue_count": 1},
+    "ansible": {"install_count": 1320, "star_count": 286, "active_issue_count": 2},
+    "git": {"install_count": 1186, "star_count": 267, "active_issue_count": 1},
+    "jenkins": {"install_count": 1094, "star_count": 241, "active_issue_count": 4},
+    "cloudformation": {
+        "install_count": 962,
+        "star_count": 228,
+        "active_issue_count": 2,
+    },
+    "helm": {"install_count": 938, "star_count": 214, "active_issue_count": 2},
+    "argocd": {"install_count": 921, "star_count": 207, "active_issue_count": 3},
+    "pulumi": {"install_count": 904, "star_count": 203, "active_issue_count": 4},
+    "crossplane": {"install_count": 876, "star_count": 198, "active_issue_count": 2},
+    "istio": {"install_count": 861, "star_count": 192, "active_issue_count": 5},
+    "nginx-ingress": {
+        "install_count": 846,
+        "star_count": 188,
+        "active_issue_count": 2,
+    },
+    "cert-manager": {
+        "install_count": 832,
+        "star_count": 181,
+        "active_issue_count": 1,
+    },
+    "flux": {"install_count": 819, "star_count": 176, "active_issue_count": 2},
+    "tekton": {"install_count": 804, "star_count": 172, "active_issue_count": 3},
+    "opa-gatekeeper": {
+        "install_count": 789,
+        "star_count": 168,
+        "active_issue_count": 2,
+    },
+    "datadog-monitors": {
+        "install_count": 775,
+        "star_count": 164,
+        "active_issue_count": 3,
+    },
+    "prometheus-rules": {
+        "install_count": 761,
+        "star_count": 159,
+        "active_issue_count": 2,
+    },
+    "aws-cdk": {"install_count": 748, "star_count": 156, "active_issue_count": 4},
+    "bicep": {"install_count": 734, "star_count": 151, "active_issue_count": 2},
+    "pulumi-gcp": {"install_count": 719, "star_count": 147, "active_issue_count": 3},
+    "pulumi-azure": {
+        "install_count": 703,
+        "star_count": 144,
+        "active_issue_count": 3,
+    },
+    "kustomize": {"install_count": 688, "star_count": 139, "active_issue_count": 1},
+    "helmfile": {"install_count": 672, "star_count": 135, "active_issue_count": 2},
+    "tanka": {"install_count": 655, "star_count": 131, "active_issue_count": 2},
+    "jsonnet": {"install_count": 641, "star_count": 128, "active_issue_count": 1},
+}
+
+
+def iter_built_in_skill_ids() -> list[str]:
+    return sorted(
+        path.stem.strip().lower()
+        for path in SKILLS_DIR.glob("*.md")
+        if path.is_file() and path.name.lower() != "readme.md"
+    )
+
+
+def _load_existing(path: Path) -> dict[str, object]:
+    if not path.exists():
+        return {"generated_at": "", "skills": {}}
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _github_headers(token: str | None) -> dict[str, str]:
+    headers = {
+        "Accept": "application/vnd.github+json",
+        "User-Agent": "DeployWhisper/skill-analytics-refresh",
+    }
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    return headers
+
+
+def _load_json_source(location: str, *, token: str | None = None) -> dict[str, object]:
+    parsed = urlparse(location)
+    if parsed.scheme in {"http", "https"}:
+        req = request.Request(
+            location,
+            headers=_github_headers(token),
+        )
+        with request.urlopen(req, timeout=15) as response:
+            return json.loads(response.read().decode("utf-8"))
+    return json.loads(Path(location).read_text(encoding="utf-8"))
+
+
+def _build_issue_query(skill_id: str, repo: str) -> str:
+    exact_skill = skill_id.replace('"', "")
+    return (
+        f"repo:{repo} is:issue is:open "
+        f'(label:"skill:{exact_skill}" OR "{exact_skill}" in:title OR "{exact_skill}" in:body)'
+    )
+
+
+def fetch_active_issue_counts(
+    skill_ids: list[str],
+    *,
+    repo: str,
+    token: str | None = None,
+) -> dict[str, int]:
+    counts: dict[str, int] = {}
+    for skill_id in skill_ids:
+        query = parse.urlencode(
+            {"q": _build_issue_query(skill_id, repo), "per_page": 1}
+        )
+        req = request.Request(
+            f"{GITHUB_API_BASE}/search/issues?{query}",
+            headers=_github_headers(token),
+        )
+        try:
+            with request.urlopen(req, timeout=15) as response:
+                payload = json.loads(response.read().decode("utf-8"))
+        except (error.URLError, error.HTTPError, json.JSONDecodeError) as exc:
+            raise RuntimeError(
+                f"Failed to refresh active issue counts for {skill_id}: {exc}"
+            ) from exc
+        counts[skill_id] = int(payload.get("total_count", 0))
+    return counts
+
+
+def fetch_popularity_metrics(
+    source: str,
+    *,
+    token: str | None = None,
+) -> dict[str, dict[str, int]]:
+    try:
+        payload = _load_json_source(source, token=token)
+    except (OSError, error.URLError, error.HTTPError, json.JSONDecodeError) as exc:
+        raise RuntimeError(f"Failed to refresh popularity metrics: {exc}") from exc
+
+    skills_payload = payload.get("skills") if isinstance(payload, dict) else None
+    if not isinstance(skills_payload, dict):
+        raise RuntimeError(
+            "Popularity metrics payload must contain a top-level 'skills' object."
+        )
+
+    metrics: dict[str, dict[str, int]] = {}
+    for skill_id, raw_metrics in skills_payload.items():
+        if not isinstance(raw_metrics, dict):
+            continue
+        metrics[str(skill_id).strip().lower()] = {
+            "install_count": int(raw_metrics.get("install_count", 0)),
+            "star_count": int(raw_metrics.get("star_count", 0)),
+        }
+    return metrics
+
+
+def build_snapshot(
+    path: Path,
+    *,
+    issue_counts: dict[str, int] | None = None,
+    popularity_metrics: dict[str, dict[str, int]] | None = None,
+    repo: str | None = None,
+    token: str | None = None,
+) -> dict[str, object]:
+    built_in_skill_ids = iter_built_in_skill_ids()
+    current_issue_counts = issue_counts or fetch_active_issue_counts(
+        built_in_skill_ids,
+        repo=repo or DEFAULT_REPOSITORY,
+        token=token,
+    )
+    if popularity_metrics is None:
+        raise RuntimeError(
+            "Daily analytics refresh requires current popularity metrics for every built-in skill."
+        )
+    missing_metrics = sorted(
+        skill_id
+        for skill_id in built_in_skill_ids
+        if skill_id not in popularity_metrics
+    )
+    if missing_metrics:
+        raise RuntimeError(
+            "Missing popularity metrics for built-in skills: "
+            + ", ".join(missing_metrics)
+        )
+    skills: dict[str, dict[str, int]] = {}
+    for skill_id in built_in_skill_ids:
+        current_metrics = dict(popularity_metrics[skill_id])
+        skills[skill_id] = {
+            "install_count": int(current_metrics.get("install_count", 0)),
+            "star_count": int(current_metrics.get("star_count", 0)),
+            "active_issue_count": int(current_issue_counts.get(skill_id, 0)),
+        }
+    return {
+        "generated_at": datetime.now(tz=UTC).isoformat().replace("+00:00", "Z"),
+        "skills": skills,
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Refresh skill analytics snapshot.")
+    parser.add_argument(
+        "--output",
+        default=str(DEFAULT_OUTPUT),
+        help="Snapshot file path to write.",
+    )
+    parser.add_argument(
+        "--repo",
+        default="",
+        help="GitHub repository slug used for open-issue lookups.",
+    )
+    parser.add_argument(
+        "--metrics-url",
+        default="",
+        help="JSON source containing per-skill install_count and star_count values.",
+    )
+    args = parser.parse_args()
+
+    output_path = Path(args.output).resolve()
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    metrics_url = (
+        args.metrics_url.strip()
+        or os.environ.get("DEPLOYWHISPER_SKILL_ANALYTICS_URL", "").strip()
+    )
+    if not metrics_url:
+        raise RuntimeError(
+            "Skill analytics refresh requires DEPLOYWHISPER_SKILL_ANALYTICS_URL or --metrics-url."
+        )
+    auth_token = os.environ.get("DEPLOYWHISPER_ANALYTICS_TOKEN") or os.environ.get(
+        "GITHUB_TOKEN"
+    )
+    payload = build_snapshot(
+        output_path,
+        popularity_metrics=fetch_popularity_metrics(metrics_url, token=auth_token),
+        repo=args.repo.strip() or None,
+        token=auth_token,
+    )
+    output_path.write_text(
+        json.dumps(payload, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/services/skill_analytics_service.py
+++ b/services/skill_analytics_service.py
@@ -1,0 +1,53 @@
+"""Shared skill analytics snapshot loading."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from pydantic import BaseModel, Field
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SKILL_ANALYTICS_PATH = REPO_ROOT / "data" / "skill-analytics.json"
+
+
+class SkillAnalyticsEntry(BaseModel):
+    """Snapshot-backed analytics for one skill."""
+
+    install_count: int = Field(default=0, ge=0)
+    star_count: int = Field(default=0, ge=0)
+    active_issue_count: int = Field(default=0, ge=0)
+
+
+class SkillAnalyticsSnapshot(BaseModel):
+    """Analytics snapshot shared by API, UI, and CLI surfaces."""
+
+    generated_at: str = Field(..., description="When the snapshot was last refreshed.")
+    skills: dict[str, SkillAnalyticsEntry] = Field(default_factory=dict)
+
+
+def load_skill_analytics_snapshot(
+    path: Path = SKILL_ANALYTICS_PATH,
+) -> SkillAnalyticsSnapshot:
+    """Load the committed analytics snapshot or return an empty default."""
+
+    if not path.exists():
+        return SkillAnalyticsSnapshot(generated_at="1970-01-01T00:00:00Z")
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    return SkillAnalyticsSnapshot.model_validate(payload)
+
+
+def fetch_skill_analytics(
+    skill_id: str,
+    *,
+    snapshot: SkillAnalyticsSnapshot | None = None,
+) -> tuple[SkillAnalyticsEntry, str]:
+    """Return analytics plus the snapshot refresh timestamp for one skill."""
+
+    loaded_snapshot = snapshot or load_skill_analytics_snapshot()
+    analytics = loaded_snapshot.skills.get(skill_id.strip().lower())
+    return (
+        analytics or SkillAnalyticsEntry(),
+        loaded_snapshot.generated_at,
+    )

--- a/services/skill_registry_service.py
+++ b/services/skill_registry_service.py
@@ -10,6 +10,7 @@ from typing import Any, Literal
 
 from pydantic import BaseModel, Field
 
+from services.skill_analytics_service import fetch_skill_analytics
 from services.skill_manifest_service import REPO_ROOT, load_skill_document
 from services.skill_test_harness_service import (
     SkillTestSummary,
@@ -21,43 +22,7 @@ CUSTOM_DIR = SKILLS_DIR / "custom"
 SkillSource = Literal["built-in", "custom-override", "custom-new"]
 SkillRegistrySort = Literal["popularity", "recency"]
 
-_SKILL_BROWSER_METADATA: dict[str, dict[str, object]] = {
-    "terraform": {
-        "download_count": 1842,
-        "star_count": 418,
-        "contributors": ["DeployWhisper"],
-    },
-    "kubernetes": {
-        "download_count": 1765,
-        "star_count": 403,
-        "contributors": ["DeployWhisper"],
-    },
-    "docker": {
-        "download_count": 1448,
-        "star_count": 332,
-        "contributors": ["DeployWhisper"],
-    },
-    "ansible": {
-        "download_count": 1320,
-        "star_count": 286,
-        "contributors": ["DeployWhisper"],
-    },
-    "git": {
-        "download_count": 1186,
-        "star_count": 267,
-        "contributors": ["DeployWhisper"],
-    },
-    "jenkins": {
-        "download_count": 1094,
-        "star_count": 241,
-        "contributors": ["DeployWhisper"],
-    },
-    "cloudformation": {
-        "download_count": 962,
-        "star_count": 228,
-        "contributors": ["DeployWhisper"],
-    },
-}
+_SKILL_BROWSER_METADATA: dict[str, dict[str, object]] = {}
 
 
 class SkillRegistryEntry(BaseModel):
@@ -89,6 +54,18 @@ class SkillRegistryEntry(BaseModel):
     )
     contributors: list[str] = Field(
         default_factory=list, description="Visible contributor names for browser UI."
+    )
+    install_count: int = Field(
+        default=0,
+        description="Current install count from the shared analytics snapshot.",
+    )
+    active_issue_count: int = Field(
+        default=0,
+        description="Open issue count from the shared analytics snapshot.",
+    )
+    analytics_updated_at: str = Field(
+        ...,
+        description="When the analytics snapshot used for this record was last refreshed.",
     )
     download_count: int = Field(
         default=0, description="Current catalog download count or seeded preview value."
@@ -147,6 +124,9 @@ class _SkillRecord(BaseModel):
     triggers: list[str] = Field(default_factory=list)
     trigger_content_patterns: list[str] = Field(default_factory=list)
     contributors: list[str] = Field(default_factory=list)
+    install_count: int = 0
+    active_issue_count: int = 0
+    analytics_updated_at: str
     download_count: int = 0
     star_count: int = 0
     updated_at: str
@@ -251,6 +231,9 @@ def _record_to_entry(
         "triggers": list(record.triggers),
         "trigger_content_patterns": list(record.trigger_content_patterns),
         "contributors": list(record.contributors),
+        "install_count": record.install_count,
+        "active_issue_count": record.active_issue_count,
+        "analytics_updated_at": record.analytics_updated_at,
         "download_count": record.download_count,
         "star_count": record.star_count,
         "install_command": f"deploywhisper skill install {record.id}",
@@ -279,6 +262,7 @@ def _load_skill_record(path: Path, *, source: SkillSource) -> _SkillRecord | Non
         parsed.manifest.name,
         path,
     )
+    analytics, analytics_updated_at = fetch_skill_analytics(skill_id)
     updated_at, updated_epoch = _updated_at(path)
     return _SkillRecord(
         id=skill_id,
@@ -299,8 +283,11 @@ def _load_skill_record(path: Path, *, source: SkillSource) -> _SkillRecord | Non
             skill_id,
             parsed.manifest.author or _default_author(source),
         ),
-        download_count=_download_count_for(skill_id),
-        star_count=_star_count_for(skill_id),
+        install_count=analytics.install_count,
+        active_issue_count=analytics.active_issue_count,
+        analytics_updated_at=analytics_updated_at,
+        download_count=analytics.install_count or _download_count_for(skill_id),
+        star_count=analytics.star_count or _star_count_for(skill_id),
         updated_at=updated_at,
         updated_at_epoch=updated_epoch,
         path=path,
@@ -419,7 +406,7 @@ def fetch_skill_registry_page(
             current_items,
             key=lambda current: (
                 (
-                    -current.download_count,
+                    -current.install_count,
                     -current.star_count,
                     current.id,
                 )

--- a/tests/test_api/test_skills.py
+++ b/tests/test_api/test_skills.py
@@ -103,6 +103,9 @@ class SkillsApiTests(unittest.TestCase):
         self.assertEqual(
             payload["data"][0]["test_suite_path"], "tests/skill-tests/terraform"
         )
+        self.assertIn("install_count", payload["data"][0])
+        self.assertIn("active_issue_count", payload["data"][0])
+        self.assertIn("analytics_updated_at", payload["data"][0])
         self.assertEqual(payload["data"][0]["test_results"]["status"], "passing")
         self.assertEqual(payload["data"][0]["triggers"], [".tf"])
 
@@ -156,6 +159,9 @@ class SkillsApiTests(unittest.TestCase):
         self.assertEqual(detail_payload["data"]["source"], "built-in")
         self.assertEqual(detail_payload["data"]["name"], "Terraform")
         self.assertEqual(detail_payload["data"]["available_versions"], 1)
+        self.assertIn("install_count", detail_payload["data"])
+        self.assertIn("active_issue_count", detail_payload["data"])
+        self.assertIn("analytics_updated_at", detail_payload["data"])
         self.assertEqual(detail_payload["data"]["test_results"]["status"], "passing")
         self.assertEqual(detail_payload["meta"]["id"], "terraform")
 

--- a/tests/test_cli/test_analyze.py
+++ b/tests/test_cli/test_analyze.py
@@ -24,6 +24,7 @@ from importlib import reload
 from integrations.github.init_service import GitHubInitOptions, GitHubInitResult
 from llm.narrator import NarrativeResult
 from services.skill_installer_service import InstalledSkillEntry, SkillInstallResult
+from services.skill_registry_service import SkillRegistryEntry
 from services.skill_test_harness_service import (
     SkillTestScenarioResult,
     SkillTestSuiteResult,
@@ -363,6 +364,138 @@ class AnalyzeCliTests(unittest.TestCase):
         self.assertEqual(ctx.exception.code, 0)
         self.assertIn("helm@1.2.0 [new, active]", output.getvalue())
         self.assertIn("terraform@2.0.0 [override, ignored]", output.getvalue())
+
+    def test_skill_list_catalog_command_prints_registry_analytics(self) -> None:
+        output = io.StringIO()
+        entry = SkillRegistryEntry(
+            id="terraform",
+            name="Terraform",
+            version="1.0.0",
+            source="built-in",
+            author="DeployWhisper",
+            license="MIT",
+            description="Terraform registry skill.",
+            tool="terraform",
+            tags=["iac"],
+            token_budget=1200,
+            test_suite_path="tests/skill-tests/terraform",
+            test_results=SkillTestSummary(
+                skill_id="terraform",
+                total_scenarios=3,
+                passed_scenarios=3,
+                failed_scenarios=0,
+                pass_rate=1.0,
+                status="passing",
+                display_text="3/3 scenarios passing",
+                generated_at="2026-04-25T00:00:00Z",
+            ),
+            triggers=[".tf"],
+            trigger_content_patterns=[],
+            contributors=["DeployWhisper"],
+            install_count=1842,
+            active_issue_count=1,
+            analytics_updated_at="2026-04-25T00:00:00Z",
+            download_count=1842,
+            star_count=418,
+            install_command="deploywhisper skill install terraform",
+            updated_at="2026-04-24T00:00:00Z",
+            available_versions=1,
+        )
+
+        with (
+            patch("cli.analyze.fetch_skill_registry_page") as fetch_page,
+            patch("sys.argv", ["deploywhisper", "skill", "list", "--catalog"]),
+            redirect_stdout(output),
+        ):
+            fetch_page.return_value.items = [entry]
+            fetch_page.return_value.total_count = 1
+            fetch_page.return_value.page = 1
+            fetch_page.return_value.page_size = 100
+            with self.assertRaises(SystemExit) as ctx:
+                main()
+
+        self.assertEqual(ctx.exception.code, 0)
+        self.assertIn("terraform", output.getvalue().lower())
+        self.assertIn("installs=1842", output.getvalue().lower())
+        self.assertIn("pass-rate=100%", output.getvalue().lower())
+        self.assertIn("active-issues=1", output.getvalue().lower())
+
+    def test_skill_list_catalog_command_fetches_all_registry_pages(self) -> None:
+        output = io.StringIO()
+        first = SkillRegistryEntry(
+            id="terraform",
+            name="Terraform",
+            version="1.0.0",
+            source="built-in",
+            author="DeployWhisper",
+            license="MIT",
+            description="Terraform registry skill.",
+            tool="terraform",
+            tags=["iac"],
+            token_budget=1200,
+            test_suite_path="tests/skill-tests/terraform",
+            test_results=None,
+            triggers=[".tf"],
+            trigger_content_patterns=[],
+            contributors=["DeployWhisper"],
+            install_count=1842,
+            active_issue_count=1,
+            analytics_updated_at="2026-04-25T00:00:00Z",
+            download_count=1842,
+            star_count=418,
+            install_command="deploywhisper skill install terraform",
+            updated_at="2026-04-24T00:00:00Z",
+            available_versions=1,
+        )
+        second = SkillRegistryEntry(
+            id="kubernetes",
+            name="Kubernetes",
+            version="1.0.0",
+            source="built-in",
+            author="DeployWhisper",
+            license="MIT",
+            description="Kubernetes registry skill.",
+            tool="kubernetes",
+            tags=["cluster"],
+            token_budget=1200,
+            test_suite_path="tests/skill-tests/kubernetes",
+            test_results=None,
+            triggers=[".yaml"],
+            trigger_content_patterns=[],
+            contributors=["DeployWhisper"],
+            install_count=1765,
+            active_issue_count=2,
+            analytics_updated_at="2026-04-25T00:00:00Z",
+            download_count=1765,
+            star_count=403,
+            install_command="deploywhisper skill install kubernetes",
+            updated_at="2026-04-24T00:00:00Z",
+            available_versions=1,
+        )
+
+        with (
+            patch("cli.analyze.fetch_skill_registry_page") as fetch_page,
+            patch("sys.argv", ["deploywhisper", "skill", "list", "--catalog"]),
+            redirect_stdout(output),
+        ):
+            fetch_page.side_effect = [
+                type(
+                    "Page",
+                    (),
+                    {"items": [first], "total_count": 2, "page": 1, "page_size": 100},
+                )(),
+                type(
+                    "Page",
+                    (),
+                    {"items": [second], "total_count": 2, "page": 2, "page_size": 100},
+                )(),
+            ]
+            with self.assertRaises(SystemExit) as ctx:
+                main()
+
+        self.assertEqual(ctx.exception.code, 0)
+        self.assertIn("terraform", output.getvalue().lower())
+        self.assertIn("kubernetes", output.getvalue().lower())
 
     def test_skill_update_command_reports_noop_when_latest_version_is_installed(
         self,

--- a/tests/test_infra/test_skill_contribution_workflow.py
+++ b/tests/test_infra/test_skill_contribution_workflow.py
@@ -2,11 +2,13 @@
 
 from __future__ import annotations
 
+import json
 import tempfile
 import unittest
 from pathlib import Path
 
 from scripts.publish_skills_registry import publish_skill
+from scripts.refresh_skill_analytics import build_snapshot, iter_built_in_skill_ids
 
 
 class SkillContributionWorkflowTests(unittest.TestCase):
@@ -45,6 +47,85 @@ class SkillContributionWorkflowTests(unittest.TestCase):
         self.assertIn("REGISTRY_REPO: deploywhisper/skills-registry", workflow)
         self.assertIn("DEPLOYWHISPER_SKILLS_REGISTRY_PUSH_TOKEN", workflow)
         self.assertIn("scripts/publish_skills_registry.py", workflow)
+
+    def test_daily_skill_analytics_refresh_workflow_exists(self) -> None:
+        workflow = Path(".github/workflows/refresh-skill-analytics.yml").read_text(
+            encoding="utf-8"
+        )
+
+        self.assertIn("Refresh Skill Analytics", workflow)
+        self.assertIn("schedule:", workflow)
+        self.assertIn("cron:", workflow)
+        self.assertIn("scripts/refresh_skill_analytics.py", workflow)
+        self.assertIn("issues: read", workflow)
+        self.assertIn("GITHUB_TOKEN", workflow)
+        self.assertIn("DEPLOYWHISPER_SKILL_ANALYTICS_URL", workflow)
+
+    def test_refresh_skill_analytics_updates_issue_counts_from_runtime_source(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            snapshot_path = Path(tmpdir) / "skill-analytics.json"
+            snapshot_path.write_text(
+                json.dumps(
+                    {
+                        "generated_at": "2026-04-24T00:00:00Z",
+                        "skills": {
+                            "terraform": {
+                                "install_count": 1842,
+                                "star_count": 418,
+                                "active_issue_count": 1,
+                            }
+                        },
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            payload = build_snapshot(
+                snapshot_path,
+                issue_counts={skill_id: 0 for skill_id in iter_built_in_skill_ids()}
+                | {"terraform": 7},
+                popularity_metrics={
+                    skill_id: {"install_count": 100, "star_count": 10}
+                    for skill_id in iter_built_in_skill_ids()
+                }
+                | {"terraform": {"install_count": 1900, "star_count": 430}},
+            )
+
+        self.assertEqual(payload["skills"]["terraform"]["install_count"], 1900)
+        self.assertEqual(payload["skills"]["terraform"]["star_count"], 430)
+        self.assertEqual(payload["skills"]["terraform"]["active_issue_count"], 7)
+
+    def test_refresh_skill_analytics_rejects_missing_popularity_metrics_for_skill(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            snapshot_path = Path(tmpdir) / "skill-analytics.json"
+            snapshot_path.write_text(
+                json.dumps(
+                    {
+                        "generated_at": "2026-04-24T00:00:00Z",
+                        "skills": {
+                            "terraform": {
+                                "install_count": 1842,
+                                "star_count": 418,
+                                "active_issue_count": 1,
+                            }
+                        },
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            with self.assertRaises(RuntimeError) as ctx:
+                build_snapshot(
+                    snapshot_path,
+                    issue_counts={"terraform": 7},
+                    popularity_metrics={},
+                )
+
+        self.assertIn("missing popularity metrics", str(ctx.exception).lower())
 
     def test_publish_skill_writes_registry_bundle_and_removes_deleted_skill(
         self,

--- a/tests/test_services/test_skill_registry_service.py
+++ b/tests/test_services/test_skill_registry_service.py
@@ -81,6 +81,9 @@ class SkillRegistryServiceTests(unittest.TestCase):
         self.assertEqual(
             page.items[0].install_command, "deploywhisper skill install terraform"
         )
+        self.assertGreater(page.items[0].install_count, 0)
+        self.assertGreaterEqual(page.items[0].active_issue_count, 0)
+        self.assertIsNotNone(page.items[0].analytics_updated_at)
         self.assertGreater(page.items[0].download_count, 0)
         self.assertGreater(page.items[0].star_count, 0)
         self.assertEqual(page.items[0].contributors, ["DeployWhisper"])
@@ -148,6 +151,9 @@ class SkillRegistryServiceTests(unittest.TestCase):
         self.assertEqual(entry.name, "Terraform")
         self.assertEqual(entry.available_versions, 1)
         self.assertEqual(entry.install_command, "deploywhisper skill install terraform")
+        self.assertGreater(entry.install_count, 0)
+        self.assertGreaterEqual(entry.active_issue_count, 0)
+        self.assertIsNotNone(entry.analytics_updated_at)
         self.assertEqual(entry.contributors, ["DeployWhisper"])
         self.assertEqual([version.version for version in versions], ["1.0.0"])
         self.assertTrue(versions[0].is_current)
@@ -338,6 +344,20 @@ class SkillRegistryServiceTests(unittest.TestCase):
                 page = fetch_skill_registry_page(sort="recency")
 
         self.assertEqual([item.id for item in page.items], ["kubernetes", "terraform"])
+
+    def test_registry_page_exposes_analytics_fields_for_browser_and_cli(self) -> None:
+        page = fetch_skill_registry_page(page_size=5)
+
+        self.assertGreater(page.total_count, 0)
+        item = page.items[0]
+        self.assertIsInstance(item.install_count, int)
+        self.assertGreaterEqual(item.install_count, 0)
+        self.assertIsInstance(item.active_issue_count, int)
+        self.assertGreaterEqual(item.active_issue_count, 0)
+        self.assertIsInstance(item.analytics_updated_at, str)
+        if item.test_results is not None:
+            self.assertGreaterEqual(item.test_results.pass_rate, 0.0)
+            self.assertLessEqual(item.test_results.pass_rate, 1.0)
 
 
 if __name__ == "__main__":

--- a/tests/test_ui/test_skills_browser.py
+++ b/tests/test_ui/test_skills_browser.py
@@ -93,8 +93,10 @@ class SkillsBrowserPageTests(unittest.TestCase):
         self.assertIn("DeployWhisper", response.text)
         self.assertIn("skills atlas", response.text)
         self.assertIn("Search the current skills registry", response.text)
-        self.assertIn("Preview downloads", response.text)
+        self.assertIn("Catalog installs", response.text)
         self.assertIn("deploywhisper skill install terraform", response.text)
+        self.assertIn("Pass rate", response.text)
+        self.assertIn("Active issues", response.text)
         self.assertIn("Terraform", response.text)
         self.assertIn("Kubernetes", response.text)
 
@@ -148,8 +150,9 @@ class SkillsBrowserPageTests(unittest.TestCase):
         self.assertIn("deploywhisper skill install terraform", response.text)
         self.assertIn("Version history", response.text)
         self.assertIn("Contributors", response.text)
-        self.assertIn("Downloads", response.text)
-        self.assertIn("Stars", response.text)
+        self.assertIn("Installs", response.text)
+        self.assertIn("Active issues", response.text)
+        self.assertIn("Analytics refreshed", response.text)
         self.assertIn("DeployWhisper", response.text)
 
     def test_skills_browser_page_includes_items_beyond_first_catalog_page(self) -> None:

--- a/ui/routes/skills.py
+++ b/ui/routes/skills.py
@@ -352,14 +352,16 @@ def _render_skill_row(skill: SkillRegistryEntry) -> None:
                         ui.label(tag).classes("dw-skill-tag")
             with ui.element("div").classes("dw-skill-metrics"):
                 for value, label in (
-                    (str(skill.download_count), "Downloads"),
-                    (str(skill.star_count), "Stars"),
+                    (str(skill.install_count), "Installs"),
                     (
-                        skill.test_results.display_text
-                        if skill.test_results
-                        else "No tests",
-                        "Harness",
+                        (
+                            f"{round(skill.test_results.pass_rate * 100):.0f}%"
+                            if skill.test_results
+                            else "n/a"
+                        ),
+                        "Pass rate",
                     ),
+                    (str(skill.active_issue_count), "Active issues"),
                 ):
                     with ui.column().classes("gap-0"):
                         ui.label(value).classes("dw-skill-metric-value")
@@ -404,12 +406,12 @@ def skills_browser_page(request: Request) -> None:
                     for value, label in (
                         (str(len(catalog)), "Visible skills"),
                         (
-                            str(sum(item.download_count for item in catalog)),
-                            "Preview downloads",
+                            str(sum(item.install_count for item in catalog)),
+                            "Catalog installs",
                         ),
                         (
-                            str(sum(item.star_count for item in catalog)),
-                            "Preview stars",
+                            str(sum(item.active_issue_count for item in catalog)),
+                            "Open issues",
                         ),
                         (
                             str(
@@ -472,7 +474,10 @@ def skills_browser_page(request: Request) -> None:
             build_page_header(
                 eyebrow="Catalog",
                 title="Search the current skills registry",
-                subtitle="Popularity and recency come from the shared registry metadata used by the browser and installer surfaces.",
+                subtitle=(
+                    "Shared registry analytics are refreshed daily and exposed through "
+                    "the same metadata contract the browser and CLI consume."
+                ),
             )
 
         with ui.column().classes("dw-skills-catalog"):
@@ -510,14 +515,16 @@ def skill_detail_page(skill_id: str) -> None:
                     ui.label(skill.install_command).classes("dw-skill-command")
                     with ui.element("div").classes("dw-skills-hero-stats"):
                         for value, label in (
-                            (str(skill.download_count), "Downloads"),
-                            (str(skill.star_count), "Stars"),
+                            (str(skill.install_count), "Installs"),
+                            (str(skill.active_issue_count), "Active issues"),
                             (_format_updated_at(skill.updated_at), "Last updated"),
                             (
-                                skill.test_results.display_text
-                                if skill.test_results
-                                else "No harness",
-                                "Test results",
+                                (
+                                    f"{round(skill.test_results.pass_rate * 100):.0f}%"
+                                    if skill.test_results
+                                    else "n/a"
+                                ),
+                                "Pass rate",
                             ),
                         ):
                             with ui.element("div").classes("dw-skills-stat"):
@@ -533,6 +540,11 @@ def skill_detail_page(skill_id: str) -> None:
                             "dw-skills-stat-value text-lg"
                         )
                         ui.label("Tracked versions").classes("dw-skills-stat-label")
+                    with ui.element("div").classes("dw-skills-stat"):
+                        ui.label(
+                            _format_updated_at(skill.analytics_updated_at)
+                        ).classes("dw-skills-stat-value text-lg")
+                        ui.label("Analytics refreshed").classes("dw-skills-stat-label")
 
         with ui.element("div").classes("dw-skill-detail-grid"):
             with ui.column().classes("dw-skill-detail-stack"):
@@ -571,5 +583,5 @@ def skill_detail_page(skill_id: str) -> None:
                 with ui.card().classes("dw-panel shadow-none dw-skill-section"):
                     ui.label("Registry snapshot").classes("dw-eyebrow")
                     ui.label(
-                        "This page reflects the same source-of-truth metadata and version history used by the shared registry and installer surfaces."
+                        "This page reflects the same source-of-truth metadata, daily analytics snapshot, and version history used by the shared registry and installer surfaces."
                     ).classes("dw-skills-body")


### PR DESCRIPTION
…e everywhere

Story 4.8 adds a shared analytics contract for the skills registry and threads it through the API, browser, and CLI so users can compare install counts, pass rates, freshness, and issue pressure from one source of truth.

The follow-up review fixes tightened the daily refresh behavior: CLI catalog output now paginates through the full registry, and the scheduled analytics job refuses to republish stale popularity data when its upstream feed is missing or incomplete.

Constraint: Analytics had to reuse the existing registry/version model and deterministic harness outputs without introducing new runtime dependencies
Rejected: Per-surface analytics adapters with separate data models | would drift the browser, API, and CLI contracts
Rejected: Silent fallback to previous install/star values during daily refresh | presents stale analytics as fresh
Confidence: high
Scope-risk: moderate
Directive: Keep install/star metrics sourced from the configured analytics feed and fail fast if the feed is incomplete rather than masking stale data
Tested: ./.venv/bin/ruff check .; ./.venv/bin/ruff format --check .; ./.venv/bin/python -m unittest tests.test_cli.test_analyze tests.test_infra.test_skill_contribution_workflow -q; ./.venv/bin/python -m unittest discover -q; bash scripts/ci-local.sh
Not-tested: End-to-end scheduled GitHub Actions execution against the live analytics feed and GitHub issue API
Related: Story 4.8 skill analytics

## What does this PR do?

<!-- Brief description of changes -->

## Type of change
- [ ] Feature (new functionality)
- [ ] Bugfix (non-breaking fix)
- [ ] Release preparation
- [ ] Hotfix (critical production fix)
- [ ] Docs / refactor / chore

## Checklist
- [ ] I have followed the branch naming convention
- [ ] Tests pass locally (`pytest tests/ -v`)
- [ ] Linting passes (`ruff check .`)
- [ ] Docker build succeeds
- [ ] I have updated docs if needed
- [ ] No secrets or .env values committed

## Related issue
Closes #