### PR TITLE
Make project switching trustworthy across the workspace

### DIFF
--- a/_bmad-output/implementation-artifacts/5-1-project-workspace-foundation.md
+++ b/_bmad-output/implementation-artifacts/5-1-project-workspace-foundation.md
@@ -13,10 +13,10 @@ so that reports, topology, history, and feedback stay isolated by project or rep
 ## Acceptance Criteria
 
 1. Users can create a project/workspace with project key, display name, and optional description, repository URL, and default branch.
-2. Web UI requires selecting or creating a project before new manual analysis uploads.
+2. Web UI requires selecting or creating a project before new manual analysis uploads, and makes the active project obvious in the shared workspace so users can change project context without returning to the dashboard upload panel.
 3. API and CLI accept `project_key` or `project_id` for new analyses and project-scoped context operations.
 4. GitHub integrations can accept an explicit project key and otherwise derive a stable default from repository name.
-5. Analysis reports, topology imports, deployment outcomes, and reviewer feedback are scoped to a project/workspace.
+5. Analysis reports, topology imports, deployment outcomes, and reviewer feedback are scoped to a project/workspace, and dashboard/history/report views refresh consistently when the active project changes.
 6. Existing installations can map legacy records into a default or unassigned project without losing history.
 7. Scope explicitly excludes RBAC, SSO, org hierarchy, hosted SaaS scoping, and deep multi-tenant behavior.
 
@@ -37,6 +37,9 @@ so that reports, topology, history, and feedback stay isolated by project or rep
 - [x] Implement AC6: legacy-data migration or default/unassigned project mapping without history loss (AC: 6)
 - [x] Implement AC7: enforce non-goals so this story does not add RBAC, SSO, org hierarchy, hosted SaaS scoping, or deep multi-tenant behavior (AC: 7)
 - [x] Add deterministic tests, docs, and rollout notes covering project-scoped analysis flows and legacy mapping (AC: 1, 2, 3, 4, 5, 6, 7)
+- [x] Implement AC2 refinement: shared-shell project selection/search flow that updates the active workspace across routed pages without requiring a return to the dashboard upload panel (AC: 2)
+- [x] Make the active project visible in shared workspace chrome and preserve project-scoped history/report context after project changes (AC: 2, 5)
+- [x] Add deterministic UI regression coverage for shared-shell project switching cues across dashboard and history surfaces (AC: 2, 5)
 
 ### Review Findings
 
@@ -85,6 +88,7 @@ so that reports, topology, history, and feedback stay isolated by project or rep
 - [Architecture](../planning-artifacts/architecture.md)
 - [Project Context](../project-context.md)
 - [Sprint Change Proposal](../planning-artifacts/sprint-change-proposal-2026-04-27-epic-5-project-workspace-foundation.md)
+- [Sprint Change Proposal](../planning-artifacts/sprint-change-proposal-2026-04-28-epic-5-project-switching.md)
 
 ## Dev Agent Record
 
@@ -118,6 +122,12 @@ GPT-5 (Codex)
 - 2026-04-28T19:05:00+05:30: `./.venv/bin/python -m unittest -q tests.test_ui.test_upload_panel tests.test_ui.test_history_page tests.test_api.test_analyses tests.test_services.test_project_service`
 - 2026-04-28T19:05:00+05:30: `./.venv/bin/ruff check ui/components/upload_panel.py tests/test_ui/test_upload_panel.py`
 - 2026-04-28T19:20:00+05:30: Story 5.1 re-review triage reconciled the remaining public-share concern against Story 3.4’s accepted `/reports/{id}` contract; no actionable 5.1 findings remained
+- 2026-04-28T21:05:00+05:30: `./.venv/bin/python -m unittest -q tests.test_ui.test_project_workspace_switcher tests.test_ui.test_app_shell tests.test_ui.test_history_page tests.test_ui.test_upload_panel tests.test_ui.test_settings_page`
+- 2026-04-28T21:10:00+05:30: `./.venv/bin/ruff check .`
+- 2026-04-28T21:11:00+05:30: `./.venv/bin/ruff format ui/theme.py`
+- 2026-04-28T21:11:00+05:30: `./.venv/bin/ruff format --check .`
+- 2026-04-28T21:14:00+05:30: `./.venv/bin/python -m unittest discover -q`
+- 2026-04-28T21:16:00+05:30: `bash scripts/ci-local.sh`
 
 ### Completion Notes List
 
@@ -132,6 +142,8 @@ GPT-5 (Codex)
 - Fixed the third Story 5.1 review pass by default-scoping API detail fetches to `unassigned`, rejecting partially invalid dual project references, clearing staged uploads on project switch, resolving the current project at settings-upload time, and allowing GitHub explicit project-key overrides to create or fail in a controlled way.
 - Verified the final Story 5.1 rerun finding is resolved in the live upload-panel flow: switching projects with staged artifacts clears pending uploads and requires re-upload under the newly selected workspace.
 - Re-ran code review after all patches. No actionable Story 5.1 findings remain; the only residual concern was the intentional public-share behavior introduced and accepted in Story 3.4.
+- Applied the 2026-04-28 project-switching correction by adding a shared-shell project selector with global create-project access, making the active/default workspace visible across routed pages, and extending regression coverage so dashboard/history surfaces reflect the same active project context.
+- Validation passed again after the cross-page workspace refinement: focused UI unittests, repo-wide Ruff check/format check, full `unittest discover -q`, and `scripts/ci-local.sh` all passed. Local CI still skipped Bandit because it is not installed in this environment.
 
 ### File List
 
@@ -167,13 +179,18 @@ GPT-5 (Codex)
 - tests/test_services/test_report_service.py
 - tests/test_services/test_topology_service.py
 - tests/test_ui/test_app_shell.py
+- tests/test_ui/test_project_workspace_switcher.py
 - tests/test_ui/test_settings_page.py
 - tests/test_ui/test_upload_panel.py
+- ui/components/project_workspace_switcher.py
 - ui/components/upload_panel.py
 - ui/routes/dashboard.py
 - ui/routes/history.py
 - ui/routes/settings.py
+- ui/theme.py
+- _bmad-output/planning-artifacts/ux-design-specification.md
 
 ### Change Log
 
 - 2026-04-28: Implemented project workspace foundations across persistence, UI/API/CLI intake, topology scoping, GitHub project derivation, and rollout documentation.
+- 2026-04-28: Refined Story 5.1 so project switching is available from shared workspace chrome, with active-project visibility and cross-page UI regression coverage.

--- a/_bmad-output/planning-artifacts/sprint-change-proposal-2026-04-28-epic-5-project-switching.md
+++ b/_bmad-output/planning-artifacts/sprint-change-proposal-2026-04-28-epic-5-project-switching.md
@@ -1,0 +1,235 @@
+# Sprint Change Proposal: Epic 5 Cross-Page Project Switching
+
+Date: 2026-04-28
+Project: deploywhisper
+Workflow: bmad-correct-course
+Mode assumption: Batch
+
+## 1. Issue Summary
+
+Story 5.1 introduced lightweight project/workspace scoping and made the dashboard upload flow require an explicit project selection before manual analysis. That solved isolation for new uploads, but it left project switching trapped inside the dashboard upload panel.
+
+Once a user navigates to History or other secondary pages, they can see only the currently active project's reports with no obvious way to identify, search, or change the active project without returning to the dashboard first. This creates a workflow break in the new project-scoped model: data is correctly isolated, but cross-page navigation does not let users intentionally move between project contexts.
+
+This is not a new product direction. It is a usability and workflow-completion gap in the Story 5.1 workspace model.
+
+## 2. Change Navigation Checklist
+
+| Item | Status | Finding |
+| --- | --- | --- |
+| 1.1 Trigger story | Done | `5-1-project-workspace-foundation` revealed the gap after completion. |
+| 1.2 Core problem | Done | Misunderstanding of original requirements: project scoping was implemented, but project context switching remained dashboard-local instead of cross-page. |
+| 1.3 Supporting evidence | Done | `ui/components/upload_panel.py` contains the only project selector; `ui/theme.py` shared navigation shell has no project control; `ui/routes/history.py` reads `get_active_project()` and scopes results but offers no switcher. |
+| 2.1 Current epic viability | Done | Epic 5 remains viable as planned. The issue is a refinement to the existing workspace foundation, not an epic-level failure. |
+| 2.2 Epic-level changes | Done | No new epic needed. Reopen and patch Story 5.1, or add an explicit follow-up note under that story's acceptance/tasks. |
+| 2.3 Future epic impact | Done | Future Epic 5 stories benefit from a clear active-project model across pages, especially history, outcomes, feedback, trends, and topology workflows. |
+| 2.4 New epic need | Done | No. The change stays inside Epic 5. |
+| 2.5 Priority/order | Done | Address before deeper Epic 5 context features so later pages do not repeat the same dashboard-only project-switch constraint. |
+| 3.1 PRD conflicts | Done | No PRD conflict. PRD already calls for lightweight project/workspace scoping for analyses, topology, history, and feedback. |
+| 3.2 Architecture conflicts | Done | No architecture rewrite needed. The change stays within the shared UI shell and existing project service boundary. |
+| 3.3 UI/UX conflicts | Done | UX spec currently defines project selection before upload, but it does not yet make cross-page project switching explicit in navigation/page-header behavior. |
+| 3.4 Secondary artifacts | Done | Story 5.1 artifact, project-workspaces docs, and UI regression coverage should be updated. |
+| 4.1 Direct adjustment | Viable | Low-to-moderate effort, low risk. Best path is a focused Story 5.1 refinement. |
+| 4.2 Rollback | Not viable | No rollback is justified. The underlying project-scoping model is correct and should be extended, not removed. |
+| 4.3 MVP review | Not viable | MVP and Phase 2 scope remain achievable. This improves usability of already-approved scope. |
+| 4.4 Recommended path | Done | Direct adjustment inside Story 5.1 with shared-shell/history-page project switching and regression coverage. |
+
+## 3. Impact Analysis
+
+### Epic Impact
+
+Epic 5 remains the correct home for this work. The issue is part of the "project/workspace foundation" story because it affects how users move between isolated history and report contexts after scoping is introduced.
+
+No epic renumbering or resequencing is required.
+
+### Story Impact
+
+Story 5.1 should be reopened for a targeted refinement. The core change is to expand the web-UI workspace behavior from:
+
+- selecting/creating a project before upload
+
+to:
+
+- selecting/creating a project before upload
+- clearly showing the active project across pages
+- allowing users to switch project context from History or the shared navigation shell
+- ensuring dashboard, history, and related report views refresh consistently when the active project changes
+
+This avoids adding a new story solely to compensate for a recently completed but incomplete workspace interaction model.
+
+### Artifact Conflicts
+
+- PRD: no requirement change needed; current scope already supports this refinement.
+- Architecture: no structural change needed; existing shared-shell and service boundaries are sufficient.
+- UX Design: navigation and project-workspace flow should explicitly mention cross-page project switching and active-project visibility.
+- Story artifact: Story 5.1 acceptance and tasks should be clarified so the behavior is testable and reviewable.
+- Project docs: `docs/project-workspaces.md` should describe the cross-page project switch behavior instead of only the dashboard upload flow.
+
+### Technical Impact
+
+Implementation should prefer one shared project-context control rather than duplicating separate selectors on every page.
+
+Likely technical touchpoints:
+
+- `ui/theme.py` for shared shell or shared header-level project context UI
+- `ui/components/upload_panel.py` to avoid conflicting dashboard-only ownership of project switching
+- `ui/routes/history.py` to surface active project context and refresh behavior
+- `ui/routes/dashboard.py` and `ui/routes/settings.py` to ensure the active project remains obvious and consistent after switching
+- `tests/test_ui/test_app_shell.py`
+- `tests/test_ui/test_history_page.py`
+- `tests/test_ui/test_upload_panel.py`
+
+The active-project state should continue to flow through `services.project_service` rather than introducing page-local project state.
+
+## 4. Detailed Change Proposals
+
+### Story: 5.1 Project workspace foundation
+
+Section: Acceptance Criteria
+
+OLD:
+
+```text
+2. Web UI requires selecting or creating a project before new manual analysis uploads.
+5. Analysis reports, topology imports, deployment outcomes, and reviewer feedback are scoped to a project/workspace.
+```
+
+NEW:
+
+```text
+2. Web UI requires selecting or creating a project before new manual analysis uploads, and makes the active project obvious in the shared workspace so users can change project context without returning to the dashboard upload panel.
+5. Analysis reports, topology imports, deployment outcomes, and reviewer feedback are scoped to a project/workspace, and dashboard/history/report views refresh consistently when the active project changes.
+```
+
+Rationale: Story 5.1 established isolation but left project switching trapped inside one page-local control. The acceptance criteria should test both isolation and cross-page usability.
+
+### Story: 5.1 Project workspace foundation
+
+Section: Tasks / Subtasks
+
+OLD:
+
+```text
+- [x] Implement AC2: web UI create/select project flow before manual analysis upload
+- [x] Add deterministic tests, docs, and rollout notes covering project-scoped analysis flows
+```
+
+NEW:
+
+```text
+- [ ] Implement AC2 refinement: shared-shell or history-page project selection/search flow that updates the active workspace across routed pages
+- [ ] Make the active project visible on dashboard, history, and settings surfaces without relying on upload-panel context
+- [ ] Add deterministic UI regression coverage for cross-page project switching and project-scoped history refresh
+```
+
+Rationale: The missing behavior is not just a label change. It needs explicit implementation and regression ownership.
+
+### UX Design Specification
+
+Section: Project Workspace Selection Flow
+
+OLD:
+
+```text
+A[Open dashboard or trigger GitHub analysis] --> B{Project already selected or derivable?}
+...
+E --> F[Upload files or submit repository-triggered analysis]
+F --> G[Report, topology, history, feedback, and outcomes are stored under that project]
+```
+
+NEW:
+
+```text
+A[Open dashboard, history, or trigger GitHub analysis] --> B{Project already selected or derivable?}
+...
+E --> F[User can confirm, search, or switch the active project from shared workspace chrome or history controls]
+F --> G[Upload files or review project-scoped reports in the selected workspace]
+G --> H[Report, topology, history, feedback, and outcomes are stored and viewed under that project]
+```
+
+Rationale: The workspace model should support both analysis submission and later report retrieval without forcing a return to the dashboard.
+
+### UX Design Specification
+
+Section: Navigation Patterns
+
+OLD:
+
+```text
+- route-level navigation for dashboard, history, settings, and admin areas
+- stable left-side shell navigation using stock Quasar patterns
+- the left navigation must remain visible on desktop and serve as the primary page-switching control
+```
+
+NEW:
+
+```text
+- route-level navigation for dashboard, history, settings, and admin areas
+- stable shell navigation also communicates the active project/workspace context
+- users can identify and switch the active project from shared workspace chrome or a history-local selector without detouring through the dashboard upload flow
+```
+
+Rationale: The new project-scoped product model changes navigation requirements, not only upload requirements.
+
+### Project Workspace Docs
+
+Section: User Flows in `docs/project-workspaces.md`
+
+OLD:
+
+```text
+- Web UI: choose an existing project or create one from the upload panel before running a manual analysis.
+```
+
+NEW:
+
+```text
+- Web UI: choose an existing project or create one before running a manual analysis, and switch the active project from shared workspace controls or the history page when moving between report sets.
+```
+
+Rationale: User-facing docs should describe the actual workspace-navigation contract, not only the initial upload step.
+
+## 5. Recommended Approach
+
+Use direct adjustment inside Story 5.1.
+
+This is a moderate sprint correction, not a major replan. The safest path is:
+
+1. Reopen Story 5.1 from `done` to `review` or `in-progress`.
+2. Update the story acceptance/tasks to include cross-page project visibility and switching.
+3. Implement one shared project-context control in the shell or one shell-plus-history pattern, not one-off selectors per page.
+4. Add regression coverage for cross-page switching and history refresh behavior.
+5. Return Story 5.1 to review and rerun code review.
+
+Effort impact:
+
+- Estimate: low-to-moderate
+- Timeline impact: small, localized follow-up
+- Risk: low-to-moderate because the change touches shared UI chrome, but it builds on existing project service behavior instead of altering the data model
+
+## 6. Implementation Handoff
+
+Scope classification: Moderate.
+
+Recommended handoff:
+
+- Product Owner / Developer:
+  - reopen Story 5.1
+  - update story text and sprint status
+  - confirm the selector placement decision (shared shell preferred; history-local acceptable if shared-shell complexity is disproportionate)
+- Developer:
+  - implement the project-switch UX
+  - keep one active-project source of truth
+  - update regression coverage and workspace docs
+- Code Review:
+  - verify active-project visibility
+  - verify switching refreshes dashboard/history/report surfaces consistently
+  - verify no page can imply "wrong project" after a switch
+
+Success criteria:
+
+- users can identify/search/select the active project from History or shared workspace chrome
+- switching project refreshes dashboard, history, and related report views consistently
+- the active project is obvious in the UI
+- deterministic regression tests lock the cross-page behavior
+

--- a/_bmad-output/planning-artifacts/ux-design-specification.md
+++ b/_bmad-output/planning-artifacts/ux-design-specification.md
@@ -763,13 +763,14 @@ Before upload or repository-triggered analysis becomes routine across multiple t
 
 ```mermaid
 flowchart TD
-    A[Open dashboard or trigger GitHub analysis] --> B{Project already selected or derivable?}
+    A[Open dashboard, history, or trigger GitHub analysis] --> B{Project already selected or derivable?}
     B -->|No| C[Create project with key, name, optional repo URL and description]
     B -->|Yes| D[Reuse existing project context]
     C --> E[Project becomes active workspace]
     D --> E
-    E --> F[Upload files or submit repository-triggered analysis]
-    F --> G[Report, topology, history, feedback, and outcomes are stored under that project]
+    E --> F[User can confirm, search, or switch the active project from shared workspace chrome]
+    F --> G[Upload files or review project-scoped reports in the selected workspace]
+    G --> H[Report, topology, history, feedback, and outcomes are stored and viewed under that project]
 ```
 
 This flow should feel closer to SonarQube's project key model than to an enterprise org/admin setup. The user should not have to think about RBAC, SSO, team hierarchy, or hosted SaaS boundaries to isolate reports cleanly.
@@ -1205,6 +1206,7 @@ DeployWhisper favors in-page review over navigation-heavy workflows.
 - route-level navigation for dashboard, history, settings, and admin areas
 - stable left-side shell navigation using stock Quasar patterns
 - the left navigation must remain visible on desktop and serve as the primary page-switching control
+- shared workspace chrome should keep the active project/workspace visible and allow project switching without forcing a detour through the dashboard upload flow
 - branding sits at the top of the navigation rail, followed by page links in a simple vertical list
 
 **Review navigation**

--- a/docs/project-workspaces.md
+++ b/docs/project-workspaces.md
@@ -12,7 +12,7 @@ DeployWhisper now scopes analyses and topology context to lightweight project/wo
 
 ### User Flows
 
-- Web UI: choose an existing project or create one from the upload panel before running a manual analysis.
+- Web UI: choose an existing project or create one before running a manual analysis, and switch the active project from the searchable full-width `Active Project` card directly below the fixed header when moving between dashboard, history, and other routed pages.
 - API:
   - `POST /api/v1/projects` creates a project
   - `POST /api/v1/analyses` accepts multipart `project_key` or `project_id`
@@ -27,6 +27,7 @@ DeployWhisper now scopes analyses and topology context to lightweight project/wo
 
 ### Guardrails
 
+- Shared workspace chrome now keeps project switching in a dedicated global card below the header, with searchable filtering, keyboard navigation, and current/default project context shown consistently across pages.
 - Explicit `project_key` / `project_id` references now fail fast when they are unknown instead of silently falling back to `unassigned`.
 - Conflicting `project_key` and `project_id` inputs are rejected.
 - Repository-derived project keys include the owner segment when available to avoid collisions between unrelated repositories with the same leaf name.

--- a/playwright.live.config.cjs
+++ b/playwright.live.config.cjs
@@ -1,0 +1,30 @@
+const { devices } = require("@playwright/test");
+
+module.exports = {
+  testDir: "./tests/e2e",
+  timeout: 5 * 60 * 1000,
+  expect: {
+    timeout: 15_000,
+  },
+  fullyParallel: false,
+  reporter: "list",
+  use: {
+    baseURL: "http://127.0.0.1:8080",
+    headless: true,
+    trace: "retain-on-failure",
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"], headless: true },
+    },
+    {
+      name: "firefox",
+      use: { ...devices["Desktop Firefox"], headless: true },
+    },
+    {
+      name: "webkit",
+      use: { ...devices["Desktop Safari"], headless: true },
+    },
+  ],
+};

--- a/tests/e2e/project_selector.spec.js
+++ b/tests/e2e/project_selector.spec.js
@@ -1,0 +1,31 @@
+const { test, expect } = require("@playwright/test");
+
+test.describe("project selector", () => {
+  test("top search selector activates the project across dashboard and history", async ({
+    page,
+  }) => {
+    await page.goto("/", { waitUntil: "networkidle" });
+
+    const searchInput = page.getByPlaceholder("Search repo or project name");
+    await expect(searchInput).toBeVisible();
+    await searchInput.click();
+    await searchInput.fill("pay");
+
+    const option = page.getByRole("button", { name: /Payments/i }).first();
+    await expect(option).toBeVisible();
+    await option.click();
+
+    await expect(page.getByText("Current project: Payments (payments)")).toBeVisible();
+    await expect(page.getByText("Payments")).toBeVisible();
+    await expect(page.getByText("acme/payments-api")).toBeVisible();
+    await expect(page.getByText("Key payments")).toBeVisible();
+
+    const dashboardProjectSelect = page.getByLabel("Project workspace");
+    await expect(dashboardProjectSelect).toContainText("Payments");
+
+    await page.goto("/history", { waitUntil: "networkidle" });
+    await expect(
+      page.getByText("Project-scoped history for Payments (payments).")
+    ).toBeVisible();
+  });
+});

--- a/tests/e2e/project_selector_live.spec.js
+++ b/tests/e2e/project_selector_live.spec.js
@@ -1,0 +1,53 @@
+const { test, expect } = require("@playwright/test");
+
+test.describe("live project selector", () => {
+  test("can create and activate a project from the top search selector", async ({
+    page,
+  }) => {
+    const suffix = Date.now().toString().slice(-6);
+    const projectKey = `payments-live-${suffix}`;
+    const projectName = `Payments Live ${suffix}`;
+    const repositorySlug = `acme/payments-live-${suffix}`;
+
+    await page.goto("/");
+
+    await page.getByRole("button", { name: "New project" }).click();
+    await page.getByLabel("Project key").fill(projectKey);
+    await page.getByLabel("Display name").fill(projectName);
+    await page
+      .getByLabel("Repository URL")
+      .fill(`https://github.com/${repositorySlug}.git`);
+    await page
+      .locator('[aria-label="Create project workspace"]')
+      .getByRole("button", { name: "Create project" })
+      .click();
+
+    const topSearch = page.getByPlaceholder("Search repo or project name");
+    await expect(topSearch).toBeVisible();
+    await topSearch.click();
+    await topSearch.fill(`live ${suffix}`);
+
+    const option = page.locator(".dw-project-option-button").filter({
+      hasText: projectName,
+    });
+    await expect(option.first()).toBeVisible();
+    await option.first().click();
+
+    await expect(
+      page.getByText(`Current project: ${projectName} (${projectKey})`)
+    ).toBeVisible();
+    await expect(
+      page.locator(".dw-project-filter-meta").filter({ hasText: repositorySlug })
+    ).toBeVisible();
+
+    const analyzeProject = page.getByLabel("Project workspace");
+    await expect(analyzeProject).toHaveValue(
+      `${projectName} · ${repositorySlug} · ${projectKey}`
+    );
+
+    await page.goto("/history");
+    await expect(
+      page.getByText(`Project-scoped history for ${projectName} (${projectKey}).`)
+    ).toBeVisible();
+  });
+});

--- a/tests/e2e/seeded_server.py
+++ b/tests/e2e/seeded_server.py
@@ -8,6 +8,9 @@ import tempfile
 from importlib import import_module, reload
 from pathlib import Path
 
+import nicegui.run as nicegui_run
+import uvicorn
+
 REPO_ROOT = Path(__file__).resolve().parents[2]
 if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
@@ -17,6 +20,16 @@ os.environ.setdefault("APP_HOST", "127.0.0.1")
 os.environ.setdefault("APP_PORT", "8080")
 os.environ.setdefault("DATABASE_URL", f"sqlite:///{_TEMP_ROOT / 'accessibility.db'}")
 os.environ.setdefault("ARTIFACT_SNAPSHOT_DIR", str(_TEMP_ROOT / "report-artifacts"))
+
+
+def _safe_nicegui_setup() -> None:
+    try:
+        nicegui_run.process_pool = None
+    except Exception:
+        pass
+
+
+nicegui_run.setup = _safe_nicegui_setup
 
 
 def _load_runtime_modules() -> tuple[object, object, object, object, object]:
@@ -243,13 +256,51 @@ def _seed_review_report(report_service_module) -> None:
     )
 
 
+def _seed_projects() -> None:
+    from services.project_service import create_project
+
+    create_project(
+        project_key="payments",
+        display_name="Payments",
+        repository_url="https://github.com/acme/payments-api.git",
+        default_branch="main",
+    )
+    create_project(
+        project_key="platform",
+        display_name="Platform",
+        repository_url="https://github.com/acme/platform-hub.git",
+        default_branch="main",
+    )
+
+
 def main() -> None:
     database_module, report_service_module = _reload_runtime()
     database_module.init_db()
+    _seed_projects()
     _seed_review_report(report_service_module)
     app_module = import_module("app")
-
-    app_module.run()
+    app_module.fastapi_app.config.add_run_config(
+        reload=False,
+        title="DeployWhisper",
+        viewport="width=device-width, initial-scale=1",
+        favicon=None,
+        dark=False,
+        language="en-US",
+        binding_refresh_interval=0.1,
+        reconnect_timeout=3.0,
+        message_history_length=1000,
+        tailwind=True,
+        unocss=None,
+        prod_js=True,
+        show_welcome_message=False,
+        markdown=False,
+    )
+    uvicorn.run(
+        app_module.create_app(),
+        host=os.environ["APP_HOST"],
+        port=int(os.environ["APP_PORT"]),
+        log_level="info",
+    )
 
 
 if __name__ == "__main__":

--- a/tests/test_ui/test_app_shell.py
+++ b/tests/test_ui/test_app_shell.py
@@ -54,6 +54,12 @@ class DashboardShellTests(unittest.TestCase):
         response = self.client.get("/")
         self.assertEqual(response.status_code, 200)
         self.assertIn("DeployWhisper", response.text)
+        self.assertIn("Active Project", response.text)
+        self.assertIn("Search repo or project name", response.text)
+        self.assertIn("New project", response.text)
+        self.assertIn("Unassigned", response.text)
+        self.assertIn("Default workspace", response.text)
+        self.assertIn("dw-project-bar", response.text)
         self.assertIn("Upload deployment artifacts", response.text)
         self.assertIn("Deploy review", response.text)
         self.assertIn("Deployment briefing", response.text)
@@ -66,7 +72,31 @@ class DashboardShellTests(unittest.TestCase):
     def test_history_page_contains_back_to_dashboard_action(self) -> None:
         response = self.client.get("/history")
         self.assertEqual(response.status_code, 200)
+        self.assertIn("Search repo or project name", response.text)
         self.assertIn("Back to dashboard", response.text)
+
+    def test_shell_reflects_active_project_across_dashboard_and_history(self) -> None:
+        payments = project_service_module.create_project(
+            project_key="payments",
+            display_name="Payments",
+        )
+        project_service_module.set_active_project(payments.id)
+
+        dashboard_response = self.client.get("/")
+        history_response = self.client.get("/history")
+
+        self.assertEqual(dashboard_response.status_code, 200)
+        self.assertEqual(history_response.status_code, 200)
+        self.assertIn("Active Project", dashboard_response.text)
+        self.assertIn("Payments", dashboard_response.text)
+        self.assertIn("Key payments", dashboard_response.text)
+        self.assertIn("Active Project", history_response.text)
+        self.assertIn("Payments", history_response.text)
+        self.assertIn("Key payments", history_response.text)
+        self.assertIn(
+            "Project-scoped history for Payments (payments).",
+            history_response.text,
+        )
 
     def test_dashboard_shows_persisted_result_provenance_when_active_report_exists(
         self,

--- a/tests/test_ui/test_project_workspace_switcher.py
+++ b/tests/test_ui/test_project_workspace_switcher.py
@@ -1,0 +1,150 @@
+"""Tests for shared project/workspace switcher helpers."""
+
+from __future__ import annotations
+
+import unittest
+
+from services.project_service import ProjectRecord
+from ui.components.project_workspace_switcher import (
+    build_project_options,
+    filter_project_records,
+    highlight_project_match,
+    split_project_option_label,
+    project_context_meta,
+    project_context_summary,
+    project_option_label,
+    project_repository_context,
+)
+
+
+class ProjectWorkspaceSwitcherTests(unittest.TestCase):
+    def _project(
+        self,
+        *,
+        project_key: str,
+        display_name: str,
+        repository_url: str | None = None,
+    ) -> ProjectRecord:
+        return ProjectRecord(
+            id=1,
+            project_key=project_key,
+            display_name=display_name,
+            description=None,
+            repository_url=repository_url,
+            default_branch=None,
+            is_default=False,
+            created_at="2026-04-28T00:00:00",
+            updated_at="2026-04-28T00:00:00",
+        )
+
+    def test_project_option_label_includes_repo_context_when_available(self) -> None:
+        project = self._project(
+            project_key="payments",
+            display_name="Payments",
+            repository_url="https://github.com/acme/payments-api.git",
+        )
+
+        self.assertEqual(project_repository_context(project), "acme/payments-api")
+        self.assertEqual(
+            project_option_label(project),
+            "Payments · acme/payments-api · payments",
+        )
+
+    def test_build_project_options_uses_searchable_project_labels(self) -> None:
+        project = self._project(project_key="payments", display_name="Payments")
+
+        options = build_project_options([project])
+
+        self.assertEqual(options, {1: "Payments · payments"})
+
+    def test_filter_project_records_matches_name_repo_and_key_case_insensitively(
+        self,
+    ) -> None:
+        projects = [
+            self._project(
+                project_key="payments",
+                display_name="Payments",
+                repository_url="https://github.com/acme/payments-api.git",
+            ),
+            self._project(
+                project_key="platform",
+                display_name="Platform Control",
+                repository_url="https://github.com/acme/platform-hub.git",
+            ),
+        ]
+
+        self.assertEqual(
+            [
+                project.project_key
+                for project in filter_project_records(projects, "pay")
+            ],
+            ["payments"],
+        )
+        self.assertEqual(
+            [
+                project.project_key
+                for project in filter_project_records(projects, "PLATFORM-HUB")
+            ],
+            ["platform"],
+        )
+        self.assertEqual(
+            [
+                project.project_key
+                for project in filter_project_records(projects, "payments")
+            ],
+            ["payments"],
+        )
+
+    def test_highlight_project_match_wraps_matching_query_in_mark(self) -> None:
+        highlighted = highlight_project_match("Payments API", "pay")
+
+        self.assertIn("<mark", highlighted)
+        self.assertIn("Pay", highlighted)
+
+    def test_split_project_option_label_breaks_primary_and_secondary_lines(
+        self,
+    ) -> None:
+        primary, secondary = split_project_option_label(
+            "Payments · acme/payments-api · payments"
+        )
+
+        self.assertEqual(primary, "Payments")
+        self.assertEqual(secondary, "acme/payments-api · payments")
+
+    def test_project_context_helpers_distinguish_default_and_active_contexts(
+        self,
+    ) -> None:
+        project = ProjectRecord(
+            id=1,
+            project_key="unassigned",
+            display_name="Unassigned",
+            description=None,
+            repository_url=None,
+            default_branch=None,
+            is_default=True,
+            created_at="2026-04-28T00:00:00",
+            updated_at="2026-04-28T00:00:00",
+        )
+
+        self.assertEqual(
+            project_context_summary(project),
+            "Unassigned",
+        )
+        self.assertEqual(
+            project_context_meta(
+                has_saved_selection=False,
+                active_project=project,
+            ),
+            "Default workspace · Key unassigned",
+        )
+        self.assertEqual(
+            project_context_meta(
+                has_saved_selection=True,
+                active_project=project,
+            ),
+            "Key unassigned",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/ui/components/project_workspace_switcher.py
+++ b/ui/components/project_workspace_switcher.py
@@ -1,0 +1,353 @@
+"""Shared project/workspace selector helpers."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Iterable
+from html import escape
+import re
+from urllib.parse import urlparse
+
+from nicegui import ui
+from nicegui.events import KeyEventArguments
+
+from services.project_service import ProjectRecord, create_project
+from ui.components.review_accessibility import (
+    decorate_modal_card,
+    decorate_modal_close,
+)
+
+
+def project_repository_context(project: ProjectRecord) -> str | None:
+    """Return a compact repository context for project labels when available."""
+    raw_value = str(project.repository_url or "").strip().rstrip("/")
+    if not raw_value:
+        return None
+    trimmed = raw_value[:-4] if raw_value.endswith(".git") else raw_value
+    if "://" in trimmed:
+        parsed = urlparse(trimmed)
+        path = parsed.path.strip("/")
+        if path:
+            return path
+        return parsed.netloc or None
+    return trimmed.lstrip("/")
+
+
+def project_option_label(project: ProjectRecord) -> str:
+    """Build a searchable label with project name plus repo/key context."""
+    repository_context = project_repository_context(project)
+    parts = [project.display_name]
+    if repository_context:
+        parts.append(repository_context)
+    parts.append(project.project_key)
+    return " · ".join(parts)
+
+
+def split_project_option_label(label: str) -> tuple[str, str]:
+    """Split a searchable label into primary and secondary lines."""
+    parts = [part.strip() for part in str(label).split("·") if part.strip()]
+    if not parts:
+        return "", ""
+    return parts[0], " · ".join(parts[1:])
+
+
+def build_project_options(projects: Iterable[ProjectRecord]) -> dict[int, str]:
+    """Return select-friendly project labels keyed by stable IDs."""
+    return {int(project.id): project_option_label(project) for project in projects}
+
+
+def filter_project_records(
+    projects: Iterable[ProjectRecord],
+    query: str | None,
+) -> list[ProjectRecord]:
+    """Filter projects by display name, repository context, or project key."""
+    normalized = str(query or "").strip().lower()
+    ordered = list(projects)
+    if not normalized:
+        return ordered
+    matches: list[ProjectRecord] = []
+    for project in ordered:
+        search_text = " ".join(
+            part
+            for part in (
+                project.display_name,
+                project_repository_context(project) or "",
+                project.project_key,
+            )
+            if part
+        ).lower()
+        if normalized in search_text:
+            matches.append(project)
+    return matches
+
+
+def highlight_project_match(text: str, query: str | None) -> str:
+    """Return safe HTML with matching query segments highlighted."""
+    normalized = str(query or "").strip()
+    safe_text = escape(text)
+    if not normalized:
+        return safe_text
+    pattern = re.compile(re.escape(normalized), re.IGNORECASE)
+    return pattern.sub(
+        lambda match: f'<mark class="dw-project-match">{escape(match.group(0))}</mark>',
+        safe_text,
+    )
+
+
+def project_context_heading() -> str:
+    """Return the shared label for the global project filter."""
+    return "Active Project"
+
+
+def project_context_summary(active_project: ProjectRecord | None) -> str:
+    """Return the current project display name for the shell."""
+    if active_project is None:
+        return "No project selected"
+    return active_project.display_name
+
+
+def project_context_meta(
+    *,
+    has_saved_selection: bool,
+    active_project: ProjectRecord | None,
+) -> str:
+    """Describe repository/key context for the current project."""
+    if active_project is None:
+        return "Choose a workspace to scope reports, history, and settings."
+    parts: list[str] = []
+    if not has_saved_selection and active_project.is_default:
+        parts.append("Default workspace")
+    repository_context = project_repository_context(active_project)
+    if repository_context:
+        parts.append(repository_context)
+    parts.append(f"Key {active_project.project_key}")
+    return " · ".join(parts)
+
+
+def build_project_combobox(
+    *,
+    projects: Iterable[ProjectRecord],
+    current_project_id: int | None,
+    on_select: Callable[[ProjectRecord], None],
+) -> None:
+    """Render a controlled, searchable project combobox."""
+    ordered_projects = list(projects)
+    state = {
+        "query": "",
+        "open": False,
+        "highlighted_index": 0,
+        "filtered": ordered_projects,
+        "committing_selection": False,
+    }
+
+    def visible_projects() -> list[ProjectRecord]:
+        return list(state["filtered"])
+
+    with ui.element("div").classes("dw-project-combobox"):
+        search_input = ui.input(
+            placeholder="Search repo or project name",
+            value="",
+        ).classes("dw-project-search-input w-full")
+        search_input.props("outlined clearable autocomplete=off")
+        dropdown_mount = ui.element("div").classes("dw-project-dropdown-anchor")
+
+    def render_dropdown() -> None:
+        dropdown_mount.clear()
+        if not state["open"]:
+            return
+        filtered = visible_projects()
+        with dropdown_mount:
+            with ui.card().classes("dw-project-dropdown-panel shadow-none"):
+                if not filtered:
+                    with ui.column().classes("dw-project-feedback-row gap-1"):
+                        ui.label("No projects found").classes("dw-project-empty-title")
+                        ui.label(
+                            "Try another project name, repository slug, or workspace key."
+                        ).classes("dw-project-empty-copy")
+                    return
+
+                with ui.column().classes("dw-project-dropdown-list gap-1"):
+                    for index, project in enumerate(filtered):
+                        is_active = project.id == current_project_id
+                        is_highlighted = index == state["highlighted_index"]
+                        primary = highlight_project_match(
+                            project.display_name,
+                            state["query"],
+                        )
+                        meta_parts = []
+                        repository_context = project_repository_context(project)
+                        if repository_context:
+                            meta_parts.append(repository_context)
+                        meta_parts.append(f"Key {project.project_key}")
+                        secondary = highlight_project_match(
+                            " · ".join(meta_parts),
+                            state["query"],
+                        )
+                        option_classes = [
+                            "dw-project-option-button",
+                            "w-full",
+                        ]
+                        if is_highlighted:
+                            option_classes.append("dw-project-option-active")
+                        if is_active:
+                            option_classes.append("dw-project-option-selected")
+                        with (
+                            ui.element("div")
+                            .props(
+                                "role=option tabindex=-1 "
+                                f"aria-selected={'true' if is_active else 'false'}"
+                            )
+                            .classes(" ".join(option_classes))
+                            .on(
+                                "pointerdown",
+                                lambda project=project: select_project(project),
+                                [],
+                                js_handler="(event) => { event.preventDefault(); emit(); }",
+                            )
+                        ):
+                            with ui.row().classes(
+                                "w-full items-start justify-between gap-3"
+                            ):
+                                with ui.column().classes("min-w-0 flex-1 gap-[2px]"):
+                                    ui.html(primary).classes(
+                                        "dw-project-option-primary"
+                                    )
+                                    ui.html(secondary).classes("dw-project-option-meta")
+                                if is_active:
+                                    ui.icon("check").classes(
+                                        "dw-project-option-check shrink-0"
+                                    )
+
+    def set_highlighted_index(index: int) -> None:
+        filtered = visible_projects()
+        if not filtered:
+            state["highlighted_index"] = 0
+            render_dropdown()
+            return
+        state["highlighted_index"] = max(0, min(index, len(filtered) - 1))
+        render_dropdown()
+
+    def apply_filter() -> None:
+        filtered = filter_project_records(ordered_projects, str(state["query"]))
+        state["filtered"] = filtered
+        if not filtered:
+            state["highlighted_index"] = 0
+        else:
+            state["highlighted_index"] = min(
+                int(state["highlighted_index"]),
+                len(filtered) - 1,
+            )
+        state["open"] = True
+        render_dropdown()
+
+    def handle_query_change() -> None:
+        state["query"] = search_input.value or ""
+        apply_filter()
+
+    def select_project(project: ProjectRecord) -> None:
+        if state["committing_selection"]:
+            return
+        state["committing_selection"] = True
+        state["open"] = False
+        render_dropdown()
+        on_select(project)
+
+    def close_dropdown() -> None:
+        state["open"] = False
+        state["committing_selection"] = False
+        render_dropdown()
+
+    def handle_keydown(event: KeyEventArguments) -> None:
+        key = event.key
+        filtered = visible_projects()
+        if key.arrow_down:
+            if not state["open"]:
+                state["open"] = True
+            if filtered:
+                state["highlighted_index"] = min(
+                    int(state["highlighted_index"]) + 1,
+                    len(filtered) - 1,
+                )
+            render_dropdown()
+            return
+        if key.arrow_up:
+            if not state["open"]:
+                state["open"] = True
+            if filtered:
+                state["highlighted_index"] = max(
+                    int(state["highlighted_index"]) - 1,
+                    0,
+                )
+            render_dropdown()
+            return
+        if key.enter:
+            if state["open"] and filtered:
+                select_project(filtered[int(state["highlighted_index"])])
+            return
+        if key.escape:
+            close_dropdown()
+
+    def handle_focus() -> None:
+        state["open"] = True
+        state["filtered"] = filter_project_records(
+            ordered_projects,
+            str(state["query"]),
+        )
+        render_dropdown()
+
+    def handle_blur() -> None:
+        ui.timer(0.2, close_dropdown, once=True, immediate=False)
+
+    search_input.on("focus", lambda _: handle_focus())
+    search_input.on("blur", lambda _: handle_blur())
+    search_input.on("keydown", handle_keydown)
+    search_input.on(
+        "update:model-value",
+        lambda _: handle_query_change(),
+    )
+
+
+def open_create_project_dialog(
+    *,
+    on_created: Callable[[ProjectRecord], None],
+) -> None:
+    """Open the shared create-project dialog and invoke a callback on success."""
+    dialog = ui.dialog()
+    with (
+        dialog,
+        ui.card().classes("w-[520px] dw-panel shadow-none p-6 gap-3") as dialog_card,
+    ):
+        decorate_modal_card(dialog_card, label="Create project workspace")
+        ui.label("Create project workspace").classes("text-lg font-medium dw-text")
+        key_input = ui.input("Project key").classes("w-full")
+        name_input = ui.input("Display name").classes("w-full")
+        description_input = ui.textarea("Description").classes("w-full")
+        repository_input = ui.input("Repository URL").classes("w-full")
+        branch_input = ui.input("Default branch").classes("w-full")
+        error_label = ui.label("").classes("text-xs dw-warning-text")
+
+        def submit_project() -> None:
+            try:
+                created = create_project(
+                    project_key=key_input.value,
+                    display_name=name_input.value,
+                    description=description_input.value or None,
+                    repository_url=repository_input.value or None,
+                    default_branch=branch_input.value or None,
+                )
+            except ValueError as exc:
+                error_label.set_text(str(exc))
+                return
+            dialog.close()
+            on_created(created)
+
+        with ui.row().classes("w-full justify-end gap-3 mt-4"):
+            cancel_button = ui.button("Cancel", on_click=dialog.close).props(
+                "outline no-caps"
+            )
+            decorate_modal_close(cancel_button)
+            ui.button(
+                "Create project",
+                on_click=submit_project,
+                color="primary",
+            ).props("unelevated no-caps")
+    dialog.open()

--- a/ui/components/upload_panel.py
+++ b/ui/components/upload_panel.py
@@ -18,7 +18,6 @@ from services.intake_service import (
     uniquify_artifact_names,
 )
 from services.project_service import (
-    create_project,
     get_active_project,
     has_active_project_selection,
     list_projects,
@@ -29,6 +28,10 @@ from services.report_service import (
 )
 from ui.components.context_completeness_panel import (
     render_context_completeness_panel,
+)
+from ui.components.project_workspace_switcher import (
+    build_project_options,
+    open_create_project_dialog as show_create_project_dialog,
 )
 from ui.components.blast_radius_graph import render_blast_radius_panel
 from ui.components.rollback_plan import render_rollback_plan
@@ -129,6 +132,7 @@ def should_clear_pending_uploads(
 def build_upload_panel(
     on_analysis_complete: Callable[[], None] | None = None,
     *,
+    on_project_change: Callable[[object], None] | None = None,
     embedded: bool = False,
     result_container=None,
 ) -> None:
@@ -189,10 +193,7 @@ def build_upload_panel(
     project_select = None
 
     def _project_options() -> dict[int, str]:
-        return {
-            int(project.id): f"{project.display_name} ({project.project_key})"
-            for project in state["projects"]
-        }
+        return build_project_options(state["projects"])
 
     def refresh_saved_report() -> None:
         active_project_id = state["active_project_id"]
@@ -213,6 +214,7 @@ def build_upload_panel(
         notify_parent: bool = False,
     ) -> None:
         state["projects"] = list_projects()
+        selected_project = None
         if selected_project_id is not None:
             selected_project = set_active_project(selected_project_id)
             state["active_project_id"] = selected_project.id
@@ -227,6 +229,8 @@ def build_upload_panel(
             else:
                 upload_widget.disable()
         refresh_saved_report()
+        if selected_project is not None and on_project_change is not None:
+            on_project_change(selected_project)
         if notify_parent and on_analysis_complete:
             on_analysis_complete()
 
@@ -258,55 +262,19 @@ def build_upload_panel(
         project_select.on_value_change(handle_project_change)
 
         def open_create_project_dialog() -> None:
-            dialog = ui.dialog()
-            with (
-                dialog,
-                ui.card().classes(
-                    "w-[520px] dw-panel shadow-none p-6 gap-3"
-                ) as dialog_card,
-            ):
-                decorate_modal_card(dialog_card, label="Create project workspace")
-                ui.label("Create project workspace").classes(
-                    "text-lg font-medium dw-text"
-                )
-                key_input = ui.input("Project key").classes("w-full")
-                name_input = ui.input("Display name").classes("w-full")
-                description_input = ui.textarea("Description").classes("w-full")
-                repository_input = ui.input("Repository URL").classes("w-full")
-                branch_input = ui.input("Default branch").classes("w-full")
-                error_label = ui.label("").classes("text-xs dw-warning-text")
-
-                def submit_project() -> None:
-                    try:
-                        created = create_project(
-                            project_key=key_input.value,
-                            display_name=name_input.value,
-                            description=description_input.value or None,
-                            repository_url=repository_input.value or None,
-                            default_branch=branch_input.value or None,
-                        )
-                    except ValueError as exc:
-                        error_label.set_text(str(exc))
-                        return
-                    dialog.close()
-                    refresh_projects(selected_project_id=created.id, notify_parent=True)
-                    render_actions()
+            show_create_project_dialog(
+                on_created=lambda created: (
+                    refresh_projects(
+                        selected_project_id=created.id,
+                        notify_parent=True,
+                    ),
+                    render_actions(),
                     ui.notify(
                         f"Project workspace created: {created.display_name}.",
                         color="positive",
-                    )
-
-                with ui.row().classes("w-full justify-end gap-3 mt-4"):
-                    cancel_button = ui.button("Cancel", on_click=dialog.close).props(
-                        "outline no-caps"
-                    )
-                    decorate_modal_close(cancel_button)
-                    ui.button(
-                        "Create project",
-                        on_click=submit_project,
-                        color="primary",
-                    ).props("unelevated no-caps")
-            dialog.open()
+                    ),
+                )
+            )
 
         ui.button(
             "Create project",

--- a/ui/routes/dashboard.py
+++ b/ui/routes/dashboard.py
@@ -29,205 +29,250 @@ def _briefing_summary_line(saved_briefings: int, high_focus: int) -> str:
 def build_dashboard() -> None:
     """Render the primary DeployWhisper workspace."""
     apply_theme()
-    build_navigation_shell("dashboard")
+    content_refresh = {"fn": lambda *_: None}
 
-    def current_project():
-        return get_active_project()
+    def handle_project_change(*_) -> None:
+        refresh_shell()
+        content_refresh["fn"]()
 
-    def current_project_id() -> int | None:
-        project = current_project()
-        return project.id if project is not None else None
+    refresh_shell = build_navigation_shell(
+        "dashboard",
+        on_project_change=handle_project_change,
+    )
 
-    with ui.column().classes("dw-main-content dw-shell gap-5"):
-        briefing_mount = None
-        stats_mount = None
-        result_mount = None
-        deploy_review_card = None
-        hero_mount = None
+    @ui.refreshable
+    def render_dashboard_content() -> None:
+        def current_project():
+            return get_active_project()
 
-        def render_briefing() -> None:
-            nonlocal briefing_mount
-            briefing = fetch_dashboard_briefing(project_id=current_project_id())
-            severity_counts = briefing["severity_counts"]
-            total_reports = max(briefing["saved_briefings"], 1)
-            segments = (
-                ("Low", severity_counts["low"], "var(--dw-green)"),
-                ("Medium", severity_counts["medium"], "var(--dw-amber)"),
-                ("High", severity_counts["high"], "var(--dw-high)"),
-                ("Critical", severity_counts["critical"], "var(--dw-red)"),
-            )
+        def current_project_id() -> int | None:
+            project = current_project()
+            return project.id if project is not None else None
 
-            briefing_mount.clear()
-            with briefing_mount:
-                with ui.card().classes("dw-panel shadow-none w-full h-full p-0"):
-                    with ui.column().classes("dw-preview gap-4 h-full justify-between"):
-                        with ui.row().classes("items-start justify-between gap-4"):
-                            with ui.column().classes("gap-2 min-w-0 flex-1"):
-                                ui.label("Deployment briefing").classes(
-                                    "dw-preview-kicker"
-                                )
-                                ui.label(
-                                    "High-context risk analysis before infrastructure changes go live"
-                                ).classes("dw-preview-title")
-                            with ui.column().classes(
-                                "dw-preview-score items-center justify-center text-center shrink-0"
-                            ):
-                                ui.label(str(briefing["weighted_focus_score"])).classes(
-                                    "dw-preview-score-value"
-                                )
-                                ui.label("Risk focus").classes("dw-preview-score-label")
-                        ui.label(
-                            _briefing_summary_line(
-                                briefing["saved_briefings"], briefing["high_focus"]
-                            )
-                        ).classes("dw-preview-body")
-                        with ui.row().classes("w-full gap-3 flex-wrap"):
-                            for value, label in (
-                                (str(briefing["total_files_scanned"]), "Files scanned"),
-                                (str(briefing["saved_briefings"]), "Saved briefings"),
-                                (str(briefing["high_focus"]), "High focus"),
-                            ):
+        with ui.column().classes("dw-main-content dw-shell gap-5"):
+            briefing_mount = None
+            stats_mount = None
+            result_mount = None
+            deploy_review_card = None
+            hero_mount = None
+
+            def render_briefing() -> None:
+                nonlocal briefing_mount
+                briefing = fetch_dashboard_briefing(project_id=current_project_id())
+                severity_counts = briefing["severity_counts"]
+                total_reports = max(briefing["saved_briefings"], 1)
+                segments = (
+                    ("Low", severity_counts["low"], "var(--dw-green)"),
+                    ("Medium", severity_counts["medium"], "var(--dw-amber)"),
+                    ("High", severity_counts["high"], "var(--dw-high)"),
+                    ("Critical", severity_counts["critical"], "var(--dw-red)"),
+                )
+
+                briefing_mount.clear()
+                with briefing_mount:
+                    with ui.card().classes("dw-panel shadow-none w-full h-full p-0"):
+                        with ui.column().classes(
+                            "dw-preview gap-4 h-full justify-between"
+                        ):
+                            with ui.row().classes("items-start justify-between gap-4"):
+                                with ui.column().classes("gap-2 min-w-0 flex-1"):
+                                    ui.label("Deployment briefing").classes(
+                                        "dw-preview-kicker"
+                                    )
+                                    ui.label(
+                                        "High-context risk analysis before infrastructure changes go live"
+                                    ).classes("dw-preview-title")
                                 with ui.column().classes(
-                                    "dw-mini-stat flex-1 min-w-[92px]"
+                                    "dw-preview-score items-center justify-center text-center shrink-0"
                                 ):
-                                    ui.label(value).classes(
-                                        "font-semibold text-lg dw-text"
+                                    ui.label(
+                                        str(briefing["weighted_focus_score"])
+                                    ).classes("dw-preview-score-value")
+                                    ui.label("Risk focus").classes(
+                                        "dw-preview-score-label"
                                     )
-                                    ui.label(label).classes(
-                                        "text-xs dw-muted uppercase tracking-[0.1em]"
-                                    )
-                        with ui.column().classes("gap-2"):
-                            ui.label(briefing["latest_summary"]).classes(
-                                "text-sm dw-muted leading-6"
-                            )
-                            with ui.row().classes("w-full gap-1 items-center"):
-                                for _, value, color in segments:
-                                    width = (
-                                        max(8, round((value / total_reports) * 100))
-                                        if briefing["saved_briefings"]
-                                        else 25
-                                    )
-                                    ui.element("span").style(
-                                        f"height: 10px; width: {width}%; border-radius: 999px; background: {color}; display: inline-block;"
-                                    )
+                            ui.label(
+                                _briefing_summary_line(
+                                    briefing["saved_briefings"], briefing["high_focus"]
+                                )
+                            ).classes("dw-preview-body")
                             with ui.row().classes("w-full gap-3 flex-wrap"):
-                                for label, value, color_class in (
-                                    ("Low", severity_counts["low"], "dw-success-text"),
+                                for value, label in (
                                     (
-                                        "Medium",
-                                        severity_counts["medium"],
-                                        "dw-warning-text",
+                                        str(briefing["total_files_scanned"]),
+                                        "Files scanned",
                                     ),
-                                    ("High", severity_counts["high"], "dw-accent-text"),
                                     (
-                                        "Critical",
-                                        severity_counts["critical"],
-                                        "dw-danger-text",
+                                        str(briefing["saved_briefings"]),
+                                        "Saved briefings",
                                     ),
+                                    (str(briefing["high_focus"]), "High focus"),
                                 ):
-                                    with ui.row().classes("items-center gap-2"):
-                                        ui.label(label).classes(
-                                            f"text-xs font-semibold uppercase tracking-[0.08em] {color_class}"
+                                    with ui.column().classes(
+                                        "dw-mini-stat flex-1 min-w-[92px]"
+                                    ):
+                                        ui.label(value).classes(
+                                            "font-semibold text-lg dw-text"
                                         )
-                                        ui.label(str(value)).classes("text-xs dw-muted")
+                                        ui.label(label).classes(
+                                            "text-xs dw-muted uppercase tracking-[0.1em]"
+                                        )
+                            with ui.column().classes("gap-2"):
+                                ui.label(briefing["latest_summary"]).classes(
+                                    "text-sm dw-muted leading-6"
+                                )
+                                with ui.row().classes("w-full gap-1 items-center"):
+                                    for _, value, color in segments:
+                                        width = (
+                                            max(8, round((value / total_reports) * 100))
+                                            if briefing["saved_briefings"]
+                                            else 25
+                                        )
+                                        ui.element("span").style(
+                                            f"height: 10px; width: {width}%; border-radius: 999px; background: {color}; display: inline-block;"
+                                        )
+                                with ui.row().classes("w-full gap-3 flex-wrap"):
+                                    for label, value, color_class in (
+                                        (
+                                            "Low",
+                                            severity_counts["low"],
+                                            "dw-success-text",
+                                        ),
+                                        (
+                                            "Medium",
+                                            severity_counts["medium"],
+                                            "dw-warning-text",
+                                        ),
+                                        (
+                                            "High",
+                                            severity_counts["high"],
+                                            "dw-accent-text",
+                                        ),
+                                        (
+                                            "Critical",
+                                            severity_counts["critical"],
+                                            "dw-danger-text",
+                                        ),
+                                    ):
+                                        with ui.row().classes("items-center gap-2"):
+                                            ui.label(label).classes(
+                                                f"text-xs font-semibold uppercase tracking-[0.08em] {color_class}"
+                                            )
+                                            ui.label(str(value)).classes(
+                                                "text-xs dw-muted"
+                                            )
 
-        def render_stats() -> None:
-            stats = fetch_dashboard_stats(project_id=current_project_id())
-            stats_mount.clear()
-            with stats_mount:
-                with ui.card().classes("w-full dw-panel shadow-none p-4"):
-                    ui.label("Analysis snapshot").classes("dw-eyebrow")
-                    with ui.row().classes("w-full items-stretch gap-2 flex-wrap mt-3"):
-                        metrics = [
-                            ("Files scanned", stats["total_files_scanned"], "dw-text"),
-                            ("Low", stats["severity_counts"]["low"], "dw-success-text"),
-                            (
-                                "Medium",
-                                stats["severity_counts"]["medium"],
-                                "dw-warning-text",
-                            ),
-                            (
-                                "High",
-                                stats["severity_counts"]["high"],
-                                "dw-accent-text",
-                            ),
-                            (
-                                "Critical",
-                                stats["severity_counts"]["critical"],
-                                "dw-danger-text",
-                            ),
-                        ]
-                        for label, value, color_class in metrics:
-                            with ui.card().classes(
-                                "dw-panel-soft shadow-none min-w-[120px] flex-1"
-                            ):
-                                with ui.column().classes("gap-1 p-3"):
-                                    ui.label(str(value)).classes(
-                                        f"text-2xl font-semibold {color_class}"
-                                    )
-                                    ui.label(label).classes(
-                                        "text-[11px] font-semibold uppercase tracking-[0.08em] dw-muted"
-                                    )
+            def render_stats() -> None:
+                stats = fetch_dashboard_stats(project_id=current_project_id())
+                stats_mount.clear()
+                with stats_mount:
+                    with ui.card().classes("w-full dw-panel shadow-none p-4"):
+                        ui.label("Analysis snapshot").classes("dw-eyebrow")
+                        with ui.row().classes(
+                            "w-full items-stretch gap-2 flex-wrap mt-3"
+                        ):
+                            metrics = [
+                                (
+                                    "Files scanned",
+                                    stats["total_files_scanned"],
+                                    "dw-text",
+                                ),
+                                (
+                                    "Low",
+                                    stats["severity_counts"]["low"],
+                                    "dw-success-text",
+                                ),
+                                (
+                                    "Medium",
+                                    stats["severity_counts"]["medium"],
+                                    "dw-warning-text",
+                                ),
+                                (
+                                    "High",
+                                    stats["severity_counts"]["high"],
+                                    "dw-accent-text",
+                                ),
+                                (
+                                    "Critical",
+                                    stats["severity_counts"]["critical"],
+                                    "dw-danger-text",
+                                ),
+                            ]
+                            for label, value, color_class in metrics:
+                                with ui.card().classes(
+                                    "dw-panel-soft shadow-none min-w-[120px] flex-1"
+                                ):
+                                    with ui.column().classes("gap-1 p-3"):
+                                        ui.label(str(value)).classes(
+                                            f"text-2xl font-semibold {color_class}"
+                                        )
+                                        ui.label(label).classes(
+                                            "text-[11px] font-semibold uppercase tracking-[0.08em] dw-muted"
+                                        )
 
-        def refresh_dashboard() -> None:
-            render_hero()
-            render_briefing()
-            render_stats()
+            def refresh_dashboard() -> None:
+                render_hero()
+                render_briefing()
+                render_stats()
 
-        def render_hero() -> None:
-            active_report = fetch_active_dashboard_report(
-                project_id=current_project_id()
-            )
-            hero_mount.clear()
-            with hero_mount:
-                if active_report is not None:
-                    render_verdict_card(active_report)
-                    ui.label(
-                        "Verdict, top risk, and trust signals stay above the detailed review sections so release decisions start with the summary."
-                    ).classes("dw-body max-w-3xl")
-                    return
+            def render_hero() -> None:
+                active_report = fetch_active_dashboard_report(
+                    project_id=current_project_id()
+                )
+                hero_mount.clear()
+                with hero_mount:
+                    if active_report is not None:
+                        render_verdict_card(active_report)
+                        ui.label(
+                            "Verdict, top risk, and trust signals stay above the detailed review sections so release decisions start with the summary."
+                        ).classes("dw-body max-w-3xl")
+                        return
 
-                ui.label("Deploy review").classes("dw-eyebrow")
-                active_project = current_project()
-                if active_project is not None:
-                    ui.label(
-                        f"Current project: {active_project.display_name} ({active_project.project_key})"
-                    ).classes(
-                        "text-xs font-semibold uppercase tracking-[0.08em] dw-muted"
+                    ui.label("Deploy review").classes("dw-eyebrow")
+                    active_project = current_project()
+                    if active_project is not None:
+                        ui.label(
+                            f"Current project: {active_project.display_name} ({active_project.project_key})"
+                        ).classes(
+                            "text-xs font-semibold uppercase tracking-[0.08em] dw-muted"
+                        )
+                    ui.html(
+                        '<div class="dw-dashboard-headline mt-3">'
+                        '<span class="dw-gradient">Know the risk before</span><br>'
+                        '<span class="dw-gradient">you hit</span> <span class="dw-accent-text">deploy</span>'
+                        "</div>"
                     )
-                ui.html(
-                    '<div class="dw-dashboard-headline mt-3">'
-                    '<span class="dw-gradient">Know the risk before</span><br>'
-                    '<span class="dw-gradient">you hit</span> <span class="dw-accent-text">deploy</span>'
-                    "</div>"
+                    ui.label(
+                        "Upload artifacts and generate one advisory briefing. One screen for verdict, blast radius, "
+                        "rollback guidance, incident similarity, and a human-readable narrative before release."
+                    ).classes("dw-body mt-4 max-w-3xl")
+
+            stats_mount = ui.column().classes("w-full")
+            with ui.row().classes("w-full items-stretch gap-5 flex-wrap"):
+                with ui.column().classes("flex-1 min-w-[320px] gap-4 self-stretch"):
+                    deploy_review_card = ui.card().classes(
+                        "dw-panel dw-dashboard-hero shadow-none w-full p-6"
+                    )
+                    with deploy_review_card:
+                        hero_mount = ui.column().classes("w-full gap-3")
+                briefing_mount = ui.column().classes(
+                    "w-full max-w-[390px] min-w-[320px] self-stretch"
                 )
-                ui.label(
-                    "Upload artifacts and generate one advisory briefing. One screen for verdict, blast radius, "
-                    "rollback guidance, incident similarity, and a human-readable narrative before release."
-                ).classes("dw-body mt-4 max-w-3xl")
 
-        stats_mount = ui.column().classes("w-full")
-        with ui.row().classes("w-full items-stretch gap-5 flex-wrap"):
-            with ui.column().classes("flex-1 min-w-[320px] gap-4 self-stretch"):
-                deploy_review_card = ui.card().classes(
-                    "dw-panel dw-dashboard-hero shadow-none w-full p-6"
+            result_mount = ui.column().classes("w-full gap-4")
+
+            with deploy_review_card:
+                build_upload_panel(
+                    on_analysis_complete=refresh_dashboard,
+                    on_project_change=handle_project_change,
+                    embedded=True,
+                    result_container=result_mount,
                 )
-                with deploy_review_card:
-                    hero_mount = ui.column().classes("w-full gap-3")
-            briefing_mount = ui.column().classes(
-                "w-full max-w-[390px] min-w-[320px] self-stretch"
-            )
 
-        result_mount = ui.column().classes("w-full gap-4")
+            refresh_dashboard()
 
-        with deploy_review_card:
-            build_upload_panel(
-                on_analysis_complete=refresh_dashboard,
-                embedded=True,
-                result_container=result_mount,
-            )
-
-        refresh_dashboard()
+    content_refresh["fn"] = lambda *_: render_dashboard_content.refresh()
+    render_dashboard_content()
 
 
 @ui.page("/history")

--- a/ui/routes/history.py
+++ b/ui/routes/history.py
@@ -37,242 +37,273 @@ def page_selection_state(
 def build_history_page() -> None:
     """Render a scanable history view with direct report retrieval."""
     apply_theme()
-    build_navigation_shell("history")
-    active_project = get_active_project()
-    active_project_id = active_project.id if active_project is not None else None
-    reports_page = fetch_filtered_analysis_history_page(
-        project_id=active_project_id,
-        page=1,
-        page_size=5,
+    content_refresh = {"fn": lambda *_: None}
+
+    def handle_project_change(*_) -> None:
+        refresh_shell()
+        content_refresh["fn"]()
+
+    refresh_shell = build_navigation_shell(
+        "history",
+        on_project_change=handle_project_change,
     )
-    reports = reports_page["items"]
-    total_report_count = reports_page["total_count"]
-    trends = fetch_risk_trends(project_id=active_project_id)
-    selected_ids: set[int] = set()
-    page_state = {"page": 1, "page_size": 5}
-    card_checkboxes: dict[int, Any] = {}
-    selection_sync = {"active": False}
 
-    with ui.column().classes("dw-main-content dw-shell gap-5"):
-        with ui.card().classes("w-full dw-panel dw-page-header shadow-none"):
-            build_page_header(
-                eyebrow="History",
-                title="Analysis history",
-                subtitle=(
-                    "Review earlier deploy briefings, audit metadata, and risk trends."
-                    if active_project is None
-                    else f"Project-scoped history for {active_project.display_name} ({active_project.project_key})."
-                ),
-                back_href="/",
-                back_label="Back to dashboard",
-            )
-        with ui.card().classes("w-full dw-panel shadow-none p-4"):
-            with ui.column().classes("gap-0"):
-                ui.label("Risk trends").classes("dw-eyebrow mb-1")
-                ui.label(
-                    f"{trends['total_reports']} reports · "
-                    f"{trends['severity_counts'].get('critical', 0)} critical · "
-                    f"{trends['severity_counts'].get('high', 0)} high"
-                ).classes("text-lg font-medium dw-text leading-6")
-                ui.label(
-                    "Top tools: "
-                    + ", ".join(
-                        f"{tool} ({count})"
-                        for tool, count in sorted(
-                            trends["tool_counts"].items(),
-                            key=lambda item: item[1],
-                            reverse=True,
-                        )[:3]
-                    )
-                ).classes("mt-[2px] text-sm dw-muted")
-        search_input = (
-            ui.input(placeholder="Search top risk or summary")
-            .props("outlined dense clearable prepend-icon=search")
-            .classes("w-full dw-search-input")
+    @ui.refreshable
+    def render_history_content() -> None:
+        active_project = get_active_project()
+        active_project_id = active_project.id if active_project is not None else None
+        reports_page = fetch_filtered_analysis_history_page(
+            project_id=active_project_id,
+            page=1,
+            page_size=5,
         )
-        actions_row = ui.row().classes(
-            "w-full items-center justify-between gap-4 flex-wrap"
-        )
-        history_column = ui.column().classes("w-full gap-3")
+        reports = reports_page["items"]
+        total_report_count = reports_page["total_count"]
+        trends = fetch_risk_trends(project_id=active_project_id)
+        selected_ids: set[int] = set()
+        page_state = {"page": 1, "page_size": 5}
+        card_checkboxes: dict[int, Any] = {}
+        selection_sync = {"active": False}
 
-        def refresh_data(query: str | None = None) -> list[dict]:
-            nonlocal reports, trends, total_report_count
-            page_payload = fetch_filtered_analysis_history_page(
-                project_id=active_project_id,
-                search=query,
-                page=page_state["page"],
-                page_size=page_state["page_size"],
-            )
-            reports = page_payload["items"]
-            total_report_count = page_payload["total_count"]
-            trends = fetch_risk_trends(project_id=active_project_id)
-            max_page = max(1, (total_report_count - 1) // page_state["page_size"] + 1)
-            page_state["page"] = min(page_state["page"], max_page)
-            return reports
-
-        def current_page_reports() -> list[dict]:
-            return reports
-
-        def open_report(report_id: int) -> None:
-            ui.navigate.to(f"/history/{report_id}")
-
-        def toggle_selection(report_id: int, selected: bool) -> None:
-            if selected:
-                selected_ids.add(report_id)
-            else:
-                selected_ids.discard(report_id)
-            if selection_sync["active"]:
-                return
-            render_history()
-            render_actions()
-
-        def toggle_select_all(selected: bool) -> None:
-            selection_sync["active"] = True
-            for report in current_page_reports():
-                if selected:
-                    selected_ids.add(report["id"])
-                else:
-                    selected_ids.discard(report["id"])
-                checkbox = card_checkboxes.get(report["id"])
-                if checkbox is not None and checkbox.value != selected:
-                    checkbox.set_value(selected)
-                    checkbox.update()
-            selection_sync["active"] = False
-            render_history()
-            render_actions()
-
-        def delete_one(report_id: int) -> None:
-            prompt_delete([report_id])
-
-        def perform_delete(report_ids: list[int]) -> None:
-            if len(report_ids) == 1:
-                removed = 1 if remove_analysis_report(report_ids[0]) else 0
-            else:
-                removed = remove_analysis_reports(report_ids)
-            for report_id in report_ids:
-                selected_ids.discard(report_id)
-            if removed:
-                ui.notify(f"Deleted {removed} analysis report(s).", color="positive")
-            else:
-                ui.notify("Report not found.", color="warning")
-            apply_filters()
-
-        def delete_selected() -> None:
-            prompt_delete(sorted(selected_ids))
-
-        def prompt_delete(report_ids: list[int]) -> None:
-            if not report_ids:
-                return
-            count = len(report_ids)
-            report_label = "report" if count == 1 else "reports"
-            with (
-                ui.dialog() as dialog,
-                ui.card().classes(
-                    "w-[420px] dw-panel shadow-none p-6 gap-3"
-                ) as dialog_card,
-            ):
-                decorate_modal_card(dialog_card, label="Delete analysis report")
-                ui.label(
-                    f"Are you sure you want to delete {count} selected {report_label}?"
-                ).classes("text-lg font-medium dw-text")
-                ui.label("This action cannot be undone.").classes("text-sm dw-muted")
-                with ui.row().classes("w-full justify-end gap-3 mt-4"):
-                    cancel_button = ui.button("Cancel", on_click=dialog.close).props(
-                        "outline no-caps"
-                    )
-                    decorate_modal_close(cancel_button)
-                    ui.button(
-                        "Confirm Delete",
-                        on_click=lambda: (dialog.close(), perform_delete(report_ids)),
-                    ).props("outline no-caps").classes("dw-danger-button")
-            dialog.open()
-
-        def render_actions() -> None:
-            actions_row.clear()
-            with actions_row:
-                visible_reports = current_page_reports()
-                visible_ids = {report["id"] for report in visible_reports}
-                all_visible_selected, _ = page_selection_state(
-                    visible_ids, selected_ids
+        with ui.column().classes("dw-main-content dw-shell gap-5"):
+            with ui.card().classes("w-full dw-panel dw-page-header shadow-none"):
+                build_page_header(
+                    eyebrow="History",
+                    title="Analysis history",
+                    subtitle=(
+                        "Review earlier deploy briefings, audit metadata, and risk trends."
+                        if active_project is None
+                        else f"Project-scoped history for {active_project.display_name} ({active_project.project_key})."
+                    ),
+                    back_href="/",
+                    back_label="Back to dashboard",
                 )
-                with ui.row().classes("items-center gap-3 flex-wrap"):
-                    select_all = ui.checkbox(value=all_visible_selected).props("dense")
-                    select_all.on_value_change(
-                        lambda event: toggle_select_all(bool(event.value))
-                    )
-                    if not visible_reports:
-                        select_all.disable()
-                    ui.label("Select all on page").classes("text-sm dw-text")
-                    start = (
-                        0
-                        if not reports
-                        else (page_state["page"] - 1) * page_state["page_size"] + 1
-                    )
-                    end = start - 1 + len(reports)
+            with ui.card().classes("w-full dw-panel shadow-none p-4"):
+                with ui.column().classes("gap-0"):
+                    ui.label("Risk trends").classes("dw-eyebrow mb-1")
                     ui.label(
-                        f"Showing {start}-{end} of {total_report_count} reports · {len(selected_ids)} selected"
-                    ).classes("text-sm dw-muted")
-                with ui.row().classes("items-center justify-end gap-4 flex-wrap"):
-                    prev_button = ui.button("Previous", color="primary").props(
-                        "flat no-caps"
-                    )
-                    if page_state["page"] == 1:
-                        prev_button.disable()
-                    prev_button.on("click", lambda _: change_page(-1))
+                        f"{trends['total_reports']} reports · "
+                        f"{trends['severity_counts'].get('critical', 0)} critical · "
+                        f"{trends['severity_counts'].get('high', 0)} high"
+                    ).classes("text-lg font-medium dw-text leading-6")
                     ui.label(
-                        f"Page {page_state['page']} / {max(1, (total_report_count - 1) // page_state['page_size'] + 1)}"
-                    ).classes("text-sm dw-muted")
-                    next_button = ui.button("Next", color="primary").props(
-                        "flat no-caps"
-                    )
-                    if page_state["page"] >= max(
-                        1, (total_report_count - 1) // page_state["page_size"] + 1
-                    ):
-                        next_button.disable()
-                    next_button.on("click", lambda _: change_page(1))
-                    bulk_delete = ui.button("Delete selected").props("outline no-caps")
-                    bulk_delete.classes("dw-danger-button")
-                    if not selected_ids:
-                        bulk_delete.disable()
-                    bulk_delete.on("click", lambda _: delete_selected())
+                        "Top tools: "
+                        + ", ".join(
+                            f"{tool} ({count})"
+                            for tool, count in sorted(
+                                trends["tool_counts"].items(),
+                                key=lambda item: item[1],
+                                reverse=True,
+                            )[:3]
+                        )
+                    ).classes("mt-[2px] text-sm dw-muted")
+            search_input = (
+                ui.input(placeholder="Search top risk or summary")
+                .props("outlined dense clearable prepend-icon=search")
+                .classes("w-full dw-search-input")
+            )
+            actions_row = ui.row().classes(
+                "w-full items-center justify-between gap-4 flex-wrap"
+            )
+            history_column = ui.column().classes("w-full gap-3")
 
-        def render_history() -> None:
-            history_column.clear()
-            card_checkboxes.clear()
-            visible_reports = current_page_reports()
-            with history_column:
-                if not visible_reports:
-                    ui.label("No reports match the current filters.").classes(
+            def refresh_data(query: str | None = None) -> list[dict]:
+                nonlocal reports, trends, total_report_count
+                page_payload = fetch_filtered_analysis_history_page(
+                    project_id=active_project_id,
+                    search=query,
+                    page=page_state["page"],
+                    page_size=page_state["page_size"],
+                )
+                reports = page_payload["items"]
+                total_report_count = page_payload["total_count"]
+                trends = fetch_risk_trends(project_id=active_project_id)
+                max_page = max(
+                    1, (total_report_count - 1) // page_state["page_size"] + 1
+                )
+                page_state["page"] = min(page_state["page"], max_page)
+                return reports
+
+            def current_page_reports() -> list[dict]:
+                return reports
+
+            def open_report(report_id: int) -> None:
+                ui.navigate.to(f"/history/{report_id}")
+
+            def toggle_selection(report_id: int, selected: bool) -> None:
+                if selected:
+                    selected_ids.add(report_id)
+                else:
+                    selected_ids.discard(report_id)
+                if selection_sync["active"]:
+                    return
+                render_history()
+                render_actions()
+
+            def toggle_select_all(selected: bool) -> None:
+                selection_sync["active"] = True
+                for report in current_page_reports():
+                    if selected:
+                        selected_ids.add(report["id"])
+                    else:
+                        selected_ids.discard(report["id"])
+                    checkbox = card_checkboxes.get(report["id"])
+                    if checkbox is not None and checkbox.value != selected:
+                        checkbox.set_value(selected)
+                        checkbox.update()
+                selection_sync["active"] = False
+                render_history()
+                render_actions()
+
+            def delete_one(report_id: int) -> None:
+                prompt_delete([report_id])
+
+            def perform_delete(report_ids: list[int]) -> None:
+                if len(report_ids) == 1:
+                    removed = 1 if remove_analysis_report(report_ids[0]) else 0
+                else:
+                    removed = remove_analysis_reports(report_ids)
+                for report_id in report_ids:
+                    selected_ids.discard(report_id)
+                if removed:
+                    ui.notify(
+                        f"Deleted {removed} analysis report(s).", color="positive"
+                    )
+                else:
+                    ui.notify("Report not found.", color="warning")
+                apply_filters()
+
+            def delete_selected() -> None:
+                prompt_delete(sorted(selected_ids))
+
+            def prompt_delete(report_ids: list[int]) -> None:
+                if not report_ids:
+                    return
+                count = len(report_ids)
+                report_label = "report" if count == 1 else "reports"
+                with (
+                    ui.dialog() as dialog,
+                    ui.card().classes(
+                        "w-[420px] dw-panel shadow-none p-6 gap-3"
+                    ) as dialog_card,
+                ):
+                    decorate_modal_card(dialog_card, label="Delete analysis report")
+                    ui.label(
+                        f"Are you sure you want to delete {count} selected {report_label}?"
+                    ).classes("text-lg font-medium dw-text")
+                    ui.label("This action cannot be undone.").classes(
                         "text-sm dw-muted"
                     )
-                    return
-                for report in visible_reports:
-                    checkbox = render_analysis_history_row(
-                        report,
-                        open_report,
-                        on_toggle=toggle_selection,
-                        on_delete=delete_one,
-                        selected=report["id"] in selected_ids,
+                    with ui.row().classes("w-full justify-end gap-3 mt-4"):
+                        cancel_button = ui.button(
+                            "Cancel", on_click=dialog.close
+                        ).props("outline no-caps")
+                        decorate_modal_close(cancel_button)
+                        ui.button(
+                            "Confirm Delete",
+                            on_click=lambda: (
+                                dialog.close(),
+                                perform_delete(report_ids),
+                            ),
+                        ).props("outline no-caps").classes("dw-danger-button")
+                dialog.open()
+
+            def render_actions() -> None:
+                actions_row.clear()
+                with actions_row:
+                    visible_reports = current_page_reports()
+                    visible_ids = {report["id"] for report in visible_reports}
+                    all_visible_selected, _ = page_selection_state(
+                        visible_ids, selected_ids
                     )
-                    card_checkboxes[report["id"]] = checkbox
+                    with ui.row().classes("items-center gap-3 flex-wrap"):
+                        select_all = ui.checkbox(value=all_visible_selected).props(
+                            "dense"
+                        )
+                        select_all.on_value_change(
+                            lambda event: toggle_select_all(bool(event.value))
+                        )
+                        if not visible_reports:
+                            select_all.disable()
+                        ui.label("Select all on page").classes("text-sm dw-text")
+                        start = (
+                            0
+                            if not reports
+                            else (page_state["page"] - 1) * page_state["page_size"] + 1
+                        )
+                        end = start - 1 + len(reports)
+                        ui.label(
+                            f"Showing {start}-{end} of {total_report_count} reports · {len(selected_ids)} selected"
+                        ).classes("text-sm dw-muted")
+                    with ui.row().classes("items-center justify-end gap-4 flex-wrap"):
+                        prev_button = ui.button("Previous", color="primary").props(
+                            "flat no-caps"
+                        )
+                        if page_state["page"] == 1:
+                            prev_button.disable()
+                        prev_button.on("click", lambda _: change_page(-1))
+                        ui.label(
+                            f"Page {page_state['page']} / {max(1, (total_report_count - 1) // page_state['page_size'] + 1)}"
+                        ).classes("text-sm dw-muted")
+                        next_button = ui.button("Next", color="primary").props(
+                            "flat no-caps"
+                        )
+                        if page_state["page"] >= max(
+                            1,
+                            (total_report_count - 1) // page_state["page_size"] + 1,
+                        ):
+                            next_button.disable()
+                        next_button.on("click", lambda _: change_page(1))
+                        bulk_delete = ui.button("Delete selected").props(
+                            "outline no-caps"
+                        )
+                        bulk_delete.classes("dw-danger-button")
+                        if not selected_ids:
+                            bulk_delete.disable()
+                        bulk_delete.on("click", lambda _: delete_selected())
 
-        def change_page(delta: int) -> None:
-            max_page = max(1, (total_report_count - 1) // page_state["page_size"] + 1)
-            page_state["page"] = min(max(1, page_state["page"] + delta), max_page)
-            refresh_data(search_input.value.strip() if search_input.value else None)
+            def render_history() -> None:
+                history_column.clear()
+                card_checkboxes.clear()
+                visible_reports = current_page_reports()
+                with history_column:
+                    if not visible_reports:
+                        ui.label("No reports match the current filters.").classes(
+                            "text-sm dw-muted"
+                        )
+                        return
+                    for report in visible_reports:
+                        checkbox = render_analysis_history_row(
+                            report,
+                            open_report,
+                            on_toggle=toggle_selection,
+                            on_delete=delete_one,
+                            selected=report["id"] in selected_ids,
+                        )
+                        card_checkboxes[report["id"]] = checkbox
+
+            def change_page(delta: int) -> None:
+                max_page = max(
+                    1, (total_report_count - 1) // page_state["page_size"] + 1
+                )
+                page_state["page"] = min(max(1, page_state["page"] + delta), max_page)
+                refresh_data(search_input.value.strip() if search_input.value else None)
+                render_history()
+                render_actions()
+
+            def apply_filters() -> None:
+                query = search_input.value.strip() if search_input.value else None
+                page_state["page"] = 1
+                refresh_data(query)
+                render_history()
+                render_actions()
+
+            search_input.on("update:model-value", lambda *_: apply_filters())
             render_history()
             render_actions()
 
-        def apply_filters() -> None:
-            query = search_input.value.strip() if search_input.value else None
-            page_state["page"] = 1
-            refresh_data(query)
-            render_history()
-            render_actions()
-
-        search_input.on("update:model-value", lambda *_: apply_filters())
-        render_history()
-        render_actions()
+    content_refresh["fn"] = lambda *_: render_history_content.refresh()
+    render_history_content()
 
 
 def _render_history_comparison_items(
@@ -413,54 +444,69 @@ def _render_history_report_comparison(
 def build_history_detail_page(report_id: int, *, show_comparison: bool = False) -> None:
     """Render one persisted report on a dedicated detail page."""
     apply_theme()
-    build_navigation_shell("history")
-    active_project = get_active_project()
-    active_project_id = active_project.id if active_project is not None else None
-    report = fetch_analysis_report(report_id, project_id=active_project_id)
-    comparison = (
-        fetch_report_comparison(report_id, project_id=active_project_id)
-        if show_comparison
-        else None
+    content_refresh = {"fn": lambda *_: None}
+
+    def handle_project_change(*_) -> None:
+        refresh_shell()
+        content_refresh["fn"]()
+
+    refresh_shell = build_navigation_shell(
+        "history",
+        on_project_change=handle_project_change,
     )
 
-    with ui.column().classes("dw-main-content dw-shell gap-5"):
-        with ui.card().classes("w-full dw-panel dw-page-header shadow-none"):
+    @ui.refreshable
+    def render_history_detail_content() -> None:
+        active_project = get_active_project()
+        active_project_id = active_project.id if active_project is not None else None
+        report = fetch_analysis_report(report_id, project_id=active_project_id)
+        comparison = (
+            fetch_report_comparison(report_id, project_id=active_project_id)
+            if show_comparison
+            else None
+        )
+
+        with ui.column().classes("dw-main-content dw-shell gap-5"):
+            with ui.card().classes("w-full dw-panel dw-page-header shadow-none"):
+                if report is None:
+                    build_page_header(
+                        eyebrow="History",
+                        title="Analysis report not found",
+                        subtitle="The requested report could not be loaded. It may have been deleted.",
+                        back_href="/history",
+                        back_label="Back to History",
+                    )
+                else:
+                    build_page_header(
+                        eyebrow="History",
+                        title="Analysis report detail",
+                        subtitle="Full-width report review with readable findings, context quality, blast radius, rollback guidance, and audit metadata.",
+                        back_href="/history",
+                        back_label="Back to History",
+                    )
             if report is None:
-                build_page_header(
-                    eyebrow="History",
-                    title="Analysis report not found",
-                    subtitle="The requested report could not be loaded. It may have been deleted.",
-                    back_href="/history",
-                    back_label="Back to History",
-                )
-            else:
-                build_page_header(
-                    eyebrow="History",
-                    title="Analysis report detail",
-                    subtitle="Full-width report review with readable findings, context quality, blast radius, rollback guidance, and audit metadata.",
-                    back_href="/history",
-                    back_label="Back to History",
-                )
-        if report is None:
-            with ui.card().classes("w-full dw-panel shadow-none p-6"):
-                ui.label(
-                    "This report is unavailable. Return to history and choose another saved analysis."
-                ).classes("text-sm dw-muted")
-            return
-        with ui.card().classes("w-full dw-panel shadow-none p-4"):
-            if show_comparison:
-                _render_history_report_comparison(report_id, comparison)
-            else:
-                with ui.row().classes(
-                    "w-full items-center justify-between gap-3 flex-wrap"
-                ):
+                with ui.card().classes("w-full dw-panel shadow-none p-6"):
                     ui.label(
-                        "Open a persisted diff against the previous comparable report."
+                        "This report is unavailable. Return to history and choose another saved analysis."
                     ).classes("text-sm dw-muted")
-                    ui.button(
-                        "Compare with previous",
-                        on_click=lambda: ui.navigate.to(
-                            f"/history/{report_id}/compare#report-comparison"
-                        ),
-                    ).props("flat no-caps").classes("dw-theme-button")
-        render_report_detail_page(report)
+                return
+            with ui.card().classes("w-full dw-panel shadow-none p-4"):
+                if show_comparison:
+                    _render_history_report_comparison(report_id, comparison)
+                else:
+                    with ui.row().classes(
+                        "w-full items-center justify-between gap-3 flex-wrap"
+                    ):
+                        ui.label(
+                            "Open a persisted diff against the previous comparable report."
+                        ).classes("text-sm dw-muted")
+                        ui.button(
+                            "Compare with previous",
+                            on_click=lambda: ui.navigate.to(
+                                f"/history/{report_id}/compare#report-comparison"
+                            ),
+                        ).props("flat no-caps").classes("dw-theme-button")
+            render_report_detail_page(report)
+
+    content_refresh["fn"] = lambda *_: render_history_detail_content.refresh()
+    render_history_detail_content()

--- a/ui/routes/settings.py
+++ b/ui/routes/settings.py
@@ -73,281 +73,308 @@ def process_custom_skill_upload_content(
 def build_settings_page() -> None:
     """Render the provider settings form."""
     apply_theme()
-    build_navigation_shell("settings")
-    active_project = get_active_project()
-    settings = get_provider_settings()
-    dashboard_duration_seconds = get_dashboard_result_display_duration_seconds()
-    topology_status = get_topology_status(
-        project_id=active_project.id if active_project is not None else None
+    content_refresh = {"fn": lambda *_: None}
+
+    def handle_project_change(*_) -> None:
+        refresh_shell()
+        content_refresh["fn"]()
+
+    refresh_shell = build_navigation_shell(
+        "settings",
+        on_project_change=handle_project_change,
     )
-    custom_skill_statuses = get_custom_skill_statuses()
-    provider_options = provider_select_options()
 
-    with ui.column().classes("dw-main-content dw-shell gap-5"):
-        with ui.card().classes("w-full dw-panel dw-page-header shadow-none"):
-            build_page_header(
-                eyebrow="Settings",
-                title="Operational settings",
-                subtitle="Manage provider access, topology context, and custom AI skills.",
-                back_href="/",
-                back_label="Back to dashboard",
-            )
-        with ui.card().classes("w-full dw-panel shadow-none"):
-            ui.label("AI provider").classes("text-lg font-medium dw-text")
-            ui.label(
-                "Configure one active provider at a time. Saved provider profiles stay in the database so you can switch between them later."
-            ).classes("text-sm dw-muted")
-            with ui.column().classes("w-full gap-1 rounded-lg dw-panel-soft px-4 py-3"):
-                ui.label("Secrets").classes("text-sm font-semibold dw-text")
+    @ui.refreshable
+    def render_settings_content() -> None:
+        active_project = get_active_project()
+        settings = get_provider_settings()
+        dashboard_duration_seconds = get_dashboard_result_display_duration_seconds()
+        topology_status = get_topology_status(
+            project_id=active_project.id if active_project is not None else None
+        )
+        custom_skill_statuses = get_custom_skill_statuses()
+        provider_options = provider_select_options()
+
+        with ui.column().classes("dw-main-content dw-shell gap-5"):
+            with ui.card().classes("w-full dw-panel dw-page-header shadow-none"):
+                build_page_header(
+                    eyebrow="Settings",
+                    title="Operational settings",
+                    subtitle="Manage provider access, topology context, and custom AI skills.",
+                    back_href="/",
+                    back_label="Back to dashboard",
+                )
+            with ui.card().classes("w-full dw-panel shadow-none"):
+                ui.label("AI provider").classes("text-lg font-medium dw-text")
                 ui.label(
-                    "Provider selection, model, and API base can be persisted. API keys are not stored in the app database and must come from environment variables or runtime secrets."
+                    "Configure one active provider at a time. Saved provider profiles stay in the database so you can switch between them later."
                 ).classes("text-sm dw-muted")
-            with ui.column().classes("w-full gap-1 rounded-lg dw-panel-soft px-4 py-3"):
-                ui.label("Provider capabilities").classes(
-                    "text-sm font-semibold dw-text"
+                with ui.column().classes(
+                    "w-full gap-1 rounded-lg dw-panel-soft px-4 py-3"
+                ):
+                    ui.label("Secrets").classes("text-sm font-semibold dw-text")
+                    ui.label(
+                        "Provider selection, model, and API base can be persisted. API keys are not stored in the app database and must come from environment variables or runtime secrets."
+                    ).classes("text-sm dw-muted")
+                with ui.column().classes(
+                    "w-full gap-1 rounded-lg dw-panel-soft px-4 py-3"
+                ):
+                    ui.label("Provider capabilities").classes(
+                        "text-sm font-semibold dw-text"
+                    )
+                    ui.label(
+                        "MCP readiness remains optional and future-facing. Current narrative flows still use structured summaries only."
+                    ).classes("text-sm dw-muted")
+                    capability_summary = ui.label("").classes("text-sm dw-muted")
+                provider_select = ui.select(
+                    options=provider_options,
+                    value=settings.provider,
+                    label="Active Provider",
+                ).classes("w-full")
+                model_input = ui.input("Model", value=settings.model).classes("w-full")
+                api_base_input = ui.input("API base", value=settings.api_base).classes(
+                    "w-full"
                 )
-                ui.label(
-                    "MCP readiness remains optional and future-facing. Current narrative flows still use structured summaries only."
+                api_key_input = ui.input(
+                    "API key",
+                    value=settings.api_key or "",
+                    password=True,
+                    password_toggle_button=True,
+                ).classes("w-full")
+                local_mode_toggle = ui.switch(
+                    "Local-only mode", value=settings.local_mode
+                )
+                feedback = ui.label(
+                    f"Current source: {settings.source} · active provider: {settings.provider}"
                 ).classes("text-sm dw-muted")
-                capability_summary = ui.label("").classes("text-sm dw-muted")
-            provider_select = ui.select(
-                options=provider_options,
-                value=settings.provider,
-                label="Active Provider",
-            ).classes("w-full")
-            model_input = ui.input("Model", value=settings.model).classes("w-full")
-            api_base_input = ui.input("API base", value=settings.api_base).classes(
-                "w-full"
-            )
-            api_key_input = ui.input(
-                "API key",
-                value=settings.api_key or "",
-                password=True,
-                password_toggle_button=True,
-            ).classes("w-full")
-            local_mode_toggle = ui.switch("Local-only mode", value=settings.local_mode)
-            feedback = ui.label(
-                f"Current source: {settings.source} · active provider: {settings.provider}"
-            ).classes("text-sm dw-muted")
-            duration_feedback = ui.label("").classes("text-sm dw-muted")
-            duration_options = {
-                60: "1 minute",
-                300: "5 minutes",
-                600: "10 minutes",
-                900: "15 minutes",
-                1800: "30 minutes",
-            }
-            duration_select = ui.select(
-                options=duration_options,
-                value=dashboard_duration_seconds,
-                label="Dashboard Result Display Duration",
-            ).classes("w-full")
+                duration_feedback = ui.label("").classes("text-sm dw-muted")
+                duration_options = {
+                    60: "1 minute",
+                    300: "5 minutes",
+                    600: "10 minutes",
+                    900: "15 minutes",
+                    1800: "30 minutes",
+                }
+                duration_select = ui.select(
+                    options=duration_options,
+                    value=dashboard_duration_seconds,
+                    label="Dashboard Result Display Duration",
+                ).classes("w-full")
 
-            def sync_provider_fields(provider_name: str) -> None:
-                selected = get_provider_settings(provider_name)
-                defaults = provider_defaults(provider_name)
-                model_input.value = selected.model or str(defaults["model"])
-                api_base_input.value = selected.api_base or str(defaults["api_base"])
-                api_key_input.value = selected.api_key or ""
-                local_mode_toggle.value = selected.local_mode
-                capabilities = selected.capabilities
-                capability_summary.text = (
-                    "Structured output: "
-                    f"{'yes' if capabilities.supports_structured_output else 'no'} · "
-                    "Local-only: "
-                    f"{'yes' if capabilities.supports_local_only_mode else 'no'} · "
-                    "Remote MCP: "
-                    f"{'yes' if capabilities.supports_remote_mcp else 'no'} · "
-                    "Local MCP: "
-                    f"{'yes' if capabilities.supports_local_mcp else 'no'} · "
-                    "Tool approval: "
-                    f"{'yes' if capabilities.supports_tool_approval else 'no'}"
-                )
-                if capabilities.supports_local_only_mode:
-                    local_mode_toggle.enable()
-                else:
-                    local_mode_toggle.disable()
-                if not capabilities.supports_local_only_mode:
-                    local_mode_toggle.value = False
-
-            provider_select.on_value_change(
-                lambda event: sync_provider_fields(str(event.value))
-            )
-            sync_provider_fields(settings.provider)
-
-            def save_settings() -> None:
-                selected_provider = str(provider_select.value)
-                local_mode = (
-                    bool(local_mode_toggle.value)
-                    if selected_provider == "ollama"
-                    else False
-                )
-                if local_mode:
-                    saved = activate_local_mode(
-                        model=model_input.value.strip(),
-                        api_base=api_base_input.value.strip(),
+                def sync_provider_fields(provider_name: str) -> None:
+                    selected = get_provider_settings(provider_name)
+                    defaults = provider_defaults(provider_name)
+                    model_input.value = selected.model or str(defaults["model"])
+                    api_base_input.value = selected.api_base or str(
+                        defaults["api_base"]
                     )
-                else:
-                    saved = save_provider_settings(
-                        provider=selected_provider,
-                        model=model_input.value.strip(),
-                        api_base=api_base_input.value.strip(),
-                        api_key=api_key_input.value.strip() or None,
-                        local_mode=local_mode,
-                        activate=True,
+                    api_key_input.value = selected.api_key or ""
+                    local_mode_toggle.value = selected.local_mode
+                    capabilities = selected.capabilities
+                    capability_summary.text = (
+                        "Structured output: "
+                        f"{'yes' if capabilities.supports_structured_output else 'no'} · "
+                        "Local-only: "
+                        f"{'yes' if capabilities.supports_local_only_mode else 'no'} · "
+                        "Remote MCP: "
+                        f"{'yes' if capabilities.supports_remote_mcp else 'no'} · "
+                        "Local MCP: "
+                        f"{'yes' if capabilities.supports_local_mcp else 'no'} · "
+                        "Tool approval: "
+                        f"{'yes' if capabilities.supports_tool_approval else 'no'}"
                     )
-                validation = validate_provider_settings(saved)
-                if validation["valid"]:
-                    feedback.text = (
-                        f"Saved provider settings: {saved.provider} · {saved.model} · "
-                        f"local_mode={saved.local_mode} · source={saved.source} · validation=ok"
-                    )
-                else:
-                    feedback.text = (
-                        f"Saved provider settings: {saved.provider} · {saved.model} · "
-                        f"local_mode={saved.local_mode} · source={saved.source} · validation failed: {validation['message']}"
-                    )
-                saved_duration = save_dashboard_result_display_duration_seconds(
-                    int(duration_select.value)
-                )
-                duration_feedback.text = f"Dashboard results will remain visible for {duration_options[saved_duration]}."
-
-            ui.button(
-                "Save AI settings", on_click=lambda: save_settings(), color="primary"
-            ).props("unelevated")
-            duration_feedback.text = f"Dashboard results currently remain visible for {duration_options[dashboard_duration_seconds]}."
-
-        with ui.card().classes("w-full dw-panel shadow-none"):
-            ui.label("Topology context").classes("text-lg font-medium dw-text")
-            ui.label(
-                "Upload or replace the service-topology JSON used by blast-radius analysis. "
-                "DeployWhisper validates the structure immediately and shows any uncertainty."
-            ).classes("text-sm dw-muted")
-            if active_project is not None:
-                ui.label(
-                    f"Active project: {active_project.display_name} ({active_project.project_key})"
-                ).classes("text-xs font-semibold uppercase tracking-[0.08em] dw-muted")
-            topology_feedback = ui.column().classes("w-full gap-2")
-
-            def render_topology_feedback(
-                status,
-                *,
-                success_message: str | None = None,
-                error_message: str | None = None,
-            ) -> None:
-                topology_feedback.clear()
-                with topology_feedback:
-                    if error_message:
-                        ui.label(error_message).classes("text-sm dw-danger-text")
-
-                    if success_message:
-                        ui.label(success_message).classes("text-sm dw-success-text")
-
-                    if status.exists:
-                        ui.label(
-                            f"{status.service_count} services · {status.dependency_count} dependencies · "
-                            f"{status.resource_key_count} resource mappings"
-                        ).classes("text-sm dw-text")
-                        updated_at = status.updated_at or "timestamp unavailable"
-                        ui.label(f"Active file: {status.path}").classes(
-                            "text-xs dw-muted"
-                        )
-                        ui.label(f"Last updated: {updated_at}").classes(
-                            "text-xs dw-muted"
-                        )
-                        if status.preview_services:
-                            ui.label(
-                                "Preview: " + ", ".join(status.preview_services)
-                            ).classes("text-xs dw-muted")
+                    if capabilities.supports_local_only_mode:
+                        local_mode_toggle.enable()
                     else:
-                        ui.label(f"Active file: {status.path}").classes(
-                            "text-xs dw-muted"
-                        )
-                        ui.label("No topology is active yet.").classes(
-                            "text-sm dw-muted"
-                        )
+                        local_mode_toggle.disable()
+                    if not capabilities.supports_local_only_mode:
+                        local_mode_toggle.value = False
 
-                    for blocking_error in status.blocking_errors:
-                        ui.label(blocking_error).classes("text-xs dw-danger-text")
-                    for warning in status.warnings:
-                        ui.label(warning).classes("text-xs dw-warning-text")
-
-            def handle_topology_upload(event) -> None:
-                current_project = get_active_project()
-                upload_result = process_topology_upload_content(
-                    event.content.read(),
-                    project_id=current_project.id
-                    if current_project is not None
-                    else None,
+                provider_select.on_value_change(
+                    lambda event: sync_provider_fields(str(event.value))
                 )
-                render_topology_feedback(
-                    upload_result["status"],
-                    success_message=upload_result["success_message"],
-                    error_message=upload_result["error_message"],
-                )
+                sync_provider_fields(settings.provider)
 
-            ui.upload(
-                on_upload=handle_topology_upload,
-                auto_upload=True,
-                multiple=False,
-                max_file_size=5_000_000,
-            ).props("accept=.json").classes("w-full")
-            render_topology_feedback(topology_status)
+                def save_settings() -> None:
+                    selected_provider = str(provider_select.value)
+                    local_mode = (
+                        bool(local_mode_toggle.value)
+                        if selected_provider == "ollama"
+                        else False
+                    )
+                    if local_mode:
+                        saved = activate_local_mode(
+                            model=model_input.value.strip(),
+                            api_base=api_base_input.value.strip(),
+                        )
+                    else:
+                        saved = save_provider_settings(
+                            provider=selected_provider,
+                            model=model_input.value.strip(),
+                            api_base=api_base_input.value.strip(),
+                            api_key=api_key_input.value.strip() or None,
+                            local_mode=local_mode,
+                            activate=True,
+                        )
+                    validation = validate_provider_settings(saved)
+                    if validation["valid"]:
+                        feedback.text = (
+                            f"Saved provider settings: {saved.provider} · {saved.model} · "
+                            f"local_mode={saved.local_mode} · source={saved.source} · validation=ok"
+                        )
+                    else:
+                        feedback.text = (
+                            f"Saved provider settings: {saved.provider} · {saved.model} · "
+                            f"local_mode={saved.local_mode} · source={saved.source} · validation failed: {validation['message']}"
+                        )
+                    saved_duration = save_dashboard_result_display_duration_seconds(
+                        int(duration_select.value)
+                    )
+                    duration_feedback.text = f"Dashboard results will remain visible for {duration_options[saved_duration]}."
 
-        with ui.card().classes("w-full dw-panel shadow-none"):
-            ui.label("Custom AI Skills").classes("text-lg font-medium dw-text")
-            ui.label(
-                "Add markdown skills under skills/custom to override built-ins or introduce team-specific guidance."
-            ).classes("text-sm dw-muted")
-            skill_feedback = ui.column().classes("w-full gap-2")
+                ui.button(
+                    "Save AI settings",
+                    on_click=lambda: save_settings(),
+                    color="primary",
+                ).props("unelevated")
+                duration_feedback.text = f"Dashboard results currently remain visible for {duration_options[dashboard_duration_seconds]}."
 
-            def render_skill_feedback(
-                statuses,
-                *,
-                success_message: str | None = None,
-                error_message: str | None = None,
-            ) -> None:
-                skill_feedback.clear()
-                with skill_feedback:
-                    if error_message:
-                        ui.label(error_message).classes("text-sm dw-danger-text")
+            with ui.card().classes("w-full dw-panel shadow-none"):
+                ui.label("Topology context").classes("text-lg font-medium dw-text")
+                ui.label(
+                    "Upload or replace the service-topology JSON used by blast-radius analysis. "
+                    "DeployWhisper validates the structure immediately and shows any uncertainty."
+                ).classes("text-sm dw-muted")
+                if active_project is not None:
+                    ui.label(
+                        f"Active project: {active_project.display_name} ({active_project.project_key})"
+                    ).classes(
+                        "text-xs font-semibold uppercase tracking-[0.08em] dw-muted"
+                    )
+                topology_feedback = ui.column().classes("w-full gap-2")
 
-                    if success_message:
-                        ui.label(success_message).classes("text-sm dw-success-text")
+                def render_topology_feedback(
+                    status,
+                    *,
+                    success_message: str | None = None,
+                    error_message: str | None = None,
+                ) -> None:
+                    topology_feedback.clear()
+                    with topology_feedback:
+                        if error_message:
+                            ui.label(error_message).classes("text-sm dw-danger-text")
 
-                    if statuses:
-                        for status in statuses:
-                            mode_text = (
-                                "override" if status.mode == "override" else "new"
-                            )
-                            state_text = "detected" if status.active else "ignored"
+                        if success_message:
+                            ui.label(success_message).classes("text-sm dw-success-text")
+
+                        if status.exists:
                             ui.label(
-                                f"{status.name} · {mode_text} · {state_text}"
+                                f"{status.service_count} services · {status.dependency_count} dependencies · "
+                                f"{status.resource_key_count} resource mappings"
                             ).classes("text-sm dw-text")
-                            ui.label(status.path).classes("text-xs dw-muted")
-                            if status.warning:
-                                ui.label(status.warning).classes(
-                                    "text-xs dw-warning-text"
+                            updated_at = status.updated_at or "timestamp unavailable"
+                            ui.label(f"Active file: {status.path}").classes(
+                                "text-xs dw-muted"
+                            )
+                            ui.label(f"Last updated: {updated_at}").classes(
+                                "text-xs dw-muted"
+                            )
+                            if status.preview_services:
+                                ui.label(
+                                    "Preview: " + ", ".join(status.preview_services)
+                                ).classes("text-xs dw-muted")
+                        else:
+                            ui.label(f"Active file: {status.path}").classes(
+                                "text-xs dw-muted"
+                            )
+                            ui.label("No topology is active yet.").classes(
+                                "text-sm dw-muted"
+                            )
+
+                        for blocking_error in status.blocking_errors:
+                            ui.label(blocking_error).classes("text-xs dw-danger-text")
+                        for warning in status.warnings:
+                            ui.label(warning).classes("text-xs dw-warning-text")
+
+                def handle_topology_upload(event) -> None:
+                    current_project = get_active_project()
+                    upload_result = process_topology_upload_content(
+                        event.content.read(),
+                        project_id=current_project.id
+                        if current_project is not None
+                        else None,
+                    )
+                    render_topology_feedback(
+                        upload_result["status"],
+                        success_message=upload_result["success_message"],
+                        error_message=upload_result["error_message"],
+                    )
+
+                ui.upload(
+                    on_upload=handle_topology_upload,
+                    auto_upload=True,
+                    multiple=False,
+                    max_file_size=5_000_000,
+                ).props("accept=.json").classes("w-full")
+                render_topology_feedback(topology_status)
+
+            with ui.card().classes("w-full dw-panel shadow-none"):
+                ui.label("Custom AI Skills").classes("text-lg font-medium dw-text")
+                ui.label(
+                    "Add markdown skills under skills/custom to override built-ins or introduce team-specific guidance."
+                ).classes("text-sm dw-muted")
+                skill_feedback = ui.column().classes("w-full gap-2")
+
+                def render_skill_feedback(
+                    statuses,
+                    *,
+                    success_message: str | None = None,
+                    error_message: str | None = None,
+                ) -> None:
+                    skill_feedback.clear()
+                    with skill_feedback:
+                        if error_message:
+                            ui.label(error_message).classes("text-sm dw-danger-text")
+
+                        if success_message:
+                            ui.label(success_message).classes("text-sm dw-success-text")
+
+                        if statuses:
+                            for status in statuses:
+                                mode_text = (
+                                    "override" if status.mode == "override" else "new"
                                 )
-                    else:
-                        ui.label("No custom skills detected.").classes(
-                            "text-sm dw-muted"
-                        )
+                                state_text = "detected" if status.active else "ignored"
+                                ui.label(
+                                    f"{status.name} · {mode_text} · {state_text}"
+                                ).classes("text-sm dw-text")
+                                ui.label(status.path).classes("text-xs dw-muted")
+                                if status.warning:
+                                    ui.label(status.warning).classes(
+                                        "text-xs dw-warning-text"
+                                    )
+                        else:
+                            ui.label("No custom skills detected.").classes(
+                                "text-sm dw-muted"
+                            )
 
-            def handle_custom_skill_upload(event) -> None:
-                upload_result = process_custom_skill_upload_content(
-                    event.name, event.content.read()
-                )
-                render_skill_feedback(
-                    upload_result["statuses"],
-                    success_message=upload_result["success_message"],
-                    error_message=upload_result["error_message"],
-                )
+                def handle_custom_skill_upload(event) -> None:
+                    upload_result = process_custom_skill_upload_content(
+                        event.name, event.content.read()
+                    )
+                    render_skill_feedback(
+                        upload_result["statuses"],
+                        success_message=upload_result["success_message"],
+                        error_message=upload_result["error_message"],
+                    )
 
-            ui.upload(
-                on_upload=handle_custom_skill_upload,
-                auto_upload=True,
-                multiple=False,
-                max_file_size=1_000_000,
-            ).props("accept=.md").classes("w-full")
-            render_skill_feedback(custom_skill_statuses)
+                ui.upload(
+                    on_upload=handle_custom_skill_upload,
+                    auto_upload=True,
+                    multiple=False,
+                    max_file_size=1_000_000,
+                ).props("accept=.md").classes("w-full")
+                render_skill_feedback(custom_skill_statuses)
+
+    content_refresh["fn"] = lambda *_: render_settings_content.refresh()
+    render_settings_content()

--- a/ui/theme.py
+++ b/ui/theme.py
@@ -2,7 +2,24 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable
+
 from nicegui import ui
+
+from services.project_service import (
+    get_active_project,
+    has_active_project_selection,
+    list_projects,
+    ProjectRecord,
+    set_active_project,
+)
+from ui.components.project_workspace_switcher import (
+    build_project_combobox,
+    open_create_project_dialog,
+    project_context_heading,
+    project_context_meta,
+    project_context_summary,
+)
 
 _BRAND_MARK_SVG = """
 <svg width="26" height="26" viewBox="0 0 80 80" fill="none" aria-hidden="true">
@@ -15,7 +32,7 @@ _BRAND_MARK_SVG = """
 </svg>
 """
 
-_THEME_HEAD_HTML = """
+_THEME_HEAD_HTML = r"""
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500&family=Sora:wght@300;400;500;600;700;800&display=swap" rel="stylesheet">
@@ -150,7 +167,7 @@ code,
   width: min(1240px, calc(100% - 32px));
   max-width: 1240px;
   margin: 0 auto;
-  padding: 122px 0 36px;
+  padding: 224px 0 36px;
   box-sizing: border-box;
 }
 
@@ -187,7 +204,7 @@ code,
   padding: 28px 30px;
 }
 
-.dw-topbar {
+.dw-header-stack {
   position: fixed;
   inset: 18px 0 auto;
   z-index: 100;
@@ -204,6 +221,203 @@ code,
   box-shadow: 0 18px 44px rgba(2, 7, 17, 0.16);
   backdrop-filter: blur(22px);
   -webkit-backdrop-filter: blur(22px);
+}
+
+.dw-topbar-primary {
+  width: 100%;
+  align-items: center;
+  gap: 16px;
+}
+
+.dw-topbar-nav {
+  min-width: 0;
+}
+
+.dw-topbar-utilities {
+  align-items: center;
+}
+
+.dw-project-bar {
+  width: min(1240px, 100%);
+  margin: 12px auto 0;
+  padding: 18px 20px;
+  border-radius: 26px;
+  border: 1px solid var(--dw-line);
+  background: linear-gradient(180deg, var(--dw-surface), var(--dw-surface-strong));
+  box-shadow: var(--dw-shadow);
+  backdrop-filter: blur(22px);
+  -webkit-backdrop-filter: blur(22px);
+}
+
+.dw-project-filter-copy {
+  min-width: 220px;
+  flex: 1 1 260px;
+}
+
+.dw-project-filter-kicker {
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--dw-muted);
+}
+
+.dw-project-filter-title {
+  color: var(--dw-text);
+  font-size: 17px;
+  line-height: 1.2;
+  font-weight: 600;
+  letter-spacing: -0.02em;
+}
+
+.dw-project-filter-meta {
+  color: var(--dw-muted);
+  font-size: 12px;
+  line-height: 1.5;
+}
+
+.dw-project-filter-controls {
+  width: min(100%, 560px);
+  flex: 1 1 420px;
+  align-items: stretch;
+  justify-content: flex-end;
+  gap: 10px;
+  overflow: visible;
+}
+
+.dw-project-bar,
+.dw-project-combobox {
+  position: relative;
+  overflow: visible;
+}
+
+.dw-project-search-input {
+  min-width: 320px;
+  flex: 1 1 360px;
+}
+
+.dw-project-search-input .q-field__control {
+  min-height: 52px;
+  border-radius: 18px;
+  background: var(--dw-surface-soft);
+  border-color: transparent !important;
+  transition: border-color 0.18s ease, box-shadow 0.18s ease, background 0.18s ease;
+}
+
+.dw-project-search-input .q-field--outlined .q-field__control:before {
+  border-color: var(--dw-line);
+}
+
+.dw-project-search-input .q-field--focused .q-field__control {
+  box-shadow: 0 0 0 4px color-mix(in srgb, var(--dw-accent) 14%, transparent);
+}
+
+.dw-project-search-input .q-field__native,
+.dw-project-search-input .q-field__input,
+.dw-project-search-input .q-field__label,
+.dw-project-search-input .q-field__marginal {
+  color: var(--dw-text) !important;
+}
+
+.dw-project-search-input .q-field__label {
+  color: var(--dw-muted) !important;
+}
+
+.dw-project-search-input .q-field__append .q-icon,
+.dw-project-search-input .q-field__prepend .q-icon {
+  color: var(--dw-accent);
+}
+
+.dw-project-dropdown-anchor {
+  position: absolute;
+  top: calc(100% + 10px);
+  left: 0;
+  right: 0;
+  z-index: 1300;
+}
+
+.dw-project-dropdown-panel {
+  border: 1px solid var(--dw-line);
+  border-radius: 20px;
+  background: color-mix(in srgb, var(--dw-surface-strong) 96%, transparent);
+  box-shadow: 0 22px 46px rgba(2, 7, 17, 0.24);
+  overflow: hidden;
+}
+
+.dw-project-dropdown-list {
+  max-height: min(360px, calc(100vh - 220px));
+  overflow-y: auto;
+  padding: 6px;
+}
+
+.dw-project-feedback-row {
+  padding: 16px 18px;
+}
+
+.dw-project-feedback-copy,
+.dw-project-empty-copy {
+  color: var(--dw-muted);
+  font-size: 12px;
+  line-height: 1.55;
+}
+
+.dw-project-option-button {
+  display: block;
+  width: 100%;
+  min-height: 76px;
+  padding: 12px 14px;
+  border-radius: 14px;
+  background: transparent;
+  text-align: left;
+  cursor: pointer;
+  transition: background 0.16s ease, transform 0.16s ease;
+  user-select: none;
+}
+
+.dw-project-option-button:hover,
+.dw-project-option-active {
+  background: var(--dw-pill-bg);
+}
+
+.dw-project-option-selected {
+  box-shadow: inset 0 0 0 1px var(--dw-accent-line);
+}
+
+.dw-project-option-primary {
+  display: block;
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--dw-text);
+  line-height: 1.35;
+  white-space: normal;
+}
+
+.dw-project-option-meta {
+  display: block;
+  margin-top: 2px;
+  color: var(--dw-muted);
+  font-size: 12px;
+  line-height: 1.45;
+  white-space: normal;
+  overflow-wrap: anywhere;
+}
+
+.dw-project-option-check {
+  color: var(--dw-accent);
+  margin-top: 2px;
+}
+
+.dw-project-empty-title {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--dw-text);
+}
+
+.dw-project-match {
+  background: color-mix(in srgb, var(--dw-accent) 22%, transparent);
+  color: var(--dw-text);
+  border-radius: 6px;
+  padding: 0 2px;
 }
 
 .dw-brand {
@@ -687,7 +901,7 @@ html[data-dw-theme="light"] .dw-dashboard-headline .dw-gradient {
 @media (max-width: 960px) {
   .dw-main-content {
     width: min(100%, calc(100% - 24px));
-    padding-top: 136px;
+    padding-top: 262px;
   }
 
   .dw-findings-grid {
@@ -705,7 +919,7 @@ html[data-dw-theme="light"] .dw-dashboard-headline .dw-gradient {
 }
 
 @media (max-width: 820px) {
-  .dw-topbar {
+  .dw-header-stack {
     inset: 12px 0 auto;
     padding: 0 12px;
   }
@@ -715,6 +929,29 @@ html[data-dw-theme="light"] .dw-dashboard-headline .dw-gradient {
     gap: 12px;
   }
 
+  .dw-project-bar {
+    margin-top: 10px;
+    padding: 16px 16px 18px;
+  }
+
+  .dw-topbar-primary {
+    align-items: flex-start;
+  }
+
+  .dw-topbar-nav {
+    width: 100%;
+    justify-content: flex-start !important;
+  }
+
+  .dw-project-filter-controls {
+    width: 100%;
+    justify-content: stretch;
+  }
+
+  .dw-project-search-input {
+    min-width: 0;
+  }
+
   .dw-brand-subtitle,
   .dw-brand-tag {
     display: none;
@@ -722,6 +959,15 @@ html[data-dw-theme="light"] .dw-dashboard-headline .dw-gradient {
 
   .dw-findings-grid {
     grid-template-columns: minmax(0, 1fr);
+  }
+
+  .dw-main-content {
+    padding-top: 308px;
+  }
+
+  .dw-project-filter-controls {
+    flex-direction: column;
+    align-items: stretch;
   }
 }
 
@@ -761,7 +1007,11 @@ def build_brand_lockup(*, href: str = "/", compact: bool = False) -> None:
                 )
 
 
-def build_navigation_shell(active: str) -> None:
+def build_navigation_shell(
+    active: str,
+    *,
+    on_project_change: Callable[[ProjectRecord], None] | None = None,
+) -> Callable[[], None]:
     """Render the shared top navigation shell."""
     nav_items = (
         ("Dashboard", "/", "dashboard"),
@@ -770,29 +1020,77 @@ def build_navigation_shell(active: str) -> None:
         ("Settings", "/settings", "settings"),
     )
 
-    with ui.element("header").classes("dw-topbar"):
-        with ui.row().classes(
-            "dw-topbar-shell w-full items-center gap-4 flex-wrap justify-between"
-        ):
-            build_brand_lockup(compact=True)
-            with ui.row().classes(
-                "items-center gap-1 flex-wrap grow justify-center max-md:w-full"
-            ):
-                for label, href, key in nav_items:
-                    classes = "dw-nav-link no-underline"
-                    if active == key:
-                        classes += " dw-nav-link-active"
-                    ui.link(label, href).classes(classes)
-            with ui.row().classes(
-                "items-center gap-2 ml-auto max-md:w-full max-md:justify-end"
-            ):
-                ui.button(
-                    "Theme",
-                    icon="contrast",
-                    on_click=lambda: ui.run_javascript(
-                        "window.dwToggleTheme && window.dwToggleTheme()"
-                    ),
-                ).props("flat no-caps").classes("dw-theme-button")
+    with ui.element("div").classes("dw-header-stack"):
+        with ui.column().classes("dw-topbar-shell w-full"):
+            with ui.row().classes("dw-topbar-primary w-full justify-between flex-wrap"):
+                build_brand_lockup(compact=True)
+                with ui.row().classes(
+                    "dw-topbar-nav items-center gap-1 flex-wrap grow justify-center max-md:w-full"
+                ):
+                    for label, href, key in nav_items:
+                        classes = "dw-nav-link no-underline"
+                        if active == key:
+                            classes += " dw-nav-link-active"
+                        ui.link(label, href).classes(classes)
+                with ui.row().classes(
+                    "dw-topbar-utilities items-center gap-2 ml-auto max-md:w-full max-md:justify-end"
+                ):
+                    ui.button(
+                        "Theme",
+                        icon="contrast",
+                        on_click=lambda: ui.run_javascript(
+                            "window.dwToggleTheme && window.dwToggleTheme()"
+                        ),
+                    ).props("flat no-caps").classes("dw-theme-button")
+
+        @ui.refreshable
+        def render_project_bar() -> None:
+            saved_selection = has_active_project_selection()
+            active_project = get_active_project()
+            current_project_id = (
+                active_project.id if saved_selection and active_project else None
+            )
+            with ui.card().classes("dw-project-bar shadow-none"):
+                with ui.row().classes(
+                    "w-full items-end justify-between gap-4 flex-wrap"
+                ):
+                    with ui.column().classes("dw-project-filter-copy gap-[3px]"):
+                        ui.label(project_context_heading()).classes(
+                            "dw-project-filter-kicker"
+                        )
+                        ui.label(project_context_summary(active_project)).classes(
+                            "dw-project-filter-title"
+                        )
+                        ui.label(
+                            project_context_meta(
+                                has_saved_selection=saved_selection,
+                                active_project=active_project,
+                            )
+                        ).classes("dw-project-filter-meta")
+                    with ui.row().classes("dw-project-filter-controls flex-wrap"):
+                        build_project_combobox(
+                            projects=list_projects(),
+                            current_project_id=current_project_id,
+                            on_select=lambda project: handle_project_change(project),
+                        )
+                        ui.button(
+                            "New project",
+                            on_click=lambda: open_create_project_dialog(
+                                on_created=lambda created: handle_project_change(
+                                    created
+                                )
+                            ),
+                            color="primary",
+                        ).props("flat no-caps").classes("dw-theme-button")
+
+        def handle_project_change(project: ProjectRecord) -> None:
+            set_active_project(project.id)
+            render_project_bar.refresh()
+            if on_project_change is not None:
+                on_project_change(project)
+
+        render_project_bar()
+    return lambda: render_project_bar.refresh()
 
 
 def build_page_header(


### PR DESCRIPTION
Story 5.1 needed more than project scoping in storage; the UI had to keep project context visible, searchable, and synchronized across dashboard, history, settings, and the upload flow.

This change adds a dedicated Active Project surface, extracts shared project-switcher logic, refreshes page content when the active project changes, and hardens the combobox interaction model so selection works reliably in live browsers. It also adds targeted browser coverage for the top selector against a live app instance.

Constraint: Active project state already lives in shared settings-backed services and had to remain the single source of truth
Constraint: Docker-hosted UI and browser-local UI needed the same interaction semantics
Rejected: Keep the Quasar select wrapper and patch around blur/click timing | browser-specific event ordering stayed fragile
Rejected: Add backend search endpoints for project lookup | local in-memory filtering is sufficient for current project counts and was not the source of the bug
Confidence: medium
Scope-risk: moderate
Reversibility: clean
Directive: Preserve pointer-first combobox selection semantics unless a replacement is proven across Chromium, Firefox, and WebKit
Tested: ./ .venv/bin/ruff check ., ./.venv/bin/ruff format --check ., ./.venv/bin/python -m unittest discover -q, bash scripts/ci-local.sh, live Playwright selector flow on Docker-backed app in Chromium/WebKit/Firefox
Not-tested: Manual validation in the user's exact interactive browser session after final rebuild
Related: Story 5.1 project workspace refinement and sprint-change-proposal-2026-04-28-epic-5-project-switching

## What does this PR do?

<!-- Brief description of changes -->

## Type of change
- [ ] Feature (new functionality)
- [ ] Bugfix (non-breaking fix)
- [ ] Release preparation
- [ ] Hotfix (critical production fix)
- [ ] Docs / refactor / chore

## Checklist
- [ ] I have followed the branch naming convention
- [ ] Tests pass locally (`pytest tests/ -v`)
- [ ] Linting passes (`ruff check .`)
- [ ] Docker build succeeds
- [ ] I have updated docs if needed
- [ ] No secrets or .env values committed

## Related issue
Closes #