### PR TITLE
Use public registry feed for skill analytics refresh

### DIFF
--- a/.github/workflows/refresh-skill-analytics.yml
+++ b/.github/workflows/refresh-skill-analytics.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Refresh analytics snapshot
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          DEPLOYWHISPER_SKILL_ANALYTICS_URL: ${{ vars.DEPLOYWHISPER_SKILL_ANALYTICS_URL }}
+          DEPLOYWHISPER_SKILL_ANALYTICS_URL: ${{ vars.DEPLOYWHISPER_SKILL_ANALYTICS_URL || 'https://deploywhisper.github.io/skills-registry/skill-popularity.json' }}
         run: |
           python scripts/refresh_skill_analytics.py \
             --repo "${{ github.repository }}"

--- a/data/skill-analytics.json
+++ b/data/skill-analytics.json
@@ -135,6 +135,11 @@
       "active_issue_count": 2,
       "install_count": 1842,
       "star_count": 418
+    },
+    "terragrunt": {
+      "active_issue_count": 0,
+      "install_count": 0,
+      "star_count": 0
     }
   }
 }

--- a/docs/skills/analytics.md
+++ b/docs/skills/analytics.md
@@ -32,11 +32,15 @@ Daily refresh is handled by:
 
 The refresh workflow now combines two runtime sources:
 
-- install and star metrics from `DEPLOYWHISPER_SKILL_ANALYTICS_URL`
+- install and star metrics from `DEPLOYWHISPER_SKILL_ANALYTICS_URL`, or from
+  the default public registry feed at
+  `https://deploywhisper.github.io/skills-registry/skill-popularity.json`
 - active issue counts from GitHub issue search
 
-The refresh script refuses to run without the metrics URL so the job does not
-silently republish stale install/star values with a fresh timestamp.
+`DEPLOYWHISPER_SKILL_ANALYTICS_URL` is optional and should only be configured
+when the workflow needs to read a different metrics feed. The metrics feed must
+contain a top-level `skills` object with every built-in skill id and
+`install_count` / `star_count` values.
 
 ## Surfaces
 

--- a/docs/skills/installer-cli.md
+++ b/docs/skills/installer-cli.md
@@ -76,7 +76,8 @@ configuration error instead of guessing a remote endpoint.
 - Registry analytics live in `data/skill-analytics.json`
 - `.github/workflows/refresh-skill-analytics.yml` refreshes the snapshot daily
 - `scripts/refresh_skill_analytics.py` refreshes active issue counts from
-  GitHub issue search and requires `DEPLOYWHISPER_SKILL_ANALYTICS_URL` for the
-  install/star popularity feed
+  GitHub issue search and reads install/star popularity from
+  `DEPLOYWHISPER_SKILL_ANALYTICS_URL`, or from the default public feed at
+  `https://deploywhisper.github.io/skills-registry/skill-popularity.json`
 - the refresh job fails explicitly if the popularity feed is missing or omits a
   built-in skill, rather than silently carrying stale metrics forward

--- a/scripts/refresh_skill_analytics.py
+++ b/scripts/refresh_skill_analytics.py
@@ -15,6 +15,9 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 SKILLS_DIR = REPO_ROOT / "skills"
 DEFAULT_OUTPUT = REPO_ROOT / "data" / "skill-analytics.json"
 DEFAULT_REPOSITORY = "deploywhisper/deploywhisper"
+DEFAULT_METRICS_URL = (
+    "https://deploywhisper.github.io/skills-registry/skill-popularity.json"
+)
 GITHUB_API_BASE = "https://api.github.com"
 
 _SEEDED_ANALYTICS: dict[str, dict[str, int]] = {
@@ -73,6 +76,7 @@ _SEEDED_ANALYTICS: dict[str, dict[str, int]] = {
     "helmfile": {"install_count": 672, "star_count": 135, "active_issue_count": 2},
     "tanka": {"install_count": 655, "star_count": 131, "active_issue_count": 2},
     "jsonnet": {"install_count": 641, "star_count": 128, "active_issue_count": 1},
+    "terragrunt": {"install_count": 0, "star_count": 0, "active_issue_count": 0},
 }
 
 
@@ -173,6 +177,16 @@ def fetch_popularity_metrics(
     return metrics
 
 
+def resolve_metrics_url(cli_value: str = "") -> str:
+    """Resolve the popularity metrics source used by the refresh job."""
+
+    return (
+        cli_value.strip()
+        or os.environ.get("DEPLOYWHISPER_SKILL_ANALYTICS_URL", "").strip()
+        or DEFAULT_METRICS_URL
+    )
+
+
 def build_snapshot(
     path: Path,
     *,
@@ -230,20 +244,16 @@ def main() -> None:
     parser.add_argument(
         "--metrics-url",
         default="",
-        help="JSON source containing per-skill install_count and star_count values.",
+        help=(
+            "JSON source containing per-skill install_count and star_count values. "
+            f"Defaults to {DEFAULT_METRICS_URL}."
+        ),
     )
     args = parser.parse_args()
 
     output_path = Path(args.output).resolve()
     output_path.parent.mkdir(parents=True, exist_ok=True)
-    metrics_url = (
-        args.metrics_url.strip()
-        or os.environ.get("DEPLOYWHISPER_SKILL_ANALYTICS_URL", "").strip()
-    )
-    if not metrics_url:
-        raise RuntimeError(
-            "Skill analytics refresh requires DEPLOYWHISPER_SKILL_ANALYTICS_URL or --metrics-url."
-        )
+    metrics_url = resolve_metrics_url(args.metrics_url)
     auth_token = os.environ.get("DEPLOYWHISPER_ANALYTICS_TOKEN") or os.environ.get(
         "GITHUB_TOKEN"
     )

--- a/tests/test_infra/test_skill_contribution_workflow.py
+++ b/tests/test_infra/test_skill_contribution_workflow.py
@@ -6,9 +6,15 @@ import json
 import tempfile
 import unittest
 from pathlib import Path
+from unittest.mock import patch
 
 from scripts.publish_skills_registry import publish_skill
-from scripts.refresh_skill_analytics import build_snapshot, iter_built_in_skill_ids
+from scripts.refresh_skill_analytics import (
+    DEFAULT_METRICS_URL,
+    build_snapshot,
+    iter_built_in_skill_ids,
+    resolve_metrics_url,
+)
 
 
 class SkillContributionWorkflowTests(unittest.TestCase):
@@ -60,6 +66,11 @@ class SkillContributionWorkflowTests(unittest.TestCase):
         self.assertIn("issues: read", workflow)
         self.assertIn("GITHUB_TOKEN", workflow)
         self.assertIn("DEPLOYWHISPER_SKILL_ANALYTICS_URL", workflow)
+        self.assertIn(DEFAULT_METRICS_URL, workflow)
+
+    def test_refresh_skill_analytics_defaults_to_public_registry_feed(self) -> None:
+        with patch.dict("os.environ", {"DEPLOYWHISPER_SKILL_ANALYTICS_URL": ""}):
+            self.assertEqual(resolve_metrics_url(), DEFAULT_METRICS_URL)
 
     def test_refresh_skill_analytics_updates_issue_counts_from_runtime_source(
         self,


### PR DESCRIPTION
## Summary
- default Refresh Skill Analytics to the public registry popularity feed
- keep DEPLOYWHISPER_SKILL_ANALYTICS_URL as an optional override
- add terragrunt to the committed analytics snapshot and update docs/tests

## Validation
- ./.venv/bin/python -m unittest tests.test_infra.test_skill_contribution_workflow -q
- ./.venv/bin/python -m unittest discover -q
- ./.venv/bin/ruff check .
- ./.venv/bin/ruff format --check .

## Registry feed
Published deploywhisper/skills-registry@3471f58 with https://deploywhisper.github.io/skills-registry/skill-popularity.json