### PR TITLE
Establish a reusable topology import foundation without breaking lega…

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Artifacts -> Parse -> Normalize -> Score -> Blast Radius -> Rollback -> Narrativ
 - Multi-tool intake for Terraform, Kubernetes, Ansible, Jenkins, and CloudFormation
 - Plain-English risk narrative and deploy recommendation
 - Advisory-only output with explicit human-review posture
-- Blast radius analysis using a service-topology file
+- Blast radius analysis using a project-scoped service-topology graph with a shared multi-source import foundation
 - Rollback plan generation with complexity signaling
 - Incident-history matching for operational memory
 - API, CLI, and web entrypoints over one shared analysis pipeline

--- a/_bmad-output/implementation-artifacts/5-2-topology-import-foundation.md
+++ b/_bmad-output/implementation-artifacts/5-2-topology-import-foundation.md
@@ -1,0 +1,113 @@
+# Story 5.2: Topology import foundation and source registry
+
+Status: done
+
+<!-- Note: Validation is optional. Run validate-create-story for quality check before dev-story. -->
+
+## Story
+
+As an admin,
+I want one topology import framework for supported source types,
+so that Terraform, CloudFormation, Kubernetes, Ansible, and future connectors can enrich blast-radius context consistently.
+
+## Acceptance Criteria
+
+1. CLI: `deploywhisper topology import --from <source> --source <uri-or-path>` routes through a shared source registry.
+2. Supported source identifiers include `terraform`, `cloudformation`, `kubernetes`, `ansible`, and `custom`.
+3. Import result records accepted, skipped, partially parsed, and unsupported resources without storing raw source artifacts.
+4. Builds or updates the service topology graph through one normalized topology-change contract.
+5. Re-import reports topology diff consistently across source types.
+6. Unsupported source types or resources produce explicit warnings instead of failing the whole import.
+
+### Requirement Traceability
+
+- Primary PRD requirements: `CTX-07`, `ADM-03`
+- Supporting PRD / NFR / differentiation requirements: `CTX-01`, `CTX-02`, `HIS-08`, `NFR-SEC-01`, `NFR-SEC-03`
+- Coverage intent: `Delta`
+- Story alignment note: Establish the shared topology import boundary after project/workspace scoping so Terraform, CloudFormation, Kubernetes, Ansible, and custom sources do not duplicate graph, diff, warning, or local-first behavior and all imported context lands in the correct project.
+
+## Tasks / Subtasks
+
+- [x] Implement AC1: shared `deploywhisper topology import --from <source> --source <uri-or-path>` CLI routing (AC: 1)
+- [x] Implement AC2: topology source registry with `terraform`, `cloudformation`, `kubernetes`, `ansible`, and `custom` identifiers (AC: 2)
+- [x] Implement AC3: import result model for accepted, skipped, partially parsed, and unsupported resources without raw source persistence (AC: 3)
+- [x] Implement AC4: normalized topology-change contract consumed by the service topology graph update path (AC: 4)
+- [x] Implement AC5: source-agnostic re-import diff behavior (AC: 5)
+- [x] Implement AC6: explicit unsupported source/resource warnings that do not fail the whole import (AC: 6)
+- [x] Ensure topology imports are project-scoped and cannot bypass the project/workspace boundary introduced in Story 5.1 (AC: 1, 3, 4, 5, 6)
+- [x] Add or update automated verification, fixtures, docs, and rollout notes required for this story (AC: 1, 2, 3, 4, 5, 6)
+
+## Dev Notes
+
+- Epic context: Context Moat (2, 15-22 (overlaps Epics 3-4), P1).
+- Epic goal: Add lightweight project/workspace isolation, automate topology discovery across supported infrastructure sources, capture deployment outcomes, and build the feedback loop. This epic turns DeployWhisper from "smart on day 1" to "measurably smarter every month" without expanding into enterprise auth or multi-tenant scope.
+- Story 5.1 is the prerequisite. Keep project/workspace scoping, project selection, and repository-derived project defaults out of this story except where the topology pipeline must consume the existing project boundary correctly.
+- This story is the foundation for the corrected Epic 5 topology scope. Keep source-specific parsing in later connector stories; this story should define the shared registry, normalized import result, topology-change contract, diff behavior, and warnings.
+- Epic 5 is the feedback/context moat. Topology freshness, deployment outcomes, and reviewer feedback are first-class context signals that must remain auditable.
+- Capture history and feedback in a way that can support later calibration and backtesting without rewriting the persistence model again.
+- Outcome and feedback ingestion should be explicit and operator-visible; hidden heuristics will undermine trust.
+- Preserve the project-context guardrails: shared analysis core, local-first handling of raw IaC, advisory-first outputs, and deterministic tests over flaky integration assumptions.
+
+### Project Structure Notes
+
+- Likely implementation surfaces: services/topology_service.py, services/report_service.py, api/routes/, models/, ui/routes/, cli/, parsers/, tests/.
+- Keep new capabilities in the correct layer instead of duplicating logic across UI, API, CLI, integrations, or docs.
+- If this story introduces a new top-level folder or runtime surface, align it with the architecture document before implementation starts.
+
+### References
+
+- [Epics](../planning-artifacts/epics.md)
+- [PRD](../planning-artifacts/prd.md)
+- [Architecture](../planning-artifacts/architecture.md)
+- [Project Context](../project-context.md)
+- [Sprint Change Proposal](../planning-artifacts/sprint-change-proposal-2026-04-27-epic-5-project-workspace-foundation.md)
+
+## Dev Agent Record
+
+### Agent Model Used
+
+GPT-5
+
+### Implementation Plan
+
+- Add failing CLI and service regression tests for source-aware topology import, normalized import results, diff reporting, unsupported-source warnings, and project scoping.
+- Refactor topology persistence behind a shared import registry and topology-change contract so CLI imports and manual uploads use the same graph update path.
+- Update operator docs and complete validation before moving the story to review.
+
+### Debug Log References
+
+- 2026-04-29T00:00:00+05:30: Loaded BMad workflow, project context, story context, sprint status, and existing topology CLI/service/tests.
+- 2026-04-29T00:00:00+05:30: Created branch `feature/5-2-topology-import-foundation`.
+- 2026-04-29T00:00:00+05:30: `./.venv/bin/python -m unittest -q tests.test_services.test_topology_service tests.test_cli.test_analyze`
+- 2026-04-29T00:00:00+05:30: `./.venv/bin/ruff check .`
+- 2026-04-29T00:00:00+05:30: `./.venv/bin/ruff format --check .`
+- 2026-04-29T00:00:00+05:30: `./.venv/bin/python -m unittest discover -q`
+- 2026-04-29T00:00:00+05:30: `bash scripts/ci-local.sh`
+- 2026-04-29T00:00:00+05:30: Re-ran `bmad-code-review` after the reviewer fixes; no findings remained.
+
+### Completion Notes List
+
+- Added a shared topology source registry and normalized import contract in `services/topology_service.py`, including `custom`, `terraform`, `cloudformation`, `kubernetes`, and `ansible` identifiers plus warning-only handling for unsupported sources and resources.
+- Reworked CLI topology import to use `deploywhisper topology import --from <source> --source <uri-or-path>`, return structured import results, and preserve project/workspace scoping through the Story 5.1 boundary.
+- Persisted topology imports as normalized graph metadata without raw source artifacts, added source-agnostic topology diff reporting, and kept manual settings uploads on the same graph update path.
+- Fixed the Story 5.2 review findings by restoring strict validation on the legacy manual topology upload/API path and keeping the default-project legacy topology mirror free of the new import metadata envelope.
+- Updated regression coverage for CLI, topology service, and context API behavior, including no-op imports for unimplemented connectors, legacy-mirror compatibility, and rejection of invalid manual topology relationships.
+- Updated workspace/operator docs to describe the new import command and the local-first, warning-based import posture.
+- Validation passed for focused topology tests, repo-wide Ruff check/format check, full `unittest discover -q`, and `scripts/ci-local.sh`. Local CI still skipped Bandit because it is not installed in this environment.
+
+### File List
+
+- README.md
+- _bmad-output/implementation-artifacts/5-2-topology-import-foundation.md
+- _bmad-output/implementation-artifacts/sprint-status.yaml
+- cli/analyze.py
+- docs/project-workspaces.md
+- services/topology_service.py
+- tests/test_api/test_context.py
+- tests/test_cli/test_analyze.py
+- tests/test_services/test_topology_service.py
+
+## Change Log
+
+- 2026-04-29: Implemented the shared topology import foundation with source-registry routing, normalized import results, topology diff reporting, project-scoped persistence, partial-parse warnings, and updated docs/tests.
+- 2026-04-29: Fixed Story 5.2 review findings by making manual topology saves fail fast on lossy graphs again and preserving the legacy topology mirror file shape for the default project.

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -1,5 +1,5 @@
 # generated: 2026-04-27
-# last_updated: 2026-04-27
+# last_updated: 2026-04-29
 # project: deploywhisper
 # project_key: NOKEY
 # tracking_system: file-system
@@ -35,7 +35,7 @@
 # - Dev moves story to review, then runs code-review
 
 generated: 2026-04-27
-last_updated: 2026-04-27
+last_updated: 2026-04-29
 project: deploywhisper
 project_key: NOKEY
 tracking_system: file-system
@@ -95,7 +95,7 @@ development_status:
 
   epic-5: in-progress
   5-1-project-workspace-foundation: done
-  5-2-topology-import-foundation: ready-for-dev
+  5-2-topology-import-foundation: done
   5-3-topology-drift-detection: ready-for-dev
   5-4-topology-freshness-badge: ready-for-dev
   5-5-deployment-history-capture: ready-for-dev

--- a/cli/analyze.py
+++ b/cli/analyze.py
@@ -9,7 +9,6 @@ import json
 import os
 import sys
 from pathlib import Path
-
 from api.errors import build_error
 from api.schemas import build_analysis_run_data, build_meta
 from integrations.github.init_service import (
@@ -45,7 +44,7 @@ from services.intake_service import (
     uniquify_artifact_names,
 )
 from services.report_service import REPORT_SCHEMA_VERSION
-from services.topology_service import save_topology_definition
+from services.topology_service import get_topology_status, import_topology_source
 
 
 def _emit_json(payload: dict, *, stream) -> None:
@@ -386,38 +385,18 @@ def _run_topology_import(args: argparse.Namespace) -> int:
             project_id=args.project_id,
             project_key=args.project_key,
         )
+        import_result = import_topology_source(
+            args.source_type,
+            args.source,
+            project_id=project.id,
+        )
+        status = get_topology_status(project_id=project.id)
     except ValueError as exc:
         _emit_json(
             build_error(
-                code=getattr(exc, "code", "invalid_project_request"),
+                code=getattr(exc, "code", "invalid_topology_definition"),
                 message=str(exc),
-            ),
-            stream=sys.stderr,
-        )
-        return 2
-
-    path = Path(args.path)
-    try:
-        raw_text = path.read_text(encoding="utf-8")
-    except OSError as exc:
-        _emit_json(
-            build_error(
-                code="topology_read_failed",
-                message="Topology file could not be read.",
-                details={"path": str(path), "reason": str(exc)},
-            ),
-            stream=sys.stderr,
-        )
-        return 2
-
-    try:
-        status = save_topology_definition(raw_text, project_id=project.id)
-    except ValueError as exc:
-        _emit_json(
-            build_error(
-                code="invalid_topology_definition",
-                message=str(exc),
-                details={"path": str(path)},
+                details=getattr(exc, "details", None),
             ),
             stream=sys.stderr,
         )
@@ -427,6 +406,7 @@ def _run_topology_import(args: argparse.Namespace) -> int:
         {
             "data": {
                 "project": project.model_dump(),
+                "import": import_result.model_dump(),
                 "topology": {
                     "path": status.path,
                     "exists": status.exists,
@@ -581,7 +561,18 @@ def build_parser() -> argparse.ArgumentParser:
     topology_subparsers.required = True
     topology_import_parser = topology_subparsers.add_parser(
         "import",
-        help="Import a topology JSON file for a project/workspace.",
+        help="Import topology context from a registered source for a project/workspace.",
+    )
+    topology_import_parser.add_argument(
+        "--from",
+        dest="source_type",
+        required=True,
+        help="Registered topology source identifier.",
+    )
+    topology_import_parser.add_argument(
+        "--source",
+        required=True,
+        help="Topology source path or URI reference.",
     )
     topology_import_parser.add_argument(
         "--project",
@@ -594,11 +585,6 @@ def build_parser() -> argparse.ArgumentParser:
         type=int,
         help="Numeric project/workspace id for the topology import.",
     )
-    topology_import_parser.add_argument(
-        "path",
-        help="Path to a topology JSON file.",
-    )
-
     github_parser = subparsers.add_parser(
         "github", help="GitHub workflow setup helpers."
     )

--- a/docs/project-workspaces.md
+++ b/docs/project-workspaces.md
@@ -22,7 +22,9 @@ DeployWhisper now scopes analyses and topology context to lightweight project/wo
   - `deploywhisper project create <key> <display-name>`
   - `deploywhisper project list`
   - `deploywhisper analyze --project <key> <artifact...>`
-  - `deploywhisper topology import --project <key> <topology.json>`
+  - `deploywhisper topology import --from custom --source <topology.json> --project <key>`
+  - `deploywhisper topology import --from terraform --source <state-or-uri> --project <key>`
+  - The topology import command now routes through a shared source registry and returns a normalized import result with accepted, skipped, partially parsed, and unsupported resources.
 - GitHub App integration: respects `DEPLOYWHISPER_GITHUB_PROJECT_KEY` when set; otherwise derives an owner-safe default from the full repository slug and creates it on demand.
 
 ### Guardrails
@@ -31,6 +33,7 @@ DeployWhisper now scopes analyses and topology context to lightweight project/wo
 - Explicit `project_key` / `project_id` references now fail fast when they are unknown instead of silently falling back to `unassigned`.
 - Conflicting `project_key` and `project_id` inputs are rejected.
 - Repository-derived project keys include the owner segment when available to avoid collisions between unrelated repositories with the same leaf name.
+- Topology import stores normalized graph metadata only. Raw source artifacts are not persisted, and unsupported resources degrade to explicit warnings instead of aborting the whole import.
 
 ### Legacy Mapping
 

--- a/services/topology_service.py
+++ b/services/topology_service.py
@@ -6,6 +6,7 @@ import json
 from datetime import UTC, datetime, timedelta
 from json import JSONDecodeError
 from pathlib import Path
+from typing import Any, Callable, Literal
 
 from pydantic import BaseModel, Field
 
@@ -15,6 +16,22 @@ from models.tables import TopologyVersion
 from services.project_service import build_project_payload, resolve_project_reference
 
 STALE_AFTER_DAYS = 30
+
+
+class TopologyImportError(ValueError):
+    """Raised when a topology import cannot proceed."""
+
+    def __init__(
+        self,
+        code: str,
+        message: str,
+        *,
+        details: dict[str, Any] | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.code = code
+        self.message = message
+        self.details = details or {}
 
 
 class TopologyStatus(BaseModel):
@@ -52,6 +69,60 @@ class TopologyStatus(BaseModel):
     )
 
 
+class TopologyImportResource(BaseModel):
+    """One normalized resource outcome produced during topology import."""
+
+    resource_ref: str = Field(..., description="Stable resource or service reference")
+    service_id: str | None = Field(
+        default=None, description="Owning service id when available"
+    )
+    message: str = Field(..., description="Operator-facing import note")
+
+
+class TopologyImportDiff(BaseModel):
+    """Normalized topology diff for one import run."""
+
+    added_services: list[str] = Field(default_factory=list)
+    removed_services: list[str] = Field(default_factory=list)
+    changed_services: list[str] = Field(default_factory=list)
+
+
+class TopologyImportResult(BaseModel):
+    """Typed import result returned to CLI and future integrations."""
+
+    source_type: str = Field(..., description="Selected topology source identifier")
+    source_ref: str = Field(..., description="Source path or URI reference")
+    applied: bool = Field(
+        default=False,
+        description="Whether the import updated the active topology graph",
+    )
+    warnings: list[str] = Field(default_factory=list)
+    accepted_resources: list[TopologyImportResource] = Field(default_factory=list)
+    skipped_resources: list[TopologyImportResource] = Field(default_factory=list)
+    partially_parsed_resources: list[TopologyImportResource] = Field(
+        default_factory=list
+    )
+    unsupported_resources: list[TopologyImportResource] = Field(default_factory=list)
+    diff: TopologyImportDiff = Field(default_factory=TopologyImportDiff)
+
+
+class TopologyChangeSet(BaseModel):
+    """Normalized topology update contract shared across source handlers."""
+
+    operation: Literal["noop", "replace"] = Field(default="replace")
+    services: list[dict[str, Any]] = Field(default_factory=list)
+    warnings: list[str] = Field(default_factory=list)
+    accepted_resources: list[TopologyImportResource] = Field(default_factory=list)
+    skipped_resources: list[TopologyImportResource] = Field(default_factory=list)
+    partially_parsed_resources: list[TopologyImportResource] = Field(
+        default_factory=list
+    )
+    unsupported_resources: list[TopologyImportResource] = Field(default_factory=list)
+
+
+TopologySourceHandler = Callable[[str], TopologyChangeSet]
+
+
 def _topology_path() -> Path:
     return Path(settings.topology_path)
 
@@ -66,6 +137,36 @@ def _invalid_stored_topology_status(path: Path, message: str) -> TopologyStatus:
         exists=True,
         blocking_errors=[message],
     )
+
+
+def _unique_messages(messages: list[str]) -> list[str]:
+    seen: set[str] = set()
+    unique: list[str] = []
+    for message in messages:
+        normalized = str(message or "").strip()
+        if not normalized or normalized in seen:
+            continue
+        seen.add(normalized)
+        unique.append(normalized)
+    return unique
+
+
+def _import_metadata(payload: dict[str, Any]) -> dict[str, Any]:
+    metadata = payload.get("metadata")
+    if not isinstance(metadata, dict):
+        return {}
+    import_metadata = metadata.get("import")
+    if not isinstance(import_metadata, dict):
+        return {}
+    return import_metadata
+
+
+def _extract_import_warnings(payload: dict[str, Any]) -> list[str]:
+    import_metadata = _import_metadata(payload)
+    warnings = import_metadata.get("warnings", [])
+    if not isinstance(warnings, list):
+        return []
+    return _unique_messages([str(item) for item in warnings])
 
 
 def _load_latest_topology_payload(
@@ -193,9 +294,9 @@ def _find_cycle(service_graph: dict[str, list[str]]) -> list[str]:
 
 
 def _build_topology_status(
-    payload: dict, *, path: Path, exists: bool
+    payload: dict[str, Any], *, path: Path, exists: bool
 ) -> TopologyStatus:
-    warnings: list[str] = []
+    warnings = list(_extract_import_warnings(payload))
     blocking_errors: list[str] = []
     services_raw = payload.get("services", [])
     if not isinstance(services_raw, list):
@@ -205,7 +306,6 @@ def _build_topology_status(
     preview_services: list[str] = []
     seen_ids: set[str] = set()
     inbound_service_ids: set[str] = set()
-    missing_refs: set[str] = set()
     service_graph: dict[str, list[str]] = {}
     dependency_count = 0
     resource_key_count = 0
@@ -294,7 +394,7 @@ def _build_topology_status(
             + "."
         )
 
-    updated_at = _parse_updated_at(payload.get("updated_at"), warnings)
+    updated_at = _parse_updated_at(str(payload.get("updated_at") or ""), warnings)
 
     return TopologyStatus(
         payload=payload,
@@ -305,8 +405,408 @@ def _build_topology_status(
         dependency_count=dependency_count,
         resource_key_count=resource_key_count,
         preview_services=preview_services[:5],
-        warnings=warnings,
+        warnings=_unique_messages(warnings),
         blocking_errors=blocking_errors,
+    )
+
+
+def _join_warnings(warnings: list[str]) -> str | None:
+    if not warnings:
+        return None
+    return " ".join(warnings)
+
+
+def _resource_ref_from_service(service_id: str, resource_keys: list[str]) -> str:
+    if resource_keys:
+        return resource_keys[0]
+    return f"service:{service_id}"
+
+
+def _parse_custom_source(source_ref: str) -> TopologyChangeSet:
+    path = Path(source_ref)
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except OSError as exc:
+        raise TopologyImportError(
+            "topology_read_failed",
+            "Topology source could not be read.",
+            details={"path": str(path), "reason": str(exc)},
+        ) from exc
+    except JSONDecodeError as exc:
+        raise TopologyImportError(
+            "invalid_topology_definition",
+            "Topology source must be valid JSON.",
+            details={"path": str(path)},
+        ) from exc
+
+    if not isinstance(payload, dict):
+        raise TopologyImportError(
+            "invalid_topology_definition",
+            "Topology source must be a JSON object.",
+            details={"path": str(path)},
+        )
+    return _build_custom_change_set(payload)
+
+
+def _build_custom_change_set(payload: dict[str, Any]) -> TopologyChangeSet:
+    services_raw = payload.get("services", [])
+    if not isinstance(services_raw, list):
+        raise TopologyImportError(
+            "invalid_topology_definition",
+            "Topology definition must provide services as a list.",
+        )
+
+    services: list[dict[str, Any]] = []
+    seen_service_ids: set[str] = set()
+    accepted_resources: list[TopologyImportResource] = []
+    skipped_resources: list[TopologyImportResource] = []
+    partially_parsed_resources: list[TopologyImportResource] = []
+
+    for index, service in enumerate(services_raw, start=1):
+        entry_ref = f"service[{index}]"
+        if not isinstance(service, dict):
+            partially_parsed_resources.append(
+                TopologyImportResource(
+                    resource_ref=entry_ref,
+                    message="Service entry was not a JSON object and was ignored.",
+                )
+            )
+            continue
+
+        service_id = str(service.get("id", "")).strip()
+        if not service_id:
+            partially_parsed_resources.append(
+                TopologyImportResource(
+                    resource_ref=entry_ref,
+                    message="Service entry is missing an id and was ignored.",
+                )
+            )
+            continue
+
+        resource_keys_raw = service.get("resource_keys", [])
+        if not isinstance(resource_keys_raw, list):
+            partially_parsed_resources.append(
+                TopologyImportResource(
+                    resource_ref=service_id,
+                    service_id=service_id,
+                    message="Resource keys were malformed and were dropped.",
+                )
+            )
+            resource_keys_raw = []
+        resource_keys = [
+            str(resource_key).strip()
+            for resource_key in resource_keys_raw
+            if str(resource_key).strip()
+        ]
+
+        if service_id in seen_service_ids:
+            skipped_resources.append(
+                TopologyImportResource(
+                    resource_ref=_resource_ref_from_service(service_id, resource_keys),
+                    service_id=service_id,
+                    message="Duplicate service id was skipped.",
+                )
+            )
+            continue
+
+        downstream_raw = service.get("downstream", [])
+        if not isinstance(downstream_raw, list):
+            partially_parsed_resources.append(
+                TopologyImportResource(
+                    resource_ref=service_id,
+                    service_id=service_id,
+                    message="Downstream targets were malformed and were dropped.",
+                )
+            )
+            downstream_raw = []
+        downstream = [
+            str(target).strip() for target in downstream_raw if str(target).strip()
+        ]
+
+        seen_service_ids.add(service_id)
+        services.append(
+            {
+                "id": service_id,
+                "label": str(service.get("label") or service_id),
+                "resource_keys": resource_keys,
+                "downstream": downstream,
+            }
+        )
+
+        if resource_keys:
+            for resource_key in resource_keys:
+                accepted_resources.append(
+                    TopologyImportResource(
+                        resource_ref=resource_key,
+                        service_id=service_id,
+                        message="Resource was mapped into the topology graph.",
+                    )
+                )
+        else:
+            accepted_resources.append(
+                TopologyImportResource(
+                    resource_ref=f"service:{service_id}",
+                    service_id=service_id,
+                    message="Service was mapped into the topology graph.",
+                )
+            )
+
+    valid_service_ids = {service["id"] for service in services}
+    normalized_services: list[dict[str, Any]] = []
+    for service in services:
+        valid_downstream: list[str] = []
+        for downstream_id in service["downstream"]:
+            if downstream_id not in valid_service_ids:
+                partially_parsed_resources.append(
+                    TopologyImportResource(
+                        resource_ref=f"{service['id']}->{downstream_id}",
+                        service_id=service["id"],
+                        message=(
+                            f"Downstream service '{downstream_id}' could not be resolved "
+                            "and was dropped."
+                        ),
+                    )
+                )
+                continue
+            valid_downstream.append(downstream_id)
+        normalized_services.append({**service, "downstream": valid_downstream})
+
+    warnings: list[str] = []
+    if partially_parsed_resources:
+        warnings.append(
+            "Topology import partially parsed one or more resources; malformed entries or unresolved relationships were skipped."
+        )
+    if skipped_resources:
+        warnings.append(
+            "Topology import skipped duplicate services while preserving the first valid definition."
+        )
+
+    if not accepted_resources and services_raw:
+        warnings.append("Topology import did not produce any valid services to apply.")
+        return TopologyChangeSet(
+            operation="noop",
+            warnings=warnings,
+            skipped_resources=skipped_resources,
+            partially_parsed_resources=partially_parsed_resources,
+        )
+
+    return TopologyChangeSet(
+        operation="replace",
+        services=normalized_services,
+        warnings=warnings,
+        accepted_resources=accepted_resources,
+        skipped_resources=skipped_resources,
+        partially_parsed_resources=partially_parsed_resources,
+    )
+
+
+def _build_unimplemented_source_handler(source_type: str) -> TopologySourceHandler:
+    def handler(source_ref: str) -> TopologyChangeSet:
+        message = (
+            f"Topology source '{source_type}' is registered but its connector is not implemented yet; "
+            "no topology changes were applied."
+        )
+        return TopologyChangeSet(
+            operation="noop",
+            warnings=[message],
+            unsupported_resources=[
+                TopologyImportResource(
+                    resource_ref=source_ref,
+                    message=message,
+                )
+            ],
+        )
+
+    return handler
+
+
+TOPOLOGY_SOURCE_REGISTRY: dict[str, TopologySourceHandler] = {
+    "custom": _parse_custom_source,
+    "terraform": _build_unimplemented_source_handler("terraform"),
+    "cloudformation": _build_unimplemented_source_handler("cloudformation"),
+    "kubernetes": _build_unimplemented_source_handler("kubernetes"),
+    "ansible": _build_unimplemented_source_handler("ansible"),
+}
+
+
+def _lookup_source_handler(source_type: str) -> TopologySourceHandler:
+    normalized = str(source_type or "").strip().lower()
+    handler = TOPOLOGY_SOURCE_REGISTRY.get(normalized)
+    if handler is not None:
+        return handler
+
+    def unsupported_handler(source_ref: str) -> TopologyChangeSet:
+        message = (
+            f"Topology source '{normalized or 'unknown'}' is unsupported; "
+            "no topology changes were applied."
+        )
+        return TopologyChangeSet(
+            operation="noop",
+            warnings=[message],
+            unsupported_resources=[
+                TopologyImportResource(
+                    resource_ref=source_ref,
+                    message=message,
+                )
+            ],
+        )
+
+    return unsupported_handler
+
+
+def _current_timestamp() -> str:
+    return datetime.now(UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def _build_payload_from_change_set(
+    *,
+    change_set: TopologyChangeSet,
+    source_type: str,
+    source_ref: str,
+) -> dict[str, Any]:
+    return {
+        "updated_at": _current_timestamp(),
+        "services": change_set.services,
+        "metadata": {
+            "import": {
+                "source_type": source_type,
+                "source_ref": source_ref,
+                "warnings": change_set.warnings,
+                "accepted_resources": [
+                    item.model_dump() for item in change_set.accepted_resources
+                ],
+                "skipped_resources": [
+                    item.model_dump() for item in change_set.skipped_resources
+                ],
+                "partially_parsed_resources": [
+                    item.model_dump() for item in change_set.partially_parsed_resources
+                ],
+                "unsupported_resources": [
+                    item.model_dump() for item in change_set.unsupported_resources
+                ],
+            }
+        },
+    }
+
+
+def _build_legacy_mirror_payload(payload: dict[str, Any]) -> dict[str, Any]:
+    return {key: value for key, value in payload.items() if key != "metadata"}
+
+
+def _persist_topology_payload(
+    payload: dict[str, Any],
+    *,
+    project: dict[str, Any],
+    source_type: str,
+) -> TopologyStatus:
+    topology_path = _topology_scope_path(project)
+    candidate_status = _build_topology_status(payload, path=topology_path, exists=False)
+    if candidate_status.blocking_errors:
+        raise TopologyImportError(
+            "invalid_topology_definition",
+            " ".join(candidate_status.blocking_errors),
+            details={"path": str(topology_path)},
+        )
+
+    with SessionLocal() as session:
+        if bool(project.get("is_default")):
+            legacy_path = _topology_path()
+            try:
+                legacy_path.parent.mkdir(parents=True, exist_ok=True)
+                legacy_path.write_text(
+                    json.dumps(_build_legacy_mirror_payload(payload), indent=2),
+                    encoding="utf-8",
+                )
+            except OSError as exc:
+                raise TopologyImportError(
+                    "topology_write_failed",
+                    "Topology definition could not be mirrored to the legacy topology file.",
+                    details={"path": str(legacy_path), "reason": str(exc)},
+                ) from exc
+        session.add(
+            TopologyVersion(
+                project_id=int(project["id"]),
+                source_type=source_type,
+                payload_json=json.dumps(payload),
+            )
+        )
+        session.commit()
+    return get_topology_status(project_id=int(project["id"]))
+
+
+def _canonical_service(service: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "id": str(service.get("id") or "").strip(),
+        "label": str(service.get("label") or "").strip(),
+        "resource_keys": sorted(
+            str(item).strip()
+            for item in service.get("resource_keys", [])
+            if str(item).strip()
+        ),
+        "downstream": sorted(
+            str(item).strip()
+            for item in service.get("downstream", [])
+            if str(item).strip()
+        ),
+    }
+
+
+def _build_topology_diff(
+    before_payload: dict[str, Any] | None,
+    after_payload: dict[str, Any] | None,
+) -> TopologyImportDiff:
+    before_services = before_payload.get("services", []) if before_payload else []
+    after_services = after_payload.get("services", []) if after_payload else []
+
+    before_map = {
+        service["id"]: _canonical_service(service)
+        for service in before_services
+        if isinstance(service, dict) and str(service.get("id") or "").strip()
+    }
+    after_map = {
+        service["id"]: _canonical_service(service)
+        for service in after_services
+        if isinstance(service, dict) and str(service.get("id") or "").strip()
+    }
+
+    added = sorted(
+        service_id for service_id in after_map if service_id not in before_map
+    )
+    removed = sorted(
+        service_id for service_id in before_map if service_id not in after_map
+    )
+    changed = sorted(
+        service_id
+        for service_id in before_map.keys() & after_map.keys()
+        if before_map[service_id] != after_map[service_id]
+    )
+    return TopologyImportDiff(
+        added_services=added,
+        removed_services=removed,
+        changed_services=changed,
+    )
+
+
+def _build_import_result(
+    *,
+    source_type: str,
+    source_ref: str,
+    applied: bool,
+    change_set: TopologyChangeSet,
+    before_payload: dict[str, Any] | None,
+    after_payload: dict[str, Any] | None,
+    warnings: list[str],
+) -> TopologyImportResult:
+    return TopologyImportResult(
+        source_type=source_type,
+        source_ref=source_ref,
+        applied=applied,
+        warnings=_unique_messages(warnings),
+        accepted_resources=change_set.accepted_resources,
+        skipped_resources=change_set.skipped_resources,
+        partially_parsed_resources=change_set.partially_parsed_resources,
+        unsupported_resources=change_set.unsupported_resources,
+        diff=_build_topology_diff(before_payload, after_payload),
     )
 
 
@@ -337,6 +837,61 @@ def get_topology_status(
     return _build_topology_status(payload, path=topology_path, exists=True)
 
 
+def import_topology_source(
+    source_type: str,
+    source_ref: str,
+    *,
+    project_id: int | None = None,
+    project_key: str | None = None,
+) -> TopologyImportResult:
+    """Import topology through the shared source registry."""
+    normalized_source_type = str(source_type or "").strip().lower()
+    if not normalized_source_type:
+        raise TopologyImportError(
+            "invalid_topology_source",
+            "Topology source type is required.",
+        )
+
+    project = build_project_payload(
+        resolve_project_reference(project_id=project_id, project_key=project_key)
+    )
+    previous_payload, _, _ = _load_latest_topology_payload(project)
+    change_set = _lookup_source_handler(normalized_source_type)(source_ref)
+    warnings = list(change_set.warnings)
+
+    if change_set.operation == "noop":
+        return _build_import_result(
+            source_type=normalized_source_type,
+            source_ref=source_ref,
+            applied=False,
+            change_set=change_set,
+            before_payload=previous_payload,
+            after_payload=previous_payload,
+            warnings=warnings,
+        )
+
+    payload = _build_payload_from_change_set(
+        change_set=change_set,
+        source_type=normalized_source_type,
+        source_ref=source_ref,
+    )
+    status = _persist_topology_payload(
+        payload,
+        project=project,
+        source_type=normalized_source_type,
+    )
+    warnings.extend(status.warnings)
+    return _build_import_result(
+        source_type=normalized_source_type,
+        source_ref=source_ref,
+        applied=True,
+        change_set=change_set,
+        before_payload=previous_payload,
+        after_payload=status.payload,
+        warnings=warnings,
+    )
+
+
 def save_topology_definition(
     raw_text: str,
     *,
@@ -355,38 +910,35 @@ def save_topology_definition(
     project = build_project_payload(
         resolve_project_reference(project_id=project_id, project_key=project_key)
     )
-    topology_path = _topology_scope_path(project)
-    payload["updated_at"] = (
-        datetime.now(UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+    validation_payload = dict(payload)
+    validation_payload["updated_at"] = _current_timestamp()
+    validation_status = _build_topology_status(
+        validation_payload,
+        path=_topology_scope_path(project),
+        exists=False,
     )
-    candidate_status = _build_topology_status(payload, path=topology_path, exists=False)
-    if candidate_status.blocking_errors:
-        raise ValueError(" ".join(candidate_status.blocking_errors))
-    with SessionLocal() as session:
-        if bool(project.get("is_default")):
-            legacy_path = _topology_path()
-            try:
-                legacy_path.parent.mkdir(parents=True, exist_ok=True)
-                legacy_path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
-            except OSError as exc:
-                raise ValueError(
-                    "Topology definition could not be mirrored to the legacy topology file."
-                ) from exc
-        session.add(
-            TopologyVersion(
-                project_id=int(project["id"]),
-                source_type="manual",
-                payload_json=json.dumps(payload),
-            )
+    if validation_status.blocking_errors:
+        raise ValueError(" ".join(validation_status.blocking_errors))
+
+    change_set = _build_custom_change_set(payload)
+    if change_set.operation == "noop" and payload.get("services"):
+        message = _join_warnings(change_set.warnings) or (
+            "Topology import did not produce any valid services to apply."
         )
-        session.commit()
-    return get_topology_status(project_id=int(project["id"]))
+        raise ValueError(message)
 
-
-def _join_warnings(warnings: list[str]) -> str | None:
-    if not warnings:
-        return None
-    return " ".join(warnings)
+    try:
+        return _persist_topology_payload(
+            _build_payload_from_change_set(
+                change_set=change_set,
+                source_type="manual",
+                source_ref="inline://manual-topology",
+            ),
+            project=project,
+            source_type="manual",
+        )
+    except TopologyImportError as exc:
+        raise ValueError(exc.message) from exc
 
 
 def load_topology(

--- a/tests/test_api/test_context.py
+++ b/tests/test_api/test_context.py
@@ -82,3 +82,29 @@ class ContextApiTests(unittest.TestCase):
             get_response.json()["data"]["topology"]["service_count"],
             1,
         )
+
+    def test_save_project_topology_rejects_invalid_relationships(self) -> None:
+        response = self.client.post(
+            "/api/v1/context/topology",
+            json={
+                "project_key": self.project.project_key,
+                "topology": {
+                    "services": [
+                        {
+                            "id": "api",
+                            "label": "API",
+                            "resource_keys": ["Deployment/api"],
+                            "downstream": ["worker"],
+                        }
+                    ]
+                },
+            },
+        )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(
+            response.json()["error"]["code"], "invalid_topology_definition"
+        )
+        self.assertIn(
+            "missing downstream services", response.json()["error"]["message"]
+        )

--- a/tests/test_cli/test_analyze.py
+++ b/tests/test_cli/test_analyze.py
@@ -841,9 +841,12 @@ class AnalyzeCliTests(unittest.TestCase):
                     "deploywhisper",
                     "topology",
                     "import",
+                    "--from",
+                    "custom",
+                    "--source",
+                    str(topology_path),
                     "--project",
                     "payments",
-                    str(topology_path),
                 ],
             ),
             redirect_stdout(output),
@@ -855,6 +858,11 @@ class AnalyzeCliTests(unittest.TestCase):
         payload = json.loads(output.getvalue())
         self.assertEqual(payload["data"]["project"]["project_key"], "payments")
         self.assertEqual(payload["data"]["topology"]["service_count"], 1)
+        self.assertEqual(payload["data"]["import"]["source_type"], "custom")
+        self.assertEqual(
+            payload["data"]["import"]["diff"]["added_services"],
+            ["api"],
+        )
 
     def test_topology_import_command_rejects_unknown_project(self) -> None:
         topology_path = Path(self.tempdir.name) / "topology.json"
@@ -869,9 +877,12 @@ class AnalyzeCliTests(unittest.TestCase):
                     "deploywhisper",
                     "topology",
                     "import",
+                    "--from",
+                    "custom",
+                    "--source",
+                    str(topology_path),
                     "--project",
                     "missing",
-                    str(topology_path),
                 ],
             ),
             redirect_stdout(stdout),
@@ -883,6 +894,44 @@ class AnalyzeCliTests(unittest.TestCase):
         self.assertEqual(ctx.exception.code, 2)
         payload = json.loads(stderr.getvalue())
         self.assertEqual(payload["error"]["code"], "project_not_found")
+
+    def test_topology_import_command_warns_without_failing_for_unknown_source(
+        self,
+    ) -> None:
+        project_service_module.create_project(
+            project_key="payments",
+            display_name="Payments",
+        )
+        output = io.StringIO()
+
+        with (
+            patch(
+                "sys.argv",
+                [
+                    "deploywhisper",
+                    "topology",
+                    "import",
+                    "--from",
+                    "pulumi",
+                    "--source",
+                    "state.json",
+                    "--project",
+                    "payments",
+                ],
+            ),
+            redirect_stdout(output),
+        ):
+            with self.assertRaises(SystemExit) as ctx:
+                main()
+
+        self.assertEqual(ctx.exception.code, 0)
+        payload = json.loads(output.getvalue())
+        self.assertFalse(payload["data"]["import"]["applied"])
+        self.assertEqual(
+            payload["data"]["import"]["unsupported_resources"][0]["resource_ref"],
+            "state.json",
+        )
+        self.assertIn("unsupported", payload["data"]["import"]["warnings"][0].lower())
 
     def test_topology_command_requires_subcommand(self) -> None:
         stderr = io.StringIO()

--- a/tests/test_services/test_topology_service.py
+++ b/tests/test_services/test_topology_service.py
@@ -18,6 +18,7 @@ import services.project_service as project_service_module
 from models.database import SessionLocal
 from services.topology_service import (
     get_topology_status,
+    import_topology_source,
     load_topology,
     save_topology_definition,
 )
@@ -80,6 +81,169 @@ class TopologyServiceTests(unittest.TestCase):
         self.assertEqual(scoped_topology["services"][0]["id"], "api")
         self.assertIsNone(default_topology)
         self.assertIn("not configured", default_warning)
+
+    def test_import_topology_source_reports_diff_and_discards_raw_source_fields(
+        self,
+    ) -> None:
+        project = project_service_module.create_project(
+            project_key="payments",
+            display_name="Payments",
+        )
+        source_path = Path(self.tempdir.name) / "topology-import.json"
+        source_path.write_text(
+            json.dumps(
+                {
+                    "services": [
+                        {
+                            "id": "api",
+                            "label": "API",
+                            "resource_keys": ["Deployment/api"],
+                            "downstream": ["worker"],
+                        },
+                        {
+                            "id": "worker",
+                            "label": "Worker",
+                            "resource_keys": ["Deployment/worker"],
+                            "downstream": [],
+                        },
+                    ],
+                    "raw_source": "do-not-persist-this",
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        first_result = import_topology_source(
+            "custom",
+            str(source_path),
+            project_key="payments",
+        )
+
+        self.assertEqual(first_result.source_type, "custom")
+        self.assertEqual(sorted(first_result.diff.added_services), ["api", "worker"])
+        self.assertEqual(first_result.diff.removed_services, [])
+        self.assertEqual(first_result.diff.changed_services, [])
+        self.assertEqual(len(first_result.accepted_resources), 2)
+        self.assertEqual(first_result.partially_parsed_resources, [])
+        self.assertEqual(first_result.unsupported_resources, [])
+
+        source_path.write_text(
+            json.dumps(
+                {
+                    "services": [
+                        {
+                            "id": "api",
+                            "label": "API v2",
+                            "resource_keys": ["Deployment/api"],
+                            "downstream": [],
+                        }
+                    ],
+                    "raw_source": "still-do-not-persist-this",
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        second_result = import_topology_source(
+            "custom",
+            str(source_path),
+            project_key="payments",
+        )
+        topology, _ = load_topology(project_key="payments")
+
+        self.assertEqual(second_result.diff.added_services, [])
+        self.assertEqual(second_result.diff.removed_services, ["worker"])
+        self.assertEqual(second_result.diff.changed_services, ["api"])
+        assert topology is not None
+        self.assertNotIn("raw_source", topology)
+        with SessionLocal() as session:
+            latest = (
+                session.query(tables_module.TopologyVersion)
+                .filter(tables_module.TopologyVersion.project_id == project.id)
+                .order_by(tables_module.TopologyVersion.id.desc())
+                .first()
+            )
+        assert latest is not None
+        self.assertNotIn("do-not-persist-this", latest.payload_json)
+        self.assertNotIn("still-do-not-persist-this", latest.payload_json)
+
+    def test_import_topology_source_records_partial_and_skipped_resources(self) -> None:
+        project_service_module.create_project(
+            project_key="payments",
+            display_name="Payments",
+        )
+        source_path = Path(self.tempdir.name) / "partial-topology.json"
+        source_path.write_text(
+            json.dumps(
+                {
+                    "services": [
+                        {
+                            "id": "api",
+                            "label": "API",
+                            "resource_keys": ["Deployment/api"],
+                            "downstream": ["worker"],
+                        },
+                        {
+                            "id": "api",
+                            "label": "Duplicate API",
+                            "resource_keys": ["Deployment/api-duplicate"],
+                            "downstream": [],
+                        },
+                        {
+                            "label": "Missing ID",
+                            "resource_keys": ["Deployment/missing-id"],
+                            "downstream": [],
+                        },
+                        "not-a-service",
+                    ]
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        result = import_topology_source(
+            "custom",
+            str(source_path),
+            project_key="payments",
+        )
+        topology, warning = load_topology(project_key="payments")
+
+        self.assertEqual(
+            [item.resource_ref for item in result.accepted_resources],
+            ["Deployment/api"],
+        )
+        self.assertEqual(len(result.skipped_resources), 1)
+        self.assertEqual(len(result.partially_parsed_resources), 3)
+        self.assertIn(
+            "worker",
+            " ".join(item.message for item in result.partially_parsed_resources),
+        )
+        assert topology is not None
+        self.assertEqual(topology["services"][0]["downstream"], [])
+        self.assertIn("partially parsed", warning)
+
+    def test_import_topology_source_warns_without_failing_for_unimplemented_source(
+        self,
+    ) -> None:
+        project_service_module.create_project(
+            project_key="payments",
+            display_name="Payments",
+        )
+
+        result = import_topology_source(
+            "terraform",
+            "s3://example-bucket/topology.tfstate",
+            project_key="payments",
+        )
+        topology, warning = load_topology(project_key="payments")
+
+        self.assertFalse(result.applied)
+        self.assertEqual(result.diff.added_services, [])
+        self.assertEqual(result.accepted_resources, [])
+        self.assertEqual(len(result.unsupported_resources), 1)
+        self.assertIn("terraform", result.warnings[0].lower())
+        self.assertIsNone(topology)
+        self.assertIn("not configured", warning)
 
     def test_load_topology_imports_legacy_file_into_default_project(self) -> None:
         legacy_path = Path(self.tempdir.name) / "legacy-topology.json"
@@ -283,6 +447,40 @@ class TopologyServiceTests(unittest.TestCase):
         self.assertIn("missing downstream services", combined_errors)
         self.assertIn("circular dependency detected", combined_errors)
         self.assertIn("orphaned services", combined_warnings)
+
+    def test_import_topology_source_keeps_legacy_default_project_mirror_compatible(
+        self,
+    ) -> None:
+        source_path = Path(self.tempdir.name) / "default-topology-import.json"
+        source_path.write_text(
+            json.dumps(
+                {
+                    "services": [
+                        {
+                            "id": "api",
+                            "label": "API",
+                            "resource_keys": ["Deployment/api"],
+                            "downstream": [],
+                        }
+                    ]
+                }
+            ),
+            encoding="utf-8",
+        )
+        legacy_path = Path(self.tempdir.name) / "legacy-topology.json"
+        fake_settings = SimpleNamespace(topology_path=str(legacy_path))
+
+        with patch("services.topology_service.settings", fake_settings):
+            result = import_topology_source("custom", str(source_path))
+            topology, warning = load_topology()
+
+        self.assertTrue(result.applied)
+        self.assertTrue(legacy_path.exists())
+        mirrored_payload = json.loads(legacy_path.read_text(encoding="utf-8"))
+        self.assertIn("services", mirrored_payload)
+        self.assertNotIn("metadata", mirrored_payload)
+        self.assertIsNotNone(topology)
+        self.assertIsNone(warning)
 
     def test_save_topology_definition_rejects_invalid_structure_and_keeps_previous_active_file(
         self,


### PR DESCRIPTION
…cy topology workflows

Story 5.2 introduces a shared topology source registry, normalized import results, and source-agnostic diff reporting for project-scoped topology context. The final pass also restored strict validation on legacy manual uploads and preserved the default-project topology mirror format so existing admin and file-based workflows remain compatible while the new CLI import path expands.

Constraint: Story 5.2 had to preserve Story 5.1 project/workspace scoping and legacy topology-file compatibility while introducing source-aware import behavior
Rejected: Reuse the warning-tolerant import path for manual settings/API uploads | silent lossy saves on existing admin workflows
Rejected: Mirror import metadata into the legacy topology file | breaks compatibility for external readers of TOPOLOGY_PATH
Confidence: high
Scope-risk: moderate
Reversibility: clean
Directive: Keep the shared CLI import path and the legacy manual upload path distinct unless future requirements explicitly redefine the admin/API validation contract
Tested: ./\.venv/bin/python -m unittest -q tests.test_services.test_topology_service tests.test_ui.test_settings_page tests.test_api.test_context; ./\.venv/bin/ruff check .; ./\.venv/bin/ruff format --check .; ./\.venv/bin/python -m unittest discover -q; bash scripts/ci-local.sh
Not-tested: Non-custom topology connector implementations beyond their current warning-only stub behavior

## What does this PR do?

<!-- Brief description of changes -->

## Type of change
- [x] Feature (new functionality)
- [ ] Bugfix (non-breaking fix)
- [ ] Release preparation
- [ ] Hotfix (critical production fix)
- [ ] Docs / refactor / chore

## Checklist
- [ ] I have followed the branch naming convention
- [ ] Tests pass locally (`pytest tests/ -v`)
- [ ] Linting passes (`ruff check .`)
- [ ] Docker build succeeds
- [ ] I have updated docs if needed
- [ ] No secrets or .env values committed

## Related issue
Closes #