### PR TITLE
Make the skills browser independent of local harness files

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,12 +8,17 @@ ENV PIP_DISABLE_PIP_VERSION_CHECK=1 \
     PYTHONUNBUFFERED=1 \
     VIRTUAL_ENV=/opt/venv
 
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends binutils \
+    && rm -rf /var/lib/apt/lists/*
+
 RUN python -m venv "${VIRTUAL_ENV}"
 ENV PATH="${VIRTUAL_ENV}/bin:${PATH}"
 
 COPY requirements.txt .
 RUN pip install --no-compile -r requirements.txt \
-    && python -c "import pathlib, shutil, site; site_packages=[pathlib.Path(path) for path in site.getsitepackages()]; patterns=('pip','pip-*','wheel','wheel-*'); [shutil.rmtree(path, ignore_errors=True) if path.is_dir() else path.unlink(missing_ok=True) for base in site_packages for pattern in patterns for path in base.glob(pattern)]; [shutil.rmtree(path, ignore_errors=True) for base in site_packages for path in base.rglob('__pycache__')]" \
+    && python -c "import pathlib, shutil, site; site_packages=[pathlib.Path(path) for path in site.getsitepackages()]; patterns=('pip','pip-*','wheel','wheel-*'); [shutil.rmtree(path, ignore_errors=True) if path.is_dir() else path.unlink(missing_ok=True) for base in site_packages for pattern in patterns for path in base.glob(pattern)]; [shutil.rmtree(path, ignore_errors=True) for base in site_packages for path in base.rglob('__pycache__')]; [shutil.rmtree(path, ignore_errors=True) for base in site_packages for name in ('tests','test','docs','examples') for path in base.rglob(name) if path.is_dir()]" \
+    && find "${VIRTUAL_ENV}" -type f \( -name '*.so' -o -name '*.so.*' \) -exec strip --strip-unneeded {} + 2>/dev/null || true \
     && rm -f "${VIRTUAL_ENV}"/bin/pip "${VIRTUAL_ENV}"/bin/pip3 "${VIRTUAL_ENV}"/bin/pip3.11
 
 

--- a/cli/analyze.py
+++ b/cli/analyze.py
@@ -216,7 +216,7 @@ def _run_skill_catalog_list() -> int:
     for item in items:
         pass_rate = (
             f"{round(item.test_results.pass_rate * 100):.0f}%"
-            if item.test_results is not None
+            if item.test_results is not None and item.test_results.status != "missing"
             else "n/a"
         )
         print(

--- a/config.py
+++ b/config.py
@@ -54,6 +54,10 @@ class Settings:
         or os.getenv("PUBLIC_APP_URL")
         or None
     )
+    public_skills_registry_url: str = os.getenv(
+        "DEPLOYWHISPER_PUBLIC_SKILLS_REGISTRY_URL",
+        "https://deploywhisper.github.io/skills-registry/",
+    )
     github_app_api_base_url: str = os.getenv(
         "DEPLOYWHISPER_GITHUB_APP_API_BASE_URL",
         "https://api.github.com",

--- a/services/skill_registry_service.py
+++ b/services/skill_registry_service.py
@@ -11,7 +11,7 @@ from typing import Any, Literal
 from pydantic import BaseModel, Field
 
 from services.skill_analytics_service import fetch_skill_analytics
-from services.skill_manifest_service import REPO_ROOT, load_skill_document
+from services.skill_manifest_service import load_skill_document
 from services.skill_test_harness_service import (
     SkillTestSummary,
     summarize_skill_test_suite,
@@ -270,7 +270,7 @@ def _load_skill_record(path: Path, *, source: SkillSource) -> _SkillRecord | Non
             path,
             strict_manifest=True,
             allow_legacy_name=False,
-            project_root=REPO_ROOT,
+            project_root=None,
         )
     except ValueError:
         return None

--- a/services/skill_test_harness_service.py
+++ b/services/skill_test_harness_service.py
@@ -165,7 +165,7 @@ def _load_active_skill(skill_id: str) -> tuple[ActiveSkill, str, Path] | None:
         path,
         strict_manifest=True,
         allow_legacy_name=False,
-        project_root=REPO_ROOT,
+        project_root=None,
     )
     if document.manifest is None:
         return None

--- a/tests/test_infra/test_container_contract.py
+++ b/tests/test_infra/test_container_contract.py
@@ -61,6 +61,7 @@ class ContainerContractTests(unittest.TestCase):
         self.assertIn(
             "COPY --chown=appuser:appuser integrations ./integrations", dockerfile
         )
+        self.assertNotIn("tests/skill-tests", dockerfile)
         self.assertIn("USER appuser", dockerfile)
         self.assertIn("HEALTHCHECK", dockerfile)
         self.assertIn('CMD ["python", "app.py"]', dockerfile)
@@ -71,6 +72,7 @@ class ContainerContractTests(unittest.TestCase):
         content = dockerignore.read_text(encoding="utf-8")
         self.assertIn(".venv", content)
         self.assertIn("tests/", content)
+        self.assertNotIn("!tests/skill-tests/**", content)
         self.assertIn("_bmad-output/", content)
 
     def test_compose_uses_single_app_service_and_unique_port(self) -> None:

--- a/tests/test_services/test_skill_registry_service.py
+++ b/tests/test_services/test_skill_registry_service.py
@@ -417,6 +417,45 @@ class SkillRegistryServiceTests(unittest.TestCase):
         self.assertEqual(featured.author, "Community Builder")
         self.assertEqual(featured.maintainer, "Community Curators")
 
+    def test_registry_page_keeps_bundled_skills_visible_when_runtime_suites_are_missing(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            repo_root = Path(tmpdir)
+            skills_dir = repo_root / "skills"
+            custom_dir = skills_dir / "custom"
+            skills_dir.mkdir(parents=True, exist_ok=True)
+            custom_dir.mkdir(parents=True, exist_ok=True)
+            (skills_dir / "terraform.md").write_text(
+                "---\n"
+                "name: terraform\n"
+                "version: 1.0.0\n"
+                "author: DeployWhisper\n"
+                "license: MIT\n"
+                "description: Built-in terraform checks.\n"
+                "test_suite_path: tests/skill-tests/terraform\n"
+                "token_budget: 1200\n"
+                "triggers: [.tf]\n"
+                "tags: [iac]\n"
+                "---\n"
+                "# Terraform\nBuilt-in guidance.\n",
+                encoding="utf-8",
+            )
+
+            with (
+                patch("services.skill_registry_service.SKILLS_DIR", skills_dir),
+                patch("services.skill_registry_service.CUSTOM_DIR", custom_dir),
+                patch("services.skill_test_harness_service.SKILLS_DIR", skills_dir),
+                patch("services.skill_test_harness_service.REPO_ROOT", repo_root),
+            ):
+                page = fetch_skill_registry_page()
+
+        self.assertEqual(page.total_count, 1)
+        self.assertEqual(page.items[0].id, "terraform")
+        assert page.items[0].test_results is not None
+        self.assertEqual(page.items[0].test_results.status, "missing")
+        self.assertEqual(page.items[0].test_results.total_scenarios, 0)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/ui/routes/skills.py
+++ b/ui/routes/skills.py
@@ -9,6 +9,7 @@ from fastapi import Request
 from nicegui import ui
 from starlette.exceptions import HTTPException as StarletteHTTPException
 
+from config import settings
 from services.skill_registry_service import (
     SkillRegistryEntry,
     SkillRegistrySort,
@@ -368,6 +369,13 @@ def _navigate_with_filters(
     ui.navigate.to(f"/skills{query}")
 
 
+def _pass_rate_label(skill: SkillRegistryEntry) -> str:
+    summary = skill.test_results
+    if summary is None or summary.status == "missing":
+        return "n/a"
+    return f"{round(summary.pass_rate * 100):.0f}%"
+
+
 def _render_editorial_badges(skill: SkillRegistryEntry) -> None:
     badges: list[tuple[str, str]] = []
     if skill.is_official:
@@ -404,14 +412,7 @@ def _render_skill_row(skill: SkillRegistryEntry) -> None:
             with ui.element("div").classes("dw-skill-metrics"):
                 for value, label in (
                     (str(skill.install_count), "Installs"),
-                    (
-                        (
-                            f"{round(skill.test_results.pass_rate * 100):.0f}%"
-                            if skill.test_results
-                            else "n/a"
-                        ),
-                        "Pass rate",
-                    ),
+                    (_pass_rate_label(skill), "Pass rate"),
                     (str(skill.active_issue_count), "Active issues"),
                 ):
                     with ui.column().classes("gap-0"):
@@ -530,6 +531,9 @@ def skills_browser_page(request: Request) -> None:
                     "the same metadata contract the browser and CLI consume."
                 ),
             )
+            ui.link("Open public registry", settings.public_skills_registry_url).props(
+                'target="_blank" rel="noreferrer"'
+            ).classes("dw-link mt-4 inline-flex")
 
         with ui.column().classes("dw-skills-catalog"):
             if not catalog:
@@ -572,14 +576,7 @@ def skill_detail_page(skill_id: str) -> None:
                             (str(skill.install_count), "Installs"),
                             (str(skill.active_issue_count), "Active issues"),
                             (_format_updated_at(skill.updated_at), "Last updated"),
-                            (
-                                (
-                                    f"{round(skill.test_results.pass_rate * 100):.0f}%"
-                                    if skill.test_results
-                                    else "n/a"
-                                ),
-                                "Pass rate",
-                            ),
+                            (_pass_rate_label(skill), "Pass rate"),
                         ):
                             with ui.element("div").classes("dw-skills-stat"):
                                 ui.label(value).classes("dw-skills-stat-value")


### PR DESCRIPTION
The runtime catalog was treating harness-suite paths as a hard requirement, so Docker deployments showed an empty /skills page unless tests/skill-tests were copied into the image. This refactor keeps bundled-skill browsing manifest-backed, degrades missing harness summaries to n/a, and points users to the published public registry explicitly instead of coupling page rendering to local test artifacts.

Constraint: Production images should not need CI-only harness fixtures to browse bundled skills
Rejected: Keep copying tests/skill-tests into the runtime image | fixes symptoms but preserves the wrong runtime dependency
Confidence: high
Scope-risk: moderate
Reversibility: clean
Directive: Treat harness scenarios as optional runtime metadata; do not make bundled-skill visibility depend on local test fixture presence again
Tested: ./.venv/bin/python -m unittest tests.test_services.test_skill_registry_service tests.test_infra.test_container_contract tests.test_ui.test_skills_browser -q
Tested: ./.venv/bin/ruff check .
Tested: ./.venv/bin/ruff format --check .
Tested: ./.venv/bin/python -m unittest discover -q
Tested: docker compose build deploywhisper
Tested: docker compose up -d deploywhisper
Tested: docker compose exec -T deploywhisper python -c 'from services.skill_registry_service import fetch_skill_registry_page; page = fetch_skill_registry_page(page_size=10); print(page.total_count)'
Not-tested: Public skills-registry site as a live backend source remains unimplemented pending a stable index/API contract

