### PR TITLE
Align GitHub App planning with self-hosted setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -632,13 +632,13 @@ evidence deltas.
 ### GitHub App Mode
 
 DeployWhisper also supports a GitHub App adapter for webhook-driven PR analysis,
-checks API publishing, and OAuth-guided installation handoff. The App adapter is
+checks API publishing, and self-hosted app setup. The App adapter is
 documented in [`docs/github-app.md`](./docs/github-app.md) and is designed to
 run in three lanes:
 
 - Action-first: workflow file + Marketplace Action
-- Advanced self-hosted GitHub App: webhook, checks, and OAuth-backed installation flow against your own DeployWhisper server
-- Combined mode: Action for explicit workflow control, self-hosted GitHub App for checks and richer installation UX
+- Advanced self-hosted GitHub App: webhook and checks against your own DeployWhisper server, with app creation and installation handled in GitHub's UI
+- Combined mode: Action for explicit workflow control, self-hosted GitHub App for checks and webhook automation
 
 The recommended open-source posture is Action-first. If you want GitHub App
 capabilities, create a private/self-hosted GitHub App in your own account or

--- a/_bmad-output/implementation-artifacts/3-9-self-hosted-github-app-setup-documentation.md
+++ b/_bmad-output/implementation-artifacts/3-9-self-hosted-github-app-setup-documentation.md
@@ -1,0 +1,108 @@
+# Story 3.9: Self-Hosted GitHub App Setup Documentation
+
+Status: ready-for-dev
+
+<!-- Note: Validation is optional. Run validate-create-story for quality check before dev-story. -->
+
+## Story
+
+As a team admin,
+I want clear instructions for creating and installing the GitHub App from GitHub Developer Settings,
+so that my team can run GitHub App mode without relying on a DeployWhisper-hosted SaaS app.
+
+## Acceptance Criteria
+
+1. Given a team wants GitHub App mode, when they read the operator docs, then they can create a private/internal GitHub App from GitHub Developer Settings without using any DeployWhisper-hosted SaaS app.
+2. Given the admin is configuring the app, when they follow the docs, then they can set the webhook URL, optional callback URL, app visibility, repository permissions, and subscribed pull request events correctly.
+3. Given the app is created, when the admin configures DeployWhisper, then the docs map each GitHub value to the correct environment variable and clearly mark secrets/private keys as environment-backed only.
+4. Given the app is installed from GitHub's UI, when the admin chooses account/organization and repositories, then the docs explain how repository selection affects webhook and check-run behavior.
+5. Given setup fails, when the admin reads troubleshooting, then they see specific remediation for missing permissions, revoked installation, unreachable webhook URL, invalid signature, missing public base URL for check-run details, and accidental required-status-check configuration.
+6. Given the setup is complete, when the admin follows the verification checklist, then they can confirm webhook delivery, PR artifact analysis, advisory check-run creation, non-blocking behavior, and report-link behavior.
+7. Automated checks or doc-focused tests cover the documented configuration examples where practical, and existing GitHub App service/API tests remain green.
+
+### Requirement Traceability
+
+- Primary PRD requirements: `WRK-03`, `WRK-05`, `WRK-07`
+- Supporting PRD / NFR / differentiation requirements: `ADM-01`, `NFR-SEC-02`, `NFR-SEC-03`, `DIF-03`, `DIF-04`
+- Coverage intent: `Delta`
+- Story alignment note: This story keeps GitHub App mode self-hosted and user-owned. Users create and install their own GitHub App from GitHub's Developer Settings UI; DeployWhisper only documents and supports that setup.
+
+## Tasks / Subtasks
+
+- [ ] Align GitHub App docs with the self-hosted product decision. (AC: 1)
+  - [ ] State clearly that DeployWhisper will not provide or require a SaaS-hosted GitHub App for this roadmap.
+  - [ ] Position the GitHub App as an advanced self-hosted option; keep GitHub Action as the default/recommended path.
+  - [ ] Remove wording that implies DeployWhisper must own a public hosted GitHub App or hosted installation flow.
+- [ ] Document GitHub Developer Settings setup. (AC: 1, 2)
+  - [ ] Walk through GitHub UI path: Settings or organization settings → Developer settings → GitHub Apps → New GitHub App.
+  - [ ] Document recommended app name, homepage URL, webhook URL, webhook secret, and app visibility.
+  - [ ] Document optional callback URL only as an optional helper if the existing OAuth route remains enabled; do not make OAuth required for normal setup.
+  - [ ] Document required repository permissions: checks read/write, pull requests read, contents read, metadata default.
+  - [ ] Document required event subscription: pull request.
+- [ ] Document DeployWhisper environment configuration. (AC: 3)
+  - [ ] Map App ID, app slug, webhook secret, private key, public base URL, PR events flag, and checks flag to the existing environment variables.
+  - [ ] Mark `DEPLOYWHISPER_GITHUB_APP_CLIENT_ID` and `DEPLOYWHISPER_GITHUB_APP_CLIENT_SECRET` as optional OAuth-helper settings, not required for manual setup.
+  - [ ] State that private keys, webhook secrets, and client secrets must remain outside the database and should be supplied through environment or secret manager configuration.
+- [ ] Document installation and repository selection from GitHub UI. (AC: 4)
+  - [ ] Explain Install App flow from the GitHub App settings page.
+  - [ ] Explain account/organization selection and repository selection.
+  - [ ] Explain that only selected repositories send eligible webhooks and receive check runs.
+- [ ] Add troubleshooting and verification guidance. (AC: 5, 6)
+  - [ ] Cover missing permissions, revoked installation, unreachable webhook URL, invalid `X-Hub-Signature-256`, missing `APP_BASE_URL` / `PUBLIC_APP_URL`, and required-status-check misconfiguration.
+  - [ ] Include verification checklist for webhook delivery, supported-artifact analysis, persisted report, check run, report link, advisory-only behavior, and 50 MB intake limit.
+- [ ] Preserve and validate existing runtime behavior. (AC: 7)
+  - [ ] Run existing GitHub App service/API tests after documentation edits.
+  - [ ] Add lightweight docs/example validation if the repo already has a suitable documentation test pattern.
+  - [ ] Do not add new product flows, hosted-app assumptions, persistent GitHub credential storage, or a tenant model.
+
+## Dev Notes
+
+- The user's product decision is explicit: DeployWhisper will not be hosted as a SaaS product for GitHub App mode. Users should create the app themselves from GitHub Developer Settings and point it at their own DeployWhisper instance.
+- Story 3.6 already added a self-hosted GitHub App adapter surface in `integrations/github/app_service.py` and `api/routes/github_app.py`. Do not rebuild that implementation for this story unless docs verification exposes a concrete bug.
+- Existing docs already include much of the intended manual setup path in `docs/github-app-self-hosted-setup.md`; this story should make the decision unambiguous and remove any implication that OAuth is required.
+- If the current OAuth start/callback route remains in code, document it as optional helper behavior only. The normal setup path is GitHub UI creation and installation.
+- Preserve the Action-first recommendation. For most users, `deploywhisper github init` and the GitHub Action remain the lowest-friction path.
+- Preserve the local-first boundary: a user's own DeployWhisper server receives webhooks and fetches changed PR artifacts. Do not introduce any flow where raw infrastructure artifacts are sent to a DeployWhisper-hosted SaaS service.
+- Preserve advisory-first behavior: check runs may show success/neutral/failure but must not become an enforcement mechanism owned by DeployWhisper.
+
+### Project Structure Notes
+
+- Expected implementation surfaces:
+  - `docs/github-app.md`
+  - `docs/github-app-self-hosted-setup.md`
+  - `README.md` only if its GitHub App setup language is stale
+  - `tests/test_services/test_github_app_service.py` and `tests/test_api/test_github_app.py` for existing runtime regression checks
+- Avoid touching database, OAuth persistence, tenant management, or hosted-app infrastructure for this story.
+- Do not place GitHub-specific setup logic into analysis services, parsers, risk scoring, or report rendering.
+
+### Previous Story Intelligence
+
+- Story 3.6 implemented the self-hosted GitHub App adapter and reopened real-operator verification.
+- Story 3.6 tightened PR artifact download to enforce the shared 50 MB intake limit.
+- Story 3.8 implemented `deploywhisper github init` with Action-first setup and advanced self-hosted GitHub App notes.
+- Existing docs already emphasize private/self-hosted GitHub App setup and defer public hosted/Marketplace rollout.
+
+### References
+
+- [Epics](../planning-artifacts/epics.md)
+- [PRD](../planning-artifacts/prd.md)
+- [Architecture](../planning-artifacts/architecture.md)
+- [Project Context](../project-context.md)
+- [Story 3.6](3-6-github-app.md)
+- [Story 3.8](3-8-installation-wizard.md)
+- [GitHub App docs](../../docs/github-app.md)
+- [Self-hosted GitHub App setup](../../docs/github-app-self-hosted-setup.md)
+
+## Dev Agent Record
+
+### Agent Model Used
+
+`gpt-5.4`
+
+### Debug Log References
+
+### Completion Notes List
+
+- Story corrected after product decision clarification: GitHub App mode is self-hosted/manual setup documentation, not an OAuth-backed hosted installation product.
+
+### File List

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -1,0 +1,131 @@
+# generated: 2026-04-27
+# last_updated: 2026-04-27
+# project: deploywhisper
+# project_key: NOKEY
+# tracking_system: file-system
+# story_location: _bmad-output/implementation-artifacts
+#
+# STATUS DEFINITIONS:
+# ==================
+# Epic Status:
+#   - backlog: Epic not yet started
+#   - in-progress: Epic actively being worked on
+#   - done: All stories in epic completed
+#
+# Epic Status Transitions:
+#   - backlog -> in-progress: Automatically when first story is created (via create-story)
+#   - in-progress -> done: Manually when all stories reach done status
+#
+# Story Status:
+#   - backlog: Story only exists in epic file
+#   - ready-for-dev: Story file created in implementation-artifacts
+#   - in-progress: Developer actively working on implementation
+#   - review: Ready for code review
+#   - done: Story completed
+#
+# Retrospective Status:
+#   - optional: Can be completed but not required
+#   - done: Retrospective has been completed
+#
+# WORKFLOW NOTES:
+# ===============
+# - Epic transitions to in-progress automatically when first story is created
+# - Stories can be worked in parallel if team capacity allows
+# - Developer typically creates next story after previous one is done to incorporate learnings
+# - Dev moves story to review, then runs code-review
+
+generated: 2026-04-27
+last_updated: 2026-04-27
+project: deploywhisper
+project_key: NOKEY
+tracking_system: file-system
+story_location: _bmad-output/implementation-artifacts
+
+development_status:
+  epic-1: in-progress
+  1-1-domain-model-foundations: done
+  1-2-evidence-extractor-service: in-progress
+  1-3-refactor-risk-scorer-to-consume-evidence: review
+  1-4-confidence-field-on-every-finding: review
+  1-5-context-completeness-on-riskassessment: review
+  1-6-narrator-runs-after-scoring: review
+  1-7-deterministic-degradation: review
+  1-8-report-schema-v2: review
+  epic-1-retrospective: optional
+
+  epic-2: in-progress
+  2-1-verdict-card-redesign: review
+  2-2-findings-table-with-evidence-badges: ready-for-dev
+  2-3-evidence-inspector-panel: review
+  2-4-context-completeness-panel: review
+  2-5-blast-radius-visualization: review
+  2-6-rollback-plan-panel: review
+  2-7-share-summary-generator: review
+  2-8-keyboard-navigation: in-progress
+  epic-2-retrospective: optional
+
+  epic-3: in-progress
+  3-1-github-action-v1: review
+  3-2-pr-comment-formatter: review
+  3-3-rerun-on-commit: review
+  3-4-shareable-report-urls: review
+  3-5-report-comparison-view: review
+  3-6-github-app: in-progress
+  3-7-check-run-integration: review
+  3-8-installation-wizard: review
+  3-9-self-hosted-github-app-setup-documentation: ready-for-dev
+  3-10-github-delivery-mode-documentation: backlog
+  3-11-advisory-policy-adapter-output-contract: backlog
+  epic-3-retrospective: optional
+
+  epic-4: in-progress
+  4-1-skills-registry-api: done
+  4-2-skills-manifest-spec-v1: review
+  4-3-skill-test-harness: review
+  4-4-skills-installer-cli: review
+  4-5-skills-browser-ui: review
+  4-6-contribution-workflow: review
+  4-7-seed-20-community-skills: done
+  4-8-skill-analytics: done
+  4-9-editorial-curation: done
+  4-10-seed-marketplace-catalog-batch-2: backlog
+  4-11-seed-marketplace-catalog-batch-3: backlog
+  4-12-seed-marketplace-catalog-batch-4: backlog
+  epic-4-retrospective: optional
+
+  epic-5: in-progress
+  5-1-terraform-state-import: ready-for-dev
+  5-2-topology-drift-detection: ready-for-dev
+  5-3-topology-freshness-badge: ready-for-dev
+  5-4-deployment-history-capture: ready-for-dev
+  5-5-reviewer-feedback-capture: ready-for-dev
+  5-6-outcome-linking: ready-for-dev
+  5-7-calibration-dashboard: ready-for-dev
+  5-8-trend-analysis: ready-for-dev
+  5-9-gcp-terraform-state-import: backlog
+  5-10-azure-terraform-state-import: backlog
+  5-11-threshold-and-reporting-defaults-management: backlog
+  5-12-policy-adapter-consumption-boundary: backlog
+  epic-5-retrospective: optional
+
+  epic-6: in-progress
+  6-1-benchmark-corpus-v1: ready-for-dev
+  6-2-scenario-annotation: ready-for-dev
+  6-3-benchmark-runner: ready-for-dev
+  6-4-comparative-runner: ready-for-dev
+  6-5-published-results-dashboard: ready-for-dev
+  6-6-quarterly-regression: ready-for-dev
+  6-7-open-source-the-corpus: ready-for-dev
+  6-8-incident-backtesting: ready-for-dev
+  6-9-benchmark-corpus-expansion-batch: backlog
+  6-10-benchmark-corpus-completion-and-quality-gate: backlog
+  6-11-hosted-and-llm-comparator-adapters: backlog
+  6-12-comparative-result-normalization-and-reporting: backlog
+  epic-6-retrospective: optional
+
+  brownfield-hardening: in-progress
+  bh-s1-lock-provider-boundary-behavior-with-regression-tests: ready-for-dev
+  bh-s2-introduce-provider-adapter-contract-and-registry: ready-for-dev
+  bh-s3-migrate-openai-anthropic-gemini-and-ollama-to-direct-sdk-adapters: ready-for-dev
+  bh-s4-migrate-openrouter-groq-and-xai-to-a-compatibility-adapter-and-remove-the-legacy-meta-provider-dependency: ready-for-dev
+  bh-s5-add-provider-capability-metadata-and-mcp-readiness-hooks: ready-for-dev

--- a/_bmad-output/planning-artifacts/epics.md
+++ b/_bmad-output/planning-artifacts/epics.md
@@ -70,15 +70,16 @@ This matrix is intentionally compact. It maps requirement families to either:
 | `EVD-01` | Existing normalized change model + `E1-S2` / `E1-S3` | Baseline + Delta | Current normalization exists; Epic 1 upgrades it into evidence-first scoring. |
 | `EVD-02..08` | `E1-S1..E1-S8`, `E2-S2..E2-S4`, `E2-S7` | Delta | These are core gaps the refreshed plan is explicitly designed to close. |
 | `RSK-01..08` | Existing repo baseline + `E1-S3`, `E1-S6`, `E1-S7`, `E2-S1`, `E2-S6`, `E2-S7` | Baseline + Delta | Unified risk exists today; Epic 1/2 make it evidence-backed, confidence-aware, and review-ready. |
-| `CTX-01..07` | Existing topology / incidents baseline + `E1-S5`, `E2-S4`, `E2-S5`, `E5-S1..E5-S8` | Baseline + Delta | Current context is manual and partial; Epic 5 turns it into a moat. |
+| `CTX-01..07` | Existing topology / incidents baseline + `E1-S5`, `E2-S4`, `E2-S5`, `E5-S1..E5-S12` | Baseline + Delta | Current context is manual and partial; Epic 5 turns it into a moat. |
 | `REV-01..07` | Existing dashboard/history baseline + `E2-S1..E2-S8` | Baseline + Delta | The current UI supports review, but Epic 2 is the target-state UX pass. |
 | `WRK-01..02` | Existing API and CLI baseline | Baseline | Preserve shared-core API/CLI behavior while adding new workflow adapters. |
-| `WRK-03..07` | `E3-S1..E3-S8` | Delta | GitHub-native delivery is new roadmap work. |
+| `WRK-03..07` | `E3-S1..E3-S11` | Delta | GitHub-native delivery is new roadmap work. |
 | `HIS-01..04` | Existing persistence/history baseline + `E5-S4`, `E5-S8` | Baseline + Delta | Persistence and history exist; Epic 5 expands them into richer learning and operations data. |
-| `HIS-05..07` | `E5-S5..E5-S8`, `E6-S1..E6-S8` | Delta | Reviewer feedback, outcomes, calibration, and backtesting are roadmap work. |
-| `ADM-01..05` | Existing settings/local-mode/topology/custom-skill baseline + `BH-S1..BH-S5` + `E4-S1..E4-S9`, `E5-S1..E5-S4` | Baseline + Delta | Admin basics exist now; marketplace and context automation extend them, and the brownfield provider track hardens the provider boundary. |
-| `ADM-06..07` | Cross-cutting governance in `E1`, `E5`, and future adapter work | Delta | Threshold/default management and policy-adapter consumption need explicit follow-through during implementation. |
-| `COM-01..07` | `E4-S1..E4-S9` | Delta | Community ecosystem requirements are fully owned by Epic 4. |
+| `HIS-05..07` | `E5-S5..E5-S8`, `E6-S1..E6-S12` | Delta | Reviewer feedback, outcomes, calibration, and backtesting are roadmap work. |
+| `ADM-01..05` | Existing settings/local-mode/topology/custom-skill baseline + `BH-S1..BH-S5` + `E4-S1..E4-S12`, `E5-S1..E5-S4` | Baseline + Delta | Admin basics exist now; marketplace and context automation extend them, and the brownfield provider track hardens the provider boundary. |
+| `ADM-06` | `E5-S11` | Delta | Threshold and reporting-default management has explicit admin story ownership. |
+| `ADM-07` | `E5-S12` | Delta | Policy adapter consumption has explicit output-contract story ownership while preserving advisory-first behavior. |
+| `COM-01..07` | `E4-S1..E4-S12` | Delta | Community ecosystem requirements are fully owned by Epic 4. |
 | `NFR-SEC-01..06` | Existing local-first/security baseline + `BH-S1..BH-S5` + Epic 1, 4, and 5 hardening | Baseline + Delta | Preserve raw-local boundaries and secret handling while expanding ecosystem and context features and reducing provider-path dependency surface. |
 | `NFR-PERF-01..04` | Cross-cutting across `E1`, `E2`, `E3`, and `E5` | Delta | Performance budgets are not their own epic; they must be pulled into story ACs during implementation. |
 | `NFR-REL-01..04` | Existing degradation/persistence baseline + `E1-S7`, `E5-*` | Baseline + Delta | Reliability exists partially today; Epic 1 and 5 raise the bar. |
@@ -477,15 +478,15 @@ Ship an official GitHub Action plus advanced self-hosted GitHub App support so D
 
 #### E3-S6: GitHub App
 **As a** DeployWhisper maintainer,
-**I want** advanced self-hosted GitHub App support complementing the Action,
-**so that** I can post check runs and richer interactions.
+**I want** a minimal self-hosted GitHub App runtime that complements the Action,
+**so that** advanced teams can install the app without mixing all GitHub capabilities into one oversized story.
 
 **Acceptance:**
-- Self-hosted GitHub App runtime and operator guide are ready for installation in a team's own GitHub account or organization
-- Supports checks API (passing/neutral/failing, always advisory)
-- Handles PR events for automatic runs (opt-in via config)
-- OAuth flow for team installation
-- Docs covering Action-first, advanced self-hosted GitHub App mode, and combined modes
+- App runtime can receive and validate GitHub webhook events in a self-hosted deployment
+- Installation configuration supports repository and organization scope
+- Operator guide documents required GitHub App permissions and local-first deployment assumptions
+- Runtime can enqueue or trigger DeployWhisper analysis for configured PR events
+- Check-run posting, manual setup verification, and combined-mode docs are handled by follow-on stories
 
 #### E3-S7: Check run integration
 **As a** reviewer,
@@ -509,6 +510,42 @@ Ship an official GitHub Action plus advanced self-hosted GitHub App support so D
 - Commits a PR to the repo with the workflow file
 - Includes README updates and example secrets configuration
 - Links to docs for common setup questions
+
+#### E3-S9: Self-hosted GitHub App setup documentation
+**As a** team admin,
+**I want** clear instructions for creating and installing the GitHub App from GitHub Developer Settings,
+**so that** my team can run GitHub App mode without relying on a DeployWhisper-hosted SaaS app.
+
+**Acceptance:**
+- Operator docs walk through GitHub Developer Settings → GitHub Apps → New GitHub App
+- Docs specify webhook URL, optional callback URL, required permissions, pull request events, and app visibility settings
+- Docs explain how users install the app into their own account or organization and select repositories from GitHub's UI
+- Secrets and private keys remain environment-backed and are not persisted in application tables
+- Verification checklist covers webhook delivery, PR artifact analysis, advisory check-run creation, and report-link behavior
+- Troubleshooting covers missing permissions, revoked installation, unreachable webhook URL, invalid signature, and required status-check misconfiguration
+
+#### E3-S10: GitHub delivery mode documentation
+**As a** platform maintainer,
+**I want** Action-first, App-only, and combined-mode setup documented clearly,
+**so that** teams can choose the least complex delivery path for their environment.
+
+**Acceptance:**
+- Documentation explains when to use the GitHub Action, self-hosted GitHub App, or both
+- Example workflows include secrets configuration and advisory-only behavior
+- Operator guide covers webhook URL, permissions, private key management, and local-first data boundaries
+- Troubleshooting section covers missed events, duplicate comments, missing check runs, and rerun behavior
+
+#### E3-S11: Advisory policy adapter output contract
+**As a** CI/CD integrator,
+**I want** a stable advisory report output contract for future policy adapters,
+**so that** policy engines can consume DeployWhisper results without changing core advisory behavior.
+
+**Acceptance:**
+- JSON contract exposes verdict, risk score, findings, evidence counts, confidence, context completeness, and advisory flags
+- Contract explicitly sets merge-blocking or enforcement decisions outside DeployWhisper core behavior
+- API and CLI can emit the same policy-adapter payload
+- Contract is documented with examples for GitHub checks and future CI adapters
+- Tests verify that NO-GO output remains advisory and does not mutate `should_block` semantics
 
 ### Epic 3 Exit Criteria
 - Install DeployWhisper on a new repo in under 5 minutes
@@ -607,12 +644,13 @@ Launch a community-driven Skills registry with browser UI, authoring toolkit, an
 
 #### E4-S7: Seed 20 community skills
 **As a** launcher,
-**I want** the marketplace to be full on day one,
-**so that** first-time visitors see an ecosystem, not an empty shelf.
+**I want** an initial first-party seed batch published,
+**so that** the marketplace has useful launch content before the full catalog is complete.
 
 **Acceptance:**
-- 20 first-party skills published at launch covering: Helm, ArgoCD, Pulumi, Crossplane, Istio, Nginx Ingress, Cert-Manager, Flux, Tekton, OPA Gatekeeper, Datadog monitors, Prometheus rules, AWS CDK, Bicep, Pulumi GCP, Pulumi Azure, Kustomize, Helmfile, Tanka, Jsonnet
+- 5 first-party skills published at launch covering a representative Terraform/Kubernetes/GitHub Actions mix
 - Each skill has: complete manifest, at least 3 test scenarios, working installation, documented risk patterns
+- Seed skill publishing process is documented so later batches use the same manifest, test, and review standards
 
 #### E4-S8: Skill analytics
 **As a** user choosing a skill,
@@ -634,6 +672,39 @@ Launch a community-driven Skills registry with browser UI, authoring toolkit, an
 - "Featured" badge for curated community skills
 - Curation guidelines in `docs/skills/curation.md`
 - Removal process for low-quality or abandoned skills
+
+#### E4-S10: Seed marketplace catalog batch 2
+**As a** launcher,
+**I want** the second seed batch to add GitOps and policy skills,
+**so that** early users see credible coverage beyond the core launch tools.
+
+**Acceptance:**
+- 5 additional first-party skills published for GitOps, ingress, certificate, and policy use cases
+- Each skill has complete manifest metadata, at least 3 test scenarios, working installation, and documented risk patterns
+- Registry browser clearly labels official seed skills versus community submissions
+- Test harness passes for all batch 2 skills in CI
+
+#### E4-S11: Seed marketplace catalog batch 3
+**As a** launcher,
+**I want** the third seed batch to cover observability and cloud-IaC skills,
+**so that** the marketplace supports realistic platform review scenarios.
+
+**Acceptance:**
+- 5 additional first-party skills published for observability and cloud-IaC review patterns
+- Each skill has complete manifest metadata, at least 3 test scenarios, working installation, and documented risk patterns
+- Skill detail pages show last updated, test pass rate, and official-maintainer status for the batch
+- Test harness passes for all batch 3 skills in CI
+
+#### E4-S12: Seed marketplace catalog batch 4
+**As a** launcher,
+**I want** the final seed batch to bring the launch catalog to 20 skills,
+**so that** first-time visitors see an ecosystem without one oversized delivery story.
+
+**Acceptance:**
+- 5 additional first-party skills published, bringing the total official seed catalog to 20
+- Coverage includes Helm, ArgoCD, Pulumi, Crossplane, Istio, Nginx Ingress, Cert-Manager, Flux, Tekton, OPA Gatekeeper, Datadog monitors, Prometheus rules, AWS CDK, Bicep, Pulumi GCP, Pulumi Azure, Kustomize, Helmfile, Tanka, and Jsonnet across the full seed set
+- All 20 skills have complete manifests, at least 3 test scenarios, working installation, and documented risk patterns
+- Registry analytics and curation surfaces can distinguish seed batch, official status, and test reliability
 
 ### Epic 4 Exit Criteria
 - Skills browser live at /skills with 20+ published skills
@@ -662,14 +733,15 @@ Automate topology discovery. Capture deployment outcomes. Build the feedback loo
 
 #### E5-S1: Terraform state import
 **As a** admin,
-**I want** to import topology from Terraform state,
-**so that** I don't hand-maintain a JSON file.
+**I want** to import AWS topology from Terraform state,
+**so that** I can stop hand-maintaining the most common topology source first.
 
 **Acceptance:**
 - CLI: `deploywhisper topology import --from terraform --state s3://my-bucket/terraform.tfstate`
-- Supports AWS, GCP, Azure Terraform providers
-- Builds service topology graph automatically
+- Supports AWS Terraform provider resources needed for the initial topology graph
+- Builds service topology graph automatically for supported AWS resources
 - Reports topology diff when re-imported
+- Unsupported providers are skipped with explicit warnings instead of failing the whole import
 
 #### E5-S2: Topology drift detection
 **As a** admin,
@@ -748,6 +820,54 @@ Automate topology discovery. Capture deployment outcomes. Build the feedback loo
 - Risk by engineer (opt-in, privacy-respecting)
 - Exportable as CSV
 
+#### E5-S9: GCP Terraform state import
+**As a** admin,
+**I want** to import GCP topology from Terraform state,
+**so that** GCP-backed services improve blast-radius accuracy without manual topology files.
+
+**Acceptance:**
+- CLI supports GCP Terraform provider resources through the existing topology import command
+- Builds service topology graph for supported GCP resources
+- Reports unsupported GCP resources in an import warning summary
+- Re-import produces a topology diff consistent with the AWS import behavior
+- Tests cover representative GCP state fixtures and partial unsupported-resource handling
+
+#### E5-S10: Azure Terraform state import
+**As a** admin,
+**I want** to import Azure topology from Terraform state,
+**so that** Azure-backed services improve blast-radius accuracy without manual topology files.
+
+**Acceptance:**
+- CLI supports Azure Terraform provider resources through the existing topology import command
+- Builds service topology graph for supported Azure resources
+- Reports unsupported Azure resources in an import warning summary
+- Re-import produces a topology diff consistent with AWS and GCP import behavior
+- Tests cover representative Azure state fixtures and partial unsupported-resource handling
+
+#### E5-S11: Threshold and reporting defaults management
+**As a** admin,
+**I want** to manage risk thresholds and report defaults without changing core code,
+**so that** teams can tune DeployWhisper behavior while preserving stable analysis semantics.
+
+**Acceptance:**
+- Settings surface exposes threshold bands, context warning defaults, and report display defaults
+- API and CLI can read the same defaults through shared configuration services
+- Changes are audit logged with actor, timestamp, and previous/new values
+- Defaults never disable sensitive-file handling or local-first protections
+- Tests verify threshold/default changes affect presentation or classification only through the approved shared boundary
+
+#### E5-S12: Policy adapter consumption boundary
+**As a** platform integrator,
+**I want** future policy adapters to consume DeployWhisper report outputs through a stable boundary,
+**so that** integrations can evaluate reports without changing the advisory-first core.
+
+**Acceptance:**
+- Shared service emits a policy-consumption payload from persisted Report data
+- Payload includes advisory verdict, evidence references, confidence, uncertainty, and recommended next actions
+- Payload excludes raw uploaded artifacts, prompts, raw model responses, and provider secrets
+- Documentation states that external policy adapters own enforcement decisions
+- Tests verify adapter payload generation does not change report persistence, UI/API/CLI semantics, or advisory-only defaults
+
 ### Epic 5 Exit Criteria
 - Topology auto-import works for AWS/GCP/Azure
 - Drift detection surfaces manual changes
@@ -775,13 +895,15 @@ Build a public benchmark corpus. Run DeployWhisper, competitors, and generic LLM
 
 #### E6-S1: Benchmark corpus v1
 **As a** maintainer,
-**I want** 100 labeled scenarios across all 5 tools,
-**so that** we have ground truth for accuracy measurement.
+**I want** the corpus schema and first labeled scenario batch,
+**so that** benchmark work starts with a reviewable foundation instead of one oversized corpus story.
 
 **Acceptance:**
-- 100 scenarios: 50 risky, 50 safe
-- Covers Terraform, Kubernetes, Ansible, Jenkins, CloudFormation (20 each)
-- Each scenario includes: artifacts, expected findings, expected severity, rationale
+- Corpus schema supports artifacts, expected findings, expected severity, rationale, reviewer labels, and tool category
+- First 20 scenarios include a balanced safe/risky mix across Terraform and Kubernetes
+- Scenario fixtures are stored in `benchmark/corpus/` as YAML or JSON
+- Validation command checks schema completeness and duplicate IDs
+- Expansion to 100 scenarios is handled by follow-on corpus batch stories
 - Stored in `benchmark/corpus/` as YAML or JSON
 - Open-source under MIT license
 
@@ -809,14 +931,15 @@ Build a public benchmark corpus. Run DeployWhisper, competitors, and generic LLM
 
 #### E6-S4: Comparative runner
 **As a** marketer,
-**I want** to run the same corpus through competitors,
-**so that** I can publish comparative results.
+**I want** the comparative runner to support local/open-source comparators first,
+**so that** the result format is proven before adding every external comparator.
 
 **Acceptance:**
-- Runner supports: tflint, kube-score, K8sGPT, vanilla LLM prompt
+- Runner supports at least tflint and kube-score through explicit comparator adapters
 - Each competitor's output mapped to comparable finding format
 - Results table: tool X scenario matrix
 - Winner-by-scenario and overall-winner reported
+- Additional comparator adapters are handled by follow-on stories
 
 #### E6-S5: Published results dashboard
 **As a** potential user,
@@ -862,6 +985,54 @@ Build a public benchmark corpus. Run DeployWhisper, competitors, and generic LLM
 - Runs DeployWhisper against the state and scores against the incident
 - Publishes anonymized case studies with permission
 - At least 1 case study published in Epic 6 timeframe
+
+#### E6-S9: Benchmark corpus expansion batch
+**As a** maintainer,
+**I want** to expand the benchmark corpus across all supported tool types,
+**so that** the corpus reaches meaningful cross-tool coverage in reviewable increments.
+
+**Acceptance:**
+- Adds at least 40 scenarios beyond the initial corpus batch
+- Covers Terraform, Kubernetes, Ansible, Jenkins, and CloudFormation with at least 8 scenarios each across the expanded set
+- Maintains safe/risky balance and expected severity labels
+- Validation command passes for all new scenarios
+- Review notes capture assumptions for ambiguous scenarios
+
+#### E6-S10: Benchmark corpus completion and quality gate
+**As a** maintainer,
+**I want** the corpus to reach 100 labeled scenarios with quality checks,
+**so that** published results have defensible ground truth.
+
+**Acceptance:**
+- Corpus reaches at least 100 scenarios: 50 risky and 50 safe
+- Each supported tool has at least 20 scenarios
+- Every scenario includes artifacts, expected findings, expected severity, rationale, and reviewer label metadata
+- Quality gate rejects unlabeled scenarios, duplicate IDs, missing expected findings, and invalid severity values
+- Corpus summary report documents tool coverage and risk distribution
+
+#### E6-S11: Hosted and LLM comparator adapters
+**As a** marketer,
+**I want** comparative runner adapters for K8sGPT and a vanilla LLM prompt,
+**so that** public comparisons include both deterministic tools and AI baselines.
+
+**Acceptance:**
+- Runner supports K8sGPT through an explicit adapter with documented setup assumptions
+- Runner supports a vanilla LLM prompt baseline without sending raw sensitive production artifacts
+- Adapter outputs map into the same comparable finding format as local comparators
+- Failure or missing credentials for hosted/LLM comparators does not fail local comparator runs
+- Tests cover adapter output normalization and degraded comparator availability
+
+#### E6-S12: Comparative result normalization and reporting
+**As a** maintainer,
+**I want** normalized comparator results and repeatable reports,
+**so that** published benchmark claims can be audited.
+
+**Acceptance:**
+- Results table records per-tool, per-scenario, and overall metrics for DeployWhisper and comparators
+- Winner-by-scenario and overall-winner logic is deterministic and documented
+- JSON and human-readable reports include corpus version, DeployWhisper version, comparator versions, and run timestamp
+- Published dashboard can consume the normalized result artifact without re-running the benchmark
+- Tests cover metric calculation, tie handling, and missing comparator outputs
 
 ### Epic 6 Exit Criteria
 - Benchmark corpus has 100+ annotated scenarios

--- a/_bmad-output/planning-artifacts/implementation-readiness-report-2026-04-27.md
+++ b/_bmad-output/planning-artifacts/implementation-readiness-report-2026-04-27.md
@@ -1,0 +1,556 @@
+---
+stepsCompleted:
+  - step-01-document-discovery
+  - step-02-prd-analysis
+  - step-03-epic-coverage-validation
+  - step-04-ux-alignment
+  - step-05-epic-quality-review
+  - step-06-final-assessment
+documentsIncluded:
+  - type: PRD
+    path: _bmad-output/planning-artifacts/prd.md
+    format: whole
+  - type: Architecture
+    path: _bmad-output/planning-artifacts/architecture.md
+    format: whole
+  - type: Epics
+    path: _bmad-output/planning-artifacts/epics.md
+    format: whole
+  - type: UX Design
+    path: _bmad-output/planning-artifacts/ux-design-specification.md
+    format: whole
+---
+
+# Implementation Readiness Assessment Report
+
+**Date:** 2026-04-27
+**Project:** deploywhisper
+
+## Document Discovery
+
+### Files Included
+
+- PRD: `_bmad-output/planning-artifacts/prd.md` (whole document)
+- Architecture: `_bmad-output/planning-artifacts/architecture.md` (whole document)
+- Epics: `_bmad-output/planning-artifacts/epics.md` (whole document)
+- UX Design: `_bmad-output/planning-artifacts/ux-design-specification.md` (whole document)
+
+### Discovery Notes
+
+- No sharded PRD, architecture, epics, or UX folders were found.
+- No duplicate whole/sharded document conflicts were found.
+- All required document categories are present.
+
+## PRD Analysis
+
+### Functional Requirements
+
+ING-01: Accept one or more artifacts from supported toolchains in a single analysis.
+
+ING-02: Auto-detect artifact type without requiring manual labeling for normal cases.
+
+ING-03: Support partial analysis when not all related artifacts are available.
+
+ING-04: Detect unsupported artifacts and explain why they were excluded.
+
+ING-05: Detect sensitive files and block unsafe downstream handling.
+
+ING-06: Preserve a submission manifest showing which artifacts were accepted, excluded, partially parsed, or failed.
+
+EVD-01: Normalize supported artifacts into a shared internal change model.
+
+EVD-02: Each finding shall reference one or more concrete evidence items.
+
+EVD-03: Evidence items shall identify artifact, location, resource, change operation, or contextual source where applicable.
+
+EVD-04: The report shall distinguish deterministic findings from model-inferred explanations.
+
+EVD-05: The report shall surface confidence and uncertainty for key findings and overall verdict.
+
+EVD-06: The report shall explain the main contributors to overall risk score.
+
+EVD-07: When context is incomplete, the report shall show explicit uncertainty instead of implying certainty.
+
+EVD-08: Evidence items persist with the report for audit and comparison.
+
+RSK-01: Produce a unified deployment risk verdict for the whole submission.
+
+RSK-02: Classify findings and verdicts by severity level.
+
+RSK-03: Detect cross-tool interactions that increase risk.
+
+RSK-04: Generate a reviewer-oriented explanation of why a risk matters operationally.
+
+RSK-05: Generate actionable remediation or verification guidance.
+
+RSK-06: Produce rollback guidance and rollback complexity score.
+
+RSK-07: Distinguish between product recommendation and human decision.
+
+RSK-08: Continue to return deterministic results if narrative generation fails.
+
+CTX-01: Compute blast radius using maintained topology context.
+
+CTX-02: Indicate when topology is stale, missing, or incomplete.
+
+CTX-03: Ingest incident records for similarity matching.
+
+CTX-04: Surface relevant incident similarity results with match confidence.
+
+CTX-05: Support service criticality and environment-aware risk context.
+
+CTX-06: Store deployment history sufficient for comparison and trend analysis.
+
+CTX-07: Support future topology auto-discovery and context connectors without replacing the core report format.
+
+REV-01: The web report shall present verdict first, then evidence, then details.
+
+REV-02: The report shall show top findings, blast radius, rollback, and uncertainty above the fold.
+
+REV-03: Users shall be able to inspect full findings and evidence details on demand.
+
+REV-04: Users shall be able to retrieve prior reports and compare analyses over time.
+
+REV-05: The system shall generate a concise share summary for PRs and approval threads.
+
+REV-06: Shared summaries shall remain explicitly advisory.
+
+REV-07: The report shall support both expert quick scan and detailed investigation.
+
+WRK-01: Expose a stable versioned REST API.
+
+WRK-02: Expose CLI access using the same analysis core.
+
+WRK-03: Support GitHub-first workflow delivery for PR review.
+
+WRK-04: Post a formatted PR summary including verdict, top risks, blast radius, rollback context, and uncertainty.
+
+WRK-05: Support rerun after new commits or changed artifacts.
+
+WRK-06: Support report links and machine-friendly summary payloads.
+
+WRK-07: Support future GitLab / Atlantis / HCP Terraform / Jenkins adapters without redesigning the core analysis object.
+
+HIS-01: Persist completed reports before showing final success.
+
+HIS-02: Retain audit metadata with each report.
+
+HIS-03: Users shall be able to search and filter historical reports.
+
+HIS-04: Managers shall be able to review risk trends over time.
+
+HIS-05: Capture reviewer feedback on report quality and correctness.
+
+HIS-06: Support outcome capture after deployment for later calibration.
+
+HIS-07: Support benchmark and backtest workflows against historical incidents.
+
+ADM-01: Admins shall configure narrative provider settings through a DeployWhisper-owned provider adapter boundary that preserves shared UI/API/CLI behavior and keeps provider secrets out of persistence.
+
+ADM-02: Admins shall enable fully local-only operation.
+
+ADM-03: Admins shall manage topology data and freshness status.
+
+ADM-04: Admins shall manage incident ingestion and indexing.
+
+ADM-05: Admins shall add or override custom skills and organization-specific heuristics.
+
+ADM-06: Admins shall manage thresholds and reporting defaults without changing core code.
+
+ADM-07: Future policy adapters shall consume report outputs without changing advisory-first core behavior.
+
+COM-01: Expose a Skills registry API for listing, fetching, and installing community-contributed skills.
+
+COM-02: Support versioned Skills with a formal manifest schema.
+
+COM-03: Automated test harness runs on every Skill submission.
+
+COM-04: Skills installer CLI: `deploywhisper skill install <name>`.
+
+COM-05: Public Skills browser UI with search, filters, and ratings.
+
+COM-06: Skill analytics: download counts, test pass rates, last-updated timestamps.
+
+COM-07: Contribution workflow: PR template, automated linting, reviewer assignment.
+
+Total FRs: 65.
+
+### Non-Functional Requirements
+
+NFR-SEC-01: Raw infrastructure artifacts shall never be sent to external LLM providers.
+
+NFR-SEC-02: Provider credentials shall not be persisted in the application database.
+
+NFR-SEC-03: Logs shall exclude secrets, raw IaC, prompts, and raw model responses.
+
+NFR-SEC-04: Sensitive-file handling shall always remain enabled.
+
+NFR-SEC-05: Fully local operation shall be possible with local model execution (Ollama).
+
+NFR-SEC-06: The narrative-provider integration path shall minimize unnecessary dependency and supply-chain surface when direct provider SDKs satisfy the required capability more safely than a multi-provider meta-abstraction.
+
+NFR-PERF-01: Standard analysis should complete in under 15 seconds for expected v1 workloads.
+
+NFR-PERF-02: PR summary generation should complete in under 5 seconds.
+
+NFR-PERF-03: History retrieval shall remain responsive for at least 1,000 stored reports in v1.
+
+NFR-PERF-04: The system shall support small-team concurrency without severe degradation.
+
+NFR-REL-01: Parser failures shall be isolated per artifact where possible.
+
+NFR-REL-02: Narrative failure shall degrade gracefully to deterministic output.
+
+NFR-REL-03: Completed reports shall be persisted before being presented as final.
+
+NFR-REL-04: Health checks and startup validation shall make runtime issues visible early.
+
+NFR-XAI-01: Severity must never be communicated by color alone.
+
+NFR-XAI-02: Key visualizations must have textual equivalents.
+
+NFR-XAI-03: Evidence and uncertainty must be readable in both UI and shared summaries.
+
+NFR-XAI-04: The interface shall remain keyboard navigable for common review workflows.
+
+NFR-OPS-01: Web, API, CLI, and integration outputs shall share one analysis core.
+
+NFR-OPS-02: The product shall preserve a stable report schema across access surfaces.
+
+NFR-OPS-03: The architecture shall support migration from SQLite to PostgreSQL without redesigning domain models.
+
+NFR-OPS-04: The architecture shall support adding async workers later without breaking existing interfaces.
+
+NFR-OPS-05: Narrative provider integrations shall be isolated behind an internal adapter interface so providers can be added, removed, upgraded, or capability-scoped without rewriting UI, API, CLI, or report persistence flows.
+
+Total NFRs: 23.
+
+### Additional Requirements
+
+DIF-01: Present evidence-backed findings rather than only natural-language summary.
+
+DIF-02: Explicitly show uncertainty and context completeness.
+
+DIF-03: Support PR-native workflow delivery as a first-class use case.
+
+DIF-04: Preserve local-first analysis boundaries as a primary product promise.
+
+DIF-05: Support learning loops from reviewer feedback and deployment outcomes.
+
+DIF-06: Enable community extension through the AI Skills marketplace.
+
+DIF-07: Publish measurable benchmark results against competing approaches.
+
+Phase 1 exit criteria: mixed-artifact analysis works reliably; reports contain evidence and uncertainty; deterministic core works without narrative; history and audit metadata persist correctly; senior reviewers consider high/critical findings credible enough to test in real workflows; evidence inspector is usable in the UI; at least 3 internal or friendly-user teams use the product.
+
+Phase 1.5 exit criteria: GitHub workflow integration is live and documented; PR summaries are reused in real reviews; rerun-on-commit works; report comparison and sharing are usable; deployment approvals start referencing reports regularly; Skills marketplace is live with 20+ seed skills; first external Skill contribution is merged.
+
+Phase 2 exit criteria: context completeness improves materially; incident similarity becomes useful in practice; deployment history and outcome capture exist; published benchmark corpus and quarterly results are available; false positive/false reassurance trends are measurable and improving; CNCF Sandbox application is submitted or accepted; GitHub stars exceed 1,000.
+
+Decisions recorded in open questions: ship GitHub Action first while also supporting a GitHub App; high/critical findings require at least one deterministic evidence item; capture analysis ID, timestamp, deploy outcome, and linked incidents first for deployment history; prioritize Terraform state, GitHub PR history, and Slack postmortem ingestion for context connectors; introduce policy adapters only after 85% high/critical precision is sustained for 3 consecutive quarterly runs; introduce hosted SaaS after Phase 2.
+
+### PRD Completeness Assessment
+
+The PRD is complete enough for traceability validation: it has explicit numbered FRs and NFRs, phase scope, release exit criteria, target users, non-goals, product principles, and key decisions. The main readiness risks to validate in later steps are scope breadth across six epics, whether every NFR has implementation/test coverage, and whether the epics preserve the local-first, advisory-first, evidence-backed product boundaries.
+
+## Epic Coverage Validation
+
+### Epic FR Coverage Extracted
+
+ING-01..06: Covered by existing repository baseline; preserve during Epic 1 migration.
+
+EVD-01: Covered by existing normalized change model plus `E1-S2` and `E1-S3`.
+
+EVD-02..08: Covered by `E1-S1..E1-S8`, `E2-S2..E2-S4`, and `E2-S7`.
+
+RSK-01..08: Covered by existing repository baseline plus `E1-S3`, `E1-S6`, `E1-S7`, `E2-S1`, `E2-S6`, and `E2-S7`.
+
+CTX-01..07: Covered by existing topology/incidents baseline plus `E1-S5`, `E2-S4`, `E2-S5`, and `E5-S1..E5-S8`.
+
+REV-01..07: Covered by existing dashboard/history baseline plus `E2-S1..E2-S8`.
+
+WRK-01..02: Covered by existing API and CLI baseline.
+
+WRK-03..07: Covered by `E3-S1..E3-S8`.
+
+HIS-01..04: Covered by existing persistence/history baseline plus `E5-S4` and `E5-S8`.
+
+HIS-05..07: Covered by `E5-S5..E5-S8` and `E6-S1..E6-S8`.
+
+ADM-01..05: Covered by existing settings/local-mode/topology/custom-skill baseline plus `BH-S1..BH-S5`, `E4-S1..E4-S9`, and `E5-S1..E5-S4`.
+
+ADM-06..07: Claimed as cross-cutting governance in `E1`, `E5`, and future adapter work.
+
+COM-01..07: Covered by `E4-S1..E4-S9`.
+
+Total PRD FRs found in epic coverage claims: 65.
+
+### Coverage Matrix
+
+| FR Number | PRD Requirement | Epic Coverage | Status |
+| --- | --- | --- | --- |
+| ING-01 | Accept one or more artifacts from supported toolchains in a single analysis | Existing repo baseline; preserve during Epic 1 migration | Covered |
+| ING-02 | Auto-detect artifact type without requiring manual labeling for normal cases | Existing repo baseline; preserve during Epic 1 migration | Covered |
+| ING-03 | Support partial analysis when not all related artifacts are available | Existing repo baseline; preserve during Epic 1 migration | Covered |
+| ING-04 | Detect unsupported artifacts and explain why they were excluded | Existing repo baseline; preserve during Epic 1 migration | Covered |
+| ING-05 | Detect sensitive files and block unsafe downstream handling | Existing repo baseline; preserve during Epic 1 migration | Covered |
+| ING-06 | Preserve a submission manifest showing accepted, excluded, partially parsed, or failed artifacts | Existing repo baseline; preserve during Epic 1 migration | Covered |
+| EVD-01 | Normalize supported artifacts into a shared internal change model | Existing normalized model plus E1-S2 / E1-S3 | Covered |
+| EVD-02 | Each finding shall reference one or more concrete evidence items | E1-S1..E1-S8, E2-S2..E2-S4, E2-S7 | Covered |
+| EVD-03 | Evidence items identify artifact, location, resource, operation, or contextual source | E1-S1..E1-S8, E2-S2..E2-S4, E2-S7 | Covered |
+| EVD-04 | Distinguish deterministic findings from model-inferred explanations | E1-S1..E1-S8, E2-S2..E2-S4, E2-S7 | Covered |
+| EVD-05 | Surface confidence and uncertainty for key findings and overall verdict | E1-S1..E1-S8, E2-S2..E2-S4, E2-S7 | Covered |
+| EVD-06 | Explain main contributors to overall risk score | E1-S1..E1-S8, E2-S2..E2-S4, E2-S7 | Covered |
+| EVD-07 | Show explicit uncertainty when context is incomplete | E1-S1..E1-S8, E2-S2..E2-S4, E2-S7 | Covered |
+| EVD-08 | Evidence items persist with report for audit and comparison | E1-S1..E1-S8, E2-S2..E2-S4, E2-S7 | Covered |
+| RSK-01 | Produce a unified deployment risk verdict | Existing baseline plus E1-S3, E1-S6, E1-S7, E2-S1, E2-S6, E2-S7 | Covered |
+| RSK-02 | Classify findings and verdicts by severity level | Existing baseline plus E1-S3, E1-S6, E1-S7, E2-S1, E2-S6, E2-S7 | Covered |
+| RSK-03 | Detect cross-tool interactions that increase risk | Existing baseline plus E1-S3, E1-S6, E1-S7, E2-S1, E2-S6, E2-S7 | Covered |
+| RSK-04 | Generate reviewer-oriented operational explanation | Existing baseline plus E1-S3, E1-S6, E1-S7, E2-S1, E2-S6, E2-S7 | Covered |
+| RSK-05 | Generate remediation or verification guidance | Existing baseline plus E1-S3, E1-S6, E1-S7, E2-S1, E2-S6, E2-S7 | Covered |
+| RSK-06 | Produce rollback guidance and rollback complexity score | Existing baseline plus E2-S6 | Covered |
+| RSK-07 | Distinguish product recommendation from human decision | Existing baseline plus Epic 1/2 advisory presentation | Covered |
+| RSK-08 | Continue deterministic results if narrative generation fails | Existing baseline plus E1-S7 | Covered |
+| CTX-01 | Compute blast radius using maintained topology context | Existing baseline plus E1-S5, E2-S4, E2-S5, E5-S1..E5-S8 | Covered |
+| CTX-02 | Indicate stale, missing, or incomplete topology | Existing baseline plus E1-S5, E2-S4, E5-S3 | Covered |
+| CTX-03 | Ingest incident records for similarity matching | Existing baseline plus E5-S6 | Covered |
+| CTX-04 | Surface incident similarity with match confidence | Existing baseline plus Epic 1/2/5 context work | Covered |
+| CTX-05 | Support service criticality and environment-aware context | Existing baseline plus E5 context work | Covered |
+| CTX-06 | Store deployment history for comparison and trend analysis | Existing baseline plus E5-S4, E5-S8 | Covered |
+| CTX-07 | Support future topology auto-discovery/connectors without replacing report format | E5-S1..E5-S8 plus stable report architecture | Covered |
+| REV-01 | Web report presents verdict first, then evidence, then details | Existing baseline plus E2-S1..E2-S8 | Covered |
+| REV-02 | Show top findings, blast radius, rollback, and uncertainty above the fold | Existing baseline plus E2-S1..E2-S8 | Covered |
+| REV-03 | Inspect full findings and evidence details on demand | Existing baseline plus E2-S2, E2-S3 | Covered |
+| REV-04 | Retrieve prior reports and compare analyses over time | Existing baseline plus E3-S5, E5-S4/E5-S8 | Covered |
+| REV-05 | Generate concise share summary for PRs and approval threads | E2-S7 and E3-S2 | Covered |
+| REV-06 | Shared summaries remain explicitly advisory | E2-S7 and E3 GitHub-native advisory delivery | Covered |
+| REV-07 | Support expert quick scan and detailed investigation | E2-S1..E2-S8 | Covered |
+| WRK-01 | Expose stable versioned REST API | Existing API baseline | Covered |
+| WRK-02 | Expose CLI access using same analysis core | Existing CLI baseline | Covered |
+| WRK-03 | Support GitHub-first workflow delivery for PR review | E3-S1..E3-S8 | Covered |
+| WRK-04 | Post formatted PR summary with verdict, top risks, blast radius, rollback, uncertainty | E3-S2 | Covered |
+| WRK-05 | Support rerun after new commits or changed artifacts | E3-S3 | Covered |
+| WRK-06 | Support report links and machine-friendly summary payloads | E3-S4, E2-S7 | Covered |
+| WRK-07 | Support future GitLab / Atlantis / HCP Terraform / Jenkins adapters without redesigning core object | E3-S1..E3-S8 plus future adapter note | Covered |
+| HIS-01 | Persist completed reports before final success | Existing baseline plus E5 | Covered |
+| HIS-02 | Retain audit metadata with each report | Existing baseline plus E5 | Covered |
+| HIS-03 | Search and filter historical reports | Existing baseline plus E5 | Covered |
+| HIS-04 | Review risk trends over time | Existing baseline plus E5-S8 | Covered |
+| HIS-05 | Capture reviewer feedback on report quality/correctness | E5-S5 | Covered |
+| HIS-06 | Support outcome capture after deployment | E5-S4, E5-S6 | Covered |
+| HIS-07 | Support benchmark and backtest workflows against historical incidents | E5-S6, E6-S1..E6-S8 | Covered |
+| ADM-01 | Configure narrative provider settings through DeployWhisper-owned adapter boundary | Existing baseline plus BH-S1..BH-S5 | Covered |
+| ADM-02 | Enable fully local-only operation | Existing baseline plus BH hardening | Covered |
+| ADM-03 | Manage topology data and freshness status | Existing baseline plus E5-S1..E5-S4 | Covered |
+| ADM-04 | Manage incident ingestion and indexing | Existing baseline plus E5 | Covered |
+| ADM-05 | Add or override custom skills and org-specific heuristics | Existing baseline plus E4-S1..E4-S9 | Covered |
+| ADM-06 | Manage thresholds and reporting defaults without changing core code | Cross-cutting governance in E1/E5/future adapter work | At Risk |
+| ADM-07 | Future policy adapters consume report outputs without changing advisory-first core behavior | Cross-cutting governance in E1/E5/future adapter work | At Risk |
+| COM-01 | Expose Skills registry API | E4-S1 | Covered |
+| COM-02 | Support versioned Skills with formal manifest schema | E4-S2 | Covered |
+| COM-03 | Automated test harness runs on every Skill submission | E4-S3, E4-S6 | Covered |
+| COM-04 | Skills installer CLI | E4-S4 | Covered |
+| COM-05 | Public Skills browser UI with search, filters, ratings | E4-S5 | Covered |
+| COM-06 | Skill analytics | E4-S8 | Covered |
+| COM-07 | Contribution workflow | E4-S6 | Covered |
+
+### Missing Requirements
+
+No PRD functional requirement is completely absent from the epics document.
+
+### At-Risk Coverage
+
+ADM-06: Admins shall manage thresholds and reporting defaults without changing core code.
+- Impact: The epics claim cross-cutting governance but do not assign this to a concrete story with acceptance criteria.
+- Recommendation: Add explicit acceptance criteria to an Epic 1 or Epic 5 story, or create a small admin/config story.
+
+ADM-07: Future policy adapters shall consume report outputs without changing advisory-first core behavior.
+- Impact: This is directionally covered, but the implementation path is described as future adapter work rather than story-level scope.
+- Recommendation: Add an explicit architectural acceptance criterion to the GitHub/workflow adapter stories or a future policy-adapter placeholder story.
+
+### Coverage Statistics
+
+- Total PRD FRs: 65
+- FRs covered in epics: 63 fully covered, 2 at-risk but claimed
+- Completely missing FRs: 0
+- Coverage percentage: 100% claimed coverage; 96.9% strong traceability
+
+## UX Alignment Assessment
+
+### UX Document Status
+
+Found: `_bmad-output/planning-artifacts/ux-design-specification.md`
+
+The UX document is marked complete, with completed workflow steps through responsive/accessibility and finalization. It is a whole document, not sharded.
+
+### UX ↔ PRD Alignment
+
+Aligned:
+
+- The PRD’s platform engineer, SRE approver, junior engineer, manager, admin, CI/automation consumer, and skills contributor users are reflected in UX target users or journey patterns.
+- The PRD’s central review question maps directly to the UX “deploy briefing before production” defining experience.
+- The PRD’s verdict-first report requirements (`REV-01`, `REV-02`, `REV-07`) align with UX rules for above-the-fold verdict, top risk, and decision hierarchy.
+- Evidence and uncertainty requirements (`EVD-02..08`, `NFR-XAI-03`) align with UX rules for evidence on demand, parser coverage, degraded analysis states, and visible uncertainty.
+- Rollback, blast radius, incident match, report history, share/re-run, and topology admin flows all have UX coverage.
+- Accessibility requirements (`NFR-XAI-01..04`) are explicitly covered by text labels, contrast, keyboard navigation, textual visualization equivalents, and no color-only status communication.
+
+Potential gaps:
+
+- PRD `COM-05` requires a public Skills browser UI with search, filters, and ratings. UX references AI Skills and admin/custom-skill validation, but does not deeply specify the public marketplace browse/detail/rating experience.
+- PRD/Epic 6 requires public benchmark results and calibration dashboards. UX covers risk trends and history scanability, but does not specify benchmark dashboard UX or comparative-results browsing.
+- PRD `HIS-05..07` and Epic 5 include reviewer feedback, outcome capture, calibration, and trend analysis. UX mentions feedback loops and manager trends, but feedback capture and calibration dashboard interactions are lighter than the PRD scope.
+
+### UX ↔ Architecture Alignment
+
+Aligned:
+
+- UX chooses NiceGUI / Quasar as the component foundation, matching architecture ADR-01 and the shared NiceGUI + FastAPI runtime.
+- UX emphasizes one shared report object rendered across review surfaces, matching the architecture’s one-analysis-core and Report Service decisions.
+- UX component strategy maps cleanly to architecture: VerdictCard, ParserCoverageRow, Evidence/ChangeRiskTable, BlastRadiusPanel, RollbackTimeline, IncidentMatchCard, and AnalysisHistoryRow are supported by the evidence, context, rollback, incident, report, and history services.
+- UX parser coverage and staged progress align with the canonical pipeline: intake, parse, skills, evidence, context, blast radius, similarity, rollback, score, narrate, assemble, persist, deliver.
+- UX share/re-run/escalation flows align with the GitHub adapter, share summary, report URL, and comparison architecture.
+- UX topology/admin validation aligns with context service, topology versions, and future topology import/drift stories.
+
+Potential architecture/UX gaps:
+
+- Architecture includes Skills Registry Service, Skill Validator, installer, registry API, and public registry repository; UX does not yet fully define the public registry browser and skill detail interaction model.
+- Architecture includes Benchmark Runner, benchmark corpus, comparator execution, and public results dashboard; UX does not yet define benchmark-result pages, filters, methodology display, or comparison tables.
+- Architecture includes feedback event persistence and calibration dashboards; UX does not yet define the per-finding feedback controls or calibration dashboard information architecture in detail.
+
+### Warnings
+
+- UX is strong for the core deploy-review workflow and sufficient for Epics 1-3.
+- UX should be extended before full Epic 4-6 implementation to cover public Skills marketplace browsing, benchmark result dashboards, reviewer feedback capture, calibration dashboards, and manager trend views.
+
+## Epic Quality Review
+
+### Summary
+
+The epic plan is strong as a product roadmap and has good requirement-family traceability. It is not yet uniformly strong as a strict implementation-ready story pack. The biggest issues are:
+
+- Several stories are technical milestones framed around developer/maintainer work rather than direct user value.
+- Several stories are too large to be independently completed as a small implementation story.
+- Acceptance criteria are generally testable but are not written in Given/When/Then format.
+- Two PRD admin/governance requirements have at-risk, cross-cutting ownership instead of concrete story-level ownership.
+
+### Critical Violations
+
+None found that fully block the roadmap from being used. No epic requires a future epic to function in a circular or impossible way, and no PRD FR is completely absent from coverage.
+
+### Major Issues
+
+1. Technical stories in Epic 1 and the Brownfield Hardening Track.
+
+Examples:
+
+- `E1-S1: Domain model foundations` is framed as developer-facing model/table setup.
+- `E1-S2: Evidence Extractor service` is service construction.
+- `E1-S3: Refactor risk scorer to consume evidence` is implementation refactoring.
+- `BH-S2: Introduce provider adapter contract and registry` is technical boundary work.
+- `BH-S4: Migrate OpenRouter, Groq, and xAI...` is dependency/runtime migration.
+
+Impact: These stories may be necessary in a brownfield system, but under strict create-epics-and-stories standards they are not ideal user-value stories. They should be tied more explicitly to reviewer/admin outcomes or kept as a labeled technical hardening track outside the product story sequence.
+
+Recommendation: Keep the Brownfield Hardening Track separate, but revise Epic 1 story titles and acceptance criteria to foreground reviewer trust outcomes. Example: “Reviewer can inspect evidence-backed findings” rather than “Domain model foundations.”
+
+2. Oversized stories.
+
+Examples:
+
+- `E3-S6: GitHub App` includes runtime, operator guide, checks API, PR events, OAuth, installation, and docs. This should be split.
+- `E4-S7: Seed 20 community skills` requires 20 skills, manifests, scenarios, installation, and risk patterns. This is an epic-sized batch.
+- `E5-S1: Terraform state import` covers AWS, GCP, and Azure provider support in one story. This should likely split by provider or capability.
+- `E6-S1: Benchmark corpus v1` requires 100 scenarios across five tools. This is too large for one implementation story.
+- `E6-S4: Comparative runner` covers multiple comparator integrations in one story.
+
+Impact: These stories are difficult to estimate, review, test, and complete independently.
+
+Recommendation: Split these into smaller vertical increments. For example, `E5-S1a AWS Terraform state import`, `E5-S1b GCP coverage`, `E5-S1c Azure coverage`; `E6-S1a corpus schema`, `E6-S1b 20 Terraform/Kubernetes seed scenarios`, then follow-on batches.
+
+3. Acceptance criteria format is not BDD-style.
+
+Most acceptance criteria are bullet lists rather than Given/When/Then. They are often testable, but not consistently structured as independent acceptance scenarios.
+
+Impact: Implementation agents and reviewers may interpret criteria differently, especially for UI and integration stories.
+
+Recommendation: Before story execution, convert active story acceptance criteria into explicit scenario-style checks. This is most important for GitHub integration, skills marketplace, feedback/calibration, and benchmark stories.
+
+4. ADM-06 and ADM-07 lack concrete story ownership.
+
+- `ADM-06` threshold/default management is only mapped to cross-cutting governance.
+- `ADM-07` policy adapter consumption is only mapped to future adapter work.
+
+Impact: These requirements can fall through during implementation because no single story is accountable.
+
+Recommendation: Add explicit story ownership or acceptance criteria before implementation reaches the relevant admin/integration scope.
+
+### Minor Concerns
+
+- Epic 6 serves trust/marketing/proof outcomes more than immediate in-product user workflow. It is strategically valid but should be treated as proof-engine work, not core deploy-review readiness.
+- Epic 4 includes public marketplace and contribution flow but the UX spec is thinner for marketplace detail pages, ratings, curation, and contribution review surfaces.
+- Some story actors are internal roles (`developer`, `maintainer`, `system`, `marketer`). That is acceptable for technical enablement, but these should be clearly marked as platform enablement stories rather than user-facing workflow stories.
+- Some dependency language is high-level rather than operationally enforced. Example: “Epic 4 can start as soon as Epic 2 is rendering the new schema” is reasonable, but should be reflected in sprint sequencing.
+
+### Dependency Review
+
+- Epic sequencing is coherent: Epic 1 evidence model precedes Epic 2 report UI; Epic 2 share/report structure supports Epic 3 PR delivery; Epic 4 can begin after schema/rendering foundations; Epics 5 and 6 depend on report/schema stability.
+- No circular dependency found.
+- No forward dependency found where an earlier epic requires a later epic to function.
+- Within-epic sequencing is generally logical, especially Epic 1, Epic 2, Epic 3, and Epic 5.
+
+### Database / Entity Timing Review
+
+- The plan does not create every future table up front in one setup story.
+- `E1-S1` creates evidence-model tables when the evidence model is introduced, which is acceptable.
+- Architecture lists future tables for skills and benchmarks, but the epics place those capabilities in Epic 4 and Epic 6 rather than forcing them into Epic 1.
+
+### Best Practices Compliance Checklist
+
+| Epic | User Value | Independent | Story Size | No Forward Dependencies | AC Quality | Traceability |
+| --- | --- | --- | --- | --- | --- | --- |
+| Brownfield Hardening | Partial | Yes | Mostly OK | Yes | Needs BDD conversion | Good |
+| Epic 1 | Partial | Yes | Mostly OK | Yes | Needs BDD conversion | Strong |
+| Epic 2 | Strong | Depends appropriately on Epic 1 | Mostly OK | Yes | Needs BDD conversion | Strong |
+| Epic 3 | Strong | Depends appropriately on Epics 1-2 | Mixed; E3-S6 large | Yes | Needs BDD conversion | Strong |
+| Epic 4 | Strong | Depends on schema/UI foundation | Mixed; E4-S7 large | Yes | Needs BDD conversion | Strong |
+| Epic 5 | Strong | Depends on stable report/context baseline | Mixed; E5-S1 large | Yes | Needs BDD conversion | Good |
+| Epic 6 | Moderate | Depends on stable analysis/report baseline | Mixed; E6-S1/E6-S4 large | Yes | Needs BDD conversion | Good |
+
+### Quality Review Recommendation
+
+The roadmap is usable for implementation planning, but individual stories should be refined before execution. The next implementation-ready pass should focus on:
+
+1. Split oversized stories.
+2. Add concrete ownership for ADM-06 and ADM-07.
+3. Convert acceptance criteria into Given/When/Then or equivalent testable scenarios.
+4. Extend UX coverage for Epic 4-6 surfaces before starting those epics.
+
+## Summary and Recommendations
+
+### Overall Status
+
+**NEEDS WORK**
+
+The planning package is strong enough to continue implementation for individually refined near-term stories, especially the existing evidence-first analysis and review flows. It is not yet fully implementation-ready for the whole remaining roadmap because several later-epic stories are too large, acceptance criteria need test-ready structure, and a few PRD requirements need clearer story ownership.
+
+### Critical Issues Requiring Immediate Action
+
+No blocker-level document gaps were found. The PRD, architecture, epics, and UX specification are all present as whole documents, and no functional requirement is completely missing from epic coverage.
+
+Before starting new roadmap implementation, address these readiness issues:
+
+1. Assign concrete story ownership for `ADM-06` threshold/default management and `ADM-07` policy adapter consumption.
+2. Split oversized stories before implementation: `E3-S6`, `E4-S7`, `E5-S1`, `E6-S1`, and `E6-S4`.
+3. Convert active story acceptance criteria into testable Given/When/Then form.
+4. Extend UX coverage before Epic 4 through Epic 6 implementation, especially marketplace browsing/detail/rating, reviewer feedback and calibration, and benchmark dashboards.
+
+### Recommended Next Steps
+
+1. Patch the epics document with explicit `ADM-06` and `ADM-07` ownership and smaller implementation slices for the oversized stories.
+2. For the next implementation slice, run `bmad-create-story` only after selecting the next sprint item and refining that story's acceptance criteria into BDD-style checks.
+3. Before Epic 4 through Epic 6 enter delivery, update the UX specification for marketplace, feedback/calibration, and benchmark reporting workflows.
+4. Refresh sprint tracking after planning refinements so implementation status matches the corrected story structure.
+
+### Final Note
+
+Assessment completed on 2026-04-27 by Codex using the BMad implementation readiness workflow. Findings: 0 duplicate or missing planning documents, 0 missing functional requirements, 2 at-risk requirements, 4 major epic-quality issues, and 4 minor roadmap readiness concerns. Proceed with refined stories, but do not treat the complete roadmap as implementation-ready until the issues above are resolved.

--- a/_bmad-output/planning-artifacts/sprint-change-proposal-2026-04-27-readiness-refinement.md
+++ b/_bmad-output/planning-artifacts/sprint-change-proposal-2026-04-27-readiness-refinement.md
@@ -1,0 +1,171 @@
+# Sprint Change Proposal: Implementation Readiness Refinement
+
+**Date:** 2026-04-27
+**Project:** deploywhisper
+**Trigger:** `bmad-check-implementation-readiness` report from 2026-04-27
+**Mode:** Batch
+**Scope:** Moderate backlog and UX refinement
+
+## 1. Issue Summary
+
+The implementation readiness assessment found that the planning package is strong enough for refined near-term implementation but not fully ready for the complete roadmap. The core issues were:
+
+- `ADM-06` and `ADM-07` had cross-cutting coverage but no concrete story ownership.
+- Several stories were too large to execute and validate as single implementation units: `E3-S6`, `E4-S7`, `E5-S1`, `E6-S1`, and `E6-S4`.
+- Later roadmap UX coverage was too light for the Skills marketplace, reviewer feedback and calibration, and benchmark dashboards.
+- Active story acceptance criteria still need BDD-style refinement during story creation.
+
+Evidence source: `_bmad-output/planning-artifacts/implementation-readiness-report-2026-04-27.md`.
+
+## 2. Impact Analysis
+
+### Epic Impact
+
+- Epic 3 remains valid, but GitHub App work is split into runtime, self-hosted setup documentation/verification, delivery-mode documentation, and advisory policy output contract stories.
+- Epic 4 remains valid, but the 20-skill seed catalog is split into four batches of five skills.
+- Epic 5 remains valid, but Terraform state import is split by cloud provider and new admin/policy stories explicitly own `ADM-06` and `ADM-07`.
+- Epic 6 remains valid, but corpus and comparator work are split into schema/initial batch, expansion, completion quality gate, hosted/LLM comparators, and normalized reporting.
+
+### Story Impact
+
+- Narrowed existing oversized stories rather than deleting them, preserving existing story files and implementation history.
+- Added follow-on stories:
+  - `E3-S9`, `E3-S10`, `E3-S11`
+  - `E4-S10`, `E4-S11`, `E4-S12`
+  - `E5-S9`, `E5-S10`, `E5-S11`, `E5-S12`
+  - `E6-S9`, `E6-S10`, `E6-S11`, `E6-S12`
+
+### Artifact Conflicts
+
+- PRD goals remain unchanged.
+- Architecture remains compatible with the split; no architecture rewrite is required.
+- UX specification needed additional interaction detail for later roadmap surfaces.
+- Sprint status needed regeneration after the epics changed.
+
+### Technical Impact
+
+No code changes are required by this course correction. The technical impact is planning and delivery sequencing:
+
+- New stories should be created before implementation starts.
+- Existing generated story files for narrowed stories may need refresh before being developed further.
+- Implementation agents must preserve the local-first, advisory-first, shared-core constraints from project context.
+
+## 3. Recommended Approach
+
+**Chosen path:** Direct Adjustment.
+
+This is the lowest-risk approach because the PRD and architecture remain coherent. The issue is delivery granularity and story ownership, not product direction. Rollback is not useful because the existing planning artifacts are still valuable, and MVP review is not needed because no core requirement became impossible.
+
+**Effort estimate:** Medium.
+
+**Risk level:** Low to medium. The main risk is that existing story files for narrowed stories can drift from the updated epic plan unless refreshed before implementation.
+
+## 4. Detailed Change Proposals
+
+### Epics
+
+**Traceability Matrix**
+
+Old:
+
+```text
+ADM-06..07: Cross-cutting governance in E1, E5, and future adapter work
+```
+
+New:
+
+```text
+ADM-06: E5-S11
+ADM-07: E5-S12
+```
+
+Rationale: Each PRD admin/governance requirement now has explicit story ownership.
+
+**Oversized Story Splits**
+
+- `E3-S6` narrowed to minimal self-hosted GitHub App runtime.
+- `E3-S9` added for self-hosted GitHub App setup documentation and verification.
+- `E3-S10` added for GitHub delivery-mode documentation.
+- `E3-S11` added for advisory policy adapter output contract.
+- `E4-S7` narrowed to the first five seed skills.
+- `E4-S10..E4-S12` added for the remaining three seed-skill batches.
+- `E5-S1` narrowed to AWS Terraform state import.
+- `E5-S9` and `E5-S10` added for GCP and Azure imports.
+- `E6-S1` narrowed to corpus schema and first 20 scenarios.
+- `E6-S9` and `E6-S10` added for corpus expansion and completion.
+- `E6-S4` narrowed to local/open-source comparators.
+- `E6-S11` and `E6-S12` added for hosted/LLM comparators and normalized reporting.
+
+### UX Specification
+
+Added flows:
+
+- Public Skills Marketplace Browse Flow.
+- Reviewer Feedback and Calibration Flow.
+- Benchmark Results Dashboard Flow.
+
+Added components:
+
+- `SkillMarketplaceCard`
+- `SkillDetailPanel`
+- `FindingFeedbackControl`
+- `CalibrationMetricPanel`
+- `BenchmarkResultsTable`
+
+Rationale: The later roadmap now has enough UX direction for story creation and implementation planning.
+
+## 5. Implementation Handoff
+
+**Scope classification:** Moderate.
+
+**Handoff recipients:**
+
+- Product Owner / Developer: maintain the corrected story backlog and sprint status.
+- Developer agent: create and implement the next selected story from the refreshed sprint status.
+- UX owner: refine visual detail later if Epic 4 through Epic 6 enter active implementation.
+
+**Success criteria:**
+
+- Epics explicitly own `ADM-06` and `ADM-07`.
+- Oversized stories are split into smaller backlog items.
+- UX spec covers marketplace, feedback/calibration, and benchmark surfaces.
+- Sprint status is regenerated and valid YAML.
+- The next story file is created from the refreshed backlog and marked `ready-for-dev`.
+
+## 6. Checklist Status
+
+- [x] 1.1 Triggering story identified as N/A; trigger came from readiness assessment.
+- [x] 1.2 Core problem defined as backlog granularity and ownership gaps.
+- [x] 1.3 Evidence captured from readiness report.
+- [x] 2.1 Current epic impact evaluated.
+- [x] 2.2 Required epic-level changes identified.
+- [x] 2.3 Remaining epics reviewed.
+- [x] 2.4 No new epic required.
+- [x] 2.5 Epic order unchanged.
+- [x] 3.1 PRD conflict check completed.
+- [x] 3.2 Architecture conflict check completed.
+- [x] 3.3 UX impact identified and addressed.
+- [x] 3.4 Sprint status follow-up identified.
+- [x] 4.1 Direct adjustment selected as viable.
+- [x] 4.2 Rollback rejected as not useful.
+- [x] 4.3 MVP review rejected as unnecessary.
+- [x] 4.4 Recommended path selected.
+- [x] 5.1 Issue summary created.
+- [x] 5.2 Epic and artifact impacts documented.
+- [x] 5.3 Recommendation documented.
+- [x] 5.4 MVP impact documented.
+- [x] 5.5 Handoff plan established.
+- [x] 6.1 Checklist reviewed.
+- [x] 6.2 Proposal reviewed for consistency.
+- [x] 6.3 Approval treated as implicit from the user's explicit request to follow the handoff step by step.
+- [x] 6.4 Sprint status update delegated to the sprint-planning workflow.
+- [x] 6.5 Next steps documented.
+
+## 7. Approval and Routing
+
+Approved for implementation by user instruction: "could you please follow the BMad-help handoff recommendation step by step".
+
+Route next to:
+
+1. `bmad-sprint-planning`
+2. `bmad-create-story`

--- a/_bmad-output/planning-artifacts/ux-design-specification.md
+++ b/_bmad-output/planning-artifacts/ux-design-specification.md
@@ -757,6 +757,54 @@ flowchart TD
 
 A secondary admin validation pattern should apply to custom AI Skills as well: when overrides or new skills are detected, the system should confirm exactly what it found and how it will be used.
 
+### Public Skills Marketplace Browse Flow
+
+The public Skills marketplace must support fast discovery and credibility assessment without turning the product into a generic app store. The primary user goal is to decide whether a skill is relevant, safe enough to install, and actively maintained.
+
+```mermaid
+flowchart TD
+    A[Open Skills marketplace] --> B[Search or filter by tool, risk category, official status, rating, and last updated]
+    B --> C[Scan skill cards with name, tool, official/community badge, rating, install count, and test pass rate]
+    C --> D[Open skill detail]
+    D --> E[Review manifest summary, risk patterns, test scenarios, analytics, and maintainer notes]
+    E --> F{Decision}
+    F -->|Install| G[Copy or run deploywhisper skill install command]
+    F -->|Evaluate later| H[Return to filtered results]
+    F -->|Report concern| I[Open contribution or issue workflow]
+```
+
+Marketplace browse surfaces should keep evidence of trust visible on every repeated item: official/community status, test pass rate, last updated timestamp, install count, and rating. Search and filters should use compact controls above the list, not a landing-page layout. Skill detail pages should lead with the skill's operational purpose and compatibility, then show manifest fields, test results, analytics, examples, and contribution metadata.
+
+### Reviewer Feedback and Calibration Flow
+
+Reviewer feedback is part of the learning loop, not a decorative reaction control. Feedback controls must appear where the user is already evaluating findings, and calibration views must explain whether DeployWhisper is becoming more or less reliable over time.
+
+```mermaid
+flowchart TD
+    A[Reviewer inspects finding] --> B[Mark useful, false positive, or missed risk]
+    B --> C[Optional reason captures context without blocking review]
+    C --> D[Feedback event is saved with finding, report, user, timestamp, and reason]
+    D --> E[Admin opens calibration dashboard]
+    E --> F[Review precision, recall, severity trends, and recent false positives or misses]
+    F --> G[Adjust thresholds or investigate skills and parser gaps]
+```
+
+Feedback controls should be compact and per-finding. The UI should not interrupt the review flow with a modal unless the user chooses to add detail. Calibration dashboards should use summary metrics first, then drill-down tables for false positives, false negatives, and severity changes. Trend views must be filterable by time window, tool, environment, and severity.
+
+### Benchmark Results Dashboard Flow
+
+Benchmark pages are proof surfaces. They should prioritize methodology, repeatability, and comparison clarity over marketing ornament.
+
+```mermaid
+flowchart TD
+    A[Open benchmark results] --> B[See latest run summary with corpus version, run date, and methodology link]
+    B --> C[Compare precision, recall, and F1 by tool and severity]
+    C --> D[Inspect comparator results and scenario-level outcomes]
+    D --> E[Download raw results or open corpus reference]
+```
+
+The benchmark dashboard should show the latest published results, corpus version, DeployWhisper version, comparator versions, and run timestamp near the top. Tables should support filters by tool, severity, comparator, and scenario outcome. Scenario detail rows should expose expected findings, actual findings, reviewer rationale, and whether the result matched ground truth. Raw result downloads and methodology links must be visible from the first viewport.
+
 ### Journey Patterns
 
 Across these flows, the product should standardize these interaction patterns:
@@ -802,13 +850,13 @@ Custom components should exist only where the product has unique operational sem
 
 #### VerdictCard
 
-**Purpose:**  
+**Purpose:**
 Provide the primary above-the-fold deploy verdict and establish the answer hierarchy for the entire page.
 
-**Usage:**  
+**Usage:**
 Always appears at the top of an analysis result. It is the first thing the user sees after analysis completes.
 
-**Anatomy:**  
+**Anatomy:**
 - risk gauge
 - GO / CAUTION / NO-GO badge
 - score value
@@ -816,36 +864,36 @@ Always appears at the top of an analysis result. It is the first thing the user 
 - top risk summary
 - persistent secondary actions such as share / re-run
 
-**States:**  
+**States:**
 - loading
 - low / medium / high / critical
 - uncertain / degraded analysis
 - re-analysis result state
 
-**Accessibility:**  
+**Accessibility:**
 - status never conveyed by color alone
 - verdict text always explicit
 - gauge must expose textual equivalent
 - actions keyboard reachable
 
-**Interaction Behavior:**  
+**Interaction Behavior:**
 Acts as the anchor for the review page. It should never disappear from the user’s understanding, even when they drill deeper into evidence.
 
 #### TopRiskCallout
 
-**Purpose:**  
+**Purpose:**
 State the most important risk in one sentence.
 
-**Usage:**  
+**Usage:**
 Directly below or adjacent to the VerdictCard.
 
-**Anatomy:**  
+**Anatomy:**
 - label
 - concise risk statement
 - optional supporting context
 - severity styling
 
-**States:**  
+**States:**
 - low-risk informational
 - elevated-risk warning
 - critical-risk alert
@@ -853,18 +901,18 @@ Directly below or adjacent to the VerdictCard.
 
 #### ParserCoverageRow
 
-**Purpose:**  
+**Purpose:**
 Show what the system actually analyzed and where uncertainty exists.
 
-**Usage:**  
+**Usage:**
 Compact summary directly under the VerdictCard, with deeper detail reflected in lower evidence sections.
 
-**Anatomy:**  
+**Anatomy:**
 - one compact status item per tool
 - analyzed / warning / failure states
 - file count and change count summary
 
-**States:**  
+**States:**
 - success
 - partial
 - failed
@@ -872,38 +920,38 @@ Compact summary directly under the VerdictCard, with deeper detail reflected in 
 
 #### ChangeRiskTable
 
-**Purpose:**  
+**Purpose:**
 Present resource-level change evidence with risk cues.
 
-**Implementation Strategy:**  
+**Implementation Strategy:**
 Custom wrapper around Quasar `q-table`, not a bespoke table implementation.
 
-**Custom additions:**  
+**Custom additions:**
 - risk-weight visual treatment
 - tool icon badge
 - action-type pill
 - monospace resource-name styling
 - grouped or filterable evidence views
 
-**Reason:**  
+**Reason:**
 Quasar already solves table mechanics; DeployWhisper adds domain-specific evidence semantics.
 
 #### BlastRadiusPanel
 
-**Purpose:**  
+**Purpose:**
 Present downstream impact in a trustworthy, readable way.
 
-**Implementation Strategy:**  
+**Implementation Strategy:**
 Panel shell plus separate graph subcomponent.
 
-**Panel shell responsibilities:**  
+**Panel shell responsibilities:**
 - title and section framing
 - legend
 - topology staleness warning
 - empty state
 - loading state
 
-**Graph subcomponent responsibilities:**  
+**Graph subcomponent responsibilities:**
 - node and edge rendering
 - impact depth display
 - zoom/pan behavior if needed
@@ -913,52 +961,124 @@ This separation preserves flexibility if the underlying graph renderer changes l
 
 #### RollbackTimeline
 
-**Purpose:**  
+**Purpose:**
 Show recovery as a sequential operational plan rather than a paragraph.
 
-**Anatomy:**  
+**Anatomy:**
 - ordered step list
 - effort or complexity indicator
 - optional timing cues
 - dependency or critical-step highlighting
 
-**States:**  
+**States:**
 - standard
 - high-complexity
 - incomplete / degraded
 
 #### IncidentMatchCard
 
-**Purpose:**  
+**Purpose:**
 Present historical incident similarity as operational context.
 
-**Anatomy:**  
+**Anatomy:**
 - incident title
 - date
 - severity
 - similarity score
 - short explanation of why the match matters
 
-**Interaction Behavior:**  
+**Interaction Behavior:**
 Should feel like a regression or prior-incident signal, not a raw database lookup.
 
 #### AnalysisHistoryRow
 
-**Purpose:**  
+**Purpose:**
 Make history scannable at speed.
 
-**Usage:**  
+**Usage:**
 Primary repeated unit in the history page.
 
-**Anatomy:**  
+**Anatomy:**
 - timestamp first
 - prominent risk badge
 - compact tool icons
 - one-line top-risk summary
 - fully clickable row behavior
 
-**Priority:**  
+**Priority:**
 Scanability first, risk badge prominence second, detail only as needed.
+
+#### SkillMarketplaceCard
+
+**Purpose:**
+Make skills easy to compare by relevance and trust signals.
+
+**Usage:**
+Repeated unit in the Skills marketplace browse page.
+
+**Anatomy:**
+- skill name and short purpose
+- tool or domain badge
+- official/community/featured status
+- rating, install count, test pass rate, and last updated
+- primary install or detail action
+
+**Interaction Behavior:**
+The entire card opens the detail page. Install remains a distinct action so users do not accidentally install while browsing.
+
+#### SkillDetailPanel
+
+**Purpose:**
+Show the information needed to decide whether a skill is relevant and safe to install.
+
+**Anatomy:**
+- manifest summary
+- compatible DeployWhisper version
+- risk patterns detected by the skill
+- test scenarios and latest pass rate
+- analytics such as installs and last updated
+- maintainer, contribution, and issue links
+
+#### FindingFeedbackControl
+
+**Purpose:**
+Capture reviewer judgment on individual findings without disrupting review.
+
+**Anatomy:**
+- useful / false positive / missed risk controls
+- optional reason selector
+- optional free-text note
+- saved-state indicator
+
+**Interaction Behavior:**
+Feedback submission should be inline and reversible where possible. Detailed reason entry should be optional and should not block the main deploy decision.
+
+#### CalibrationMetricPanel
+
+**Purpose:**
+Show admins whether DeployWhisper is calibrated over time.
+
+**Anatomy:**
+- precision, recall, and F1 summary
+- severity breakdown
+- false positive and false negative trend
+- time-window selector
+- drill-down link to feedback events and deployment outcomes
+
+#### BenchmarkResultsTable
+
+**Purpose:**
+Present public benchmark outcomes with enough context to audit product claims.
+
+**Anatomy:**
+- corpus version, run date, DeployWhisper version, comparator versions
+- precision, recall, and F1 by tool and severity
+- scenario-level expected versus actual results
+- raw result download action
+- methodology link
+
+**Interaction Behavior:**
+Filters should support tool, severity, comparator, and scenario outcome. Scenario rows expand in place to show reviewer rationale and matched or missed findings.
 
 ### Component Implementation Strategy
 

--- a/docs/github-app-self-hosted-setup.md
+++ b/docs/github-app-self-hosted-setup.md
@@ -9,7 +9,7 @@ This is the recommended GitHub App model for the open-source product.
 Use this guide if you want:
 
 - Action-first as the default integration mode
-- GitHub check runs, webhook-driven PR analysis, and OAuth-backed install flow
+- GitHub check runs and webhook-driven PR analysis
 - your own DeployWhisper server to receive and analyze PR artifacts
 - no dependency on a public hosted DeployWhisper GitHub App
 
@@ -20,6 +20,7 @@ Use this guide if you want:
 - Your own DeployWhisper server fetches changed PR artifacts
 - Your own DeployWhisper server creates advisory check runs and report links
 - The app does not need to be public or listed on GitHub Marketplace
+- App creation, account or organization selection, and repository selection happen in GitHub's own Developer Settings and Install App UI
 
 ## Prerequisites
 
@@ -35,14 +36,13 @@ Set these on your DeployWhisper server:
 - `DEPLOYWHISPER_GITHUB_APP_ENABLED=true`
 - `DEPLOYWHISPER_GITHUB_APP_ID`
 - `DEPLOYWHISPER_GITHUB_APP_SLUG`
-- `DEPLOYWHISPER_GITHUB_APP_CLIENT_ID`
-- `DEPLOYWHISPER_GITHUB_APP_CLIENT_SECRET`
 - `DEPLOYWHISPER_GITHUB_APP_WEBHOOK_SECRET`
 - `DEPLOYWHISPER_GITHUB_APP_PRIVATE_KEY` or `DEPLOYWHISPER_GITHUB_APP_PRIVATE_KEY_PATH`
 - `APP_BASE_URL` or `PUBLIC_APP_URL`
 
 Optional:
 
+- `DEPLOYWHISPER_GITHUB_APP_CLIENT_ID` and `DEPLOYWHISPER_GITHUB_APP_CLIENT_SECRET` if you intentionally enable the optional OAuth helper route
 - `DEPLOYWHISPER_GITHUB_APP_PR_EVENTS_ENABLED=true`
 - `DEPLOYWHISPER_GITHUB_APP_CHECKS_ENABLED=true`
 - `DEPLOYWHISPER_GITHUB_APP_API_BASE_URL`
@@ -75,6 +75,7 @@ Recommended values:
   `https://<your-deploywhisper-base-url>`
 - Callback URL:
   `https://<your-deploywhisper-base-url>/api/v1/github/app/oauth/callback`
+- If you are not using the optional OAuth helper route, leave user authorization disabled or treat this callback URL as optional setup metadata. The normal self-hosted setup path does not require OAuth.
 - Setup URL:
   Leave blank unless you later build a dedicated install UI
 - Webhook URL:
@@ -153,14 +154,14 @@ For most teams, the recommended rollout order is:
 
 1. Start with the DeployWhisper GitHub Action
 2. Confirm your DeployWhisper instance and report links are working
-3. Add the self-hosted GitHub App only if you want richer GitHub-native checks and install flow
+3. Add the self-hosted GitHub App only if you want richer GitHub-native checks and webhook automation
 
 ## Combined mode
 
 Combined mode means:
 
 - Action handles explicit workflow execution and PR comments
-- Self-hosted GitHub App handles checks API, webhook automation, and installation UX
+- Self-hosted GitHub App handles checks API and webhook automation after installation from GitHub's UI
 
 Both still point at your own DeployWhisper server.
 
@@ -173,3 +174,15 @@ This guide does not cover:
 - a SaaS trust model where other users send PR data to a third-party hosted DeployWhisper service
 
 Those are separate product decisions and are intentionally deferred from the current open-source self-hosted deployment model.
+
+## Optional OAuth helper route
+
+The repository includes OAuth start/callback endpoints for advanced setups, but they are not required for the standard self-hosted GitHub App path. The standard path is:
+
+1. Create the GitHub App in GitHub Developer Settings
+2. Configure webhook, permissions, events, and private key
+3. Install the app from GitHub's own `Install App` UI
+4. Configure DeployWhisper environment variables
+5. Verify webhook delivery and advisory check runs
+
+Do not store GitHub client secrets, webhook secrets, private keys, or user access tokens in the application database.

--- a/docs/github-app.md
+++ b/docs/github-app.md
@@ -5,8 +5,8 @@ DeployWhisper now supports an advanced self-hosted GitHub App adapter alongside 
 ## Why this exists
 
 - Action-first mode keeps repository-local workflow ownership simple and best matches the project's local-first trust posture.
-- Advanced self-hosted GitHub App mode adds richer GitHub-native capabilities like checks, webhook-driven PR automation, and OAuth-based team installation.
-- Combined mode lets teams keep the Action for explicit workflow control while enabling their own self-hosted GitHub App for checks and installation UX.
+- Advanced self-hosted GitHub App mode adds richer GitHub-native capabilities like checks and webhook-driven PR automation while letting each team create its own GitHub App in GitHub Developer Settings.
+- Combined mode lets teams keep the Action for explicit workflow control while enabling their own self-hosted GitHub App for checks and webhook automation.
 
 ## Modes
 
@@ -19,15 +19,16 @@ DeployWhisper now supports an advanced self-hosted GitHub App adapter alongside 
 ### Advanced self-hosted GitHub App
 
 - Create a private or internal GitHub App in your own GitHub account or organization
-- Point its webhook and OAuth callback URLs at your own DeployWhisper server
+- Point its webhook URL at your own DeployWhisper server
+- Configure an OAuth callback URL only if you intentionally enable the optional OAuth helper route
 - Enable PR automation with `DEPLOYWHISPER_GITHUB_APP_PR_EVENTS_ENABLED=true`
-- Use `/api/v1/github/app/oauth/start` to begin the user authorization flow
+- Install the app into your own account or organization from GitHub's `Install App` UI
 - Follow the operator guide in [`docs/github-app-self-hosted-setup.md`](./github-app-self-hosted-setup.md)
 
 ### Combined mode
 
 - Keep the Action for explicit workflow dispatch and PR comments
-- Install your own self-hosted GitHub App for checks API integration and richer installation/auth flows
+- Install your own self-hosted GitHub App for checks API integration and webhook automation
 - Both paths still use the same DeployWhisper analysis core and persisted report/share contracts
 
 ## Positioning
@@ -43,14 +44,13 @@ The current open-source product is intentionally not positioned around a public 
 - `DEPLOYWHISPER_GITHUB_APP_ENABLED=true`
 - `DEPLOYWHISPER_GITHUB_APP_ID`
 - `DEPLOYWHISPER_GITHUB_APP_SLUG`
-- `DEPLOYWHISPER_GITHUB_APP_CLIENT_ID`
-- `DEPLOYWHISPER_GITHUB_APP_CLIENT_SECRET`
 - `DEPLOYWHISPER_GITHUB_APP_WEBHOOK_SECRET`
 - `DEPLOYWHISPER_GITHUB_APP_PRIVATE_KEY` or `DEPLOYWHISPER_GITHUB_APP_PRIVATE_KEY_PATH`
 - `APP_BASE_URL` or `PUBLIC_APP_URL`
 
 Optional:
 
+- `DEPLOYWHISPER_GITHUB_APP_CLIENT_ID` and `DEPLOYWHISPER_GITHUB_APP_CLIENT_SECRET` if you intentionally enable the optional OAuth helper route
 - `DEPLOYWHISPER_GITHUB_APP_PR_EVENTS_ENABLED=true`
 - `DEPLOYWHISPER_GITHUB_APP_CHECKS_ENABLED=true`
 - `DEPLOYWHISPER_GITHUB_APP_API_BASE_URL`
@@ -67,12 +67,15 @@ Optional:
 - Do not configure `DeployWhisper / Risk Analysis` as a required status check in branch protection
 - Shared report URLs remain the deep-link target for richer investigation
 
-## OAuth and installation flow
+## Manual installation flow
 
-1. Start the user authorization flow at `/api/v1/github/app/oauth/start`
-2. GitHub redirects back to `/api/v1/github/app/oauth/callback`
-3. DeployWhisper exchanges the code for a GitHub App user access token
-4. The callback page hands the maintainer off to the GitHub App installation URL
+1. Create the GitHub App from GitHub Developer Settings in your own account or organization
+2. Configure the webhook URL and secret to point at your own DeployWhisper server
+3. Configure the required repository permissions and pull request event subscription
+4. Generate the app private key and set the DeployWhisper environment variables
+5. Install the app from GitHub's `Install App` UI and choose the repositories it can access
+
+The optional OAuth start/callback routes are helper endpoints only. They are not required for the normal self-hosted setup path and should not be treated as a DeployWhisper-hosted app installation product.
 
 ## Operator guide
 


### PR DESCRIPTION
The readiness pass initially split GitHub App work too far toward an OAuth installation product. DeployWhisper's open-source posture is Action-first with user-owned self-hosted GitHub App setup, so the roadmap, Story 3.9, and docs now make GitHub Developer Settings / Install App UI the expected path.

Constraint: DeployWhisper is not planned as a SaaS-hosted GitHub App product

Rejected: Build an OAuth-backed hosted installation workflow | conflicts with self-hosted local-first product posture

Confidence: high

Scope-risk: narrow

Directive: Keep GitHub App setup user-owned and self-hosted unless the product strategy explicitly changes

Tested: git diff --check

Tested: ./.venv/bin/python -m unittest tests.test_services.test_github_app_service tests.test_api.test_github_app -q

## What does this PR do?

<!-- Brief description of changes -->

## Type of change
- [ ] Feature (new functionality)
- [ ] Bugfix (non-breaking fix)
- [ ] Release preparation
- [ ] Hotfix (critical production fix)
- [ ] Docs / refactor / chore

## Checklist
- [ ] I have followed the branch naming convention
- [ ] Tests pass locally (`pytest tests/ -v`)
- [ ] Linting passes (`ruff check .`)
- [ ] Docker build succeeds
- [ ] I have updated docs if needed
- [ ] No secrets or .env values committed

## Related issue
Closes #