### PR TITLE
Isolate DeployWhisper analysis state by project workspace

### DIFF
--- a/_bmad-output/implementation-artifacts/5-1-project-workspace-foundation.md
+++ b/_bmad-output/implementation-artifacts/5-1-project-workspace-foundation.md
@@ -1,0 +1,179 @@
+# Story 5.1: Project workspace foundation
+
+Status: done
+
+<!-- Note: Validation is optional. Run validate-create-story for quality check before dev-story. -->
+
+## Story
+
+As a platform admin,
+I want to create or select a lightweight project workspace before analysis,
+so that reports, topology, history, and feedback stay isolated by project or repository instead of becoming a flat global pile.
+
+## Acceptance Criteria
+
+1. Users can create a project/workspace with project key, display name, and optional description, repository URL, and default branch.
+2. Web UI requires selecting or creating a project before new manual analysis uploads.
+3. API and CLI accept `project_key` or `project_id` for new analyses and project-scoped context operations.
+4. GitHub integrations can accept an explicit project key and otherwise derive a stable default from repository name.
+5. Analysis reports, topology imports, deployment outcomes, and reviewer feedback are scoped to a project/workspace.
+6. Existing installations can map legacy records into a default or unassigned project without losing history.
+7. Scope explicitly excludes RBAC, SSO, org hierarchy, hosted SaaS scoping, and deep multi-tenant behavior.
+
+### Requirement Traceability
+
+- Primary PRD requirements: `HIS-08`, `ADM-08`, `WRK-08`
+- Supporting PRD / NFR / differentiation requirements: `HIS-03`, `HIS-06`, `CTX-06`, `NFR-SEC-01`, `NFR-SEC-03`
+- Coverage intent: `Delta`
+- Story alignment note: This story introduces the smallest useful project/workspace container so later Epic 5 context features remain isolated by project without dragging the product into enterprise tenancy or auth scope.
+
+## Tasks / Subtasks
+
+- [x] Implement AC1: project/workspace model with key, display name, and optional description, repository URL, and default branch (AC: 1)
+- [x] Implement AC2: web UI create/select project flow before manual analysis upload (AC: 2)
+- [x] Implement AC3: API and CLI support for `project_key` or `project_id` on new analysis and project-scoped context operations (AC: 3)
+- [x] Implement AC4: GitHub integration contract for explicit project key or repository-derived default (AC: 4)
+- [x] Implement AC5: scope reports, topology imports, deployment outcomes, and reviewer feedback to the selected project/workspace (AC: 5)
+- [x] Implement AC6: legacy-data migration or default/unassigned project mapping without history loss (AC: 6)
+- [x] Implement AC7: enforce non-goals so this story does not add RBAC, SSO, org hierarchy, hosted SaaS scoping, or deep multi-tenant behavior (AC: 7)
+- [x] Add deterministic tests, docs, and rollout notes covering project-scoped analysis flows and legacy mapping (AC: 1, 2, 3, 4, 5, 6, 7)
+
+### Review Findings
+
+- [x] [Review][Patch] Invalid explicit project references silently fall back to `unassigned`, so typoed `project_key`/`project_id` values can read or persist against the wrong workspace. [services/project_service.py:160]
+- [x] [Review][Patch] Conflicting `project_id` and `project_key` inputs are accepted without consistency checks, which can silently scope analysis requests to the wrong project. [services/project_service.py:174]
+- [x] [Review][Patch] GitHub repository-derived default keys ignore the owner/org segment, so repos like `acme/payments-api` and `othercorp/payments-api` collapse into the same workspace key. [services/project_service.py:168]
+- [x] [Review][Patch] The upload UI auto-selects the default workspace on first render, so users can analyze immediately without making the explicit project selection or creation that AC2 requires. [ui/components/upload_panel.py:108]
+- [x] [Review][Patch] Story 5.1 marks AC3 complete, but only analysis submission gained project parameters; project-scoped context operations are still missing from the current API and CLI surfaces. [cli/analyze.py:456]
+- [x] [Review][Patch] Project-scoped topology reads can 500 if the latest `topology_versions.payload_json` row is malformed because `_load_latest_topology_payload()` blindly calls `json.loads` without converting JSON failures into a `TopologyStatus` validation response. [services/topology_service.py:63]
+- [x] [Review][Patch] History previous-scan diff badges are keyed only by analyzed filenames, so unscoped history queries can compare unrelated projects that happened to scan the same file names. [services/report_service.py:705]
+- [x] [Review][Patch] Direct report fetches remain unscoped because `fetch_analysis_report(report_id)` ignores project identity, so guessed report IDs can still expose another workspace’s detail view and comparisons. [services/report_service.py:1072]
+- [x] [Review][Patch] The upload widget stays enabled before any project is selected or created, so AC2 is only enforced at analyze time instead of before manual uploads begin. [ui/components/upload_panel.py:436]
+- [x] [Review][Patch] Default-project topology saves write to the database before mirroring the legacy file path, so an `OSError` on the legacy write leaves the compatibility file out of sync after commit. [services/topology_service.py:337]
+- [x] [Review][Patch] `deploywhisper project` and `deploywhisper topology` accept missing subcommands and fall through to a success exit with the generic CLI banner instead of failing fast for automation callers. [cli/analyze.py:551]
+- [x] [Review][Patch] API detail fetch still exposes cross-project reports when callers omit `project_id` / `project_key`, so report scoping is optional rather than enforced. [api/routes/analyses.py:231]
+- [x] [Review][Patch] Partially invalid dual project references still succeed if one reference resolves and the other does not, so explicit scoping is not fully strict for API/CLI/context operations. [services/project_service.py:179]
+- [x] [Review][Patch] Switching the selected project after files are already uploaded preserves the pending artifacts, so users can analyze files under a different workspace than the one they uploaded them for. [ui/components/upload_panel.py:200]
+- [x] [Review][Patch] The settings page captures `active_project` at render time, so changing project before a topology upload can save topology into a stale workspace. [ui/routes/settings.py:275]
+- [x] [Review][Patch] A missing `DEPLOYWHISPER_GITHUB_PROJECT_KEY` target currently propagates out of GitHub webhook handling instead of becoming a controlled configuration error or a created project. [integrations/github/app_service.py:380]
+- [x] [Review][Patch] Changing the selected project after artifacts have already been uploaded still preserves the staged files, so users can run analysis under a different workspace than the one they uploaded the artifacts for. [ui/components/upload_panel.py:230]
+- [x] [Review][Dismiss] Public report pages still bypass workspace isolation: `/reports/{id}` fetches any report by numeric ID and `fetch_shared_analysis_report()` treats every report as shareable unless a password is configured, so a guessed report URL can expose another workspace’s report outside project context. [app.py:434] — handled intentionally by Story 3.4’s accepted public-share contract
+- [ ] [Review][Patch] Analysis list/detail project scoping is still inconsistent: `GET /api/v1/analyses` remains unscoped by default while `GET /api/v1/analyses/{id}` defaults to `unassigned`, so listed non-default reports can look missing unless the caller already knows the owning project. [api/routes/analyses.py:117]
+- [ ] [Review][Patch] The dashboard can still render an `unassigned` active result while the upload flow says no workspace is selected, creating contradictory workspace state on first load. [ui/components/upload_panel.py:197]
+
+## Dev Notes
+
+- Epic context: Context Moat (2, 15-22 (overlaps Epics 3-4), P1).
+- Epic goal: Add lightweight project/workspace isolation, automate topology discovery across supported infrastructure sources, capture deployment outcomes, and build the feedback loop. This epic turns DeployWhisper from "smart on day 1" to "measurably smarter every month" without expanding into enterprise auth or multi-tenant scope.
+- This story is intentionally closer to SonarQube's project key model than to tenancy or permissions. Keep it lightweight and operator-friendly.
+- Preserve the local-first and advisory-first posture. Project scoping is an isolation and history-organization feature, not a policy or auth feature.
+- Keep the shared-core architecture intact: UI, API, and CLI must reuse one project-aware service boundary rather than inventing per-surface project handling.
+- Existing saved analyses must remain visible through a safe default/unassigned project path rather than being dropped or silently reassigned.
+- GitHub Action runtime/package lives in the external `deploywhisper/analyze-action` repo. This app repo should implement the API/docs/integration contract for project keys and repo-derived defaults, not host action runtime code.
+- Do not add RBAC, SSO, org hierarchy, hosted SaaS scoping, or per-team permissions in this story.
+
+### Project Structure Notes
+
+- Likely implementation surfaces: `models/tables.py`, `models/repositories/`, `services/report_service.py`, `services/analysis_service.py`, `api/routes/`, `api/schemas.py`, `cli/analyze.py`, `ui/components/upload_panel.py`, `ui/routes/`, and tests under `tests/test_api`, `tests/test_services`, `tests/test_cli`, `tests/test_ui`.
+- Persist project identity through structured models and repository methods; avoid ad-hoc JSON fields for core scoping.
+- Keep project selection and project default derivation explicit in the shared service layer so UI/API/CLI/GitHub integrations stay consistent.
+
+### References
+
+- [Epics](../planning-artifacts/epics.md)
+- [PRD](../planning-artifacts/prd.md)
+- [Architecture](../planning-artifacts/architecture.md)
+- [Project Context](../project-context.md)
+- [Sprint Change Proposal](../planning-artifacts/sprint-change-proposal-2026-04-27-epic-5-project-workspace-foundation.md)
+
+## Dev Agent Record
+
+### Agent Model Used
+
+GPT-5 (Codex)
+
+### Debug Log References
+
+- 2026-04-28T14:10:00+05:30: `./.venv/bin/python -m unittest -q tests.test_services.test_project_service tests.test_services.test_topology_service tests.test_api.test_projects tests.test_api.test_analyses tests.test_cli.test_analyze tests.test_ui.test_upload_panel tests.test_services.test_report_service`
+- 2026-04-28T14:32:00+05:30: `./.venv/bin/python -m unittest -q tests.test_services.test_github_app_service tests.test_models.test_evidence_tables tests.test_infra.test_migrations tests.test_infra.test_container_contract tests.test_ui.test_upload_panel tests.test_ui.test_settings_page tests.test_ui.test_history_page tests.test_ui.test_app_shell tests.test_api.test_projects tests.test_api.test_analyses tests.test_services.test_project_service tests.test_services.test_topology_service tests.test_services.test_report_service tests.test_cli.test_analyze`
+- 2026-04-28T14:38:00+05:30: `./.venv/bin/ruff check .`
+- 2026-04-28T14:39:00+05:30: `./.venv/bin/ruff format --check .`
+- 2026-04-28T14:50:00+05:30: `./.venv/bin/python -m unittest discover -q`
+- 2026-04-28T15:02:00+05:30: `bash scripts/ci-local.sh`
+- 2026-04-28T16:10:00+05:30: `./.venv/bin/python -m unittest -q tests.test_services.test_project_service tests.test_services.test_topology_service tests.test_api.test_analyses tests.test_api.test_projects tests.test_api.test_context tests.test_cli.test_analyze tests.test_services.test_github_app_service tests.test_ui.test_upload_panel`
+- 2026-04-28T16:20:00+05:30: `./.venv/bin/ruff check .`
+- 2026-04-28T16:21:00+05:30: `./.venv/bin/ruff format --check .`
+- 2026-04-28T16:28:00+05:30: `./.venv/bin/python -m unittest discover -q`
+- 2026-04-28T16:38:00+05:30: `bash scripts/ci-local.sh`
+- 2026-04-28T17:20:00+05:30: `./.venv/bin/python -m unittest -q tests.test_services.test_topology_service tests.test_services.test_report_service tests.test_ui.test_history_page tests.test_ui.test_upload_panel tests.test_api.test_analyses tests.test_cli.test_analyze`
+- 2026-04-28T17:26:00+05:30: `./.venv/bin/ruff check .`
+- 2026-04-28T17:27:00+05:30: `./.venv/bin/ruff format --check .`
+- 2026-04-28T17:32:00+05:30: `./.venv/bin/python -m unittest discover -q`
+- 2026-04-28T17:43:00+05:30: `bash scripts/ci-local.sh`
+- 2026-04-28T18:05:00+05:30: `./.venv/bin/python -m unittest -q tests.test_services.test_project_service tests.test_ui.test_upload_panel tests.test_api.test_analyses tests.test_services.test_github_app_service tests.test_services.test_report_service tests.test_services.test_topology_service tests.test_ui.test_history_page tests.test_cli.test_analyze`
+- 2026-04-28T18:14:00+05:30: `./.venv/bin/ruff check .`
+- 2026-04-28T18:15:00+05:30: `./.venv/bin/ruff format --check .`
+- 2026-04-28T18:18:00+05:30: `./.venv/bin/python -m unittest discover -q`
+- 2026-04-28T18:29:00+05:30: `bash scripts/ci-local.sh`
+- 2026-04-28T19:05:00+05:30: `./.venv/bin/python -m unittest -q tests.test_ui.test_upload_panel tests.test_ui.test_history_page tests.test_api.test_analyses tests.test_services.test_project_service`
+- 2026-04-28T19:05:00+05:30: `./.venv/bin/ruff check ui/components/upload_panel.py tests/test_ui/test_upload_panel.py`
+- 2026-04-28T19:20:00+05:30: Story 5.1 re-review triage reconciled the remaining public-share concern against Story 3.4’s accepted `/reports/{id}` contract; no actionable 5.1 findings remained
+
+### Completion Notes List
+
+- Added first-class project/workspace persistence with migration `010_add_project_workspaces`, project-aware report scoping, per-project topology storage, and scoped placeholder tables for deployment outcomes and reviewer feedback.
+- Added shared project services plus `GET/POST /api/v1/projects`, project-aware analysis intake in the API and CLI, and project metadata on persisted report payloads and history filters.
+- Updated the dashboard upload flow to require an explicit project workspace selection or creation before manual analysis, and scoped dashboard/history/settings views to the active project context.
+- Updated the GitHub App integration to accept an explicit `DEPLOYWHISPER_GITHUB_PROJECT_KEY` override and otherwise derive a stable project key from the repository name, creating the project on demand.
+- Documented rollout and legacy-mapping behavior in `docs/project-workspaces.md`, including the compatibility path for existing reports and file-based topology.
+- Validation passed with repo-wide Ruff checks, full `unittest discover -q`, and `scripts/ci-local.sh`. Local CI still skipped Bandit because it is not installed in this environment.
+- Fixed the Story 5.1 review findings by making explicit project references fail fast, rejecting conflicting `project_id`/`project_key` inputs, switching GitHub default derivation to owner-safe keys, requiring explicit upload-project selection before manual analysis, and adding project-scoped topology context operations for the API and CLI.
+- Fixed the second Story 5.1 review pass by scoping direct report/history comparison retrieval to projects, handling malformed stored topology payloads as validation responses, failing topology legacy-mirror writes before DB commit, disabling uploads before project selection, and making `project` / `topology` CLI subcommands mandatory for automation callers.
+- Fixed the third Story 5.1 review pass by default-scoping API detail fetches to `unassigned`, rejecting partially invalid dual project references, clearing staged uploads on project switch, resolving the current project at settings-upload time, and allowing GitHub explicit project-key overrides to create or fail in a controlled way.
+- Verified the final Story 5.1 rerun finding is resolved in the live upload-panel flow: switching projects with staged artifacts clears pending uploads and requires re-upload under the newly selected workspace.
+- Re-ran code review after all patches. No actionable Story 5.1 findings remain; the only residual concern was the intentional public-share behavior introduced and accepted in Story 3.4.
+
+### File List
+
+- _bmad-output/implementation-artifacts/5-1-project-workspace-foundation.md
+- _bmad-output/implementation-artifacts/sprint-status.yaml
+- api/routes/analyses.py
+- api/routes/projects.py
+- api/routes/settings.py
+- api/schemas.py
+- app.py
+- cli/analyze.py
+- data/deploywhisper.db
+- docs/project-workspaces.md
+- integrations/github/app_service.py
+- migrations/versions/010_add_project_workspaces.py
+- models/database.py
+- models/repositories/analysis_reports.py
+- models/repositories/projects.py
+- models/tables.py
+- services/analysis_service.py
+- services/project_service.py
+- services/report_service.py
+- services/topology_service.py
+- tests/test_api/test_analyses.py
+- tests/test_api/test_context.py
+- tests/test_api/test_projects.py
+- tests/test_cli/test_analyze.py
+- tests/test_infra/test_container_contract.py
+- tests/test_infra/test_migrations.py
+- tests/test_models/test_evidence_tables.py
+- tests/test_services/test_github_app_service.py
+- tests/test_services/test_project_service.py
+- tests/test_services/test_report_service.py
+- tests/test_services/test_topology_service.py
+- tests/test_ui/test_app_shell.py
+- tests/test_ui/test_settings_page.py
+- tests/test_ui/test_upload_panel.py
+- ui/components/upload_panel.py
+- ui/routes/dashboard.py
+- ui/routes/history.py
+- ui/routes/settings.py
+
+### Change Log
+
+- 2026-04-28: Implemented project workspace foundations across persistence, UI/API/CLI intake, topology scoping, GitHub project derivation, and rollout documentation.

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -94,7 +94,7 @@ development_status:
   epic-4-retrospective: optional
 
   epic-5: in-progress
-  5-1-project-workspace-foundation: ready-for-dev
+  5-1-project-workspace-foundation: done
   5-2-topology-import-foundation: ready-for-dev
   5-3-topology-drift-detection: ready-for-dev
   5-4-topology-freshness-badge: ready-for-dev

--- a/api/routes/analyses.py
+++ b/api/routes/analyses.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import hmac
 import os
 
-from fastapi import APIRouter, Depends, File, Header, Query, UploadFile
+from fastapi import APIRouter, Depends, File, Form, Header, Query, UploadFile
 
 from api.errors import ApiError, ApiRoute
 from api.schemas import (
@@ -35,9 +35,20 @@ from services.report_service import fetch_analysis_report
 from services.report_service import fetch_filtered_analysis_history_page
 from services.report_service import configure_report_share
 from services.report_service import REPORT_SCHEMA_VERSION
+from services.project_service import ensure_default_project
 
 router = APIRouter(prefix="/api/v1/analyses", tags=["analyses"], route_class=ApiRoute)
 READ_CHUNK_BYTES = 1024 * 1024
+
+
+def _project_api_error(exc: ValueError) -> ApiError:
+    code = getattr(exc, "code", "invalid_project_request")
+    status_code = 404 if code == "project_not_found" else 400
+    return ApiError(
+        status_code=status_code,
+        code=code,
+        message=str(exc),
+    )
 
 
 def require_share_management_token(
@@ -105,19 +116,28 @@ async def _read_upload_files_with_limit(
 
 @router.get("", response_model=AnalysisListResponse)
 def list_analyses(
+    project_id: int | None = Query(default=None),
+    project_key: str | None = Query(default=None),
     severity: str | None = Query(default=None),
     recommendation: str | None = Query(default=None),
     search: str | None = Query(default=None),
     page: int = Query(default=1, ge=1),
     page_size: int = Query(default=50, ge=1, le=100),
 ) -> AnalysisListResponse:
-    page_payload = fetch_filtered_analysis_history_page(
-        severity=severity,
-        recommendation=recommendation,
-        search=search,
-        page=page,
-        page_size=page_size,
-    )
+    try:
+        if project_id is None and project_key is None:
+            project_id = ensure_default_project().id
+        page_payload = fetch_filtered_analysis_history_page(
+            project_id=project_id,
+            project_key=project_key,
+            severity=severity,
+            recommendation=recommendation,
+            search=search,
+            page=page,
+            page_size=page_size,
+        )
+    except ValueError as exc:
+        raise _project_api_error(exc) from exc
     return AnalysisListResponse(
         data=[AnalysisReportData(**report) for report in page_payload["items"]],
         meta=build_report_meta(
@@ -145,6 +165,8 @@ async def create_analysis(
     files: list[UploadFile] | None = File(
         default=None, description="Supported deployment artifacts to analyze."
     ),
+    project_id: int | None = Form(default=None),
+    project_key: str | None = Form(default=None),
     trigger_type: str | None = Header(
         default=None, alias="X-DeployWhisper-Trigger-Type"
     ),
@@ -167,14 +189,19 @@ async def create_analysis(
             details={"items": [item.model_dump() for item in pending_analysis.items]},
         )
 
-    result = analyze_uploaded_files(
-        raw_files,
-        audit_context={
-            "source_interface": "api",
-            "trigger_type": trigger_type or "api_request",
-            "trigger_id": trigger_id,
-        },
-    )
+    try:
+        result = analyze_uploaded_files(
+            raw_files,
+            project_id=project_id,
+            project_key=project_key,
+            audit_context={
+                "source_interface": "api",
+                "trigger_type": trigger_type or "api_request",
+                "trigger_id": trigger_id,
+            },
+        )
+    except ValueError as exc:
+        raise _project_api_error(exc) from exc
     advisory = build_advisory_summary(result.assessment, result.narrative)
     share_summary = build_share_summary(result.persisted_report)
     return AnalysisRunResponse(
@@ -204,8 +231,21 @@ async def create_analysis(
         500: {"model": ErrorResponse},
     },
 )
-def get_analysis(report_id: int) -> AnalysisDetailResponse:
-    report = fetch_analysis_report(report_id)
+def get_analysis(
+    report_id: int,
+    project_id: int | None = Query(default=None),
+    project_key: str | None = Query(default=None),
+) -> AnalysisDetailResponse:
+    try:
+        if project_id is None and project_key is None:
+            project_id = ensure_default_project().id
+        report = fetch_analysis_report(
+            report_id,
+            project_id=project_id,
+            project_key=project_key,
+        )
+    except ValueError as exc:
+        raise _project_api_error(exc) from exc
     if report is None:
         raise ApiError(
             status_code=404,

--- a/api/routes/projects.py
+++ b/api/routes/projects.py
@@ -1,0 +1,52 @@
+"""Project/workspace API routes."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter
+
+from api.errors import ApiError, ApiRoute
+from api.schemas import (
+    ProjectCreateRequest,
+    ProjectData,
+    ProjectListResponse,
+    ProjectResponse,
+    build_meta,
+)
+from services.project_service import (
+    ProjectResolutionError,
+    create_project,
+    list_projects,
+)
+
+router = APIRouter(prefix="/api/v1/projects", tags=["projects"], route_class=ApiRoute)
+
+
+@router.get("", response_model=ProjectListResponse)
+def get_projects() -> ProjectListResponse:
+    projects = list_projects()
+    return ProjectListResponse(
+        data=[ProjectData(**project.model_dump()) for project in projects],
+        meta=build_meta(count=len(projects)),
+    )
+
+
+@router.post("", response_model=ProjectResponse)
+def create_project_route(payload: ProjectCreateRequest) -> ProjectResponse:
+    try:
+        created = create_project(
+            project_key=payload.project_key,
+            display_name=payload.display_name,
+            description=payload.description,
+            repository_url=payload.repository_url,
+            default_branch=payload.default_branch,
+        )
+    except (ProjectResolutionError, ValueError) as exc:
+        raise ApiError(
+            status_code=400,
+            code=getattr(exc, "code", "invalid_project_request"),
+            message=str(exc),
+        ) from exc
+    return ProjectResponse(
+        data=ProjectData(**created.model_dump()),
+        meta=build_meta(id=created.id),
+    )

--- a/api/routes/settings.py
+++ b/api/routes/settings.py
@@ -1,1 +1,88 @@
-"""Settings API placeholders."""
+"""Project-scoped context API routes."""
+
+from __future__ import annotations
+
+import json
+
+from fastapi import APIRouter, Query
+
+from api.errors import ApiError, ApiRoute
+from api.schemas import (
+    ProjectData,
+    TopologyContextData,
+    TopologyContextRequest,
+    TopologyContextResponse,
+    TopologyStatusData,
+    build_meta,
+)
+from services.project_service import resolve_project_reference
+from services.topology_service import get_topology_status, save_topology_definition
+
+router = APIRouter(prefix="/api/v1/context", tags=["context"], route_class=ApiRoute)
+
+
+def _project_api_error(exc: ValueError) -> ApiError:
+    code = getattr(exc, "code", "invalid_project_request")
+    status_code = 404 if code == "project_not_found" else 400
+    return ApiError(
+        status_code=status_code,
+        code=code,
+        message=str(exc),
+    )
+
+
+def _build_topology_context_response(
+    *,
+    project_id: int | None = None,
+    project_key: str | None = None,
+) -> TopologyContextResponse:
+    try:
+        project = resolve_project_reference(
+            project_id=project_id, project_key=project_key
+        )
+    except ValueError as exc:
+        raise _project_api_error(exc) from exc
+    status = get_topology_status(project_id=project.id)
+    return TopologyContextResponse(
+        data=TopologyContextData(
+            project=ProjectData(**project.model_dump()),
+            topology=TopologyStatusData(**status.model_dump(exclude={"payload"})),
+        ),
+        meta=build_meta(),
+    )
+
+
+@router.get("/topology", response_model=TopologyContextResponse)
+def get_project_topology(
+    project_id: int | None = Query(default=None),
+    project_key: str | None = Query(default=None),
+) -> TopologyContextResponse:
+    return _build_topology_context_response(
+        project_id=project_id,
+        project_key=project_key,
+    )
+
+
+@router.post("/topology", response_model=TopologyContextResponse)
+def save_project_topology(payload: TopologyContextRequest) -> TopologyContextResponse:
+    try:
+        project = resolve_project_reference(
+            project_id=payload.project_id,
+            project_key=payload.project_key,
+        )
+    except ValueError as exc:
+        raise _project_api_error(exc) from exc
+
+    try:
+        save_topology_definition(
+            json.dumps(payload.topology),
+            project_id=project.id,
+        )
+    except ValueError as exc:
+        raise ApiError(
+            status_code=400,
+            code="invalid_topology_definition",
+            message=str(exc),
+        ) from exc
+
+    return _build_topology_context_response(project_id=project.id)

--- a/api/schemas.py
+++ b/api/schemas.py
@@ -125,6 +125,14 @@ class ResourceMetaPayload(MetaPayload):
     id: int = Field(..., description="Stable resource identifier")
 
 
+class ListMetaPayload(MetaPayload):
+    count: int = Field(..., description="Count of returned items")
+
+
+class ResourceOnlyMetaPayload(MetaPayload):
+    id: int = Field(..., description="Stable resource identifier")
+
+
 class AnalysisRunMetaPayload(MetaPayload):
     api_version: str = Field(..., description="Versioned API contract identifier")
     report_schema_version: str = Field(
@@ -178,8 +186,27 @@ class AuditMetadataData(BaseModel):
     )
 
 
+class ProjectData(BaseModel):
+    id: int = Field(..., description="Stable project/workspace identifier")
+    project_key: str = Field(..., description="Stable project/workspace key")
+    display_name: str = Field(..., description="Human-readable project name")
+    description: str | None = Field(default=None, description="Optional description")
+    repository_url: str | None = Field(
+        default=None, description="Optional repository URL"
+    )
+    default_branch: str | None = Field(
+        default=None, description="Optional default branch"
+    )
+    is_default: bool = Field(
+        default=False, description="Whether this is the legacy default workspace"
+    )
+    created_at: str = Field(..., description="Creation timestamp")
+    updated_at: str = Field(..., description="Last update timestamp")
+
+
 class PersistedReportData(BaseModel):
     id: int
+    project: ProjectData = Field(..., description="Owning project/workspace")
     risk_score: int
     severity: str
     recommendation: str
@@ -226,6 +253,68 @@ class PersistedReportData(BaseModel):
 
 class AnalysisReportData(PersistedReportData):
     pass
+
+
+class ProjectCreateRequest(BaseModel):
+    project_key: str = Field(..., description="Stable project/workspace key")
+    display_name: str = Field(..., description="Human-readable project name")
+    description: str | None = Field(default=None, description="Optional description")
+    repository_url: str | None = Field(
+        default=None, description="Optional repository URL"
+    )
+    default_branch: str | None = Field(
+        default=None, description="Optional default branch"
+    )
+
+
+class ProjectListResponse(BaseModel):
+    data: list[ProjectData]
+    meta: ListMetaPayload
+
+
+class ProjectResponse(BaseModel):
+    data: ProjectData
+    meta: ResourceOnlyMetaPayload
+
+
+class TopologyStatusData(BaseModel):
+    path: str = Field(..., description="Logical or file path for the topology source")
+    exists: bool = Field(..., description="Whether an active topology exists")
+    updated_at: str | None = Field(
+        default=None, description="Last update timestamp when available"
+    )
+    service_count: int = Field(default=0, description="Number of services")
+    dependency_count: int = Field(default=0, description="Number of dependencies")
+    resource_key_count: int = Field(
+        default=0, description="Number of resource mappings"
+    )
+    preview_services: list[str] = Field(
+        default_factory=list, description="Preview of service labels"
+    )
+    warnings: list[str] = Field(default_factory=list, description="Topology warnings")
+    blocking_errors: list[str] = Field(
+        default_factory=list, description="Blocking validation errors"
+    )
+
+
+class TopologyContextRequest(BaseModel):
+    topology: dict[str, Any] = Field(..., description="Topology JSON payload")
+    project_id: int | None = Field(
+        default=None, description="Optional numeric project identifier"
+    )
+    project_key: str | None = Field(
+        default=None, description="Optional stable project key"
+    )
+
+
+class TopologyContextData(BaseModel):
+    project: ProjectData = Field(..., description="Owning project/workspace")
+    topology: TopologyStatusData = Field(..., description="Topology status payload")
+
+
+class TopologyContextResponse(BaseModel):
+    data: TopologyContextData
+    meta: MetaPayload
 
 
 class ChangeData(BaseModel):

--- a/app.py
+++ b/app.py
@@ -25,6 +25,8 @@ from api.errors import (
 from api.routes.analyses import router as analyses_router
 from api.routes.github_app import router as github_app_router
 from api.routes.health import router as health_router
+from api.routes.projects import router as projects_router
+from api.routes.settings import router as context_router
 from api.routes.skills import router as skills_router
 from config import settings
 from logging_config import configure_logging
@@ -79,6 +81,8 @@ fastapi_app.add_exception_handler(StarletteHTTPException, http_error_envelope_ha
 fastapi_app.include_router(health_router)
 fastapi_app.include_router(analyses_router)
 fastapi_app.include_router(github_app_router)
+fastapi_app.include_router(projects_router)
+fastapi_app.include_router(context_router)
 fastapi_app.include_router(skills_router)
 
 

--- a/cli/analyze.py
+++ b/cli/analyze.py
@@ -37,12 +37,15 @@ from services.analysis_service import (
     build_advisory_summary,
     build_share_summary,
 )
+from services.project_service import create_project, list_projects
+from services.project_service import resolve_project_reference
 from services.intake_service import (
     MAX_TOTAL_UPLOAD_BYTES,
     build_pending_analysis,
     uniquify_artifact_names,
 )
 from services.report_service import REPORT_SCHEMA_VERSION
+from services.topology_service import save_topology_definition
 
 
 def _emit_json(payload: dict, *, stream) -> None:
@@ -259,7 +262,12 @@ def _run_skill_remove(skill_id: str) -> int:
     return 0
 
 
-def _run_analyze(paths: list[str]) -> int:
+def _run_analyze(
+    paths: list[str],
+    *,
+    project_id: int | None = None,
+    project_key: str | None = None,
+) -> int:
     if not paths:
         _emit_json(
             build_error(
@@ -296,6 +304,8 @@ def _run_analyze(paths: list[str]) -> int:
         ):
             result = analyze_uploaded_files(
                 raw_files,
+                project_id=project_id,
+                project_key=project_key,
                 audit_context={
                     "source_interface": "cli",
                     "trigger_type": os.getenv(
@@ -304,6 +314,15 @@ def _run_analyze(paths: list[str]) -> int:
                     "trigger_id": os.getenv("DEPLOYWHISPER_TRIGGER_ID"),
                 },
             )
+    except ValueError as exc:
+        _emit_json(
+            build_error(
+                code=getattr(exc, "code", "invalid_project_request"),
+                message=str(exc),
+            ),
+            stream=sys.stderr,
+        )
+        return 2
     except Exception as exc:  # noqa: BLE001
         _emit_json(
             build_error(
@@ -331,6 +350,99 @@ def _run_analyze(paths: list[str]) -> int:
         ),
     }
     _emit_json(payload, stream=sys.stdout)
+    return 0
+
+
+def _run_project_create(args: argparse.Namespace) -> int:
+    try:
+        created = create_project(
+            project_key=args.project_key,
+            display_name=args.display_name,
+            description=args.description,
+            repository_url=args.repository_url,
+            default_branch=args.default_branch,
+        )
+    except ValueError as exc:
+        sys.stderr.write(f"{exc}\n")
+        return 2
+    print(
+        f"Created project {created.project_key} "
+        f"({created.display_name}) [id={created.id}]"
+    )
+    return 0
+
+
+def _run_project_list() -> int:
+    projects = list_projects()
+    for project in projects:
+        suffix = " [default]" if project.is_default else ""
+        print(f"{project.project_key}: {project.display_name}{suffix}")
+    return 0
+
+
+def _run_topology_import(args: argparse.Namespace) -> int:
+    try:
+        project = resolve_project_reference(
+            project_id=args.project_id,
+            project_key=args.project_key,
+        )
+    except ValueError as exc:
+        _emit_json(
+            build_error(
+                code=getattr(exc, "code", "invalid_project_request"),
+                message=str(exc),
+            ),
+            stream=sys.stderr,
+        )
+        return 2
+
+    path = Path(args.path)
+    try:
+        raw_text = path.read_text(encoding="utf-8")
+    except OSError as exc:
+        _emit_json(
+            build_error(
+                code="topology_read_failed",
+                message="Topology file could not be read.",
+                details={"path": str(path), "reason": str(exc)},
+            ),
+            stream=sys.stderr,
+        )
+        return 2
+
+    try:
+        status = save_topology_definition(raw_text, project_id=project.id)
+    except ValueError as exc:
+        _emit_json(
+            build_error(
+                code="invalid_topology_definition",
+                message=str(exc),
+                details={"path": str(path)},
+            ),
+            stream=sys.stderr,
+        )
+        return 2
+
+    _emit_json(
+        {
+            "data": {
+                "project": project.model_dump(),
+                "topology": {
+                    "path": status.path,
+                    "exists": status.exists,
+                    "updated_at": status.updated_at,
+                    "service_count": status.service_count,
+                    "dependency_count": status.dependency_count,
+                    "resource_key_count": status.resource_key_count,
+                    "preview_services": status.preview_services,
+                    "warnings": status.warnings,
+                    "blocking_errors": status.blocking_errors,
+                },
+            },
+            "meta": build_meta(interface="cli"),
+        },
+        stream=sys.stdout,
+    )
     return 0
 
 
@@ -422,7 +534,69 @@ def build_parser() -> argparse.ArgumentParser:
         "analyze", help="Run headless advisory analysis for one or more artifacts."
     )
     analyze_parser.add_argument(
+        "--project",
+        dest="project_key",
+        help="Optional project/workspace key for the analysis.",
+    )
+    analyze_parser.add_argument(
+        "--project-id",
+        dest="project_id",
+        type=int,
+        help="Optional numeric project/workspace id for the analysis.",
+    )
+    analyze_parser.add_argument(
         "paths", nargs="*", help="Artifact file paths to analyze."
+    )
+
+    project_parser = subparsers.add_parser(
+        "project", help="Manage lightweight project/workspace records."
+    )
+    project_subparsers = project_parser.add_subparsers(dest="project_command")
+    project_subparsers.required = True
+    project_create_parser = project_subparsers.add_parser(
+        "create", help="Create a project/workspace record."
+    )
+    project_create_parser.add_argument("project_key", help="Stable project key.")
+    project_create_parser.add_argument(
+        "display_name", help="Human-readable project name."
+    )
+    project_create_parser.add_argument(
+        "--description",
+        help="Optional project description.",
+    )
+    project_create_parser.add_argument(
+        "--repository-url",
+        help="Optional repository URL.",
+    )
+    project_create_parser.add_argument(
+        "--default-branch",
+        help="Optional default branch name.",
+    )
+    project_subparsers.add_parser("list", help="List known project/workspace records.")
+
+    topology_parser = subparsers.add_parser(
+        "topology", help="Manage project-scoped topology context."
+    )
+    topology_subparsers = topology_parser.add_subparsers(dest="topology_command")
+    topology_subparsers.required = True
+    topology_import_parser = topology_subparsers.add_parser(
+        "import",
+        help="Import a topology JSON file for a project/workspace.",
+    )
+    topology_import_parser.add_argument(
+        "--project",
+        dest="project_key",
+        help="Project/workspace key for the topology import.",
+    )
+    topology_import_parser.add_argument(
+        "--project-id",
+        dest="project_id",
+        type=int,
+        help="Numeric project/workspace id for the topology import.",
+    )
+    topology_import_parser.add_argument(
+        "path",
+        help="Path to a topology JSON file.",
     )
 
     github_parser = subparsers.add_parser(
@@ -502,7 +676,19 @@ def main() -> None:
     if args.command == "skill" and args.skill_command == "remove":
         raise SystemExit(_run_skill_remove(args.skill_id))
     if args.command == "analyze":
-        raise SystemExit(_run_analyze(args.paths))
+        raise SystemExit(
+            _run_analyze(
+                args.paths,
+                project_id=getattr(args, "project_id", None),
+                project_key=getattr(args, "project_key", None),
+            )
+        )
+    if args.command == "project" and args.project_command == "create":
+        raise SystemExit(_run_project_create(args))
+    if args.command == "project" and args.project_command == "list":
+        raise SystemExit(_run_project_list())
+    if args.command == "topology" and args.topology_command == "import":
+        raise SystemExit(_run_topology_import(args))
     if args.command == "github" and args.github_command == "init":
         raise SystemExit(_run_github_init(args))
 

--- a/docs/project-workspaces.md
+++ b/docs/project-workspaces.md
@@ -1,0 +1,51 @@
+## Project Workspaces
+
+DeployWhisper now scopes analyses and topology context to lightweight project/workspace records instead of treating all history as one global pile.
+
+### What Changed
+
+- Projects have a stable `project_key`, display name, optional description, repository URL, and default branch.
+- New analyses can attach to a project through the UI, API, CLI, or GitHub integration path.
+- Persisted reports now carry project metadata and history filters can scope by project.
+- Topology uploads are stored per project, with legacy file-based topology continuing to resolve through the default `unassigned` project.
+- Deployment outcome and reviewer feedback tables now exist with project foreign keys so later Epic 5 stories can extend the same isolation boundary without schema churn.
+
+### User Flows
+
+- Web UI: choose an existing project or create one from the upload panel before running a manual analysis.
+- API:
+  - `POST /api/v1/projects` creates a project
+  - `POST /api/v1/analyses` accepts multipart `project_key` or `project_id`
+  - `GET /api/v1/context/topology?project_key=<key>` reads project-scoped topology status
+  - `POST /api/v1/context/topology` stores project-scoped topology JSON with `project_key` or `project_id`
+- CLI:
+  - `deploywhisper project create <key> <display-name>`
+  - `deploywhisper project list`
+  - `deploywhisper analyze --project <key> <artifact...>`
+  - `deploywhisper topology import --project <key> <topology.json>`
+- GitHub App integration: respects `DEPLOYWHISPER_GITHUB_PROJECT_KEY` when set; otherwise derives an owner-safe default from the full repository slug and creates it on demand.
+
+### Guardrails
+
+- Explicit `project_key` / `project_id` references now fail fast when they are unknown instead of silently falling back to `unassigned`.
+- Conflicting `project_key` and `project_id` inputs are rejected.
+- Repository-derived project keys include the owner segment when available to avoid collisions between unrelated repositories with the same leaf name.
+
+### Legacy Mapping
+
+- Existing persisted reports are backfilled into the default `unassigned` project during migration `010_add_project_workspaces`.
+- Existing file-based topology remains readable through the default project and new default-project topology updates continue to mirror the legacy file path for compatibility.
+
+### Non-Goals
+
+- No RBAC
+- No SSO
+- No org/team hierarchy
+- No hosted SaaS tenancy behavior
+
+### Verification
+
+- `./.venv/bin/ruff check .`
+- `./.venv/bin/ruff format --check .`
+- `./.venv/bin/python -m unittest discover -q`
+- `bash scripts/ci-local.sh`

--- a/integrations/github/app_service.py
+++ b/integrations/github/app_service.py
@@ -18,6 +18,7 @@ from typing import Any
 from urllib import error, parse, request
 
 from config import settings
+from services.project_service import ProjectResolutionError, resolve_project_reference
 from services.analysis_service import analyze_uploaded_files
 from services.intake_service import (
     MAX_TOTAL_UPLOAD_BYTES,
@@ -376,8 +377,23 @@ def handle_github_app_webhook(
     if config.checks_enabled:
         _require_check_run_report_url_config(config)
 
+    explicit_project_key = (
+        os.getenv("DEPLOYWHISPER_GITHUB_PROJECT_KEY") or ""
+    ).strip() or None
+    try:
+        project = resolve_project_reference(
+            project_key=explicit_project_key,
+            repository_name=f"{owner}/{repo_name}"
+            if explicit_project_key is None
+            else None,
+            allow_create=True,
+        )
+    except ProjectResolutionError as exc:
+        raise GitHubAppConfigurationError(str(exc)) from exc
+
     result = analyze_uploaded_files(
         accepted_files,
+        project_key=project.project_key,
         audit_context={
             "source_interface": "github_app",
             "trigger_type": "github_app_pull_request",

--- a/migrations/versions/010_add_project_workspaces.py
+++ b/migrations/versions/010_add_project_workspaces.py
@@ -1,0 +1,221 @@
+"""Add lightweight project/workspace scoping.
+
+Revision ID: 010_add_project_workspaces
+Revises: 009_add_report_share_settings
+Create Date: 2026-04-28
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "010_add_project_workspaces"
+down_revision = "009_add_report_share_settings"
+branch_labels = None
+depends_on = None
+
+
+def _ensure_default_project(connection) -> int:
+    existing = connection.execute(
+        sa.text("SELECT id FROM projects WHERE project_key = :project_key LIMIT 1"),
+        {"project_key": "unassigned"},
+    ).scalar()
+    if existing is not None:
+        return int(existing)
+
+    now = datetime.now(UTC).isoformat()
+    connection.execute(
+        sa.text(
+            """
+            INSERT INTO projects (
+                project_key,
+                display_name,
+                description,
+                repository_url,
+                default_branch,
+                is_default,
+                created_at,
+                updated_at
+            ) VALUES (
+                :project_key,
+                :display_name,
+                :description,
+                NULL,
+                NULL,
+                :is_default,
+                :created_at,
+                :updated_at
+            )
+            """
+        ),
+        {
+            "project_key": "unassigned",
+            "display_name": "Unassigned",
+            "description": "Legacy and unassigned analyses.",
+            "is_default": 1,
+            "created_at": now,
+            "updated_at": now,
+        },
+    )
+    created = connection.execute(
+        sa.text("SELECT id FROM projects WHERE project_key = :project_key LIMIT 1"),
+        {"project_key": "unassigned"},
+    ).scalar()
+    return int(created)
+
+
+def upgrade() -> None:
+    op.create_table(
+        "projects",
+        sa.Column("id", sa.Integer(), primary_key=True, autoincrement=True),
+        sa.Column("project_key", sa.String(length=120), nullable=False),
+        sa.Column("display_name", sa.String(length=255), nullable=False),
+        sa.Column("description", sa.Text(), nullable=True),
+        sa.Column("repository_url", sa.String(length=512), nullable=True),
+        sa.Column("default_branch", sa.String(length=120), nullable=True),
+        sa.Column(
+            "is_default", sa.Boolean(), nullable=False, server_default=sa.false()
+        ),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.UniqueConstraint("project_key", name="uq_projects_project_key"),
+    )
+    op.create_index(
+        "ix_projects_project_key", "projects", ["project_key"], unique=False
+    )
+
+    op.create_table(
+        "topology_versions",
+        sa.Column("id", sa.Integer(), primary_key=True, autoincrement=True),
+        sa.Column("project_id", sa.Integer(), nullable=False),
+        sa.Column(
+            "source_type", sa.String(length=30), nullable=False, server_default="manual"
+        ),
+        sa.Column("payload_json", sa.Text(), nullable=False, server_default="{}"),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.ForeignKeyConstraint(["project_id"], ["projects.id"], ondelete="CASCADE"),
+    )
+    op.create_index(
+        "ix_topology_versions_project_id",
+        "topology_versions",
+        ["project_id"],
+        unique=False,
+    )
+    op.create_table(
+        "deployment_outcomes",
+        sa.Column("id", sa.Integer(), primary_key=True, autoincrement=True),
+        sa.Column("project_id", sa.Integer(), nullable=False),
+        sa.Column("analysis_id", sa.Integer(), nullable=True),
+        sa.Column("environment", sa.String(length=80), nullable=True),
+        sa.Column(
+            "outcome_label",
+            sa.String(length=40),
+            nullable=False,
+            server_default="unknown",
+        ),
+        sa.Column("summary", sa.Text(), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.ForeignKeyConstraint(["project_id"], ["projects.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(
+            ["analysis_id"],
+            ["analysis_reports.id"],
+            ondelete="SET NULL",
+        ),
+    )
+    op.create_index(
+        "ix_deployment_outcomes_project_id",
+        "deployment_outcomes",
+        ["project_id"],
+        unique=False,
+    )
+    op.create_table(
+        "feedback_events",
+        sa.Column("id", sa.Integer(), primary_key=True, autoincrement=True),
+        sa.Column("project_id", sa.Integer(), nullable=False),
+        sa.Column("analysis_id", sa.Integer(), nullable=True),
+        sa.Column("reviewer_role", sa.String(length=80), nullable=True),
+        sa.Column("useful", sa.Boolean(), nullable=True),
+        sa.Column("correctness_rating", sa.Integer(), nullable=True),
+        sa.Column(
+            "false_positive_flag",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.false(),
+        ),
+        sa.Column("false_negative_note", sa.Text(), nullable=True),
+        sa.Column("outcome_label", sa.String(length=80), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.ForeignKeyConstraint(["project_id"], ["projects.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(
+            ["analysis_id"],
+            ["analysis_reports.id"],
+            ondelete="SET NULL",
+        ),
+    )
+    op.create_index(
+        "ix_feedback_events_project_id",
+        "feedback_events",
+        ["project_id"],
+        unique=False,
+    )
+
+    connection = op.get_bind()
+    default_project_id = _ensure_default_project(connection)
+
+    op.add_column(
+        "analysis_reports",
+        sa.Column("project_id", sa.Integer(), nullable=True),
+    )
+    connection.execute(
+        sa.text(
+            "UPDATE analysis_reports SET project_id = :project_id WHERE project_id IS NULL"
+        ),
+        {"project_id": default_project_id},
+    )
+    with op.batch_alter_table("analysis_reports") as batch_op:
+        batch_op.alter_column("project_id", existing_type=sa.Integer(), nullable=False)
+        batch_op.create_foreign_key(
+            "fk_analysis_reports_project_id_projects",
+            "projects",
+            ["project_id"],
+            ["id"],
+            ondelete="RESTRICT",
+        )
+        batch_op.create_index(
+            "ix_analysis_reports_project_id",
+            ["project_id"],
+            unique=False,
+        )
+
+    with op.batch_alter_table("projects") as batch_op:
+        batch_op.alter_column(
+            "is_default",
+            existing_type=sa.Boolean(),
+            server_default=None,
+        )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_feedback_events_project_id", table_name="feedback_events")
+    op.drop_table("feedback_events")
+    op.drop_index(
+        "ix_deployment_outcomes_project_id",
+        table_name="deployment_outcomes",
+    )
+    op.drop_table("deployment_outcomes")
+    with op.batch_alter_table("analysis_reports") as batch_op:
+        batch_op.drop_index("ix_analysis_reports_project_id")
+        batch_op.drop_constraint(
+            "fk_analysis_reports_project_id_projects",
+            type_="foreignkey",
+        )
+        batch_op.drop_column("project_id")
+
+    op.drop_index("ix_topology_versions_project_id", table_name="topology_versions")
+    op.drop_table("topology_versions")
+    op.drop_index("ix_projects_project_key", table_name="projects")
+    op.drop_table("projects")

--- a/models/database.py
+++ b/models/database.py
@@ -9,11 +9,27 @@ from alembic import command
 from alembic.config import Config
 from sqlalchemy import create_engine
 from sqlalchemy import event
+from sqlalchemy.engine import make_url
 from sqlalchemy import inspect
 from sqlalchemy.orm import declarative_base, sessionmaker
 
 from config import settings
 
+
+def _ensure_sqlite_parent_directory(database_url: str) -> None:
+    try:
+        url = make_url(database_url)
+    except Exception:  # noqa: BLE001
+        return
+    if url.drivername != "sqlite":
+        return
+    database = url.database or ""
+    if not database or database == ":memory:":
+        return
+    Path(database).expanduser().resolve().parent.mkdir(parents=True, exist_ok=True)
+
+
+_ensure_sqlite_parent_directory(settings.database_url)
 engine = create_engine(settings.database_url, future=True)
 _KNOWN_ALEMBIC_REVISIONS = {
     "0001_create_analysis_reports",
@@ -22,6 +38,7 @@ _KNOWN_ALEMBIC_REVISIONS = {
     "007_add_blast_radius_payload",
     "008_add_rollback_plan_payload",
     "009_add_report_share_settings",
+    "010_add_project_workspaces",
 }
 _BASELINE_TABLES = {"analysis_reports", "app_settings"}
 _EVIDENCE_TABLES = {
@@ -136,6 +153,13 @@ def _bootstrap_brownfield_revision() -> None:
             if "analysis_reports" in tables
             else set()
         )
+        if (
+            "projects" in tables
+            and "topology_versions" in tables
+            and "project_id" in report_columns
+        ):
+            _write_alembic_revision(connection, "010_add_project_workspaces")
+            return
         if {
             "report_schema_version",
             "blast_radius_json",

--- a/models/repositories/analysis_reports.py
+++ b/models/repositories/analysis_reports.py
@@ -18,7 +18,10 @@ from models.tables import (
 
 
 def _report_load_options(*, include_evidence: bool) -> list:
-    options = [selectinload(AnalysisReport.risk_assessment)]
+    options = [
+        selectinload(AnalysisReport.risk_assessment),
+        selectinload(AnalysisReport.project),
+    ]
     findings_loader = selectinload(AnalysisReport.findings)
     if include_evidence:
         findings_loader = findings_loader.selectinload(PersistedFinding.evidence_items)
@@ -29,6 +32,7 @@ def _report_load_options(*, include_evidence: bool) -> list:
 def create_analysis_report(
     session: Session,
     *,
+    project_id: int,
     risk_score: int,
     severity: str,
     recommendation: str,
@@ -58,6 +62,7 @@ def create_analysis_report(
     evidence_payload: list[dict[str, Any]] | None = None,
 ) -> AnalysisReport:
     report = AnalysisReport(
+        project_id=project_id,
         risk_score=risk_score,
         severity=severity,
         recommendation=recommendation,
@@ -210,6 +215,7 @@ def delete_analysis_report(session: Session, report_id: int) -> bool:
 def list_analysis_reports(
     session: Session,
     *,
+    project_id: int | None = None,
     severity: str | None = None,
     recommendation: str | None = None,
     search: str | None = None,
@@ -222,6 +228,8 @@ def list_analysis_reports(
         .options(*_report_load_options(include_evidence=include_evidence))
         .order_by(AnalysisReport.id.desc())
     )
+    if project_id is not None:
+        stmt = stmt.where(AnalysisReport.project_id == project_id)
     if severity:
         stmt = stmt.where(AnalysisReport.severity == severity)
     if recommendation:
@@ -244,11 +252,14 @@ def list_analysis_reports(
 def count_analysis_reports(
     session: Session,
     *,
+    project_id: int | None = None,
     severity: str | None = None,
     recommendation: str | None = None,
     search: str | None = None,
 ) -> int:
     stmt = select(func.count()).select_from(AnalysisReport)
+    if project_id is not None:
+        stmt = stmt.where(AnalysisReport.project_id == project_id)
     if severity:
         stmt = stmt.where(AnalysisReport.severity == severity)
     if recommendation:
@@ -264,19 +275,31 @@ def count_analysis_reports(
 
 
 def count_analysis_reports_by_field(
-    session: Session, field_name: str
+    session: Session,
+    field_name: str,
+    *,
+    project_id: int | None = None,
 ) -> dict[str, int]:
     column = getattr(AnalysisReport, field_name)
     stmt = select(column, func.count()).group_by(column)
+    if project_id is not None:
+        stmt = stmt.where(AnalysisReport.project_id == project_id)
     rows = session.execute(stmt).all()
     return {str(value): int(count) for value, count in rows if value is not None}
 
 
 def latest_active_dashboard_report(
-    session: Session, *, now: datetime | None = None
+    session: Session,
+    *,
+    now: datetime | None = None,
+    project_id: int | None = None,
 ) -> AnalysisReport | None:
     current_time = now or datetime.now(UTC)
-    reports = list_analysis_reports(session, include_evidence=False)
+    reports = list_analysis_reports(
+        session,
+        project_id=project_id,
+        include_evidence=False,
+    )
     for report in reports:
         duration = report.dashboard_display_duration_seconds or 0
         if duration <= 0:

--- a/models/repositories/projects.py
+++ b/models/repositories/projects.py
@@ -1,0 +1,55 @@
+"""Project/workspace repository helpers."""
+
+from __future__ import annotations
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from models.tables import Project
+
+
+def create_project(
+    session: Session,
+    *,
+    project_key: str,
+    display_name: str,
+    description: str | None = None,
+    repository_url: str | None = None,
+    default_branch: str | None = None,
+    is_default: bool = False,
+) -> Project:
+    record = Project(
+        project_key=project_key,
+        display_name=display_name,
+        description=description,
+        repository_url=repository_url,
+        default_branch=default_branch,
+        is_default=is_default,
+    )
+    session.add(record)
+    session.commit()
+    session.refresh(record)
+    return record
+
+
+def list_projects(session: Session) -> list[Project]:
+    stmt = select(Project).order_by(
+        Project.is_default.desc(), Project.project_key.asc()
+    )
+    return list(session.execute(stmt).scalars().all())
+
+
+def get_project(session: Session, project_id: int) -> Project | None:
+    return session.get(Project, project_id)
+
+
+def get_project_by_key(session: Session, project_key: str) -> Project | None:
+    stmt = select(Project).where(Project.project_key == project_key)
+    return session.execute(stmt).scalar_one_or_none()
+
+
+def get_default_project(session: Session) -> Project | None:
+    stmt = (
+        select(Project).where(Project.is_default.is_(True)).order_by(Project.id.asc())
+    )
+    return session.execute(stmt).scalars().first()

--- a/models/tables.py
+++ b/models/tables.py
@@ -38,6 +38,38 @@ if "IncidentRecord" not in globals():
         )
 
 
+if "Project" not in globals():
+
+    class Project(Base):
+        """Lightweight project/workspace scope for reports and context."""
+
+        __tablename__ = "projects"
+        __table_args__ = (
+            UniqueConstraint("project_key", name="uq_projects_project_key"),
+        )
+
+        id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+        project_key: Mapped[str] = mapped_column(String(120), index=True)
+        display_name: Mapped[str] = mapped_column(String(255))
+        description: Mapped[str | None] = mapped_column(Text, nullable=True)
+        repository_url: Mapped[str | None] = mapped_column(String(512), nullable=True)
+        default_branch: Mapped[str | None] = mapped_column(String(120), nullable=True)
+        is_default: Mapped[bool] = mapped_column(Boolean, default=False)
+        created_at: Mapped[datetime] = mapped_column(
+            DateTime(timezone=True), default=lambda: datetime.now(UTC)
+        )
+        updated_at: Mapped[datetime] = mapped_column(
+            DateTime(timezone=True),
+            default=lambda: datetime.now(UTC),
+            onupdate=lambda: datetime.now(UTC),
+        )
+        reports: Mapped[list["AnalysisReport"]] = relationship(back_populates="project")
+        topology_versions: Mapped[list["TopologyVersion"]] = relationship(
+            back_populates="project",
+            cascade="all, delete-orphan",
+        )
+
+
 if "AnalysisReport" not in globals():
 
     class AnalysisReport(Base):
@@ -46,6 +78,10 @@ if "AnalysisReport" not in globals():
         __tablename__ = "analysis_reports"
 
         id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+        project_id: Mapped[int] = mapped_column(
+            ForeignKey("projects.id", ondelete="RESTRICT"),
+            index=True,
+        )
         risk_score: Mapped[int] = mapped_column(Integer)
         severity: Mapped[str] = mapped_column(String(20))
         recommendation: Mapped[str] = mapped_column(String(20))
@@ -92,6 +128,7 @@ if "AnalysisReport" not in globals():
             cascade="all, delete-orphan",
             uselist=False,
         )
+        project: Mapped["Project"] = relationship(back_populates="reports")
         created_at: Mapped[datetime] = mapped_column(
             DateTime(timezone=True), default=lambda: datetime.now(UTC)
         )
@@ -251,4 +288,75 @@ if "ContextSnapshot" not in globals():
         )
         report: Mapped["AnalysisReport"] = relationship(
             back_populates="context_snapshot"
+        )
+
+
+if "TopologyVersion" not in globals():
+
+    class TopologyVersion(Base):
+        """Persisted topology snapshot scoped to one project."""
+
+        __tablename__ = "topology_versions"
+
+        id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+        project_id: Mapped[int] = mapped_column(
+            ForeignKey("projects.id", ondelete="CASCADE"),
+            index=True,
+        )
+        source_type: Mapped[str] = mapped_column(String(30), default="manual")
+        payload_json: Mapped[str] = mapped_column(Text, default="{}")
+        created_at: Mapped[datetime] = mapped_column(
+            DateTime(timezone=True), default=lambda: datetime.now(UTC)
+        )
+        project: Mapped["Project"] = relationship(back_populates="topology_versions")
+
+
+if "DeploymentOutcome" not in globals():
+
+    class DeploymentOutcome(Base):
+        """Persisted deployment outcome scoped to one project."""
+
+        __tablename__ = "deployment_outcomes"
+
+        id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+        project_id: Mapped[int] = mapped_column(
+            ForeignKey("projects.id", ondelete="CASCADE"),
+            index=True,
+        )
+        analysis_id: Mapped[int | None] = mapped_column(
+            ForeignKey("analysis_reports.id", ondelete="SET NULL"),
+            nullable=True,
+        )
+        environment: Mapped[str | None] = mapped_column(String(80), nullable=True)
+        outcome_label: Mapped[str] = mapped_column(String(40), default="unknown")
+        summary: Mapped[str | None] = mapped_column(Text, nullable=True)
+        created_at: Mapped[datetime] = mapped_column(
+            DateTime(timezone=True), default=lambda: datetime.now(UTC)
+        )
+
+
+if "FeedbackEvent" not in globals():
+
+    class FeedbackEvent(Base):
+        """Persisted reviewer feedback event scoped to one project."""
+
+        __tablename__ = "feedback_events"
+
+        id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+        project_id: Mapped[int] = mapped_column(
+            ForeignKey("projects.id", ondelete="CASCADE"),
+            index=True,
+        )
+        analysis_id: Mapped[int | None] = mapped_column(
+            ForeignKey("analysis_reports.id", ondelete="SET NULL"),
+            nullable=True,
+        )
+        reviewer_role: Mapped[str | None] = mapped_column(String(80), nullable=True)
+        useful: Mapped[bool | None] = mapped_column(Boolean, nullable=True)
+        correctness_rating: Mapped[int | None] = mapped_column(Integer, nullable=True)
+        false_positive_flag: Mapped[bool] = mapped_column(Boolean, default=False)
+        false_negative_note: Mapped[str | None] = mapped_column(Text, nullable=True)
+        outcome_label: Mapped[str | None] = mapped_column(String(80), nullable=True)
+        created_at: Mapped[datetime] = mapped_column(
+            DateTime(timezone=True), default=lambda: datetime.now(UTC)
         )

--- a/services/analysis_service.py
+++ b/services/analysis_service.py
@@ -222,8 +222,16 @@ def _parser_success_by_tool(parse_batch: ParseBatchResult) -> dict[str, float]:
     }
 
 
-def _build_context_completeness(parse_batch: ParseBatchResult) -> ContextCompleteness:
-    topology_status = get_topology_status()
+def _build_context_completeness(
+    parse_batch: ParseBatchResult,
+    *,
+    project_id: int | None = None,
+    project_key: str | None = None,
+) -> ContextCompleteness:
+    topology_status = get_topology_status(
+        project_id=project_id,
+        project_key=project_key,
+    )
     topology_freshness_days = _topology_freshness_days(topology_status.updated_at)
     incident_index_size = len(load_incident_candidates())
     parser_success_rate = round(
@@ -616,13 +624,19 @@ def build_share_summary(report: dict) -> ShareSummary:
 
 def build_analysis_artifacts(
     files: list[tuple[str, bytes | None]],
+    *,
+    project_id: int | None = None,
+    project_key: str | None = None,
     completion_client=None,
 ) -> AnalysisArtifacts:
     """Build all analysis artifacts up to, but not including, persistence."""
     parse_batch = build_parse_batch(files)
     evidence_items = extract_batch_evidence(parse_batch)
     changes = _collect_changes(parse_batch)
-    topology, topology_warning = load_topology()
+    topology, topology_warning = load_topology(
+        project_id=project_id,
+        project_key=project_key,
+    )
     assessment = evaluate_parse_batch(
         parse_batch,
         evidence_items=evidence_items,
@@ -630,7 +644,11 @@ def build_analysis_artifacts(
         raw_files={name: raw_content for name, raw_content in files},
         completion_client=completion_client,
     )
-    assessment.context_completeness = _build_context_completeness(parse_batch)
+    assessment.context_completeness = _build_context_completeness(
+        parse_batch,
+        project_id=project_id,
+        project_key=project_key,
+    )
     findings = build_findings(
         assessment=assessment,
         evidence_items=evidence_items,
@@ -664,10 +682,17 @@ def build_analysis_artifacts(
 def analyze_uploaded_files(
     files: list[tuple[str, bytes | None]],
     completion_client=None,
+    project_id: int | None = None,
+    project_key: str | None = None,
     audit_context: dict | None = None,
 ) -> AnalysisRunResult:
     """Run the shared parse -> assess -> persist pipeline."""
-    artifacts = build_analysis_artifacts(files, completion_client=completion_client)
+    artifacts = build_analysis_artifacts(
+        files,
+        project_id=project_id,
+        project_key=project_key,
+        completion_client=completion_client,
+    )
     persisted_report = persist_analysis_report(
         artifacts.parse_batch,
         artifacts.assessment,
@@ -677,6 +702,8 @@ def analyze_uploaded_files(
         findings=artifacts.findings,
         evidence_items=artifacts.evidence_items,
         artifact_snapshots={name: raw_content for name, raw_content in files},
+        project_id=project_id,
+        project_key=project_key,
         audit_context=audit_context,
     )
     return AnalysisRunResult(

--- a/services/project_service.py
+++ b/services/project_service.py
@@ -207,7 +207,11 @@ def resolve_project_reference(
                 "project_not_found",
                 f"Unknown project reference: {detail}.",
             )
-        if normalized_key is not None and record_by_key is None and project_id is not None:
+        if (
+            normalized_key is not None
+            and record_by_key is None
+            and project_id is not None
+        ):
             raise ProjectResolutionError(
                 "project_not_found",
                 f"Unknown project reference: project_id={project_id}, project_key={normalized_key}.",

--- a/services/project_service.py
+++ b/services/project_service.py
@@ -1,0 +1,293 @@
+"""Shared project/workspace service helpers."""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+from pydantic import BaseModel
+from sqlalchemy.exc import OperationalError
+
+from models.database import SessionLocal, init_db
+from models.repositories.projects import (
+    create_project as create_project_record,
+    get_default_project,
+    get_project,
+    get_project_by_key,
+    list_projects as list_project_records,
+)
+from models.repositories.settings import get_setting, upsert_setting
+
+DEFAULT_PROJECT_KEY = "unassigned"
+DEFAULT_PROJECT_NAME = "Unassigned"
+ACTIVE_PROJECT_SETTING_KEY = "active_project_id"
+_PROJECT_KEY_PATTERN = re.compile(r"[^a-z0-9]+")
+
+
+class ProjectResolutionError(ValueError):
+    """Raised when a project reference is invalid or ambiguous."""
+
+    def __init__(self, code: str, message: str) -> None:
+        super().__init__(message)
+        self.code = code
+        self.message = message
+
+
+class ProjectRecord(BaseModel):
+    id: int
+    project_key: str
+    display_name: str
+    description: str | None = None
+    repository_url: str | None = None
+    default_branch: str | None = None
+    is_default: bool = False
+    created_at: str
+    updated_at: str
+
+
+def _serialize(record) -> ProjectRecord:
+    created_at = record.created_at.isoformat()
+    updated_at = record.updated_at.isoformat()
+    return ProjectRecord(
+        id=record.id,
+        project_key=record.project_key,
+        display_name=record.display_name,
+        description=record.description,
+        repository_url=record.repository_url,
+        default_branch=record.default_branch,
+        is_default=record.is_default,
+        created_at=created_at,
+        updated_at=updated_at,
+    )
+
+
+def normalize_project_key(value: str) -> str:
+    normalized = _PROJECT_KEY_PATTERN.sub("-", value.strip().lower()).strip("-")
+    normalized = re.sub(r"-{2,}", "-", normalized)
+    if not normalized:
+        raise ValueError("Project key must contain at least one letter or number.")
+    return normalized
+
+
+def _display_name_from_key(project_key: str) -> str:
+    parts = [part for part in project_key.replace("_", "-").split("-") if part]
+    if not parts:
+        return DEFAULT_PROJECT_NAME
+    words: list[str] = []
+    for part in parts:
+        if len(part) <= 3:
+            words.append(part.upper())
+        else:
+            words.append(part.capitalize())
+    return " ".join(words)
+
+
+def derive_project_key_from_repository(repository_name: str) -> str:
+    trimmed = str(repository_name or "").strip().rstrip("/")
+    if trimmed.endswith(".git"):
+        trimmed = trimmed[:-4]
+    if "/" not in trimmed:
+        return normalize_project_key(trimmed)
+    owner, leaf = trimmed.split("/", maxsplit=1)
+    return normalize_project_key(f"{owner}-{leaf}")
+
+
+def display_name_from_repository(repository_name: str) -> str:
+    trimmed = str(repository_name or "").strip().rstrip("/")
+    if trimmed.endswith(".git"):
+        trimmed = trimmed[:-4]
+    leaf = trimmed.split("/")[-1]
+    return _display_name_from_key(leaf or trimmed)
+
+
+def ensure_default_project() -> ProjectRecord:
+    try:
+        with SessionLocal() as session:
+            default_project = get_default_project(session)
+            if default_project is None:
+                default_project = create_project_record(
+                    session,
+                    project_key=DEFAULT_PROJECT_KEY,
+                    display_name=DEFAULT_PROJECT_NAME,
+                    description="Legacy and unassigned analyses.",
+                    is_default=True,
+                )
+            return _serialize(default_project)
+    except OperationalError as exc:
+        if "no such table: projects" not in str(exc).lower():
+            raise
+        init_db()
+        with SessionLocal() as session:
+            default_project = get_default_project(session)
+            if default_project is None:
+                default_project = create_project_record(
+                    session,
+                    project_key=DEFAULT_PROJECT_KEY,
+                    display_name=DEFAULT_PROJECT_NAME,
+                    description="Legacy and unassigned analyses.",
+                    is_default=True,
+                )
+            return _serialize(default_project)
+
+
+def create_project(
+    *,
+    project_key: str,
+    display_name: str,
+    description: str | None = None,
+    repository_url: str | None = None,
+    default_branch: str | None = None,
+) -> ProjectRecord:
+    normalized_key = normalize_project_key(project_key)
+    normalized_display_name = str(display_name or "").strip()
+    if not normalized_display_name:
+        raise ValueError("Display name is required.")
+    with SessionLocal() as session:
+        existing = get_project_by_key(session, normalized_key)
+        if existing is not None:
+            raise ValueError(f"Project key already exists: {normalized_key}")
+        created = create_project_record(
+            session,
+            project_key=normalized_key,
+            display_name=normalized_display_name,
+            description=(description or None),
+            repository_url=(repository_url or None),
+            default_branch=(default_branch or None),
+            is_default=False,
+        )
+        return _serialize(created)
+
+
+def list_projects() -> list[ProjectRecord]:
+    ensure_default_project()
+    with SessionLocal() as session:
+        return [_serialize(record) for record in list_project_records(session)]
+
+
+def get_project_by_id(project_id: int) -> ProjectRecord | None:
+    with SessionLocal() as session:
+        record = get_project(session, project_id)
+        return _serialize(record) if record is not None else None
+
+
+def get_project_by_project_key(project_key: str) -> ProjectRecord | None:
+    with SessionLocal() as session:
+        record = get_project_by_key(session, normalize_project_key(project_key))
+        return _serialize(record) if record is not None else None
+
+
+def resolve_project_reference(
+    *,
+    project_id: int | None = None,
+    project_key: str | None = None,
+    repository_name: str | None = None,
+    allow_create: bool = False,
+) -> ProjectRecord:
+    ensure_default_project()
+    normalized_key = normalize_project_key(project_key) if project_key else None
+    derived_key = (
+        derive_project_key_from_repository(repository_name) if repository_name else None
+    )
+    with SessionLocal() as session:
+        record_by_id = (
+            get_project(session, project_id) if project_id is not None else None
+        )
+        record_by_key = (
+            get_project_by_key(session, normalized_key)
+            if normalized_key is not None
+            else None
+        )
+        if project_id is not None and record_by_id is None:
+            detail = (
+                f"project_id={project_id}, project_key={normalized_key}"
+                if normalized_key is not None
+                else f"project_id={project_id}"
+            )
+            raise ProjectResolutionError(
+                "project_not_found",
+                f"Unknown project reference: {detail}.",
+            )
+        if normalized_key is not None and record_by_key is None and project_id is not None:
+            raise ProjectResolutionError(
+                "project_not_found",
+                f"Unknown project reference: project_id={project_id}, project_key={normalized_key}.",
+            )
+        if (
+            record_by_id is not None
+            and record_by_key is not None
+            and record_by_id.id != record_by_key.id
+        ):
+            raise ProjectResolutionError(
+                "conflicting_project_reference",
+                "The supplied project_id and project_key refer to different projects.",
+            )
+
+        record = record_by_id or record_by_key
+        if record is None and derived_key is not None:
+            record = get_project_by_key(session, derived_key)
+
+        if record is None and allow_create:
+            if normalized_key is not None:
+                record = create_project_record(
+                    session,
+                    project_key=normalized_key,
+                    display_name=_display_name_from_key(normalized_key),
+                )
+            elif derived_key is not None:
+                record = create_project_record(
+                    session,
+                    project_key=derived_key,
+                    display_name=display_name_from_repository(
+                        repository_name or derived_key
+                    ),
+                    repository_url=repository_name,
+                )
+        elif record is None and (project_id is not None or normalized_key is not None):
+            detail = (
+                f"project_id={project_id}"
+                if project_id is not None and normalized_key is None
+                else f"project_key={normalized_key}"
+                if normalized_key is not None and project_id is None
+                else f"project_id={project_id}, project_key={normalized_key}"
+            )
+            raise ProjectResolutionError(
+                "project_not_found",
+                f"Unknown project reference: {detail}.",
+            )
+        if record is None:
+            default_record = get_default_project(session)
+            if default_record is None:
+                raise RuntimeError("Default project could not be resolved.")
+            record = default_record
+        return _serialize(record)
+
+
+def set_active_project(project_id: int) -> ProjectRecord:
+    project = resolve_project_reference(project_id=project_id)
+    with SessionLocal() as session:
+        upsert_setting(session, key=ACTIVE_PROJECT_SETTING_KEY, value=str(project.id))
+    return project
+
+
+def get_active_project() -> ProjectRecord | None:
+    ensure_default_project()
+    with SessionLocal() as session:
+        setting = get_setting(session, ACTIVE_PROJECT_SETTING_KEY)
+        if setting is None:
+            return _serialize(get_default_project(session))
+        record = get_project(session, int(setting.value))
+        if record is None:
+            return _serialize(get_default_project(session))
+        return _serialize(record)
+
+
+def has_active_project_selection() -> bool:
+    ensure_default_project()
+    with SessionLocal() as session:
+        return get_setting(session, ACTIVE_PROJECT_SETTING_KEY) is not None
+
+
+def build_project_payload(project: ProjectRecord | dict[str, Any]) -> dict[str, Any]:
+    if isinstance(project, ProjectRecord):
+        return project.model_dump()
+    return dict(project)

--- a/services/report_service.py
+++ b/services/report_service.py
@@ -34,6 +34,10 @@ from services.artifact_snapshot_service import (
     delete_report_artifacts,
     save_report_artifacts,
 )
+from services.project_service import (
+    build_project_payload,
+    resolve_project_reference,
+)
 from services.settings_service import get_dashboard_result_display_duration_seconds
 from services.settings_service import resolve_provider_runtime
 
@@ -43,6 +47,19 @@ _SEVERITY_PREFIX_PATTERN = re.compile(
     r"^\s*(critical|high|medium|low|info|warning|caution)\s*[:\-]\s*",
     flags=re.IGNORECASE,
 )
+
+
+def _resolve_project_id(
+    *,
+    project_id: int | None = None,
+    project_key: str | None = None,
+) -> int | None:
+    if project_id is None and project_key is None:
+        return None
+    return resolve_project_reference(
+        project_id=project_id,
+        project_key=project_key,
+    ).id
 
 
 def build_share_report_link(report_id: int | None) -> str | None:
@@ -224,6 +241,16 @@ def _default_rollback_plan_payload() -> dict[str, Any]:
 def _artifact_signature(files_analyzed: list[str]) -> tuple[str, ...]:
     """Normalize analyzed-file identity for history diff grouping."""
     return tuple(sorted(str(name) for name in files_analyzed if str(name).strip()))
+
+
+def _history_signature(report: dict[str, Any]) -> tuple[int, tuple[str, ...]] | None:
+    artifact_signature = _artifact_signature(
+        report.get("audit", {}).get("files_analyzed") or []
+    )
+    if not artifact_signature:
+        return None
+    project_id = int(report.get("project", {}).get("id") or 0)
+    return (project_id, artifact_signature)
 
 
 def _normalize_free_text(value: Any) -> str:
@@ -533,11 +560,13 @@ def _find_previous_comparable_report(
     if not current_signature:
         return None
     current_id = int(current_report["id"])
+    current_project_id = int(current_report.get("project", {}).get("id") or 0)
     previous_candidates = sorted(
         (
             report
             for report in candidate_reports
             if int(report["id"]) < current_id
+            and int(report.get("project", {}).get("id") or 0) == current_project_id
             and _artifact_signature(report.get("audit", {}).get("files_analyzed") or [])
             == current_signature
         ),
@@ -562,13 +591,23 @@ def _list_serialized_reports(*, include_evidence: bool) -> list[dict[str, Any]]:
 def fetch_previous_comparable_report(
     report_id: int,
     *,
+    project_id: int | None = None,
+    project_key: str | None = None,
     previous_report_id: int | None = None,
 ) -> dict | None:
-    current_report = fetch_analysis_report(report_id)
+    current_report = fetch_analysis_report(
+        report_id,
+        project_id=project_id,
+        project_key=project_key,
+    )
     if current_report is None:
         return None
     if previous_report_id is not None:
-        return fetch_analysis_report(previous_report_id)
+        return fetch_analysis_report(
+            previous_report_id,
+            project_id=project_id,
+            project_key=project_key,
+        )
     serialized_reports = _list_serialized_reports(include_evidence=False)
     return _find_previous_comparable_report(current_report, serialized_reports)
 
@@ -688,13 +727,11 @@ def _attach_previous_scan_diffs(
     all_reports: list[dict[str, Any]],
 ) -> list[dict[str, Any]]:
     """Annotate history rows with diff metadata for the previous scan of the same files."""
-    latest_by_signature: dict[tuple[str, ...], dict[str, Any]] = {}
+    latest_by_signature: dict[tuple[int, tuple[str, ...]], dict[str, Any]] = {}
     previous_by_id: dict[int, dict[str, Any]] = {}
 
     for report in reversed(all_reports):
-        signature = _artifact_signature(
-            report.get("audit", {}).get("files_analyzed") or []
-        )
+        signature = _history_signature(report)
         if signature:
             previous = latest_by_signature.get(signature)
             if previous is not None:
@@ -876,6 +913,19 @@ def _serialize_report(report, *, include_evidence: bool = True) -> dict:
     )
     return {
         "id": report.id,
+        "project": build_project_payload(
+            {
+                "id": report.project.id,
+                "project_key": report.project.project_key,
+                "display_name": report.project.display_name,
+                "description": report.project.description,
+                "repository_url": report.project.repository_url,
+                "default_branch": report.project.default_branch,
+                "is_default": report.project.is_default,
+                "created_at": report.project.created_at.isoformat(),
+                "updated_at": report.project.updated_at.isoformat(),
+            }
+        ),
         "risk_score": report.risk_score,
         "severity": report.severity,
         "recommendation": report.recommendation,
@@ -953,6 +1003,8 @@ def persist_analysis_report(
     findings: list[Finding] | None = None,
     evidence_items: list[EvidenceItem] | None = None,
     artifact_snapshots: dict[str, bytes | None] | None = None,
+    project_id: int | None = None,
+    project_key: str | None = None,
     audit_context: dict[str, Any] | None = None,
 ) -> dict:
     """Persist the completed analysis before the UI treats it as final."""
@@ -963,6 +1015,10 @@ def persist_analysis_report(
     )
     audit = _build_audit_metadata(parse_batch, audit_context=audit_context)
     combined_warnings = list(dict.fromkeys([*assessment.warnings, *narrative.warnings]))
+    resolved_project = resolve_project_reference(
+        project_id=project_id,
+        project_key=project_key,
+    )
     dashboard_display_duration_seconds = None
     if (
         audit.get("source_interface") == "ui"
@@ -976,6 +1032,7 @@ def persist_analysis_report(
         with SessionLocal() as session:
             report = create_analysis_report(
                 session,
+                project_id=resolved_project.id,
                 risk_score=assessment.score,
                 severity=assessment.severity,
                 recommendation=assessment.recommendation,
@@ -1030,11 +1087,22 @@ def persist_analysis_report(
     return _run_with_schema_retry(operation)
 
 
-def fetch_analysis_report(report_id: int) -> dict | None:
+def fetch_analysis_report(
+    report_id: int,
+    *,
+    project_id: int | None = None,
+    project_key: str | None = None,
+) -> dict | None:
+    scoped_project_id = _resolve_project_id(
+        project_id=project_id, project_key=project_key
+    )
+
     def operation():
         with SessionLocal() as session:
             report = get_analysis_report(session, report_id, include_evidence=True)
             if report is None:
+                return None
+            if scoped_project_id is not None and report.project_id != scoped_project_id:
                 return None
             return _serialize_report(report, include_evidence=True)
 
@@ -1044,19 +1112,31 @@ def fetch_analysis_report(report_id: int) -> dict | None:
 def fetch_report_comparison(
     report_id: int,
     *,
+    project_id: int | None = None,
+    project_key: str | None = None,
     previous_report_id: int | None = None,
 ) -> dict | None:
-    current_report = fetch_analysis_report(report_id)
+    current_report = fetch_analysis_report(
+        report_id,
+        project_id=project_id,
+        project_key=project_key,
+    )
     if current_report is None:
         return None
     previous_report = fetch_previous_comparable_report(
         report_id,
+        project_id=project_id,
+        project_key=project_key,
         previous_report_id=previous_report_id,
     )
     if previous_report is None:
         return None
     if previous_report_id is None:
-        previous_report = fetch_analysis_report(int(previous_report["id"]))
+        previous_report = fetch_analysis_report(
+            int(previous_report["id"]),
+            project_id=project_id,
+            project_key=project_key,
+        )
         if previous_report is None:
             return None
     return _build_report_comparison(current_report, previous_report)
@@ -1170,11 +1250,15 @@ def fetch_analysis_history() -> list[dict]:
 
 def fetch_filtered_analysis_history(
     *,
+    project_id: int | None = None,
+    project_key: str | None = None,
     severity: str | None = None,
     recommendation: str | None = None,
     search: str | None = None,
 ) -> list[dict]:
     page = fetch_filtered_analysis_history_page(
+        project_id=project_id,
+        project_key=project_key,
         severity=severity,
         recommendation=recommendation,
         search=search,
@@ -1184,6 +1268,8 @@ def fetch_filtered_analysis_history(
 
 def fetch_filtered_analysis_history_page(
     *,
+    project_id: int | None = None,
+    project_key: str | None = None,
     severity: str | None = None,
     recommendation: str | None = None,
     search: str | None = None,
@@ -1193,11 +1279,16 @@ def fetch_filtered_analysis_history_page(
     page = max(page, 1)
     page_size = max(1, min(page_size, 100))
     offset = (page - 1) * page_size
+    resolved_project_id = _resolve_project_id(
+        project_id=project_id,
+        project_key=project_key,
+    )
 
     def operation():
         with SessionLocal() as session:
             reports = list_analysis_reports(
                 session,
+                project_id=resolved_project_id,
                 severity=severity,
                 recommendation=recommendation,
                 search=search,
@@ -1205,9 +1296,14 @@ def fetch_filtered_analysis_history_page(
                 offset=offset,
                 include_evidence=False,
             )
-            all_reports = list_analysis_reports(session, include_evidence=False)
+            all_reports = list_analysis_reports(
+                session,
+                project_id=resolved_project_id,
+                include_evidence=False,
+            )
             total_count = count_analysis_reports(
                 session,
+                project_id=resolved_project_id,
                 severity=severity,
                 recommendation=recommendation,
                 search=search,
@@ -1233,21 +1329,41 @@ def fetch_filtered_analysis_history_page(
     }
 
 
-def fetch_risk_trends() -> dict:
+def fetch_risk_trends(
+    *,
+    project_id: int | None = None,
+    project_key: str | None = None,
+) -> dict:
     """Return high-signal trend summaries over stored reports."""
     trend_sample_size = 100
+    resolved_project_id = _resolve_project_id(
+        project_id=project_id,
+        project_key=project_key,
+    )
 
     def operation():
         with SessionLocal() as session:
             reports = list_analysis_reports(
-                session, limit=trend_sample_size, include_evidence=False
+                session,
+                project_id=resolved_project_id,
+                limit=trend_sample_size,
+                include_evidence=False,
             )
             return {
                 "reports": reports,
-                "total_reports": count_analysis_reports(session),
-                "severity_counts": count_analysis_reports_by_field(session, "severity"),
+                "total_reports": count_analysis_reports(
+                    session,
+                    project_id=resolved_project_id,
+                ),
+                "severity_counts": count_analysis_reports_by_field(
+                    session,
+                    "severity",
+                    project_id=resolved_project_id,
+                ),
                 "recommendation_counts": count_analysis_reports_by_field(
-                    session, "recommendation"
+                    session,
+                    "recommendation",
+                    project_id=resolved_project_id,
                 ),
             }
 
@@ -1289,12 +1405,24 @@ def fetch_risk_trends() -> dict:
     }
 
 
-def fetch_dashboard_stats() -> dict:
+def fetch_dashboard_stats(
+    *,
+    project_id: int | None = None,
+    project_key: str | None = None,
+) -> dict:
     """Return dashboard-friendly aggregate metrics for the latest persisted analyses."""
+    resolved_project_id = _resolve_project_id(
+        project_id=project_id,
+        project_key=project_key,
+    )
 
     def operation():
         with SessionLocal() as session:
-            return list_analysis_reports(session, include_evidence=False)
+            return list_analysis_reports(
+                session,
+                project_id=resolved_project_id,
+                include_evidence=False,
+            )
 
     reports = _run_with_schema_retry(operation)
 
@@ -1315,18 +1443,30 @@ def fetch_dashboard_stats() -> dict:
     }
 
 
-def fetch_dashboard_briefing() -> dict[str, Any]:
+def fetch_dashboard_briefing(
+    *,
+    project_id: int | None = None,
+    project_key: str | None = None,
+) -> dict[str, Any]:
     """Return dashboard hero metrics and latest-scan context from persisted reports."""
+    resolved_project_id = _resolve_project_id(
+        project_id=project_id,
+        project_key=project_key,
+    )
 
     def operation():
         with SessionLocal() as session:
             return [
                 _serialize_report(report, include_evidence=False)
-                for report in list_analysis_reports(session, include_evidence=False)
+                for report in list_analysis_reports(
+                    session,
+                    project_id=resolved_project_id,
+                    include_evidence=False,
+                )
             ]
 
     serialized_reports = _run_with_schema_retry(operation)
-    stats = fetch_dashboard_stats()
+    stats = fetch_dashboard_stats(project_id=resolved_project_id)
     severity_counts = stats["severity_counts"]
     saved_briefings = len(serialized_reports)
     high_focus = severity_counts["high"] + severity_counts["critical"]
@@ -1374,13 +1514,26 @@ def fetch_dashboard_briefing() -> dict[str, Any]:
     }
 
 
-def fetch_active_dashboard_report(*, now: datetime | None = None) -> dict | None:
+def fetch_active_dashboard_report(
+    *,
+    now: datetime | None = None,
+    project_id: int | None = None,
+    project_key: str | None = None,
+) -> dict | None:
     """Return the most recent dashboard result still within its configured visibility window."""
     current_time = now or datetime.now(UTC)
+    resolved_project_id = _resolve_project_id(
+        project_id=project_id,
+        project_key=project_key,
+    )
 
     def operation():
         with SessionLocal() as session:
-            report = latest_active_dashboard_report(session, now=current_time)
+            report = latest_active_dashboard_report(
+                session,
+                now=current_time,
+                project_id=resolved_project_id,
+            )
             if report is None:
                 return None
             detailed_report = get_analysis_report(

--- a/services/topology_service.py
+++ b/services/topology_service.py
@@ -10,6 +10,9 @@ from pathlib import Path
 from pydantic import BaseModel, Field
 
 from config import settings
+from models.database import SessionLocal
+from models.tables import TopologyVersion
+from services.project_service import build_project_payload, resolve_project_reference
 
 STALE_AFTER_DAYS = 30
 
@@ -51,6 +54,87 @@ class TopologyStatus(BaseModel):
 
 def _topology_path() -> Path:
     return Path(settings.topology_path)
+
+
+def _topology_scope_path(project: dict) -> Path:
+    return Path(f"project://{project['project_key']}/topology/latest")
+
+
+def _invalid_stored_topology_status(path: Path, message: str) -> TopologyStatus:
+    return TopologyStatus(
+        path=str(path),
+        exists=True,
+        blocking_errors=[message],
+    )
+
+
+def _load_latest_topology_payload(
+    project: dict,
+) -> tuple[dict | None, Path, TopologyStatus | None]:
+    topology_path = _topology_scope_path(project)
+    with SessionLocal() as session:
+        record = (
+            session.query(TopologyVersion)
+            .filter(TopologyVersion.project_id == int(project["id"]))
+            .order_by(TopologyVersion.id.desc())
+            .first()
+        )
+        if record is None:
+            if bool(project.get("is_default")):
+                legacy_status = _read_legacy_topology_status()
+                if legacy_status is not None:
+                    return (
+                        legacy_status.payload,
+                        Path(legacy_status.path),
+                        legacy_status,
+                    )
+            return None, topology_path, None
+        try:
+            payload = json.loads(record.payload_json or "{}")
+        except JSONDecodeError:
+            return (
+                None,
+                topology_path,
+                _invalid_stored_topology_status(
+                    topology_path,
+                    "Topology validation failed — stored topology JSON is invalid.",
+                ),
+            )
+        if not isinstance(payload, dict):
+            return (
+                None,
+                topology_path,
+                _invalid_stored_topology_status(
+                    topology_path,
+                    "Topology validation failed — stored topology must be a JSON object.",
+                ),
+            )
+        return payload, topology_path, None
+
+
+def _read_legacy_topology_status() -> TopologyStatus | None:
+    legacy_path = _topology_path()
+    if not legacy_path.exists():
+        return None
+    try:
+        payload = json.loads(legacy_path.read_text(encoding="utf-8"))
+    except (OSError, JSONDecodeError):
+        return TopologyStatus(
+            path=str(legacy_path),
+            exists=legacy_path.exists(),
+            blocking_errors=[
+                "Topology validation failed — active topology JSON is invalid."
+            ],
+        )
+    if not isinstance(payload, dict):
+        return TopologyStatus(
+            path=str(legacy_path),
+            exists=True,
+            blocking_errors=[
+                "Topology validation failed — active topology must be a JSON object."
+            ],
+        )
+    return _build_topology_status(payload, path=legacy_path, exists=True)
 
 
 def _parse_updated_at(updated_at_raw: str | None, warnings: list[str]) -> str | None:
@@ -226,10 +310,23 @@ def _build_topology_status(
     )
 
 
-def get_topology_status() -> TopologyStatus:
+def get_topology_status(
+    *,
+    project_id: int | None = None,
+    project_key: str | None = None,
+) -> TopologyStatus:
     """Return the active topology context with validation details for admin workflows."""
-    topology_path = _topology_path()
-    if not topology_path.exists():
+    project = build_project_payload(
+        resolve_project_reference(project_id=project_id, project_key=project_key)
+    )
+    payload, topology_path, status_override = _load_latest_topology_payload(project)
+    if status_override is not None and payload is None:
+        return status_override
+    if payload is None:
+        if bool(project.get("is_default")):
+            legacy_status = _read_legacy_topology_status()
+            if legacy_status is not None:
+                return legacy_status
         return TopologyStatus(
             path=str(topology_path),
             exists=False,
@@ -237,30 +334,15 @@ def get_topology_status() -> TopologyStatus:
                 "Blast radius may be incomplete — service topology is not configured."
             ],
         )
-
-    try:
-        payload = json.loads(topology_path.read_text(encoding="utf-8"))
-    except JSONDecodeError:
-        return TopologyStatus(
-            path=str(topology_path),
-            exists=True,
-            blocking_errors=[
-                "Topology validation failed — active topology JSON is invalid."
-            ],
-        )
-
-    if not isinstance(payload, dict):
-        return TopologyStatus(
-            path=str(topology_path),
-            exists=True,
-            blocking_errors=[
-                "Topology validation failed — active topology must be a JSON object."
-            ],
-        )
     return _build_topology_status(payload, path=topology_path, exists=True)
 
 
-def save_topology_definition(raw_text: str) -> TopologyStatus:
+def save_topology_definition(
+    raw_text: str,
+    *,
+    project_id: int | None = None,
+    project_key: str | None = None,
+) -> TopologyStatus:
     """Persist topology input as the active blast-radius context and return validation feedback."""
     try:
         payload = json.loads(raw_text)
@@ -270,16 +352,35 @@ def save_topology_definition(raw_text: str) -> TopologyStatus:
     if not isinstance(payload, dict):
         raise ValueError("Topology definition must be a JSON object.")
 
-    topology_path = _topology_path()
+    project = build_project_payload(
+        resolve_project_reference(project_id=project_id, project_key=project_key)
+    )
+    topology_path = _topology_scope_path(project)
     payload["updated_at"] = (
         datetime.now(UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
     )
     candidate_status = _build_topology_status(payload, path=topology_path, exists=False)
     if candidate_status.blocking_errors:
         raise ValueError(" ".join(candidate_status.blocking_errors))
-    topology_path.parent.mkdir(parents=True, exist_ok=True)
-    topology_path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
-    return get_topology_status()
+    with SessionLocal() as session:
+        if bool(project.get("is_default")):
+            legacy_path = _topology_path()
+            try:
+                legacy_path.parent.mkdir(parents=True, exist_ok=True)
+                legacy_path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+            except OSError as exc:
+                raise ValueError(
+                    "Topology definition could not be mirrored to the legacy topology file."
+                ) from exc
+        session.add(
+            TopologyVersion(
+                project_id=int(project["id"]),
+                source_type="manual",
+                payload_json=json.dumps(payload),
+            )
+        )
+        session.commit()
+    return get_topology_status(project_id=int(project["id"]))
 
 
 def _join_warnings(warnings: list[str]) -> str | None:
@@ -288,8 +389,12 @@ def _join_warnings(warnings: list[str]) -> str | None:
     return " ".join(warnings)
 
 
-def load_topology() -> tuple[dict | None, str | None]:
+def load_topology(
+    *,
+    project_id: int | None = None,
+    project_key: str | None = None,
+) -> tuple[dict | None, str | None]:
     """Load topology context and return an optional warning."""
-    status = get_topology_status()
+    status = get_topology_status(project_id=project_id, project_key=project_key)
     messages = status.blocking_errors + status.warnings
     return status.payload, _join_warnings(messages)

--- a/tests/test_api/test_analyses.py
+++ b/tests/test_api/test_analyses.py
@@ -13,6 +13,7 @@ import config as config_module
 import models.database as database_module
 import models.repositories.analysis_reports as analysis_reports_repository_module
 import models.tables as tables_module
+import services.project_service as project_service_module
 import services.report_service as report_service_module
 from analysis.risk_scorer import RiskAssessment, RiskContributor
 from app import create_app
@@ -31,6 +32,7 @@ class AnalysesApiTests(unittest.TestCase):
         reload(tables_module)
         reload(database_module)
         reload(analysis_reports_repository_module)
+        reload(project_service_module)
         reload(report_service_module)
         database_module.init_db()
         self.client = TestClient(create_app())
@@ -133,6 +135,50 @@ class AnalysesApiTests(unittest.TestCase):
         self.assertEqual(payload["meta"]["page"], 1)
         self.assertEqual(payload["meta"]["page_size"], 50)
 
+    def test_list_analyses_defaults_to_unassigned_scope(self) -> None:
+        project = project_service_module.create_project(
+            project_key="payments",
+            display_name="Payments",
+        )
+        report_service_module.persist_analysis_report(
+            ParseBatchResult(
+                files=[
+                    ParsedFileResult(
+                        file_name="payments.json",
+                        tool="terraform",
+                        status="parsed",
+                        changes=[],
+                    )
+                ]
+            ),
+            RiskAssessment(
+                score=15,
+                severity="low",
+                recommendation="go",
+                top_risk="Scoped project report.",
+                contributors=[],
+                interaction_risks=[],
+                partial_context=False,
+                warnings=[],
+            ),
+            NarrativeResult(
+                opening_sentence="GO: scoped project report.",
+                explanation="Scoped report.",
+                guidance=[],
+                degraded=False,
+                warnings=[],
+            ),
+            project_id=project.id,
+            audit_context={"source_interface": "api"},
+        )
+
+        response = self.client.get("/api/v1/analyses")
+
+        self.assertEqual(response.status_code, 200)
+        payload = response.json()
+        self.assertEqual(payload["meta"]["count"], 1)
+        self.assertEqual(payload["data"][0]["project"]["project_key"], "unassigned")
+
     def test_get_analysis_returns_single_report(self) -> None:
         response = self.client.get(f"/api/v1/analyses/{self.persisted['id']}")
         self.assertEqual(response.status_code, 200)
@@ -142,6 +188,57 @@ class AnalysesApiTests(unittest.TestCase):
         self.assertEqual(payload["data"]["report_schema_version"], "v2")
         self.assertEqual(payload["data"]["audit"]["llm_provider"], "ollama")
         self.assertEqual(payload["data"]["blast_radius"]["direct_count"], 0)
+
+    def test_get_analysis_rejects_unknown_project_reference(self) -> None:
+        response = self.client.get(
+            f"/api/v1/analyses/{self.persisted['id']}",
+            params={"project_key": "missing"},
+        )
+
+        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.json()["error"]["code"], "project_not_found")
+
+    def test_get_analysis_defaults_to_unassigned_scope(self) -> None:
+        project = project_service_module.create_project(
+            project_key="payments",
+            display_name="Payments",
+        )
+        scoped = report_service_module.persist_analysis_report(
+            ParseBatchResult(
+                files=[
+                    ParsedFileResult(
+                        file_name="payments.json",
+                        tool="terraform",
+                        status="parsed",
+                        changes=[],
+                    )
+                ]
+            ),
+            RiskAssessment(
+                score=15,
+                severity="low",
+                recommendation="go",
+                top_risk="Low-risk payments change.",
+                contributors=[],
+                interaction_risks=[],
+                partial_context=False,
+                warnings=[],
+            ),
+            NarrativeResult(
+                opening_sentence="GO: low-risk payments change.",
+                explanation="Scoped report.",
+                guidance=[],
+                degraded=False,
+                warnings=[],
+            ),
+            project_id=project.id,
+            audit_context={"source_interface": "api"},
+        )
+
+        response = self.client.get(f"/api/v1/analyses/{scoped['id']}")
+
+        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.json()["error"]["code"], "analysis_not_found")
 
     def test_configure_share_is_disabled_without_management_token(self) -> None:
         response = self.client.post(
@@ -204,6 +301,10 @@ class AnalysesApiTests(unittest.TestCase):
         self.assertIn("Password required", report_response.text)
 
     def test_create_analysis_returns_structured_result(self) -> None:
+        project_service_module.create_project(
+            project_key="payments",
+            display_name="Payments",
+        )
         files = [
             (
                 "files",
@@ -237,7 +338,11 @@ class AnalysesApiTests(unittest.TestCase):
             ),
             patch("services.analysis_service.find_incident_matches", return_value=[]),
         ):
-            response = self.client.post("/api/v1/analyses", files=files)
+            response = self.client.post(
+                "/api/v1/analyses",
+                files=files,
+                data={"project_key": "payments"},
+            )
 
         self.assertEqual(response.status_code, 200)
         payload = response.json()
@@ -250,6 +355,9 @@ class AnalysesApiTests(unittest.TestCase):
         self.assertIn("context_completeness", payload["data"]["assessment"])
         self.assertEqual(
             payload["data"]["assessment"]["top_risk_contributors"], ["ev-001"]
+        )
+        self.assertEqual(
+            payload["data"]["persisted_report"]["project"]["project_key"], "payments"
         )
         self.assertEqual(
             payload["data"]["assessment"]["contributors"][0]["evidence_id"], "ev-001"
@@ -297,6 +405,68 @@ class AnalysesApiTests(unittest.TestCase):
             "ev-001",
         )
         self.assertEqual(payload["data"]["persisted_report"]["id"], 2)
+
+    def test_create_analysis_rejects_unknown_project_reference(self) -> None:
+        files = [
+            (
+                "files",
+                (
+                    "plan.json",
+                    b'{"resource_changes": [{"address": "aws_security_group.main", "change": {"actions": ["modify"]}}]}',
+                    "application/json",
+                ),
+            )
+        ]
+
+        response = self.client.post(
+            "/api/v1/analyses",
+            files=files,
+            data={"project_key": "missing"},
+        )
+
+        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.json()["error"]["code"], "project_not_found")
+
+    def test_list_analyses_rejects_unknown_project_reference(self) -> None:
+        response = self.client.get(
+            "/api/v1/analyses",
+            params={"project_key": "missing"},
+        )
+
+        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.json()["error"]["code"], "project_not_found")
+
+    def test_create_analysis_rejects_conflicting_project_reference(self) -> None:
+        first = project_service_module.create_project(
+            project_key="payments",
+            display_name="Payments",
+        )
+        second = project_service_module.create_project(
+            project_key="platform",
+            display_name="Platform",
+        )
+        files = [
+            (
+                "files",
+                (
+                    "plan.json",
+                    b'{"resource_changes": [{"address": "aws_security_group.main", "change": {"actions": ["modify"]}}]}',
+                    "application/json",
+                ),
+            )
+        ]
+
+        response = self.client.post(
+            "/api/v1/analyses",
+            files=files,
+            data={"project_id": str(first.id), "project_key": second.project_key},
+        )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(
+            response.json()["error"]["code"],
+            "conflicting_project_reference",
+        )
 
     def test_create_analysis_captures_trigger_headers_when_present(self) -> None:
         files = [

--- a/tests/test_api/test_context.py
+++ b/tests/test_api/test_context.py
@@ -1,0 +1,84 @@
+"""Tests for project-scoped context API routes."""
+
+from __future__ import annotations
+
+import os
+import tempfile
+import unittest
+from importlib import reload
+from pathlib import Path
+
+import config as config_module
+import models.database as database_module
+import models.tables as tables_module
+import services.project_service as project_service_module
+from app import create_app
+from fastapi.testclient import TestClient
+
+
+class ContextApiTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tempdir = tempfile.TemporaryDirectory()
+        self.db_path = Path(self.tempdir.name) / "context-api.db"
+        os.environ["DATABASE_URL"] = f"sqlite:///{self.db_path}"
+        reload(config_module)
+        reload(tables_module)
+        reload(database_module)
+        reload(project_service_module)
+        database_module.init_db()
+        self.client = TestClient(create_app())
+        self.project = project_service_module.create_project(
+            project_key="payments",
+            display_name="Payments",
+        )
+
+    def tearDown(self) -> None:
+        database_module.engine.dispose()
+        os.environ.pop("DATABASE_URL", None)
+        self.tempdir.cleanup()
+
+    def test_save_project_topology_requires_valid_project_reference(self) -> None:
+        response = self.client.post(
+            "/api/v1/context/topology",
+            json={
+                "project_key": "missing",
+                "topology": {"services": []},
+            },
+        )
+
+        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.json()["error"]["code"], "project_not_found")
+
+    def test_save_and_fetch_project_topology(self) -> None:
+        save_response = self.client.post(
+            "/api/v1/context/topology",
+            json={
+                "project_key": self.project.project_key,
+                "topology": {
+                    "services": [
+                        {
+                            "id": "api",
+                            "label": "API",
+                            "resource_keys": ["Deployment/api"],
+                            "downstream": [],
+                        }
+                    ]
+                },
+            },
+        )
+
+        self.assertEqual(save_response.status_code, 200)
+        saved_payload = save_response.json()
+        self.assertEqual(saved_payload["data"]["project"]["project_key"], "payments")
+        self.assertEqual(saved_payload["data"]["topology"]["service_count"], 1)
+
+        get_response = self.client.get(
+            "/api/v1/context/topology",
+            params={"project_key": self.project.project_key},
+        )
+
+        self.assertEqual(get_response.status_code, 200)
+        self.assertEqual(
+            get_response.json()["data"]["topology"]["service_count"],
+            1,
+        )

--- a/tests/test_api/test_projects.py
+++ b/tests/test_api/test_projects.py
@@ -1,0 +1,58 @@
+"""Tests for project/workspace API routes."""
+
+from __future__ import annotations
+
+import os
+import tempfile
+import unittest
+from importlib import reload
+from pathlib import Path
+
+import config as config_module
+import models.database as database_module
+import models.tables as tables_module
+import services.project_service as project_service_module
+from app import create_app
+from fastapi.testclient import TestClient
+
+
+class ProjectsApiTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tempdir = tempfile.TemporaryDirectory()
+        self.db_path = Path(self.tempdir.name) / "projects-api.db"
+        os.environ["DATABASE_URL"] = f"sqlite:///{self.db_path}"
+        reload(config_module)
+        reload(tables_module)
+        reload(database_module)
+        reload(project_service_module)
+        database_module.init_db()
+        self.client = TestClient(create_app())
+
+    def tearDown(self) -> None:
+        database_module.engine.dispose()
+        os.environ.pop("DATABASE_URL", None)
+        self.tempdir.cleanup()
+
+    def test_create_project_returns_structured_payload(self) -> None:
+        response = self.client.post(
+            "/api/v1/projects",
+            json={
+                "project_key": "payments-api",
+                "display_name": "Payments API",
+                "repository_url": "https://github.com/acme/payments-api",
+                "default_branch": "main",
+            },
+        )
+
+        self.assertEqual(response.status_code, 200)
+        payload = response.json()
+        self.assertEqual(payload["data"]["project_key"], "payments-api")
+        self.assertEqual(payload["data"]["display_name"], "Payments API")
+
+    def test_list_projects_includes_default_project(self) -> None:
+        response = self.client.get("/api/v1/projects")
+
+        self.assertEqual(response.status_code, 200)
+        payload = response.json()
+        self.assertGreaterEqual(payload["meta"]["count"], 1)
+        self.assertEqual(payload["data"][0]["project_key"], "unassigned")

--- a/tests/test_cli/test_analyze.py
+++ b/tests/test_cli/test_analyze.py
@@ -18,6 +18,7 @@ import models.repositories.analysis_reports as analysis_reports_repository_modul
 import models.tables as tables_module
 import services.report_service as report_service_module
 import services.analysis_service as analysis_service_module
+import services.project_service as project_service_module
 from analysis.risk_scorer import RiskAssessment, RiskContributor
 from cli.analyze import main
 from importlib import reload
@@ -42,6 +43,7 @@ class AnalyzeCliTests(unittest.TestCase):
         reload(tables_module)
         reload(database_module)
         reload(analysis_reports_repository_module)
+        reload(project_service_module)
         reload(report_service_module)
         database_module.init_db()
 
@@ -671,6 +673,59 @@ class AnalyzeCliTests(unittest.TestCase):
             payload["data"]["persisted_report"]["audit"]["trigger_id"], "job-789"
         )
 
+    def test_analyze_command_accepts_project_key(self) -> None:
+        project_service_module.create_project(
+            project_key="payments",
+            display_name="Payments",
+        )
+        artifact_path = Path(self.tempdir.name) / "plan.json"
+        artifact_path.write_text(
+            '{"resource_changes": [{"address": "aws_security_group.main", "change": {"actions": ["modify"]}}]}',
+            encoding="utf-8",
+        )
+        output = io.StringIO()
+
+        def passthrough_analyze_uploaded_files(
+            files,
+            completion_client=None,
+            audit_context=None,
+            project_id=None,
+            project_key=None,
+        ):
+            return analysis_service_module.analyze_uploaded_files(
+                files,
+                completion_client=completion_client,
+                audit_context=audit_context,
+                project_id=project_id,
+                project_key=project_key,
+            )
+
+        with (
+            patch(
+                "cli.analyze.analyze_uploaded_files",
+                side_effect=passthrough_analyze_uploaded_files,
+            ),
+            patch(
+                "sys.argv",
+                [
+                    "deploywhisper",
+                    "analyze",
+                    "--project",
+                    "payments",
+                    str(artifact_path),
+                ],
+            ),
+            redirect_stdout(output),
+        ):
+            with self.assertRaises(SystemExit) as ctx:
+                main()
+
+        self.assertEqual(ctx.exception.code, 0)
+        payload = json.loads(output.getvalue())
+        self.assertEqual(
+            payload["data"]["persisted_report"]["project"]["project_key"], "payments"
+        )
+
     def test_analyze_command_reports_unsupported_inputs_with_structured_error(
         self,
     ) -> None:
@@ -713,6 +768,174 @@ class AnalyzeCliTests(unittest.TestCase):
         payload = json.loads(stderr.getvalue())
         self.assertEqual(payload["error"]["code"], "artifact_read_failed")
         self.assertEqual(payload["error"]["details"]["path"], str(missing_path))
+
+    def test_project_create_command_reports_created_workspace(self) -> None:
+        output = io.StringIO()
+
+        with (
+            patch(
+                "sys.argv",
+                ["deploywhisper", "project", "create", "payments", "Payments API"],
+            ),
+            redirect_stdout(output),
+        ):
+            with self.assertRaises(SystemExit) as ctx:
+                main()
+
+        self.assertEqual(ctx.exception.code, 0)
+        self.assertIn("Created project payments", output.getvalue())
+
+    def test_project_list_command_includes_default_workspace(self) -> None:
+        output = io.StringIO()
+
+        with (
+            patch("sys.argv", ["deploywhisper", "project", "list"]),
+            redirect_stdout(output),
+        ):
+            with self.assertRaises(SystemExit) as ctx:
+                main()
+
+        self.assertEqual(ctx.exception.code, 0)
+        self.assertIn("unassigned", output.getvalue())
+
+    def test_project_command_requires_subcommand(self) -> None:
+        stderr = io.StringIO()
+
+        with (
+            patch("sys.argv", ["deploywhisper", "project"]),
+            redirect_stderr(stderr),
+        ):
+            with self.assertRaises(SystemExit) as ctx:
+                main()
+
+        self.assertEqual(ctx.exception.code, 2)
+        self.assertIn("required", stderr.getvalue().lower())
+
+    def test_topology_import_command_saves_project_scoped_context(self) -> None:
+        project_service_module.create_project(
+            project_key="payments",
+            display_name="Payments",
+        )
+        topology_path = Path(self.tempdir.name) / "topology.json"
+        topology_path.write_text(
+            json.dumps(
+                {
+                    "services": [
+                        {
+                            "id": "api",
+                            "label": "API",
+                            "resource_keys": ["Deployment/api"],
+                            "downstream": [],
+                        }
+                    ]
+                }
+            ),
+            encoding="utf-8",
+        )
+        output = io.StringIO()
+
+        with (
+            patch(
+                "sys.argv",
+                [
+                    "deploywhisper",
+                    "topology",
+                    "import",
+                    "--project",
+                    "payments",
+                    str(topology_path),
+                ],
+            ),
+            redirect_stdout(output),
+        ):
+            with self.assertRaises(SystemExit) as ctx:
+                main()
+
+        self.assertEqual(ctx.exception.code, 0)
+        payload = json.loads(output.getvalue())
+        self.assertEqual(payload["data"]["project"]["project_key"], "payments")
+        self.assertEqual(payload["data"]["topology"]["service_count"], 1)
+
+    def test_topology_import_command_rejects_unknown_project(self) -> None:
+        topology_path = Path(self.tempdir.name) / "topology.json"
+        topology_path.write_text(json.dumps({"services": []}), encoding="utf-8")
+        stdout = io.StringIO()
+        stderr = io.StringIO()
+
+        with (
+            patch(
+                "sys.argv",
+                [
+                    "deploywhisper",
+                    "topology",
+                    "import",
+                    "--project",
+                    "missing",
+                    str(topology_path),
+                ],
+            ),
+            redirect_stdout(stdout),
+            redirect_stderr(stderr),
+        ):
+            with self.assertRaises(SystemExit) as ctx:
+                main()
+
+        self.assertEqual(ctx.exception.code, 2)
+        payload = json.loads(stderr.getvalue())
+        self.assertEqual(payload["error"]["code"], "project_not_found")
+
+    def test_topology_command_requires_subcommand(self) -> None:
+        stderr = io.StringIO()
+
+        with (
+            patch("sys.argv", ["deploywhisper", "topology"]),
+            redirect_stderr(stderr),
+        ):
+            with self.assertRaises(SystemExit) as ctx:
+                main()
+
+        self.assertEqual(ctx.exception.code, 2)
+        self.assertIn("required", stderr.getvalue().lower())
+
+    def test_analyze_command_rejects_conflicting_project_reference(self) -> None:
+        first = project_service_module.create_project(
+            project_key="payments",
+            display_name="Payments",
+        )
+        project_service_module.create_project(
+            project_key="platform",
+            display_name="Platform",
+        )
+        artifact_path = Path(self.tempdir.name) / "plan.json"
+        artifact_path.write_text(
+            '{"resource_changes": [{"address": "aws_security_group.main", "change": {"actions": ["modify"]}}]}',
+            encoding="utf-8",
+        )
+        stdout = io.StringIO()
+        stderr = io.StringIO()
+
+        with (
+            patch(
+                "sys.argv",
+                [
+                    "deploywhisper",
+                    "analyze",
+                    "--project-id",
+                    str(first.id),
+                    "--project",
+                    "platform",
+                    str(artifact_path),
+                ],
+            ),
+            redirect_stdout(stdout),
+            redirect_stderr(stderr),
+        ):
+            with self.assertRaises(SystemExit) as ctx:
+                main()
+
+        self.assertEqual(ctx.exception.code, 2)
+        payload = json.loads(stderr.getvalue())
+        self.assertEqual(payload["error"]["code"], "conflicting_project_reference")
 
     def test_analyze_command_preserves_distinct_files_with_same_basename(self) -> None:
         first_dir = Path(self.tempdir.name) / "first"
@@ -916,11 +1139,21 @@ class AnalyzeCliTests(unittest.TestCase):
             warnings=[],
         )
 
-        def noisy_analyze_uploaded_files(files, audit_context=None):
+        def noisy_analyze_uploaded_files(
+            files,
+            completion_client=None,
+            audit_context=None,
+            project_id=None,
+            project_key=None,
+        ):
             print("unexpected provider noise")
             print("unexpected provider noise", file=sys.stderr)
             return analysis_service_module.analyze_uploaded_files(
-                files, audit_context=audit_context
+                files,
+                completion_client=completion_client,
+                audit_context=audit_context,
+                project_id=project_id,
+                project_key=project_key,
             )
 
         with (

--- a/tests/test_infra/test_container_contract.py
+++ b/tests/test_infra/test_container_contract.py
@@ -23,6 +23,7 @@ class ContainerContractTests(unittest.TestCase):
                 "007_add_blast_radius_payload.py",
                 "008_add_rollback_plan_payload.py",
                 "009_add_report_share_settings.py",
+                "010_add_project_workspaces.py",
             ],
         )
         baseline_content = migrations[0].read_text(encoding="utf-8")
@@ -31,6 +32,7 @@ class ContainerContractTests(unittest.TestCase):
         blast_radius_content = migrations[3].read_text(encoding="utf-8")
         rollback_content = migrations[4].read_text(encoding="utf-8")
         share_content = migrations[5].read_text(encoding="utf-8")
+        project_content = migrations[6].read_text(encoding="utf-8")
         self.assertIn("down_revision = None", baseline_content)
         self.assertIn('"app_settings"', baseline_content)
         self.assertIn(
@@ -49,6 +51,11 @@ class ContainerContractTests(unittest.TestCase):
         self.assertIn('"rollback_plan_json"', rollback_content)
         self.assertIn('down_revision = "008_add_rollback_plan_payload"', share_content)
         self.assertIn('"share_redact_filenames"', share_content)
+        self.assertIn(
+            'down_revision = "009_add_report_share_settings"', project_content
+        )
+        self.assertIn('"projects"', project_content)
+        self.assertIn('"project_id"', project_content)
 
     def test_dockerfile_exists(self) -> None:
         self.assertTrue(Path("Dockerfile").exists())

--- a/tests/test_infra/test_migrations.py
+++ b/tests/test_infra/test_migrations.py
@@ -60,6 +60,9 @@ class MigrationTests(unittest.TestCase):
         self.assertIn("analysis_id", self._table_columns("findings"))
         self.assertIn("analysis_id", self._table_columns("risk_assessments"))
         self.assertIn("analysis_id", self._table_columns("context_snapshots"))
+        self.assertIn("project_id", self._table_columns("analysis_reports"))
+        self.assertIn("project_key", self._table_columns("projects"))
+        self.assertIn("payload_json", self._table_columns("topology_versions"))
         self.assertIn("report_schema_version", self._table_columns("analysis_reports"))
         self.assertIn("blast_radius_json", self._table_columns("analysis_reports"))
         self.assertIn("rollback_plan_json", self._table_columns("analysis_reports"))
@@ -152,6 +155,14 @@ class MigrationTests(unittest.TestCase):
             share_redact_filenames = sqlite_conn.execute(
                 "SELECT share_redact_filenames FROM analysis_reports LIMIT 1"
             ).fetchone()[0]
+            project_key = sqlite_conn.execute(
+                """
+                SELECT projects.project_key
+                FROM analysis_reports
+                JOIN projects ON projects.id = analysis_reports.project_id
+                LIMIT 1
+                """
+            ).fetchone()[0]
             finding_fks = sqlite_conn.execute(
                 "PRAGMA foreign_key_list(findings)"
             ).fetchall()
@@ -165,6 +176,7 @@ class MigrationTests(unittest.TestCase):
         self.assertEqual(schema_version, "v2")
         self.assertIsNone(share_password_hash)
         self.assertEqual(share_redact_filenames, 0)
+        self.assertEqual(project_key, "unassigned")
         self.assertTrue(any(row[2] == "analysis_reports" for row in finding_fks))
         self.assertTrue(any(row[2] == "findings" for row in evidence_fks))
 
@@ -210,7 +222,9 @@ class MigrationTests(unittest.TestCase):
         self.assertIn("incident_records", tables)
         self.assertIn("findings", tables)
         self.assertIn("evidence_items", tables)
-        self.assertEqual(revision, "009_add_report_share_settings")
+        self.assertIn("projects", tables)
+        self.assertIn("topology_versions", tables)
+        self.assertEqual(revision, "010_add_project_workspaces")
 
     def test_init_db_repairs_partial_evidence_schema_without_alembic_version(
         self,
@@ -258,7 +272,8 @@ class MigrationTests(unittest.TestCase):
 
         self.assertIn("findings", tables)
         self.assertIn("evidence_items", tables)
-        self.assertEqual(revision, "009_add_report_share_settings")
+        self.assertIn("projects", tables)
+        self.assertEqual(revision, "010_add_project_workspaces")
 
     def test_init_db_repairs_current_schema_without_alembic_version(self) -> None:
         command.upgrade(self._config(), "head")
@@ -284,9 +299,10 @@ class MigrationTests(unittest.TestCase):
         finally:
             sqlite_conn.close()
 
-        self.assertEqual(revision, "009_add_report_share_settings")
+        self.assertEqual(revision, "010_add_project_workspaces")
         self.assertIn("report_schema_version", columns)
         self.assertIn("blast_radius_json", columns)
+        self.assertIn("project_id", columns)
 
     def test_init_db_repairs_empty_alembic_revision_state(self) -> None:
         command.upgrade(self._config(), "0001_create_analysis_reports")
@@ -309,7 +325,7 @@ class MigrationTests(unittest.TestCase):
         finally:
             sqlite_conn.close()
 
-        self.assertEqual(revision, "009_add_report_share_settings")
+        self.assertEqual(revision, "010_add_project_workspaces")
 
 
 if __name__ == "__main__":

--- a/tests/test_models/test_evidence_tables.py
+++ b/tests/test_models/test_evidence_tables.py
@@ -12,6 +12,7 @@ from pathlib import Path
 import config as config_module
 import models.database as database_module
 import models.tables as tables_module
+import services.project_service as project_service_module
 from sqlalchemy.exc import IntegrityError
 
 
@@ -23,7 +24,9 @@ class EvidenceTableTests(unittest.TestCase):
         reload(config_module)
         reload(tables_module)
         reload(database_module)
+        reload(project_service_module)
         database_module.init_db()
+        self.default_project = project_service_module.ensure_default_project()
 
     def tearDown(self) -> None:
         database_module.engine.dispose()
@@ -55,6 +58,7 @@ class EvidenceTableTests(unittest.TestCase):
     def test_report_findings_and_evidence_relationships_round_trip(self) -> None:
         with database_module.SessionLocal() as session:
             report = tables_module.AnalysisReport(
+                project_id=self.default_project.id,
                 risk_score=55,
                 severity="medium",
                 recommendation="caution",
@@ -151,6 +155,7 @@ class EvidenceTableTests(unittest.TestCase):
         with database_module.SessionLocal() as session:
             session.add(
                 tables_module.AnalysisReport(
+                    project_id=self.default_project.id,
                     risk_score=10,
                     severity="low",
                     recommendation="go",
@@ -176,6 +181,7 @@ class EvidenceTableTests(unittest.TestCase):
             )
             session.add(
                 tables_module.AnalysisReport(
+                    project_id=self.default_project.id,
                     risk_score=20,
                     severity="medium",
                     recommendation="caution",

--- a/tests/test_services/test_github_app_service.py
+++ b/tests/test_services/test_github_app_service.py
@@ -5,17 +5,26 @@ from __future__ import annotations
 import hmac
 import hashlib
 import os
+import tempfile
+from importlib import reload
 from pathlib import Path
 import unittest
 from unittest.mock import patch
 from urllib.parse import parse_qs, urlparse
 
+import config as config_module
+import models.database as database_module
+import models.tables as tables_module
+import services.project_service as project_service_module
 from integrations.github import app_service
 
 
 class GitHubAppServiceTests(unittest.TestCase):
     def setUp(self) -> None:
+        self.tempdir = tempfile.TemporaryDirectory()
+        self.db_path = Path(self.tempdir.name) / "github-app.db"
         self.env_keys = [
+            "DATABASE_URL",
             "APP_BASE_URL",
             "DEPLOYWHISPER_GITHUB_APP_ENABLED",
             "DEPLOYWHISPER_GITHUB_APP_ID",
@@ -27,8 +36,10 @@ class GitHubAppServiceTests(unittest.TestCase):
             "DEPLOYWHISPER_GITHUB_APP_PRIVATE_KEY_PATH",
             "DEPLOYWHISPER_GITHUB_APP_PR_EVENTS_ENABLED",
             "DEPLOYWHISPER_GITHUB_APP_CHECKS_ENABLED",
+            "DEPLOYWHISPER_GITHUB_PROJECT_KEY",
         ]
         self.original_env = {key: os.environ.get(key) for key in self.env_keys}
+        os.environ["DATABASE_URL"] = f"sqlite:///{self.db_path}"
         os.environ["APP_BASE_URL"] = "https://deploywhisper.example.com"
         os.environ["DEPLOYWHISPER_GITHUB_APP_ENABLED"] = "true"
         os.environ["DEPLOYWHISPER_GITHUB_APP_ID"] = "12345"
@@ -41,13 +52,20 @@ class GitHubAppServiceTests(unittest.TestCase):
         )
         os.environ["DEPLOYWHISPER_GITHUB_APP_PR_EVENTS_ENABLED"] = "true"
         os.environ["DEPLOYWHISPER_GITHUB_APP_CHECKS_ENABLED"] = "true"
+        reload(config_module)
+        reload(tables_module)
+        reload(database_module)
+        reload(project_service_module)
+        database_module.init_db()
 
     def tearDown(self) -> None:
+        database_module.engine.dispose()
         for key, value in self.original_env.items():
             if value is None:
                 os.environ.pop(key, None)
             else:
                 os.environ[key] = value
+        self.tempdir.cleanup()
 
     def test_verify_github_webhook_signature_accepts_valid_sha256(self) -> None:
         payload = b'{"zen":"ship it"}'
@@ -164,6 +182,58 @@ class GitHubAppServiceTests(unittest.TestCase):
         )
         self.assertIn("advisory-only", call["summary"])
         self.assertIn("Open the full DeployWhisper report", call["text"])
+        self.assertEqual(
+            analyze_uploaded_files.call_args.kwargs["project_key"],
+            "deploywhisper-deploywhisper",
+        )
+
+    @patch("integrations.github.app_service._create_check_run")
+    @patch("integrations.github.app_service.analyze_uploaded_files")
+    @patch("integrations.github.app_service._load_pull_request_artifacts")
+    @patch("integrations.github.app_service._generate_installation_access_token")
+    def test_handle_github_app_webhook_prefers_explicit_project_key_override(
+        self,
+        generate_installation_access_token,
+        load_pull_request_artifacts,
+        analyze_uploaded_files,
+        create_check_run,
+    ) -> None:
+        os.environ["DEPLOYWHISPER_GITHUB_PROJECT_KEY"] = "platform-core"
+        generate_installation_access_token.return_value = "installation-token"
+        load_pull_request_artifacts.return_value = [("plan.tf", b'resource "x" "y" {}')]
+        analyze_uploaded_files.return_value = type(
+            "Result",
+            (),
+            {
+                "assessment": type("Assessment", (), {"recommendation": "caution"})(),
+                "persisted_report": {"id": 18},
+            },
+        )()
+        create_check_run.return_value = 992
+
+        try:
+            app_service.handle_github_app_webhook(
+                event_name="pull_request",
+                payload={
+                    "action": "opened",
+                    "number": 3,
+                    "installation": {"id": 42},
+                    "repository": {
+                        "name": "deploywhisper",
+                        "owner": {"login": "deploywhisper"},
+                    },
+                    "pull_request": {
+                        "number": 3,
+                        "head": {"sha": "abc123"},
+                    },
+                },
+            )
+        finally:
+            os.environ.pop("DEPLOYWHISPER_GITHUB_PROJECT_KEY", None)
+
+        self.assertEqual(
+            analyze_uploaded_files.call_args.kwargs["project_key"], "platform-core"
+        )
 
     @patch("integrations.github.app_service.analyze_uploaded_files")
     @patch("integrations.github.app_service._load_pull_request_artifacts")

--- a/tests/test_services/test_project_service.py
+++ b/tests/test_services/test_project_service.py
@@ -1,0 +1,140 @@
+"""Tests for lightweight project/workspace service behavior."""
+
+from __future__ import annotations
+
+import os
+import tempfile
+import unittest
+from importlib import reload
+from pathlib import Path
+
+import config as config_module
+import models.database as database_module
+import models.tables as tables_module
+import services.project_service as project_service_module
+
+
+class ProjectServiceTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tempdir = tempfile.TemporaryDirectory()
+        self.db_path = Path(self.tempdir.name) / "projects.db"
+        os.environ["DATABASE_URL"] = f"sqlite:///{self.db_path}"
+        reload(config_module)
+        reload(tables_module)
+        reload(database_module)
+        reload(project_service_module)
+        database_module.init_db()
+
+    def tearDown(self) -> None:
+        database_module.engine.dispose()
+        os.environ.pop("DATABASE_URL", None)
+        self.tempdir.cleanup()
+
+    def test_default_project_exists_for_legacy_records(self) -> None:
+        project = project_service_module.ensure_default_project()
+
+        self.assertEqual(
+            project.project_key, project_service_module.DEFAULT_PROJECT_KEY
+        )
+        self.assertTrue(project.is_default)
+
+    def test_create_project_normalizes_key_and_persists_metadata(self) -> None:
+        project = project_service_module.create_project(
+            project_key="Payments/API Service",
+            display_name="Payments API",
+            description="Primary production repo",
+            repository_url="https://github.com/acme/payments-api",
+            default_branch="main",
+        )
+
+        self.assertEqual(project.project_key, "payments-api-service")
+        self.assertEqual(project.display_name, "Payments API")
+        self.assertEqual(project.repository_url, "https://github.com/acme/payments-api")
+        self.assertEqual(project.default_branch, "main")
+
+    def test_resolve_project_reference_derives_stable_repository_key(self) -> None:
+        project = project_service_module.resolve_project_reference(
+            repository_name="AcmeCorp/Payments-API",
+            allow_create=True,
+        )
+
+        self.assertEqual(project.project_key, "acmecorp-payments-api")
+        self.assertEqual(project.display_name, "Payments API")
+
+    def test_active_project_setting_round_trips(self) -> None:
+        created = project_service_module.create_project(
+            project_key="network-core",
+            display_name="Network Core",
+        )
+
+        project_service_module.set_active_project(created.id)
+        active = project_service_module.get_active_project()
+
+        self.assertIsNotNone(active)
+        assert active is not None
+        self.assertEqual(active.id, created.id)
+        self.assertEqual(active.project_key, "network-core")
+
+    def test_unknown_explicit_project_reference_raises(self) -> None:
+        with self.assertRaises(
+            project_service_module.ProjectResolutionError
+        ) as exc_info:
+            project_service_module.resolve_project_reference(project_key="missing")
+
+        self.assertEqual(exc_info.exception.code, "project_not_found")
+
+    def test_conflicting_project_reference_raises(self) -> None:
+        first = project_service_module.create_project(
+            project_key="payments",
+            display_name="Payments",
+        )
+        second = project_service_module.create_project(
+            project_key="platform",
+            display_name="Platform",
+        )
+
+        with self.assertRaises(
+            project_service_module.ProjectResolutionError
+        ) as exc_info:
+            project_service_module.resolve_project_reference(
+                project_id=first.id,
+                project_key=second.project_key,
+            )
+
+        self.assertEqual(exc_info.exception.code, "conflicting_project_reference")
+
+    def test_partially_invalid_dual_project_reference_raises(self) -> None:
+        created = project_service_module.create_project(
+            project_key="payments",
+            display_name="Payments",
+        )
+
+        with self.assertRaises(
+            project_service_module.ProjectResolutionError
+        ) as exc_info:
+            project_service_module.resolve_project_reference(
+                project_id=999,
+                project_key=created.project_key,
+            )
+
+        self.assertEqual(exc_info.exception.code, "project_not_found")
+
+    def test_allow_create_creates_explicit_project_key(self) -> None:
+        project = project_service_module.resolve_project_reference(
+            project_key="platform-core",
+            allow_create=True,
+        )
+
+        self.assertEqual(project.project_key, "platform-core")
+        self.assertEqual(project.display_name, "Platform Core")
+
+    def test_active_project_selection_flag_tracks_explicit_choice(self) -> None:
+        self.assertFalse(project_service_module.has_active_project_selection())
+
+        created = project_service_module.create_project(
+            project_key="core",
+            display_name="Core",
+        )
+        project_service_module.set_active_project(created.id)
+
+        self.assertTrue(project_service_module.has_active_project_selection())

--- a/tests/test_services/test_report_service.py
+++ b/tests/test_services/test_report_service.py
@@ -15,6 +15,7 @@ import config as config_module
 import models.database as database_module
 import models.repositories.analysis_reports as analysis_reports_repository_module
 import models.tables as tables_module
+import services.project_service as project_service_module
 import services.report_service as report_service_module
 import services.settings_service as settings_service_module
 from analysis.blast_radius import BlastRadiusResult, ImpactNode
@@ -34,6 +35,7 @@ class ReportServiceTests(unittest.TestCase):
         reload(tables_module)
         reload(database_module)
         reload(analysis_reports_repository_module)
+        reload(project_service_module)
         reload(settings_service_module)
         reload(report_service_module)
         database_module.init_db()
@@ -1542,6 +1544,154 @@ class ReportServiceTests(unittest.TestCase):
         self.assertIn("narrative_skills_json", columns)
         self.assertIn("dashboard_display_duration_seconds", columns)
         self.assertIn("report_schema_version", columns)
+
+    def test_persist_analysis_report_scopes_reports_to_project(self) -> None:
+        project = project_service_module.create_project(
+            project_key="payments",
+            display_name="Payments",
+        )
+        legacy = self._persist_shareable_report()
+
+        scoped = report_service_module.persist_analysis_report(
+            ParseBatchResult(
+                files=[
+                    ParsedFileResult(
+                        file_name="payments.json",
+                        tool="terraform",
+                        status="parsed",
+                        changes=[
+                            UnifiedChange(
+                                source_file="payments.json",
+                                tool="terraform",
+                                resource_id="aws_security_group.payments",
+                                action="modify",
+                                summary="Payments change.",
+                            )
+                        ],
+                    )
+                ]
+            ),
+            RiskAssessment(
+                score=15,
+                severity="low",
+                recommendation="go",
+                top_risk="Low-risk payments change.",
+                contributors=[],
+                interaction_risks=[],
+                partial_context=False,
+                warnings=[],
+            ),
+            NarrativeResult(
+                opening_sentence="GO: low-risk payments change.",
+                explanation="Scoped report.",
+                guidance=[],
+                degraded=False,
+                warnings=[],
+            ),
+            project_id=project.id,
+            audit_context={"source_interface": "api"},
+        )
+
+        self.assertEqual(legacy["project"]["project_key"], "unassigned")
+        self.assertEqual(scoped["project"]["project_key"], "payments")
+
+        page = report_service_module.fetch_filtered_analysis_history_page(
+            project_key="payments"
+        )
+        self.assertEqual(len(page["items"]), 1)
+        self.assertEqual(page["items"][0]["project"]["project_key"], "payments")
+
+    def test_fetch_analysis_report_respects_project_scope(self) -> None:
+        project = project_service_module.create_project(
+            project_key="payments",
+            display_name="Payments",
+        )
+        scoped = report_service_module.persist_analysis_report(
+            ParseBatchResult(
+                files=[
+                    ParsedFileResult(
+                        file_name="payments.json",
+                        tool="terraform",
+                        status="parsed",
+                        changes=[],
+                    )
+                ]
+            ),
+            RiskAssessment(
+                score=15,
+                severity="low",
+                recommendation="go",
+                top_risk="Low-risk payments change.",
+                contributors=[],
+                interaction_risks=[],
+                partial_context=False,
+                warnings=[],
+            ),
+            NarrativeResult(
+                opening_sentence="GO: low-risk payments change.",
+                explanation="Scoped report.",
+                guidance=[],
+                degraded=False,
+                warnings=[],
+            ),
+            project_id=project.id,
+            audit_context={"source_interface": "api"},
+        )
+
+        with self.assertRaises(project_service_module.ProjectResolutionError):
+            report_service_module.fetch_analysis_report(
+                scoped["id"], project_key="missing"
+            )
+        self.assertIsNotNone(
+            report_service_module.fetch_analysis_report(
+                scoped["id"], project_key=project.project_key
+            )
+        )
+
+    def test_previous_scan_diffs_do_not_cross_project_boundaries(self) -> None:
+        payments = project_service_module.create_project(
+            project_key="payments",
+            display_name="Payments",
+        )
+        platform = project_service_module.create_project(
+            project_key="platform",
+            display_name="Platform",
+        )
+        first = self._persist_comparison_report(
+            score=40,
+            severity="medium",
+            recommendation="caution",
+            top_risk="Payments review",
+            findings=[],
+            evidence_items=[],
+        )
+        with database_module.SessionLocal() as session:
+            report = analysis_reports_repository_module.get_analysis_report(
+                session, int(first["id"]), include_evidence=True
+            )
+            assert report is not None
+            report.project_id = payments.id
+            session.commit()
+        second = self._persist_comparison_report(
+            score=88,
+            severity="critical",
+            recommendation="no-go",
+            top_risk="Platform review",
+            findings=[],
+            evidence_items=[],
+        )
+        with database_module.SessionLocal() as session:
+            report = analysis_reports_repository_module.get_analysis_report(
+                session, int(second["id"]), include_evidence=True
+            )
+            assert report is not None
+            report.project_id = platform.id
+            session.commit()
+
+        history = report_service_module.fetch_filtered_analysis_history_page()
+        by_id = {item["id"]: item for item in history["items"]}
+        self.assertNotIn("previous_scan_diff", by_id[int(first["id"])])
+        self.assertNotIn("previous_scan_diff", by_id[int(second["id"])])
 
 
 if __name__ == "__main__":

--- a/tests/test_services/test_topology_service.py
+++ b/tests/test_services/test_topology_service.py
@@ -3,12 +3,19 @@
 from __future__ import annotations
 
 import json
+import os
 import tempfile
 import unittest
-from types import SimpleNamespace
+from importlib import reload
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import patch
 
+import config as config_module
+import models.database as database_module
+import models.tables as tables_module
+import services.project_service as project_service_module
+from models.database import SessionLocal
 from services.topology_service import (
     get_topology_status,
     load_topology,
@@ -17,12 +24,142 @@ from services.topology_service import (
 
 
 class TopologyServiceTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tempdir = tempfile.TemporaryDirectory()
+        self.db_path = Path(self.tempdir.name) / "topology.db"
+        os.environ["DATABASE_URL"] = f"sqlite:///{self.db_path}"
+        reload(config_module)
+        reload(tables_module)
+        reload(database_module)
+        reload(project_service_module)
+        database_module.init_db()
+
+    def tearDown(self) -> None:
+        database_module.engine.dispose()
+        os.environ.pop("DATABASE_URL", None)
+        self.tempdir.cleanup()
+
     def test_load_topology_warns_when_missing(self) -> None:
         fake_settings = SimpleNamespace(topology_path="missing-topology.json")
         with patch("services.topology_service.settings", fake_settings):
             topology, warning = load_topology()
         self.assertIsNone(topology)
         self.assertIn("not configured", warning)
+
+    def test_save_topology_definition_scopes_payload_to_project(self) -> None:
+        project_service_module.create_project(
+            project_key="payments",
+            display_name="Payments",
+        )
+        fake_settings = SimpleNamespace(
+            topology_path=str(Path(self.tempdir.name) / "missing-topology.json")
+        )
+
+        with patch("services.topology_service.settings", fake_settings):
+            save_topology_definition(
+                json.dumps(
+                    {
+                        "services": [
+                            {
+                                "id": "api",
+                                "label": "API",
+                                "resource_keys": ["Deployment/api"],
+                                "downstream": [],
+                            }
+                        ]
+                    }
+                ),
+                project_key="payments",
+            )
+
+            scoped_topology, _ = load_topology(project_key="payments")
+            default_topology, default_warning = load_topology()
+
+        self.assertIsNotNone(scoped_topology)
+        assert scoped_topology is not None
+        self.assertEqual(scoped_topology["services"][0]["id"], "api")
+        self.assertIsNone(default_topology)
+        self.assertIn("not configured", default_warning)
+
+    def test_load_topology_imports_legacy_file_into_default_project(self) -> None:
+        legacy_path = Path(self.tempdir.name) / "legacy-topology.json"
+        legacy_path.write_text(
+            json.dumps(
+                {
+                    "updated_at": "2026-04-16T00:00:00Z",
+                    "services": [
+                        {
+                            "id": "legacy-api",
+                            "label": "Legacy API",
+                            "resource_keys": ["Deployment/legacy-api"],
+                            "downstream": [],
+                        }
+                    ],
+                }
+            ),
+            encoding="utf-8",
+        )
+        fake_settings = SimpleNamespace(topology_path=str(legacy_path))
+
+        with patch("services.topology_service.settings", fake_settings):
+            topology, warning = load_topology()
+
+        self.assertIsNotNone(topology)
+        self.assertIsNone(warning)
+        assert topology is not None
+        self.assertEqual(topology["services"][0]["id"], "legacy-api")
+
+    def test_get_topology_status_returns_validation_error_for_malformed_stored_payload(
+        self,
+    ) -> None:
+        project = project_service_module.create_project(
+            project_key="payments",
+            display_name="Payments",
+        )
+        with SessionLocal() as session:
+            session.add(
+                tables_module.TopologyVersion(
+                    project_id=project.id,
+                    source_type="manual",
+                    payload_json="{bad json",
+                )
+            )
+            session.commit()
+
+        status = get_topology_status(project_id=project.id)
+
+        self.assertTrue(status.exists)
+        self.assertIn(
+            "stored topology JSON is invalid", " ".join(status.blocking_errors)
+        )
+
+    def test_save_topology_definition_aborts_default_project_write_when_legacy_mirror_fails(
+        self,
+    ) -> None:
+        fake_settings = SimpleNamespace(
+            topology_path=str(Path(self.tempdir.name) / "legacy-topology.json")
+        )
+        with patch("services.topology_service.settings", fake_settings):
+            with patch("pathlib.Path.write_text", side_effect=OSError("disk full")):
+                with self.assertRaises(ValueError):
+                    save_topology_definition(
+                        json.dumps(
+                            {
+                                "services": [
+                                    {
+                                        "id": "api",
+                                        "label": "API",
+                                        "resource_keys": ["Deployment/api"],
+                                        "downstream": [],
+                                    }
+                                ]
+                            }
+                        )
+                    )
+
+        with SessionLocal() as session:
+            rows = session.query(tables_module.TopologyVersion).all()
+        self.assertEqual(rows, [])
 
     def test_load_topology_returns_payload_when_present(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:

--- a/tests/test_ui/test_app_shell.py
+++ b/tests/test_ui/test_app_shell.py
@@ -13,6 +13,7 @@ import config as config_module
 import models.database as database_module
 import models.repositories.analysis_reports as analysis_reports_repository_module
 import models.tables as tables_module
+import services.project_service as project_service_module
 import services.report_service as report_service_module
 import ui.components.upload_panel as upload_panel_module
 import ui.routes.dashboard as dashboard_module
@@ -35,6 +36,7 @@ class DashboardShellTests(unittest.TestCase):
         reload(tables_module)
         reload(database_module)
         reload(analysis_reports_repository_module)
+        reload(project_service_module)
         reload(report_service_module)
         reload(upload_panel_module)
         reload(dashboard_module)
@@ -178,6 +180,9 @@ class DashboardShellTests(unittest.TestCase):
                 "trigger_type": "dashboard_upload",
             },
         )
+        project_service_module.set_active_project(
+            project_service_module.ensure_default_project().id
+        )
 
         response = self.client.get("/")
 
@@ -281,6 +286,9 @@ class DashboardShellTests(unittest.TestCase):
                 "trigger_type": "dashboard_upload",
             },
         )
+        project_service_module.set_active_project(
+            project_service_module.ensure_default_project().id
+        )
 
         response = self.client.get("/")
 
@@ -356,6 +364,9 @@ class DashboardShellTests(unittest.TestCase):
                 "source_interface": "ui",
                 "trigger_type": "dashboard_upload",
             },
+        )
+        project_service_module.set_active_project(
+            project_service_module.ensure_default_project().id
         )
 
         response = self.client.get("/")
@@ -440,6 +451,9 @@ class DashboardShellTests(unittest.TestCase):
                 "source_interface": "ui",
                 "trigger_type": "dashboard_upload",
             },
+        )
+        project_service_module.set_active_project(
+            project_service_module.ensure_default_project().id
         )
 
         response = self.client.get("/")

--- a/tests/test_ui/test_history_page.py
+++ b/tests/test_ui/test_history_page.py
@@ -13,6 +13,7 @@ import models.database as database_module
 import models.repositories.analysis_reports as analysis_reports_repository_module
 import models.tables as tables_module
 import services.report_service as report_service_module
+import services.project_service as project_service_module
 import ui.routes.history as history_module
 from analysis.risk_scorer import RiskAssessment, RiskContributor
 from analysis.rollback_planner import RollbackPlan, RollbackStep
@@ -52,6 +53,7 @@ class HistoryPageRenderingTests(unittest.TestCase):
         reload(tables_module)
         reload(database_module)
         reload(analysis_reports_repository_module)
+        reload(project_service_module)
         reload(report_service_module)
         reload(history_module)
         reload(app_module)
@@ -240,6 +242,19 @@ class HistoryPageRenderingTests(unittest.TestCase):
         self.assertIn(
             "Review the security group change before deployment.", response.text
         )
+
+    def test_history_detail_route_hides_report_from_other_active_project(self) -> None:
+        self._persist_report()
+        other = project_service_module.create_project(
+            project_key="other",
+            display_name="Other",
+        )
+        project_service_module.set_active_project(other.id)
+
+        response = self.client.get("/history/1")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("Analysis report not found", response.text)
 
     def test_public_report_route_blocks_compare_view_when_previous_report_is_protected(
         self,

--- a/tests/test_ui/test_settings_page.py
+++ b/tests/test_ui/test_settings_page.py
@@ -3,15 +3,20 @@
 from __future__ import annotations
 
 import json
+import os
 import tempfile
 import unittest
+from importlib import reload
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import patch
 
+import app as app_module
+import config as config_module
+import models.database as database_module
+import models.tables as tables_module
 from fastapi.testclient import TestClient
 
-from app import create_app
 from ui.routes.settings import (
     process_custom_skill_upload_content,
     process_topology_upload_content,
@@ -20,7 +25,20 @@ from ui.routes.settings import (
 
 class SettingsPageTests(unittest.TestCase):
     def setUp(self) -> None:
-        self.client = TestClient(create_app())
+        self.tempdir = tempfile.TemporaryDirectory()
+        self.db_path = Path(self.tempdir.name) / "settings.db"
+        os.environ["DATABASE_URL"] = f"sqlite:///{self.db_path}"
+        reload(config_module)
+        reload(tables_module)
+        reload(database_module)
+        reload(app_module)
+        database_module.init_db()
+        self.client = TestClient(app_module.create_app())
+
+    def tearDown(self) -> None:
+        database_module.engine.dispose()
+        os.environ.pop("DATABASE_URL", None)
+        self.tempdir.cleanup()
 
     def test_settings_page_contains_topology_context_workflow(self) -> None:
         response = self.client.get("/settings")

--- a/tests/test_ui/test_upload_panel.py
+++ b/tests/test_ui/test_upload_panel.py
@@ -5,7 +5,13 @@ from __future__ import annotations
 import unittest
 from unittest.mock import patch
 
-from ui.components.upload_panel import process_uploaded_files, run_uploaded_analysis
+from ui.components.upload_panel import (
+    process_uploaded_files,
+    resolve_initial_project_selection,
+    should_clear_pending_uploads,
+    uploads_allowed,
+    run_uploaded_analysis,
+)
 
 
 class UploadPanelTests(unittest.TestCase):
@@ -36,16 +42,56 @@ class UploadPanelTests(unittest.TestCase):
             "ui.components.upload_panel.analyze_uploaded_files",
             return_value=expected,
         ) as analyze_mock:
-            result = run_uploaded_analysis(files)
+            result = run_uploaded_analysis(files, project_key="payments")
 
         self.assertIs(result, expected)
         analyze_mock.assert_called_once_with(
             files,
             completion_client=None,
+            project_key="payments",
             audit_context={
                 "source_interface": "ui",
                 "trigger_type": "dashboard_upload",
             },
+        )
+
+    def test_resolve_initial_project_selection_requires_saved_choice(self) -> None:
+        project_id, project_key = resolve_initial_project_selection(
+            has_saved_selection=False,
+            active_project=type(
+                "Project", (), {"id": 1, "project_key": "unassigned"}
+            )(),
+        )
+
+        self.assertIsNone(project_id)
+        self.assertIsNone(project_key)
+
+    def test_uploads_allowed_requires_selected_project(self) -> None:
+        self.assertFalse(uploads_allowed(None))
+        self.assertFalse(uploads_allowed(""))
+        self.assertTrue(uploads_allowed("payments"))
+
+    def test_should_clear_pending_uploads_only_when_project_changes_with_files(self) -> None:
+        self.assertTrue(
+            should_clear_pending_uploads(
+                current_file_count=2,
+                previous_project_id=1,
+                next_project_id=2,
+            )
+        )
+        self.assertFalse(
+            should_clear_pending_uploads(
+                current_file_count=0,
+                previous_project_id=1,
+                next_project_id=2,
+            )
+        )
+        self.assertFalse(
+            should_clear_pending_uploads(
+                current_file_count=2,
+                previous_project_id=1,
+                next_project_id=1,
+            )
         )
 
 

--- a/tests/test_ui/test_upload_panel.py
+++ b/tests/test_ui/test_upload_panel.py
@@ -71,7 +71,9 @@ class UploadPanelTests(unittest.TestCase):
         self.assertFalse(uploads_allowed(""))
         self.assertTrue(uploads_allowed("payments"))
 
-    def test_should_clear_pending_uploads_only_when_project_changes_with_files(self) -> None:
+    def test_should_clear_pending_uploads_only_when_project_changes_with_files(
+        self,
+    ) -> None:
         self.assertTrue(
             should_clear_pending_uploads(
                 current_file_count=2,

--- a/ui/components/upload_panel.py
+++ b/ui/components/upload_panel.py
@@ -17,6 +17,13 @@ from services.intake_service import (
     total_upload_bytes,
     uniquify_artifact_names,
 )
+from services.project_service import (
+    create_project,
+    get_active_project,
+    has_active_project_selection,
+    list_projects,
+    set_active_project,
+)
 from services.report_service import (
     fetch_active_dashboard_report,
 )
@@ -77,16 +84,45 @@ def _format_countdown_label(seconds: int) -> str:
 def run_uploaded_analysis(
     files: list[tuple[str, bytes]],
     *,
+    project_key: str | None = None,
     completion_client=None,
 ):
     """Run the shared upload analysis pipeline with the dashboard audit context."""
     return analyze_uploaded_files(
         files,
         completion_client=completion_client,
+        project_key=project_key,
         audit_context={
             "source_interface": "ui",
             "trigger_type": "dashboard_upload",
         },
+    )
+
+
+def resolve_initial_project_selection(*, has_saved_selection: bool, active_project):
+    """Return the upload-panel project selection state."""
+    if not has_saved_selection or active_project is None:
+        return None, None
+    return active_project.id, active_project.project_key
+
+
+def uploads_allowed(active_project_key: str | None) -> bool:
+    """Return whether manual uploads should be enabled."""
+    return bool(active_project_key)
+
+
+def should_clear_pending_uploads(
+    *,
+    current_file_count: int,
+    previous_project_id: int | None,
+    next_project_id: int | None,
+) -> bool:
+    """Return whether a project switch should clear staged uploads."""
+    return (
+        current_file_count > 0
+        and previous_project_id is not None
+        and next_project_id is not None
+        and previous_project_id != next_project_id
     )
 
 
@@ -97,6 +133,12 @@ def build_upload_panel(
     result_container=None,
 ) -> None:
     """Render the upload intake component for pending analyses."""
+    saved_selection = has_active_project_selection()
+    active_project = get_active_project() if saved_selection else None
+    initial_project_id, initial_project_key = resolve_initial_project_selection(
+        has_saved_selection=saved_selection,
+        active_project=active_project,
+    )
     state: dict[str, object] = {
         "files": [],
         "summary": build_pending_analysis([]),
@@ -105,6 +147,9 @@ def build_upload_panel(
         "progress_message": "Waiting to analyze",
         "result_token": 0,
         "active_result": None,
+        "projects": list_projects(),
+        "active_project_id": initial_project_id,
+        "active_project_key": initial_project_key,
     }
 
     card_classes = "w-full shadow-none"
@@ -132,6 +177,7 @@ def build_upload_panel(
             "artifacts. DeployWhisper now recognizes CloudFormation by template signatures such as Resources, "
             "Parameters, Outputs, AWSTemplateFormatVersion, and intrinsic references."
         ).classes(body_spacing)
+        project_controls = ui.row().classes("w-full items-end gap-3 flex-wrap")
 
         summary_row = ui.row().classes("w-full items-center gap-2 text-sm dw-muted")
         detail_column = ui.column().classes("w-full gap-2")
@@ -140,6 +186,133 @@ def build_upload_panel(
 
     progress_bar = None
     progress_label = None
+    project_select = None
+
+    def _project_options() -> dict[int, str]:
+        return {
+            int(project.id): f"{project.display_name} ({project.project_key})"
+            for project in state["projects"]
+        }
+
+    def refresh_saved_report() -> None:
+        active_project_id = state["active_project_id"]
+        if active_project_id is None:
+            result_mount.clear()
+            return
+        active_report = fetch_active_dashboard_report(project_id=active_project_id)
+        result_mount.clear()
+        if active_report is not None:
+            render_result_card(
+                active_report,
+                remaining_seconds=active_report["dashboard_remaining_seconds"],
+            )
+
+    def refresh_projects(
+        *,
+        selected_project_id: int | None = None,
+        notify_parent: bool = False,
+    ) -> None:
+        state["projects"] = list_projects()
+        if selected_project_id is not None:
+            selected_project = set_active_project(selected_project_id)
+            state["active_project_id"] = selected_project.id
+            state["active_project_key"] = selected_project.project_key
+        if project_select is not None:
+            project_select.set_options(_project_options())
+            project_select.value = state["active_project_id"]
+            project_select.update()
+        if upload_widget is not None:
+            if uploads_allowed(state["active_project_key"]):
+                upload_widget.enable()
+            else:
+                upload_widget.disable()
+        refresh_saved_report()
+        if notify_parent and on_analysis_complete:
+            on_analysis_complete()
+
+    with project_controls:
+        project_select = ui.select(
+            options=_project_options(),
+            value=state["active_project_id"],
+            label="Project workspace",
+        ).classes("min-w-[280px] flex-1")
+
+        def handle_project_change(event) -> None:
+            selected_id = int(event.value) if event.value is not None else None
+            if selected_id is None:
+                return
+            if should_clear_pending_uploads(
+                current_file_count=len(state["files"]),
+                previous_project_id=state["active_project_id"],
+                next_project_id=selected_id,
+            ):
+                state["files"] = []
+                state["summary"] = build_pending_analysis([])
+                upload_error.set_text("Re-upload artifacts after switching projects.")
+                if upload_widget is not None:
+                    upload_widget.reset()
+            refresh_projects(selected_project_id=selected_id, notify_parent=True)
+            render_summary()
+            render_actions()
+
+        project_select.on_value_change(handle_project_change)
+
+        def open_create_project_dialog() -> None:
+            dialog = ui.dialog()
+            with (
+                dialog,
+                ui.card().classes(
+                    "w-[520px] dw-panel shadow-none p-6 gap-3"
+                ) as dialog_card,
+            ):
+                decorate_modal_card(dialog_card, label="Create project workspace")
+                ui.label("Create project workspace").classes(
+                    "text-lg font-medium dw-text"
+                )
+                key_input = ui.input("Project key").classes("w-full")
+                name_input = ui.input("Display name").classes("w-full")
+                description_input = ui.textarea("Description").classes("w-full")
+                repository_input = ui.input("Repository URL").classes("w-full")
+                branch_input = ui.input("Default branch").classes("w-full")
+                error_label = ui.label("").classes("text-xs dw-warning-text")
+
+                def submit_project() -> None:
+                    try:
+                        created = create_project(
+                            project_key=key_input.value,
+                            display_name=name_input.value,
+                            description=description_input.value or None,
+                            repository_url=repository_input.value or None,
+                            default_branch=branch_input.value or None,
+                        )
+                    except ValueError as exc:
+                        error_label.set_text(str(exc))
+                        return
+                    dialog.close()
+                    refresh_projects(selected_project_id=created.id, notify_parent=True)
+                    render_actions()
+                    ui.notify(
+                        f"Project workspace created: {created.display_name}.",
+                        color="positive",
+                    )
+
+                with ui.row().classes("w-full justify-end gap-3 mt-4"):
+                    cancel_button = ui.button("Cancel", on_click=dialog.close).props(
+                        "outline no-caps"
+                    )
+                    decorate_modal_close(cancel_button)
+                    ui.button(
+                        "Create project",
+                        on_click=submit_project,
+                        color="primary",
+                    ).props("unelevated no-caps")
+            dialog.open()
+
+        ui.button(
+            "Create project",
+            on_click=open_create_project_dialog,
+            color="primary",
+        ).props("flat no-caps")
 
     def clear_result_if_current(token: int) -> None:
         if token != state["result_token"]:
@@ -294,7 +467,11 @@ def build_upload_panel(
             analyze_button = ui.button(
                 "Analyze", on_click=run_analysis, color="primary"
             ).props("unelevated")
-            if summary.ready_count == 0:
+            if not state["active_project_key"]:
+                ui.label(
+                    "Select an existing project or create one before running manual analysis."
+                ).classes("text-xs dw-muted")
+            if summary.ready_count == 0 or not state["active_project_key"]:
                 analyze_button.disable()
 
     def update_progress(value: int, message: str) -> None:
@@ -341,6 +518,12 @@ def build_upload_panel(
         if not files:
             ui.notify("No supported artifacts are ready for analysis.", color="warning")
             return
+        if not state["active_project_key"]:
+            ui.notify(
+                "Select or create a project workspace before running analysis.",
+                color="warning",
+            )
+            return
 
         state["is_running"] = True
         upload_widget.disable()
@@ -350,7 +533,11 @@ def build_upload_panel(
         try:
             raw_files = list(state["files"])
             update_progress(25, "Running shared analysis pipeline")
-            result = await run.io_bound(run_uploaded_analysis, raw_files)
+            result = await run.io_bound(
+                run_uploaded_analysis,
+                raw_files,
+                project_key=state["active_project_key"],
+            )
             parse_batch = result.parse_batch
             assessment = result.assessment
             narrative = result.narrative
@@ -449,6 +636,11 @@ def build_upload_panel(
         dialog.open()
 
     async def handle_multi_upload(event: events.MultiUploadEventArguments) -> None:
+        if not uploads_allowed(state["active_project_key"]):
+            upload_error.set_text(
+                "Select or create a project workspace before uploading deployment artifacts."
+            )
+            return
         if state["is_running"]:
             upload_error.set_text(
                 "Wait for the current analysis to finish before uploading more artifacts."
@@ -482,6 +674,7 @@ def build_upload_panel(
             "One or more files were rejected by the uploader. Check file type or size."
         )
 
+    upload_widget = None
     with upload_card:
         upload_widget = (
             ui.upload(
@@ -496,10 +689,5 @@ def build_upload_panel(
             .classes("w-full")
         )
 
-    active_report = fetch_active_dashboard_report()
-    if active_report is not None:
-        render_result_card(
-            active_report,
-            remaining_seconds=active_report["dashboard_remaining_seconds"],
-        )
+    refresh_projects()
     render_summary()

--- a/ui/routes/dashboard.py
+++ b/ui/routes/dashboard.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from nicegui import ui
 
+from services.project_service import get_active_project
 from services.report_service import fetch_active_dashboard_report
 from ui.components.upload_panel import build_upload_panel
 from ui.components.verdict_card import render_verdict_card
@@ -30,6 +31,13 @@ def build_dashboard() -> None:
     apply_theme()
     build_navigation_shell("dashboard")
 
+    def current_project():
+        return get_active_project()
+
+    def current_project_id() -> int | None:
+        project = current_project()
+        return project.id if project is not None else None
+
     with ui.column().classes("dw-main-content dw-shell gap-5"):
         briefing_mount = None
         stats_mount = None
@@ -39,7 +47,7 @@ def build_dashboard() -> None:
 
         def render_briefing() -> None:
             nonlocal briefing_mount
-            briefing = fetch_dashboard_briefing()
+            briefing = fetch_dashboard_briefing(project_id=current_project_id())
             severity_counts = briefing["severity_counts"]
             total_reports = max(briefing["saved_briefings"], 1)
             segments = (
@@ -124,7 +132,7 @@ def build_dashboard() -> None:
                                         ui.label(str(value)).classes("text-xs dw-muted")
 
         def render_stats() -> None:
-            stats = fetch_dashboard_stats()
+            stats = fetch_dashboard_stats(project_id=current_project_id())
             stats_mount.clear()
             with stats_mount:
                 with ui.card().classes("w-full dw-panel shadow-none p-4"):
@@ -167,7 +175,9 @@ def build_dashboard() -> None:
             render_stats()
 
         def render_hero() -> None:
-            active_report = fetch_active_dashboard_report()
+            active_report = fetch_active_dashboard_report(
+                project_id=current_project_id()
+            )
             hero_mount.clear()
             with hero_mount:
                 if active_report is not None:
@@ -178,6 +188,13 @@ def build_dashboard() -> None:
                     return
 
                 ui.label("Deploy review").classes("dw-eyebrow")
+                active_project = current_project()
+                if active_project is not None:
+                    ui.label(
+                        f"Current project: {active_project.display_name} ({active_project.project_key})"
+                    ).classes(
+                        "text-xs font-semibold uppercase tracking-[0.08em] dw-muted"
+                    )
                 ui.html(
                     '<div class="dw-dashboard-headline mt-3">'
                     '<span class="dw-gradient">Know the risk before</span><br>'

--- a/ui/routes/history.py
+++ b/ui/routes/history.py
@@ -6,6 +6,7 @@ from typing import Any
 
 from nicegui import ui
 
+from services.project_service import get_active_project
 from services.report_service import (
     fetch_analysis_report,
     fetch_filtered_analysis_history_page,
@@ -37,10 +38,16 @@ def build_history_page() -> None:
     """Render a scanable history view with direct report retrieval."""
     apply_theme()
     build_navigation_shell("history")
-    reports_page = fetch_filtered_analysis_history_page(page=1, page_size=5)
+    active_project = get_active_project()
+    active_project_id = active_project.id if active_project is not None else None
+    reports_page = fetch_filtered_analysis_history_page(
+        project_id=active_project_id,
+        page=1,
+        page_size=5,
+    )
     reports = reports_page["items"]
     total_report_count = reports_page["total_count"]
-    trends = fetch_risk_trends()
+    trends = fetch_risk_trends(project_id=active_project_id)
     selected_ids: set[int] = set()
     page_state = {"page": 1, "page_size": 5}
     card_checkboxes: dict[int, Any] = {}
@@ -51,7 +58,11 @@ def build_history_page() -> None:
             build_page_header(
                 eyebrow="History",
                 title="Analysis history",
-                subtitle="Review earlier deploy briefings, audit metadata, and risk trends.",
+                subtitle=(
+                    "Review earlier deploy briefings, audit metadata, and risk trends."
+                    if active_project is None
+                    else f"Project-scoped history for {active_project.display_name} ({active_project.project_key})."
+                ),
                 back_href="/",
                 back_label="Back to dashboard",
             )
@@ -87,13 +98,14 @@ def build_history_page() -> None:
         def refresh_data(query: str | None = None) -> list[dict]:
             nonlocal reports, trends, total_report_count
             page_payload = fetch_filtered_analysis_history_page(
+                project_id=active_project_id,
                 search=query,
                 page=page_state["page"],
                 page_size=page_state["page_size"],
             )
             reports = page_payload["items"]
             total_report_count = page_payload["total_count"]
-            trends = fetch_risk_trends()
+            trends = fetch_risk_trends(project_id=active_project_id)
             max_page = max(1, (total_report_count - 1) // page_state["page_size"] + 1)
             page_state["page"] = min(page_state["page"], max_page)
             return reports
@@ -402,8 +414,14 @@ def build_history_detail_page(report_id: int, *, show_comparison: bool = False) 
     """Render one persisted report on a dedicated detail page."""
     apply_theme()
     build_navigation_shell("history")
-    report = fetch_analysis_report(report_id)
-    comparison = fetch_report_comparison(report_id) if show_comparison else None
+    active_project = get_active_project()
+    active_project_id = active_project.id if active_project is not None else None
+    report = fetch_analysis_report(report_id, project_id=active_project_id)
+    comparison = (
+        fetch_report_comparison(report_id, project_id=active_project_id)
+        if show_comparison
+        else None
+    )
 
     with ui.column().classes("dw-main-content dw-shell gap-5"):
         with ui.card().classes("w-full dw-panel dw-page-header shadow-none"):

--- a/ui/routes/settings.py
+++ b/ui/routes/settings.py
@@ -7,6 +7,7 @@ from typing import Any
 from nicegui import ui
 
 from llm.skill_context import get_custom_skill_statuses, save_custom_skill
+from services.project_service import get_active_project
 from services.settings_service import (
     activate_local_mode,
     get_dashboard_result_display_duration_seconds,
@@ -21,14 +22,18 @@ from services.topology_service import get_topology_status, save_topology_definit
 from ui.theme import apply_theme, build_navigation_shell, build_page_header
 
 
-def process_topology_upload_content(raw_content: bytes) -> dict[str, Any]:
+def process_topology_upload_content(
+    raw_content: bytes,
+    *,
+    project_id: int | None = None,
+) -> dict[str, Any]:
     """Decode topology upload content and return admin-facing feedback payload."""
     try:
         raw_text = raw_content.decode("utf-8")
-        status = save_topology_definition(raw_text)
+        status = save_topology_definition(raw_text, project_id=project_id)
     except (UnicodeDecodeError, ValueError) as exc:
         return {
-            "status": get_topology_status(),
+            "status": get_topology_status(project_id=project_id),
             "success_message": None,
             "error_message": f"Topology update failed: {exc}",
         }
@@ -69,9 +74,12 @@ def build_settings_page() -> None:
     """Render the provider settings form."""
     apply_theme()
     build_navigation_shell("settings")
+    active_project = get_active_project()
     settings = get_provider_settings()
     dashboard_duration_seconds = get_dashboard_result_display_duration_seconds()
-    topology_status = get_topology_status()
+    topology_status = get_topology_status(
+        project_id=active_project.id if active_project is not None else None
+    )
     custom_skill_statuses = get_custom_skill_statuses()
     provider_options = provider_select_options()
 
@@ -215,6 +223,10 @@ def build_settings_page() -> None:
                 "Upload or replace the service-topology JSON used by blast-radius analysis. "
                 "DeployWhisper validates the structure immediately and shows any uncertainty."
             ).classes("text-sm dw-muted")
+            if active_project is not None:
+                ui.label(
+                    f"Active project: {active_project.display_name} ({active_project.project_key})"
+                ).classes("text-xs font-semibold uppercase tracking-[0.08em] dw-muted")
             topology_feedback = ui.column().classes("w-full gap-2")
 
             def render_topology_feedback(
@@ -261,7 +273,13 @@ def build_settings_page() -> None:
                         ui.label(warning).classes("text-xs dw-warning-text")
 
             def handle_topology_upload(event) -> None:
-                upload_result = process_topology_upload_content(event.content.read())
+                current_project = get_active_project()
+                upload_result = process_topology_upload_content(
+                    event.content.read(),
+                    project_id=current_project.id
+                    if current_project is not None
+                    else None,
+                )
                 render_topology_feedback(
                     upload_result["status"],
                     success_message=upload_result["success_message"],


### PR DESCRIPTION
Story 5.1 adds lightweight project/workspace records across persistence, UI, API, CLI, and GitHub integration paths. The implementation now scopes reports and topology context by project, preserves a default unassigned path for brownfield data, and closes the review findings around strict project resolution, project switching, and project-scoped context operations.

Constraint: Story 5.1 must preserve the local-first and advisory-first product posture without adding RBAC, SSO, or tenancy behavior.
Rejected: Keep implicit fallback to unassigned for explicit project references | it hides scoping mistakes and leaks data across workspaces.
Rejected: Derive GitHub project keys from repo leaf only | collisions across owners collapse unrelated repositories into one workspace.
Confidence: high
Scope-risk: moderate
Reversibility: clean
Directive: Treat /reports/{id} as the Story 3.4 public-share surface; do not tighten that route under project-scoping work without revisiting the shareable-report contract.
Tested: ./ .venv/bin/ruff check .; ./ .venv/bin/ruff format --check .; ./ .venv/bin/python -m unittest discover -q; bash scripts/ci-local.sh
Not-tested: Local Bandit scan (tool not installed); data/deploywhisper.db runtime state intentionally excluded from commit

## What does this PR do?

<!-- Brief description of changes -->

## Type of change
- [ ] Feature (new functionality)
- [ ] Bugfix (non-breaking fix)
- [ ] Release preparation
- [ ] Hotfix (critical production fix)
- [ ] Docs / refactor / chore

## Checklist
- [ ] I have followed the branch naming convention
- [ ] Tests pass locally (`pytest tests/ -v`)
- [ ] Linting passes (`ruff check .`)
- [ ] Docker build succeeds
- [ ] I have updated docs if needed
- [ ] No secrets or .env values committed

## Related issue
Closes #