### PR TITLE
Make topology drift checks observable and actually scheduled

### DIFF
--- a/_bmad-output/implementation-artifacts/5-3-topology-drift-detection.md
+++ b/_bmad-output/implementation-artifacts/5-3-topology-drift-detection.md
@@ -1,0 +1,111 @@
+# Story 5.3: Topology drift detection
+
+Status: done
+
+<!-- Note: Validation is optional. Run validate-create-story for quality check before dev-story. -->
+
+## Story
+
+As a admin,
+I want to know when topology is out of sync,
+so that I can trigger a re-import.
+
+## Acceptance Criteria
+
+1. Scheduled drift check (configurable, default daily)
+2. Alerts when >10% of resources changed since last import
+3. Drift report lists added/removed/modified resources
+4. Configurable via settings UI
+
+### Requirement Traceability
+
+- Primary PRD requirements: `CTX-02`, `CTX-07`
+- Supporting PRD / NFR / differentiation requirements: `ADM-03`
+- Coverage intent: `Delta`
+- Story alignment note: Drift detection turns existing freshness warnings into a proactive context-management capability.
+
+## Tasks / Subtasks
+
+- [x] Implement AC1: Scheduled drift check (configurable, default daily) (AC: 1)
+- [x] Implement AC2: Alerts when >10% of resources changed since last import (AC: 2)
+- [x] Implement AC3: Drift report lists added/removed/modified resources (AC: 3)
+- [x] Implement AC4: Configurable via settings UI (AC: 4)
+- [x] Add or update automated verification, fixtures, docs, and rollout notes required for this story (AC: 1, 2, 3, 4)
+
+## Dev Notes
+
+- Epic context: Context Moat (2, 15-22 (overlaps Epics 3-4), P1).
+- Epic goal: Automate topology discovery across supported infrastructure sources. Capture deployment outcomes. Build the feedback loop. This epic turns DeployWhisper from "smart on day 1" to "measurably smarter every month".
+- This story contributes directly to context moat and should build on the shared topology import/source registry contract from Story 5.2 rather than implementing source-specific drift logic.
+- Drift checks must work consistently for Terraform, CloudFormation, Kubernetes, Ansible, and custom topology sources as those connectors are added.
+- Epic 5 is the feedback/context moat. Topology freshness, deployment outcomes, and reviewer feedback are first-class context signals that must remain auditable.
+- Capture history and feedback in a way that can support later calibration and backtesting without rewriting the persistence model again.
+- Outcome and feedback ingestion should be explicit and operator-visible; hidden heuristics will undermine trust.
+- Preserve the project-context guardrails: shared analysis core, local-first handling of raw IaC, advisory-first outputs, and deterministic tests over flaky integration assumptions.
+
+### Project Structure Notes
+
+- Likely implementation surfaces: services/topology_service.py, services/report_service.py, api/routes/, models/, ui/routes/, cli/, tests/, ui/routes/settings.py.
+- Keep new capabilities in the correct layer instead of duplicating logic across UI, API, CLI, integrations, or docs.
+- If this story introduces a new top-level folder or runtime surface, align it with the architecture document before implementation starts.
+
+### References
+
+- [Epics](../planning-artifacts/epics.md)
+- [PRD](../planning-artifacts/prd.md)
+- [Architecture](../planning-artifacts/architecture.md)
+- [Project Context](../project-context.md)
+
+## Dev Agent Record
+
+### Agent Model Used
+
+GPT-5
+
+### Implementation Plan
+
+- Add failing regression tests for scheduled drift checks, thresholding, drift report output, and settings-driven configuration.
+- Extend the shared topology service with persisted drift state and source-agnostic drift computation over the Story 5.2 import foundation.
+- Wire the drift configuration and reporting into the existing settings/admin surfaces, then complete validation before moving the story to review.
+
+### Debug Log References
+
+- 2026-04-29T00:00:00+05:30: Loaded Story 5.3, sprint status, and project context on a clean `develop` worktree.
+- 2026-04-29T00:00:00+05:30: Created branch `feature/5-3-topology-drift-detection`.
+- 2026-04-29T00:00:00+05:30: `./.venv/bin/python -m unittest -q tests.test_services.test_settings_service tests.test_services.test_topology_service tests.test_ui.test_settings_page`
+- 2026-04-29T00:00:00+05:30: `./.venv/bin/ruff check .`
+- 2026-04-29T00:00:00+05:30: `./.venv/bin/ruff format --check .`
+- 2026-04-29T00:00:00+05:30: `./.venv/bin/python -m unittest discover -q`
+- 2026-04-29T00:00:00+05:30: `bash scripts/ci-local.sh`
+- 2026-04-29T00:00:00+05:30: Re-ran `bmad-code-review`, fixed the two findings, and revalidated the topology drift scheduler/API surfaces.
+- 2026-04-29T00:00:00+05:30: Re-ran `bmad-code-review` after the scheduler/API fixes; no findings remained.
+
+### Completion Notes List
+
+- Added persisted topology drift cadence settings with a default daily interval and shared service helpers for reading and saving the configured schedule.
+- Extended the shared topology service with drift status models, resource-level drift comparison, >10% alerting, cached per-project drift snapshots, and due-check execution layered on top of the Story 5.2 import source metadata.
+- Exposed the latest topology drift summary and drift cadence selector in the settings page so operators can review scheduled checks and adjust the cadence without leaving the existing topology context workflow.
+- Fixed the Story 5.3 review findings by adding a real startup scheduler loop that runs due drift passes in the background, exposing drift payloads through the project context API, and listing added/removed/modified resource names in the settings UI.
+- Added deterministic regression coverage for drift interval settings, due scheduled checks, resource-level added/removed/modified drift reports, threshold alerting, manual-topology unavailability, and settings-page visibility.
+- Updated workspace docs to describe the per-project topology drift cadence and alert posture.
+- Validation passed for the focused drift suites, repo-wide Ruff check/format check, full `unittest discover -q`, and `scripts/ci-local.sh`. Local CI still skipped Bandit because it is not installed in this environment.
+
+### File List
+
+- _bmad-output/implementation-artifacts/5-3-topology-drift-detection.md
+- _bmad-output/implementation-artifacts/sprint-status.yaml
+- api/schemas.py
+- app.py
+- docs/project-workspaces.md
+- services/settings_service.py
+- services/topology_service.py
+- tests/test_api/test_context.py
+- tests/test_services/test_settings_service.py
+- tests/test_services/test_topology_service.py
+- tests/test_ui/test_settings_page.py
+- ui/routes/settings.py
+
+## Change Log
+
+- 2026-04-29: Implemented scheduled topology drift detection with persisted cadence settings, resource-level drift reports, threshold alerts, settings-page controls, and regression coverage.
+- 2026-04-29: Fixed Story 5.3 review findings by adding a real background scheduler pass and surfacing drift resource lists through API and settings UI.

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -96,7 +96,7 @@ development_status:
   epic-5: in-progress
   5-1-project-workspace-foundation: done
   5-2-topology-import-foundation: done
-  5-3-topology-drift-detection: ready-for-dev
+  5-3-topology-drift-detection: done
   5-4-topology-freshness-badge: ready-for-dev
   5-5-deployment-history-capture: ready-for-dev
   5-6-reviewer-feedback-capture: ready-for-dev

--- a/api/schemas.py
+++ b/api/schemas.py
@@ -295,6 +295,45 @@ class TopologyStatusData(BaseModel):
     blocking_errors: list[str] = Field(
         default_factory=list, description="Blocking validation errors"
     )
+    drift: "TopologyDriftStatusData | None" = Field(
+        default=None, description="Latest drift check summary when available"
+    )
+
+
+class TopologyDriftStatusData(BaseModel):
+    status: str = Field(..., description="Current topology drift state")
+    checked_at: str | None = Field(
+        default=None, description="ISO timestamp for the latest drift check"
+    )
+    next_check_at: str | None = Field(
+        default=None, description="ISO timestamp for the next scheduled drift check"
+    )
+    interval_hours: int = Field(
+        default=24, description="Configured drift check cadence in hours"
+    )
+    source_type: str | None = Field(
+        default=None, description="Imported topology source identifier when available"
+    )
+    source_ref: str | None = Field(
+        default=None, description="Imported topology source reference when available"
+    )
+    total_resource_count: int = Field(
+        default=0, description="Total resources considered during the drift check"
+    )
+    changed_resource_count: int = Field(
+        default=0, description="Number of changed resources in the latest drift check"
+    )
+    change_percent: float = Field(
+        default=0.0, description="Percentage of changed resources"
+    )
+    alert: bool = Field(
+        default=False,
+        description="Whether the drift report exceeds the alert threshold",
+    )
+    added_resources: list[str] = Field(default_factory=list)
+    removed_resources: list[str] = Field(default_factory=list)
+    modified_resources: list[str] = Field(default_factory=list)
+    warnings: list[str] = Field(default_factory=list)
 
 
 class TopologyContextRequest(BaseModel):

--- a/app.py
+++ b/app.py
@@ -2,10 +2,13 @@
 
 from __future__ import annotations
 
+import asyncio
+import contextlib
 from contextlib import asynccontextmanager
 from html import escape
 import hashlib
 import hmac
+import logging
 
 from fastapi import Form, Request
 from fastapi.exceptions import RequestValidationError
@@ -38,10 +41,13 @@ from services.report_service import (
     fetch_shared_report_comparison,
 )
 from services.skill_manifest_service import build_skill_manifest_v1_schema
+from services.topology_service import run_due_topology_drift_checks
 from ui.routes.dashboard import build_dashboard
 import ui.routes.skills as skills_ui_routes  # noqa: F401
 
 configure_logging()
+logger = logging.getLogger(__name__)
+TOPOLOGY_DRIFT_SCHEDULER_POLL_SECONDS = 60
 
 
 def _ensure_nicegui_config_defaults() -> None:
@@ -86,7 +92,28 @@ fastapi_app.include_router(context_router)
 fastapi_app.include_router(skills_router)
 
 
-_original_lifespan = fastapi_app.router.lifespan_context
+if not hasattr(fastapi_app, "_deploywhisper_original_lifespan_context"):
+    fastapi_app._deploywhisper_original_lifespan_context = (
+        fastapi_app.router.lifespan_context
+    )
+
+_original_lifespan = fastapi_app._deploywhisper_original_lifespan_context
+
+
+async def _topology_drift_scheduler_loop(stop_event: asyncio.Event) -> None:
+    """Run topology drift checks on a lightweight polling loop."""
+    while not stop_event.is_set():
+        try:
+            run_due_topology_drift_checks()
+        except Exception:
+            logger.exception("Topology drift scheduler pass failed.")
+        try:
+            await asyncio.wait_for(
+                stop_event.wait(),
+                timeout=TOPOLOGY_DRIFT_SCHEDULER_POLL_SECONDS,
+            )
+        except TimeoutError:
+            continue
 
 
 @asynccontextmanager
@@ -94,10 +121,22 @@ async def lifespan(app):
     """Compose NiceGUI startup/shutdown with DeployWhisper app initialization."""
     async with _original_lifespan(app):
         init_db()
-        yield
+        stop_event = asyncio.Event()
+        drift_scheduler_task = asyncio.create_task(
+            _topology_drift_scheduler_loop(stop_event)
+        )
+        try:
+            yield
+        finally:
+            stop_event.set()
+            drift_scheduler_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await drift_scheduler_task
 
 
-fastapi_app.router.lifespan_context = lifespan
+if not getattr(fastapi_app, "_deploywhisper_lifespan_installed", False):
+    fastapi_app.router.lifespan_context = lifespan
+    fastapi_app._deploywhisper_lifespan_installed = True
 
 
 @fastapi_app.get("/api/v1", include_in_schema=False)

--- a/docs/project-workspaces.md
+++ b/docs/project-workspaces.md
@@ -8,6 +8,7 @@ DeployWhisper now scopes analyses and topology context to lightweight project/wo
 - New analyses can attach to a project through the UI, API, CLI, or GitHub integration path.
 - Persisted reports now carry project metadata and history filters can scope by project.
 - Topology uploads are stored per project, with legacy file-based topology continuing to resolve through the default `unassigned` project.
+- Topology drift checks now run on a persisted cadence (daily by default), reuse the imported source reference when available, and surface per-project added/removed/modified resource reports in settings.
 - Deployment outcome and reviewer feedback tables now exist with project foreign keys so later Epic 5 stories can extend the same isolation boundary without schema churn.
 
 ### User Flows
@@ -34,6 +35,7 @@ DeployWhisper now scopes analyses and topology context to lightweight project/wo
 - Conflicting `project_key` and `project_id` inputs are rejected.
 - Repository-derived project keys include the owner segment when available to avoid collisions between unrelated repositories with the same leaf name.
 - Topology import stores normalized graph metadata only. Raw source artifacts are not persisted, and unsupported resources degrade to explicit warnings instead of aborting the whole import.
+- Drift cadence is persisted through the settings UI, and scheduled drift checks warn when more than 10% of mapped resources changed since the last import.
 
 ### Legacy Mapping
 

--- a/services/settings_service.py
+++ b/services/settings_service.py
@@ -138,6 +138,8 @@ PROVIDER_CATALOG: dict[str, dict[str, str | bool | None]] = {
 
 DASHBOARD_RESULT_DURATION_OPTIONS = [60, 300, 600, 900, 1800]
 DEFAULT_DASHBOARD_RESULT_DURATION_SECONDS = 300
+TOPOLOGY_DRIFT_CHECK_INTERVAL_OPTIONS = [6, 12, 24, 168]
+DEFAULT_TOPOLOGY_DRIFT_CHECK_INTERVAL_HOURS = 24
 PROVIDER_ENV_API_KEYS: dict[str, tuple[str, ...]] = {
     "openai": ("OPENAI_API_KEY",),
     "anthropic": ("ANTHROPIC_API_KEY",),
@@ -484,3 +486,36 @@ def save_dashboard_result_display_duration_seconds(seconds: int) -> int:
             session, key="dashboard_result_display_duration_seconds", value=str(seconds)
         )
     return seconds
+
+
+def get_topology_drift_check_interval_hours() -> int:
+    """Return the configured topology drift check interval."""
+    try:
+        with SessionLocal() as session:
+            interval = get_setting(session, "topology_drift_check_interval_hours")
+    except OperationalError:
+        interval = None
+
+    if interval:
+        try:
+            hours = int(interval.value)
+        except ValueError:
+            hours = DEFAULT_TOPOLOGY_DRIFT_CHECK_INTERVAL_HOURS
+        if hours in TOPOLOGY_DRIFT_CHECK_INTERVAL_OPTIONS:
+            return hours
+    return DEFAULT_TOPOLOGY_DRIFT_CHECK_INTERVAL_HOURS
+
+
+def save_topology_drift_check_interval_hours(hours: int) -> int:
+    """Persist the topology drift check interval."""
+    if hours not in TOPOLOGY_DRIFT_CHECK_INTERVAL_OPTIONS:
+        raise ValueError(
+            "Topology drift check interval must be one of the supported preset values."
+        )
+    with SessionLocal() as session:
+        upsert_setting(
+            session,
+            key="topology_drift_check_interval_hours",
+            value=str(hours),
+        )
+    return hours

--- a/services/topology_service.py
+++ b/services/topology_service.py
@@ -12,10 +12,17 @@ from pydantic import BaseModel, Field
 
 from config import settings
 from models.database import SessionLocal
+from models.repositories.settings import get_setting, upsert_setting
 from models.tables import TopologyVersion
-from services.project_service import build_project_payload, resolve_project_reference
+from services.project_service import (
+    build_project_payload,
+    list_projects,
+    resolve_project_reference,
+)
+from services.settings_service import get_topology_drift_check_interval_hours
 
 STALE_AFTER_DAYS = 30
+TOPOLOGY_DRIFT_ALERT_THRESHOLD_PERCENT = 10.0
 
 
 class TopologyImportError(ValueError):
@@ -32,6 +39,84 @@ class TopologyImportError(ValueError):
         self.code = code
         self.message = message
         self.details = details or {}
+
+
+class TopologyDriftStatus(BaseModel):
+    """Summary of the latest topology drift check for one project."""
+
+    status: Literal["up_to_date", "drifted", "unsupported", "unavailable"] = Field(
+        default="unavailable"
+    )
+    checked_at: str | None = Field(
+        default=None, description="ISO timestamp for the latest drift check"
+    )
+    next_check_at: str | None = Field(
+        default=None, description="ISO timestamp for the next scheduled drift check"
+    )
+    interval_hours: int = Field(
+        default=24, description="Configured drift check cadence in hours"
+    )
+    source_type: str | None = Field(
+        default=None, description="Imported topology source identifier when available"
+    )
+    source_ref: str | None = Field(
+        default=None, description="Imported topology source reference when available"
+    )
+    total_resource_count: int = Field(
+        default=0, description="Total resources considered during the drift check"
+    )
+    changed_resource_count: int = Field(
+        default=0, description="Number of changed resources in the latest drift check"
+    )
+    change_percent: float = Field(
+        default=0.0, description="Percentage of changed resources"
+    )
+    alert: bool = Field(
+        default=False,
+        description="Whether the drift report exceeds the alert threshold",
+    )
+    added_resources: list[str] = Field(default_factory=list)
+    removed_resources: list[str] = Field(default_factory=list)
+    modified_resources: list[str] = Field(default_factory=list)
+    warnings: list[str] = Field(default_factory=list)
+
+
+class TopologyDriftData(BaseModel):
+    """API/UI-facing drift payload nested under topology status."""
+
+    status: str = Field(..., description="Current drift state label")
+    checked_at: str | None = Field(
+        default=None, description="ISO timestamp for the latest drift check"
+    )
+    next_check_at: str | None = Field(
+        default=None, description="ISO timestamp for the next scheduled drift check"
+    )
+    interval_hours: int = Field(
+        default=24, description="Configured drift check cadence in hours"
+    )
+    source_type: str | None = Field(
+        default=None, description="Imported topology source identifier when available"
+    )
+    source_ref: str | None = Field(
+        default=None, description="Imported topology source reference when available"
+    )
+    total_resource_count: int = Field(
+        default=0, description="Total resources considered during the drift check"
+    )
+    changed_resource_count: int = Field(
+        default=0, description="Number of changed resources in the latest drift check"
+    )
+    change_percent: float = Field(
+        default=0.0, description="Percentage of changed resources"
+    )
+    alert: bool = Field(
+        default=False,
+        description="Whether the drift report exceeds the alert threshold",
+    )
+    added_resources: list[str] = Field(default_factory=list)
+    removed_resources: list[str] = Field(default_factory=list)
+    modified_resources: list[str] = Field(default_factory=list)
+    warnings: list[str] = Field(default_factory=list)
 
 
 class TopologyStatus(BaseModel):
@@ -66,6 +151,9 @@ class TopologyStatus(BaseModel):
     blocking_errors: list[str] = Field(
         default_factory=list,
         description="Validation errors that make the topology unsafe to activate",
+    )
+    drift: TopologyDriftStatus | None = Field(
+        default=None, description="Latest topology drift check summary when available"
     )
 
 
@@ -167,6 +255,155 @@ def _extract_import_warnings(payload: dict[str, Any]) -> list[str]:
     if not isinstance(warnings, list):
         return []
     return _unique_messages([str(item) for item in warnings])
+
+
+def _resource_snapshot(payload: dict[str, Any] | None) -> dict[str, dict[str, Any]]:
+    if not payload:
+        return {}
+    snapshot: dict[str, dict[str, Any]] = {}
+    services_raw = payload.get("services", [])
+    if not isinstance(services_raw, list):
+        return {}
+    for service in services_raw:
+        if not isinstance(service, dict):
+            continue
+        service_id = str(service.get("id") or "").strip()
+        if not service_id:
+            continue
+        resource_keys_raw = service.get("resource_keys", [])
+        resource_keys = [
+            str(resource_key).strip()
+            for resource_key in resource_keys_raw
+            if str(resource_key).strip()
+        ]
+        if not resource_keys:
+            resource_keys = [f"service:{service_id}"]
+        signature = {
+            "service_id": service_id,
+            "label": str(service.get("label") or service_id),
+            "downstream": sorted(
+                str(target).strip()
+                for target in service.get("downstream", [])
+                if str(target).strip()
+            ),
+        }
+        for resource_key in resource_keys:
+            snapshot[resource_key] = signature
+    return snapshot
+
+
+def _drift_setting_key(project: dict[str, Any]) -> str:
+    return f"topology_drift_status::{project['id']}"
+
+
+def _parse_iso_datetime(value: str | None) -> datetime | None:
+    if not value:
+        return None
+    try:
+        return datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+
+
+def _build_next_check_at(checked_at: str | None, interval_hours: int) -> str | None:
+    checked_at_dt = _parse_iso_datetime(checked_at)
+    if checked_at_dt is None:
+        return None
+    return (
+        (checked_at_dt + timedelta(hours=interval_hours))
+        .replace(microsecond=0)
+        .isoformat()
+        .replace("+00:00", "Z")
+    )
+
+
+def _load_cached_topology_drift(project: dict[str, Any]) -> TopologyDriftStatus | None:
+    with SessionLocal() as session:
+        record = get_setting(session, _drift_setting_key(project))
+    if record is None:
+        return None
+    try:
+        payload = json.loads(record.value)
+    except JSONDecodeError:
+        return None
+    if not isinstance(payload, dict):
+        return None
+    return TopologyDriftStatus(**payload)
+
+
+def _save_topology_drift(
+    project: dict[str, Any], drift_status: TopologyDriftStatus
+) -> TopologyDriftStatus:
+    with SessionLocal() as session:
+        upsert_setting(
+            session,
+            key=_drift_setting_key(project),
+            value=json.dumps(drift_status.model_dump()),
+        )
+    return drift_status
+
+
+def _is_drift_check_due(
+    cached_status: TopologyDriftStatus | None, interval_hours: int
+) -> bool:
+    if cached_status is None:
+        return True
+    checked_at = _parse_iso_datetime(cached_status.checked_at)
+    if checked_at is None:
+        return True
+    return datetime.now(UTC) >= checked_at + timedelta(hours=interval_hours)
+
+
+def _build_drift_status(
+    *,
+    status: Literal["up_to_date", "drifted", "unsupported", "unavailable"],
+    interval_hours: int,
+    source_type: str | None,
+    source_ref: str | None,
+    total_resource_count: int = 0,
+    added_resources: list[str] | None = None,
+    removed_resources: list[str] | None = None,
+    modified_resources: list[str] | None = None,
+    warnings: list[str] | None = None,
+) -> TopologyDriftStatus:
+    checked_at = _current_timestamp()
+    added = sorted(added_resources or [])
+    removed = sorted(removed_resources or [])
+    modified = sorted(modified_resources or [])
+    changed_count = len(added) + len(removed) + len(modified)
+    total = max(total_resource_count, len(added) + len(removed) + len(modified))
+    change_percent = 0.0 if total == 0 else (changed_count / total) * 100.0
+    alert = change_percent > TOPOLOGY_DRIFT_ALERT_THRESHOLD_PERCENT
+    drift_warnings = list(warnings or [])
+    if status == "drifted":
+        threshold_text = "above" if alert else "within"
+        drift_warnings.append(
+            f"Topology drift detected — {change_percent:.1f}% of resources changed since the last import, {threshold_text} the {TOPOLOGY_DRIFT_ALERT_THRESHOLD_PERCENT:.0f}% alert threshold."
+        )
+    return TopologyDriftStatus(
+        status=status,
+        checked_at=checked_at,
+        next_check_at=_build_next_check_at(checked_at, interval_hours),
+        interval_hours=interval_hours,
+        source_type=source_type,
+        source_ref=source_ref,
+        total_resource_count=total_resource_count,
+        changed_resource_count=changed_count,
+        change_percent=round(change_percent, 2),
+        alert=alert,
+        added_resources=added,
+        removed_resources=removed,
+        modified_resources=modified,
+        warnings=_unique_messages(drift_warnings),
+    )
+
+
+def run_due_topology_drift_checks() -> list[TopologyDriftStatus]:
+    """Run due topology drift checks for every known project."""
+    drift_statuses: list[TopologyDriftStatus] = []
+    for project in list_projects():
+        drift_statuses.append(check_topology_drift(project_id=project.id))
+    return drift_statuses
 
 
 def _load_latest_topology_payload(
@@ -810,6 +1047,139 @@ def _build_import_result(
     )
 
 
+def check_topology_drift(
+    *,
+    project_id: int | None = None,
+    project_key: str | None = None,
+    force: bool = False,
+) -> TopologyDriftStatus:
+    """Run or reuse a scheduled topology drift check for one project."""
+    interval_hours = get_topology_drift_check_interval_hours()
+    project = build_project_payload(
+        resolve_project_reference(project_id=project_id, project_key=project_key)
+    )
+    payload, _, status_override = _load_latest_topology_payload(project)
+    import_metadata = _import_metadata(payload or {})
+    source_type = str(import_metadata.get("source_type") or "").strip() or None
+    source_ref = str(import_metadata.get("source_ref") or "").strip() or None
+    cached_status = _load_cached_topology_drift(project)
+
+    if not force and not _is_drift_check_due(cached_status, interval_hours):
+        return cached_status or _build_drift_status(
+            status="unavailable",
+            interval_hours=interval_hours,
+            source_type=source_type,
+            source_ref=source_ref,
+            warnings=["Topology drift check is unavailable."],
+        )
+
+    if payload is None or status_override is not None:
+        return _save_topology_drift(
+            project,
+            _build_drift_status(
+                status="unavailable",
+                interval_hours=interval_hours,
+                source_type=source_type,
+                source_ref=source_ref,
+                warnings=[
+                    "Topology drift is unavailable because no valid topology import is active."
+                ],
+            ),
+        )
+
+    if not source_type or not source_ref:
+        return _save_topology_drift(
+            project,
+            _build_drift_status(
+                status="unavailable",
+                interval_hours=interval_hours,
+                source_type=source_type,
+                source_ref=source_ref,
+                warnings=[
+                    "Topology drift is unavailable because the active topology does not include an import source reference."
+                ],
+            ),
+        )
+
+    if source_type == "manual":
+        return _save_topology_drift(
+            project,
+            _build_drift_status(
+                status="unavailable",
+                interval_hours=interval_hours,
+                source_type=source_type,
+                source_ref=source_ref,
+                warnings=[
+                    "Topology drift is unavailable for manual topology uploads because there is no source connector to re-evaluate."
+                ],
+            ),
+        )
+
+    try:
+        change_set = _lookup_source_handler(source_type)(source_ref)
+    except TopologyImportError as exc:
+        return _save_topology_drift(
+            project,
+            _build_drift_status(
+                status="unavailable",
+                interval_hours=interval_hours,
+                source_type=source_type,
+                source_ref=source_ref,
+                warnings=[str(exc)],
+            ),
+        )
+
+    if change_set.operation != "replace":
+        return _save_topology_drift(
+            project,
+            _build_drift_status(
+                status="unsupported",
+                interval_hours=interval_hours,
+                source_type=source_type,
+                source_ref=source_ref,
+                warnings=change_set.warnings
+                or [
+                    "Topology drift is not supported for the active source connector yet."
+                ],
+            ),
+        )
+
+    current_resources = _resource_snapshot(payload)
+    candidate_payload = {"services": change_set.services}
+    candidate_resources = _resource_snapshot(candidate_payload)
+    added_resources = sorted(
+        resource_ref
+        for resource_ref in candidate_resources
+        if resource_ref not in current_resources
+    )
+    removed_resources = sorted(
+        resource_ref
+        for resource_ref in current_resources
+        if resource_ref not in candidate_resources
+    )
+    modified_resources = sorted(
+        resource_ref
+        for resource_ref in current_resources.keys() & candidate_resources.keys()
+        if current_resources[resource_ref] != candidate_resources[resource_ref]
+    )
+    drift_status = _build_drift_status(
+        status=(
+            "drifted"
+            if added_resources or removed_resources or modified_resources
+            else "up_to_date"
+        ),
+        interval_hours=interval_hours,
+        source_type=source_type,
+        source_ref=source_ref,
+        total_resource_count=max(len(current_resources), len(candidate_resources)),
+        added_resources=added_resources,
+        removed_resources=removed_resources,
+        modified_resources=modified_resources,
+        warnings=change_set.warnings,
+    )
+    return _save_topology_drift(project, drift_status)
+
+
 def get_topology_status(
     *,
     project_id: int | None = None,
@@ -834,7 +1204,9 @@ def get_topology_status(
                 "Blast radius may be incomplete — service topology is not configured."
             ],
         )
-    return _build_topology_status(payload, path=topology_path, exists=True)
+    status = _build_topology_status(payload, path=topology_path, exists=True)
+    status.drift = check_topology_drift(project_id=int(project["id"]))
+    return status
 
 
 def import_topology_source(

--- a/tests/test_api/test_context.py
+++ b/tests/test_api/test_context.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import os
 import tempfile
 import unittest
@@ -82,6 +83,7 @@ class ContextApiTests(unittest.TestCase):
             get_response.json()["data"]["topology"]["service_count"],
             1,
         )
+        self.assertIn("drift", get_response.json()["data"]["topology"])
 
     def test_save_project_topology_rejects_invalid_relationships(self) -> None:
         response = self.client.post(
@@ -108,3 +110,70 @@ class ContextApiTests(unittest.TestCase):
         self.assertIn(
             "missing downstream services", response.json()["error"]["message"]
         )
+
+    def test_fetch_project_topology_includes_drift_resource_lists(self) -> None:
+        topology_path = Path(self.tempdir.name) / "drift-topology.json"
+        topology_path.write_text(
+            json.dumps(
+                {
+                    "services": [
+                        {
+                            "id": "api",
+                            "label": "API",
+                            "resource_keys": ["Deployment/api"],
+                            "downstream": [],
+                        },
+                        {
+                            "id": "billing",
+                            "label": "Billing",
+                            "resource_keys": ["Deployment/billing"],
+                            "downstream": [],
+                        },
+                    ]
+                }
+            ),
+            encoding="utf-8",
+        )
+        import services.topology_service as topology_service_module
+
+        topology_service_module.import_topology_source(
+            "custom",
+            str(topology_path),
+            project_key=self.project.project_key,
+        )
+        topology_path.write_text(
+            json.dumps(
+                {
+                    "services": [
+                        {
+                            "id": "api",
+                            "label": "API",
+                            "resource_keys": ["Deployment/api"],
+                            "downstream": ["worker"],
+                        },
+                        {
+                            "id": "worker",
+                            "label": "Worker",
+                            "resource_keys": ["Deployment/worker"],
+                            "downstream": [],
+                        },
+                    ]
+                }
+            ),
+            encoding="utf-8",
+        )
+        topology_service_module.check_topology_drift(
+            project_key=self.project.project_key,
+            force=True,
+        )
+
+        response = self.client.get(
+            "/api/v1/context/topology",
+            params={"project_key": self.project.project_key},
+        )
+
+        self.assertEqual(response.status_code, 200)
+        drift = response.json()["data"]["topology"]["drift"]
+        self.assertEqual(drift["added_resources"], ["Deployment/worker"])
+        self.assertEqual(drift["removed_resources"], ["Deployment/billing"])
+        self.assertEqual(drift["modified_resources"], ["Deployment/api"])

--- a/tests/test_services/test_settings_service.py
+++ b/tests/test_services/test_settings_service.py
@@ -413,3 +413,17 @@ class SettingsServiceTests(unittest.TestCase):
         self.assertEqual(
             settings_service_module.get_dashboard_result_display_duration_seconds(), 900
         )
+
+    def test_save_and_get_topology_drift_check_interval_hours(self) -> None:
+        self.assertEqual(
+            settings_service_module.get_topology_drift_check_interval_hours(),
+            settings_service_module.DEFAULT_TOPOLOGY_DRIFT_CHECK_INTERVAL_HOURS,
+        )
+
+        saved = settings_service_module.save_topology_drift_check_interval_hours(168)
+
+        self.assertEqual(saved, 168)
+        self.assertEqual(
+            settings_service_module.get_topology_drift_check_interval_hours(),
+            168,
+        )

--- a/tests/test_services/test_topology_service.py
+++ b/tests/test_services/test_topology_service.py
@@ -15,11 +15,14 @@ import config as config_module
 import models.database as database_module
 import models.tables as tables_module
 import services.project_service as project_service_module
+import services.settings_service as settings_service_module
 from models.database import SessionLocal
 from services.topology_service import (
+    check_topology_drift,
     get_topology_status,
     import_topology_source,
     load_topology,
+    run_due_topology_drift_checks,
     save_topology_definition,
 )
 
@@ -33,6 +36,7 @@ class TopologyServiceTests(unittest.TestCase):
         reload(tables_module)
         reload(database_module)
         reload(project_service_module)
+        reload(settings_service_module)
         database_module.init_db()
 
     def tearDown(self) -> None:
@@ -244,6 +248,203 @@ class TopologyServiceTests(unittest.TestCase):
         self.assertIn("terraform", result.warnings[0].lower())
         self.assertIsNone(topology)
         self.assertIn("not configured", warning)
+
+    def test_check_topology_drift_reports_added_removed_and_modified_resources(
+        self,
+    ) -> None:
+        project_service_module.create_project(
+            project_key="payments",
+            display_name="Payments",
+        )
+        source_path = Path(self.tempdir.name) / "drift-topology.json"
+        source_path.write_text(
+            json.dumps(
+                {
+                    "services": [
+                        {
+                            "id": "api",
+                            "label": "API",
+                            "resource_keys": ["Deployment/api"],
+                            "downstream": [],
+                        },
+                        {
+                            "id": "billing",
+                            "label": "Billing",
+                            "resource_keys": ["Deployment/billing"],
+                            "downstream": [],
+                        },
+                    ]
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        import_topology_source("custom", str(source_path), project_key="payments")
+
+        source_path.write_text(
+            json.dumps(
+                {
+                    "services": [
+                        {
+                            "id": "api",
+                            "label": "API",
+                            "resource_keys": ["Deployment/api"],
+                            "downstream": ["worker"],
+                        },
+                        {
+                            "id": "worker",
+                            "label": "Worker",
+                            "resource_keys": ["Deployment/worker"],
+                            "downstream": [],
+                        },
+                    ]
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        drift = check_topology_drift(project_key="payments", force=True)
+        status = get_topology_status(project_key="payments")
+
+        self.assertTrue(drift.alert)
+        self.assertGreater(drift.change_percent, 10.0)
+        self.assertEqual(drift.added_resources, ["Deployment/worker"])
+        self.assertEqual(drift.removed_resources, ["Deployment/billing"])
+        self.assertEqual(drift.modified_resources, ["Deployment/api"])
+        self.assertEqual(drift.status, "drifted")
+        self.assertIsNotNone(status.drift)
+        assert status.drift is not None
+        self.assertEqual(status.drift.status, "drifted")
+
+    def test_get_topology_status_runs_due_scheduled_drift_check_by_default(
+        self,
+    ) -> None:
+        project_service_module.create_project(
+            project_key="payments",
+            display_name="Payments",
+        )
+        source_path = Path(self.tempdir.name) / "scheduled-drift-topology.json"
+        source_path.write_text(
+            json.dumps(
+                {
+                    "services": [
+                        {
+                            "id": "api",
+                            "label": "API",
+                            "resource_keys": ["Deployment/api"],
+                            "downstream": [],
+                        }
+                    ]
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        import_topology_source("custom", str(source_path), project_key="payments")
+
+        status = get_topology_status(project_key="payments")
+
+        self.assertIsNotNone(status.drift)
+        assert status.drift is not None
+        self.assertEqual(status.drift.interval_hours, 24)
+        self.assertEqual(status.drift.status, "up_to_date")
+        self.assertFalse(status.drift.alert)
+        self.assertIsNotNone(status.drift.checked_at)
+        self.assertIsNotNone(status.drift.next_check_at)
+
+    def test_check_topology_drift_marks_manual_topology_as_unavailable(self) -> None:
+        project_service_module.create_project(
+            project_key="payments",
+            display_name="Payments",
+        )
+        save_topology_definition(
+            json.dumps(
+                {
+                    "services": [
+                        {
+                            "id": "api",
+                            "label": "API",
+                            "resource_keys": ["Deployment/api"],
+                            "downstream": [],
+                        }
+                    ]
+                }
+            ),
+            project_key="payments",
+        )
+
+        drift = check_topology_drift(project_key="payments", force=True)
+
+        self.assertEqual(drift.status, "unavailable")
+        self.assertFalse(drift.alert)
+        self.assertIn("manual", " ".join(drift.warnings).lower())
+
+    def test_run_due_topology_drift_checks_updates_projects_with_due_imports(
+        self,
+    ) -> None:
+        project = project_service_module.create_project(
+            project_key="payments",
+            display_name="Payments",
+        )
+        source_path = Path(self.tempdir.name) / "scheduler-drift-topology.json"
+        source_path.write_text(
+            json.dumps(
+                {
+                    "services": [
+                        {
+                            "id": "api",
+                            "label": "API",
+                            "resource_keys": ["Deployment/api"],
+                            "downstream": [],
+                        }
+                    ]
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        import_topology_source("custom", str(source_path), project_key="payments")
+        source_path.write_text(
+            json.dumps(
+                {
+                    "services": [
+                        {
+                            "id": "api",
+                            "label": "API",
+                            "resource_keys": ["Deployment/api"],
+                            "downstream": ["worker"],
+                        },
+                        {
+                            "id": "worker",
+                            "label": "Worker",
+                            "resource_keys": ["Deployment/worker"],
+                            "downstream": [],
+                        },
+                    ]
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        with SessionLocal() as session:
+            cached_drift = session.get(
+                tables_module.AppSetting,
+                f"topology_drift_status::{project.id}",
+            )
+            assert cached_drift is not None
+            cached_payload = json.loads(cached_drift.value)
+            cached_payload["checked_at"] = "2026-04-01T00:00:00Z"
+            cached_payload["next_check_at"] = "2026-04-02T00:00:00Z"
+            cached_drift.value = json.dumps(cached_payload)
+            session.commit()
+
+        run_due_topology_drift_checks()
+        status = get_topology_status(project_key="payments")
+
+        self.assertIsNotNone(status.drift)
+        assert status.drift is not None
+        self.assertEqual(status.drift.status, "drifted")
+        self.assertEqual(status.drift.added_resources, ["Deployment/worker"])
 
     def test_load_topology_imports_legacy_file_into_default_project(self) -> None:
         legacy_path = Path(self.tempdir.name) / "legacy-topology.json"

--- a/tests/test_ui/test_settings_page.py
+++ b/tests/test_ui/test_settings_page.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import json
 import os
 import tempfile
@@ -15,6 +16,7 @@ import app as app_module
 import config as config_module
 import models.database as database_module
 import models.tables as tables_module
+import services.project_service as project_service_module
 from fastapi.testclient import TestClient
 
 from ui.routes.settings import (
@@ -53,6 +55,87 @@ class SettingsPageTests(unittest.TestCase):
         self.assertIn("Dashboard Result Display Duration", response.text)
         self.assertIn("Topology context", response.text)
         self.assertIn("blast-radius analysis", response.text)
+        self.assertIn("Drift check cadence", response.text)
+        self.assertIn("Topology drift", response.text)
+
+    def test_settings_page_lists_drift_resource_names(self) -> None:
+        project = project_service_module.create_project(
+            project_key="payments",
+            display_name="Payments",
+        )
+        project_service_module.set_active_project(project.id)
+        source_path = Path(self.tempdir.name) / "ui-drift-topology.json"
+        source_path.write_text(
+            json.dumps(
+                {
+                    "services": [
+                        {
+                            "id": "api",
+                            "label": "API",
+                            "resource_keys": ["Deployment/api"],
+                            "downstream": [],
+                        },
+                        {
+                            "id": "billing",
+                            "label": "Billing",
+                            "resource_keys": ["Deployment/billing"],
+                            "downstream": [],
+                        },
+                    ]
+                }
+            ),
+            encoding="utf-8",
+        )
+        import services.topology_service as topology_service_module
+
+        topology_service_module.import_topology_source(
+            "custom",
+            str(source_path),
+            project_key="payments",
+        )
+        source_path.write_text(
+            json.dumps(
+                {
+                    "services": [
+                        {
+                            "id": "api",
+                            "label": "API",
+                            "resource_keys": ["Deployment/api"],
+                            "downstream": ["worker"],
+                        },
+                        {
+                            "id": "worker",
+                            "label": "Worker",
+                            "resource_keys": ["Deployment/worker"],
+                            "downstream": [],
+                        },
+                    ]
+                }
+            ),
+            encoding="utf-8",
+        )
+        topology_service_module.check_topology_drift(
+            project_key="payments",
+            force=True,
+        )
+
+        response = self.client.get("/settings")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("Deployment/worker", response.text)
+        self.assertIn("Deployment/billing", response.text)
+        self.assertIn("Deployment/api", response.text)
+
+    def test_topology_drift_scheduler_loop_runs_a_pass(self) -> None:
+        stop_event = asyncio.Event()
+
+        def run_once() -> None:
+            stop_event.set()
+
+        with patch("app.run_due_topology_drift_checks", side_effect=run_once) as mocked:
+            asyncio.run(app_module._topology_drift_scheduler_loop(stop_event))
+
+        self.assertTrue(mocked.called)
 
     def test_process_topology_upload_content_reports_success_for_valid_upload(
         self,

--- a/ui/routes/settings.py
+++ b/ui/routes/settings.py
@@ -11,11 +11,14 @@ from services.project_service import get_active_project
 from services.settings_service import (
     activate_local_mode,
     get_dashboard_result_display_duration_seconds,
+    get_topology_drift_check_interval_hours,
     provider_defaults,
     provider_select_options,
     get_provider_settings,
     save_dashboard_result_display_duration_seconds,
     save_provider_settings,
+    save_topology_drift_check_interval_hours,
+    TOPOLOGY_DRIFT_CHECK_INTERVAL_OPTIONS,
     validate_provider_settings,
 )
 from services.topology_service import get_topology_status, save_topology_definition
@@ -89,6 +92,7 @@ def build_settings_page() -> None:
         active_project = get_active_project()
         settings = get_provider_settings()
         dashboard_duration_seconds = get_dashboard_result_display_duration_seconds()
+        drift_interval_hours = get_topology_drift_check_interval_hours()
         topology_status = get_topology_status(
             project_id=active_project.id if active_project is not None else None
         )
@@ -252,6 +256,18 @@ def build_settings_page() -> None:
                         "text-xs font-semibold uppercase tracking-[0.08em] dw-muted"
                     )
                 topology_feedback = ui.column().classes("w-full gap-2")
+                drift_interval_options = {
+                    hours: (
+                        "Every 6 hours"
+                        if hours == 6
+                        else "Every 12 hours"
+                        if hours == 12
+                        else "Daily"
+                        if hours == 24
+                        else "Weekly"
+                    )
+                    for hours in TOPOLOGY_DRIFT_CHECK_INTERVAL_OPTIONS
+                }
 
                 def render_topology_feedback(
                     status,
@@ -295,6 +311,71 @@ def build_settings_page() -> None:
                             ui.label(blocking_error).classes("text-xs dw-danger-text")
                         for warning in status.warnings:
                             ui.label(warning).classes("text-xs dw-warning-text")
+                        ui.separator()
+                        ui.label("Topology drift").classes(
+                            "text-sm font-semibold dw-text"
+                        )
+                        if status.drift is None:
+                            ui.label("No drift check has run yet.").classes(
+                                "text-xs dw-muted"
+                            )
+                        else:
+                            drift = status.drift
+                            ui.label(
+                                f"Status: {drift.status.replace('_', ' ')}"
+                            ).classes("text-xs dw-text")
+                            ui.label(
+                                f"Drift check cadence: {drift.interval_hours} hour(s)"
+                            ).classes("text-xs dw-muted")
+                            if drift.checked_at:
+                                ui.label(f"Last checked: {drift.checked_at}").classes(
+                                    "text-xs dw-muted"
+                                )
+                            if drift.next_check_at:
+                                ui.label(f"Next check: {drift.next_check_at}").classes(
+                                    "text-xs dw-muted"
+                                )
+                            if (
+                                drift.added_resources
+                                or drift.removed_resources
+                                or drift.modified_resources
+                            ):
+                                ui.label(
+                                    "Changed resources: "
+                                    f"+{len(drift.added_resources)} / "
+                                    f"-{len(drift.removed_resources)} / "
+                                    f"~{len(drift.modified_resources)}"
+                                ).classes("text-xs dw-text")
+                                if drift.added_resources:
+                                    ui.label(
+                                        "Added: " + ", ".join(drift.added_resources)
+                                    ).classes("text-xs dw-muted")
+                                if drift.removed_resources:
+                                    ui.label(
+                                        "Removed: " + ", ".join(drift.removed_resources)
+                                    ).classes("text-xs dw-muted")
+                                if drift.modified_resources:
+                                    ui.label(
+                                        "Modified: "
+                                        + ", ".join(drift.modified_resources)
+                                    ).classes("text-xs dw-muted")
+                            for warning in drift.warnings:
+                                ui.label(warning).classes("text-xs dw-warning-text")
+
+                def save_drift_interval(event) -> None:
+                    try:
+                        saved_interval = save_topology_drift_check_interval_hours(
+                            int(event.value)
+                        )
+                    except ValueError as exc:
+                        ui.notify(str(exc), type="negative")
+                        return
+                    ui.notify(
+                        "Topology drift cadence updated to "
+                        f"{drift_interval_options.get(saved_interval, saved_interval)}.",
+                        type="positive",
+                    )
+                    render_settings_content.refresh()
 
                 def handle_topology_upload(event) -> None:
                     current_project = get_active_project()
@@ -316,6 +397,14 @@ def build_settings_page() -> None:
                     multiple=False,
                     max_file_size=5_000_000,
                 ).props("accept=.json").classes("w-full")
+                drift_interval_select = ui.select(
+                    options=drift_interval_options,
+                    value=drift_interval_hours,
+                    label="Drift check cadence",
+                ).classes("w-full")
+                drift_interval_select.on_value_change(
+                    lambda event: save_drift_interval(event)
+                )
                 render_topology_feedback(topology_status)
 
             with ui.card().classes("w-full dw-panel shadow-none"):


### PR DESCRIPTION
Story 5.3 adds persisted topology drift cadence, resource-level drift reporting, and a background scheduler pass so drift detection becomes an operational signal instead of an on-demand calculation hidden behind one page load. The follow-up review fixes also exposed the drift report through the context API and the settings UI so operators can act on the result without guessing from summary counts.

Constraint: Story 5.3 had to build on the Story 5.2 topology import metadata without introducing a new worker stack or dependency
Rejected: Keep drift checks opportunistic on topology reads only | does not satisfy the scheduled-check acceptance criterion
Rejected: Expose only aggregate drift counts in UI/API | does not satisfy the resource-level drift report acceptance criterion
Confidence: high
Scope-risk: moderate
Reversibility: clean
Directive: Keep cadence enforcement in the drift service even if the scheduler cadence changes later, so ad-hoc callers and background passes share one source of truth
Tested: ./\.venv/bin/python -m unittest -q tests.test_services.test_topology_service tests.test_api.test_context tests.test_ui.test_settings_page; ./\.venv/bin/ruff check .; ./\.venv/bin/ruff format --check .; ./\.venv/bin/python -m unittest discover -q; bash scripts/ci-local.sh
Not-tested: Long-running multi-hour scheduler behavior in a persistent live process beyond startup/pass-level regression coverage

## What does this PR do?

<!-- Brief description of changes -->

## Type of change
- [ ] Feature (new functionality)
- [ ] Bugfix (non-breaking fix)
- [ ] Release preparation
- [ ] Hotfix (critical production fix)
- [ ] Docs / refactor / chore

## Checklist
- [ ] I have followed the branch naming convention
- [ ] Tests pass locally (`pytest tests/ -v`)
- [ ] Linting passes (`ruff check .`)
- [ ] Docker build succeeds
- [ ] I have updated docs if needed
- [ ] No secrets or .env values committed

## Related issue
Closes #