### PR TITLE
Capture deployment outcomes as auditable project-scoped history

### DIFF
--- a/_bmad-output/implementation-artifacts/5-5-deployment-history-capture.md
+++ b/_bmad-output/implementation-artifacts/5-5-deployment-history-capture.md
@@ -1,0 +1,111 @@
+# Story 5.5: Deployment history capture
+
+Status: review
+
+<!-- Note: Validation is optional. Run validate-create-story for quality check before dev-story. -->
+
+## Story
+
+As a engineering manager,
+I want every deployment and its outcome tracked,
+so that I can measure risk trends over time.
+
+## Acceptance Criteria
+
+1. Webhook endpoint accepts deployment outcome notifications
+2. Webhook payload: analysis_id, outcome (success/failure/rolled_back), deployed_at, linked_incident_id
+3. CLI alternative: `deploywhisper outcome record --analysis-id X --outcome success`
+4. History queryable via API
+
+### Requirement Traceability
+
+- Primary PRD requirements: `CTX-06`, `HIS-06`
+- Supporting PRD / NFR / differentiation requirements: `HIS-01`, `HIS-02`
+- Coverage intent: `Baseline + Delta`
+- Story alignment note: Extend current report persistence into deployment-outcome capture without breaking audit history.
+
+## Tasks / Subtasks
+
+- [x] Implement AC1: Webhook endpoint accepts deployment outcome notifications (AC: 1)
+- [x] Implement AC2: Webhook payload: analysis_id, outcome (success/failure/rolled_back), deployed_at, linked_incident_id (AC: 2)
+- [x] Implement AC3: CLI alternative: `deploywhisper outcome record --analysis-id X --outcome success` (AC: 3)
+- [x] Implement AC4: History queryable via API (AC: 4)
+- [x] Add or update automated verification, fixtures, docs, and rollout notes required for this story (AC: 1, 2, 3, 4)
+
+## Dev Notes
+
+- Epic context: Context Moat (2, 15-22 (overlaps Epics 3-4), P1).
+- Epic goal: Automate topology discovery across supported infrastructure sources. Capture deployment outcomes. Build the feedback loop. This epic turns DeployWhisper from "smart on day 1" to "measurably smarter every month".
+- This story contributes directly to context moat and should be scoped so later stories can build on stable contracts rather than rewrites.
+- Epic 5 is the feedback/context moat. Topology freshness, deployment outcomes, and reviewer feedback are first-class context signals that must remain auditable.
+- Capture history and feedback in a way that can support later calibration and backtesting without rewriting the persistence model again.
+- Outcome and feedback ingestion should be explicit and operator-visible; hidden heuristics will undermine trust.
+- Preserve the project-context guardrails: shared analysis core, local-first handling of raw IaC, advisory-first outputs, and deterministic tests over flaky integration assumptions.
+
+### Project Structure Notes
+
+- Likely implementation surfaces: services/topology_service.py, services/report_service.py, api/routes/, models/, ui/routes/, cli/, tests/.
+- Keep new capabilities in the correct layer instead of duplicating logic across UI, API, CLI, integrations, or docs.
+- If this story introduces a new top-level folder or runtime surface, align it with the architecture document before implementation starts.
+
+### References
+
+- [Epics](../planning-artifacts/epics.md)
+- [PRD](../planning-artifacts/prd.md)
+- [Architecture](../planning-artifacts/architecture.md)
+- [Project Context](../project-context.md)
+
+## Dev Agent Record
+
+### Agent Model Used
+
+GPT-5 (Codex)
+
+### Debug Log References
+
+- `./.venv/bin/python -m unittest -q tests.test_infra.test_migrations tests.test_services.test_deployment_outcome_service tests.test_api.test_deployments tests.test_cli.test_analyze`
+- `./.venv/bin/python -m unittest -q tests.test_infra.test_migrations tests.test_api.test_deployments tests.test_services.test_deployment_outcome_service tests.test_cli.test_analyze`
+- `./.venv/bin/python -m unittest -q tests.test_infra.test_migrations`
+- `./.venv/bin/ruff check .`
+- `./.venv/bin/ruff format --check .`
+- `./.venv/bin/python -m unittest discover -q`
+- `bash scripts/ci-local.sh`
+
+### Completion Notes List
+
+- Added migration `011_add_deployment_outcome_fields` so deployment outcomes now persist `deployed_at` and optional `linked_incident_id` without replacing the existing Epic 5 project-scoped table.
+- Added shared deployment outcome capture/query support through `services/deployment_outcome_service.py` and `models/repositories/deployment_outcomes.py`, with validation that derives the owning project from `analysis_id` and rejects mismatched project references.
+- Added `POST /api/v1/deployments/outcomes` and `GET /api/v1/deployments/outcomes` for webhook-style ingestion and API history queries.
+- Added CLI support for `deploywhisper outcome record --analysis-id X --outcome success`, plus optional `--deployed-at`, `--linked-incident-id`, `--environment`, and validation-only project flags.
+- Added operator documentation and rollout notes in `docs/deployment-history.md`.
+- Added regression coverage for migrations, shared service behavior, API contracts, CLI behavior, and migration inventory expectations.
+- Validation passed with repo-wide Ruff checks, focused regression tests, full `unittest discover -q`, and `bash scripts/ci-local.sh`. Local CI still skipped Bandit because Bandit is not installed in this environment.
+- Fixed code-review finding: migration `011_add_deployment_outcome_fields` now backfills `incident_records` into the Alembic chain so `alembic upgrade head` yields a complete schema without relying on ORM metadata side effects.
+- Fixed code-review finding: `POST /api/v1/deployments/outcomes` now requires `X-DeployWhisper-Outcome-Token`, and the docs/tests were updated to reflect the explicit mutation-token requirement.
+- Fixed follow-up code-review finding: migration `011_add_deployment_outcome_fields` now records whether it created `incident_records` and drops that table on downgrade only when `011` introduced it, preserving pre-existing schemas while restoring revision `010` accurately.
+
+### File List
+
+- `_bmad-output/implementation-artifacts/5-5-deployment-history-capture.md`
+- `_bmad-output/implementation-artifacts/sprint-status.yaml`
+- `api/routes/deployments.py`
+- `api/schemas.py`
+- `app.py`
+- `cli/analyze.py`
+- `docs/deployment-history.md`
+- `migrations/versions/011_add_deployment_outcome_fields.py`
+- `models/database.py`
+- `models/repositories/deployment_outcomes.py`
+- `models/tables.py`
+- `services/deployment_outcome_service.py`
+- `tests/test_api/test_deployments.py`
+- `tests/test_cli/test_analyze.py`
+- `tests/test_infra/test_container_contract.py`
+- `tests/test_infra/test_migrations.py`
+- `tests/test_services/test_deployment_outcome_service.py`
+
+### Change Log
+
+- 2026-04-30: Implemented Story 5.5 deployment outcome capture across migration, shared service, API, CLI, tests, and rollout documentation.
+- 2026-04-30: Fixed Story 5.5 review findings for pure-Alembic incident schema coverage and authenticated outcome ingestion.
+- 2026-04-30: Fixed Story 5.5 review finding for accurate downgrade behavior when `011` creates `incident_records`.

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -98,7 +98,7 @@ development_status:
   5-2-topology-import-foundation: done
   5-3-topology-drift-detection: done
   5-4-topology-freshness-badge: review
-  5-5-deployment-history-capture: ready-for-dev
+  5-5-deployment-history-capture: review
   5-6-reviewer-feedback-capture: ready-for-dev
   5-7-outcome-linking: ready-for-dev
   5-8-calibration-dashboard: ready-for-dev

--- a/api/routes/deployments.py
+++ b/api/routes/deployments.py
@@ -1,0 +1,139 @@
+"""Deployment outcome API routes."""
+
+from __future__ import annotations
+
+import hmac
+import os
+
+from fastapi import APIRouter, Depends, Header, Query
+
+from api.errors import ApiError, ApiRoute
+from api.schemas import (
+    DeploymentOutcomeCreateRequest,
+    DeploymentOutcomeData,
+    DeploymentOutcomeListResponse,
+    DeploymentOutcomeResponse,
+    ErrorResponse,
+    build_meta,
+)
+from config import settings
+from services.deployment_outcome_service import (
+    list_deployment_outcomes,
+    record_deployment_outcome,
+)
+
+router = APIRouter(
+    prefix="/api/v1/deployments",
+    tags=["deployments"],
+    route_class=ApiRoute,
+)
+
+
+def require_deployment_outcome_token(
+    outcome_token: str | None = Header(
+        default=None,
+        alias="X-DeployWhisper-Outcome-Token",
+    ),
+) -> None:
+    configured_token = (
+        os.getenv("DEPLOYWHISPER_OUTCOME_TOKEN")
+        or os.getenv("APP_DEPLOYMENT_OUTCOME_TOKEN")
+        or settings.deployment_outcome_token
+        or ""
+    ).strip()
+    if not configured_token:
+        raise ApiError(
+            status_code=405,
+            code="deployment_outcome_ingest_disabled",
+            message=(
+                "Deployment outcome ingestion is disabled. Set "
+                "DEPLOYWHISPER_OUTCOME_TOKEN to enable it."
+            ),
+        )
+    if not outcome_token or not hmac.compare_digest(outcome_token, configured_token):
+        raise ApiError(
+            status_code=403,
+            code="deployment_outcome_ingest_forbidden",
+            message="Deployment outcome ingestion requires a valid management token.",
+        )
+
+
+def _deployment_api_error(exc: ValueError) -> ApiError:
+    code = getattr(exc, "code", "invalid_deployment_request")
+    status_code = (
+        404
+        if code in {"analysis_not_found", "project_not_found", "incident_not_found"}
+        else 400
+    )
+    return ApiError(
+        status_code=status_code,
+        code=code,
+        message=str(exc),
+    )
+
+
+@router.post(
+    "/outcomes",
+    response_model=DeploymentOutcomeResponse,
+    responses={
+        400: {"model": ErrorResponse},
+        404: {"model": ErrorResponse},
+        422: {"model": ErrorResponse},
+        500: {"model": ErrorResponse},
+    },
+)
+def create_deployment_outcome_route(
+    payload: DeploymentOutcomeCreateRequest,
+    _: None = Depends(require_deployment_outcome_token),
+) -> DeploymentOutcomeResponse:
+    try:
+        recorded = record_deployment_outcome(
+            analysis_id=payload.analysis_id,
+            outcome=payload.outcome,
+            deployed_at=payload.deployed_at,
+            linked_incident_id=payload.linked_incident_id,
+            environment=payload.environment,
+            summary=payload.summary,
+            project_id=payload.project_id,
+            project_key=payload.project_key,
+            source_interface="api",
+        )
+    except ValueError as exc:
+        raise _deployment_api_error(exc) from exc
+    return DeploymentOutcomeResponse(
+        data=DeploymentOutcomeData(**recorded),
+        meta=build_meta(id=recorded["id"]),
+    )
+
+
+@router.get(
+    "/outcomes",
+    response_model=DeploymentOutcomeListResponse,
+    responses={
+        400: {"model": ErrorResponse},
+        404: {"model": ErrorResponse},
+        422: {"model": ErrorResponse},
+        500: {"model": ErrorResponse},
+    },
+)
+def get_deployment_outcomes(
+    analysis_id: int | None = Query(default=None),
+    outcome: str | None = Query(default=None),
+    project_id: int | None = Query(default=None),
+    project_key: str | None = Query(default=None),
+    limit: int = Query(default=100, ge=1, le=200),
+) -> DeploymentOutcomeListResponse:
+    try:
+        outcomes = list_deployment_outcomes(
+            analysis_id=analysis_id,
+            outcome=outcome,
+            project_id=project_id,
+            project_key=project_key,
+            limit=limit,
+        )
+    except ValueError as exc:
+        raise _deployment_api_error(exc) from exc
+    return DeploymentOutcomeListResponse(
+        data=[DeploymentOutcomeData(**item) for item in outcomes],
+        meta=build_meta(count=len(outcomes)),
+    )

--- a/api/schemas.py
+++ b/api/schemas.py
@@ -88,6 +88,7 @@ ParseStatus = Literal["parsed", "failed", "skipped"]
 RiskSeverity = Literal["low", "medium", "high", "critical"]
 DeployRecommendation = Literal["go", "caution", "no-go"]
 RollbackComplexity = Literal["low", "medium", "high"]
+DeploymentOutcomeLabel = Literal["success", "failure", "rolled_back"]
 
 
 class IntakeItem(BaseModel):
@@ -274,6 +275,66 @@ class ProjectListResponse(BaseModel):
 
 class ProjectResponse(BaseModel):
     data: ProjectData
+    meta: ResourceOnlyMetaPayload
+
+
+class DeploymentOutcomeCreateRequest(BaseModel):
+    analysis_id: int = Field(..., description="Analysis identifier for the deployment.")
+    outcome: DeploymentOutcomeLabel = Field(
+        ..., description="Final deployment result for the analyzed change."
+    )
+    deployed_at: str = Field(..., description="Deployment completion timestamp.")
+    linked_incident_id: int | None = Field(
+        default=None,
+        description="Optional linked incident identifier when the deployment failed.",
+    )
+    environment: str | None = Field(
+        default=None,
+        description="Optional environment label such as prod or staging.",
+    )
+    summary: str | None = Field(
+        default=None,
+        description="Optional operator summary for the deployment outcome.",
+    )
+    project_id: int | None = Field(
+        default=None,
+        description="Optional numeric project/workspace identifier.",
+    )
+    project_key: str | None = Field(
+        default=None,
+        description="Optional stable project/workspace key.",
+    )
+
+
+class DeploymentOutcomeData(BaseModel):
+    id: int = Field(..., description="Stable deployment outcome identifier.")
+    project: ProjectData = Field(..., description="Owning project/workspace.")
+    analysis_id: int | None = Field(
+        default=None,
+        description="Analysis report identifier tied to this deployment.",
+    )
+    outcome: DeploymentOutcomeLabel = Field(
+        ..., description="Normalized deployment outcome label."
+    )
+    deployed_at: str = Field(..., description="Deployment completion timestamp.")
+    linked_incident_id: int | None = Field(
+        default=None,
+        description="Linked incident identifier when available.",
+    )
+    environment: str | None = Field(
+        default=None, description="Optional environment label."
+    )
+    summary: str | None = Field(default=None, description="Optional operator summary.")
+    created_at: str = Field(..., description="Outcome record creation timestamp.")
+
+
+class DeploymentOutcomeListResponse(BaseModel):
+    data: list[DeploymentOutcomeData]
+    meta: ListMetaPayload
+
+
+class DeploymentOutcomeResponse(BaseModel):
+    data: DeploymentOutcomeData
     meta: ResourceOnlyMetaPayload
 
 

--- a/app.py
+++ b/app.py
@@ -26,6 +26,7 @@ from api.errors import (
     validation_error_handler,
 )
 from api.routes.analyses import router as analyses_router
+from api.routes.deployments import router as deployments_router
 from api.routes.github_app import router as github_app_router
 from api.routes.health import router as health_router
 from api.routes.projects import router as projects_router
@@ -92,6 +93,7 @@ fastapi_app.add_exception_handler(RequestValidationError, validation_error_handl
 fastapi_app.add_exception_handler(StarletteHTTPException, http_error_envelope_handler)
 fastapi_app.include_router(health_router)
 fastapi_app.include_router(analyses_router)
+fastapi_app.include_router(deployments_router)
 fastapi_app.include_router(github_app_router)
 fastapi_app.include_router(projects_router)
 fastapi_app.include_router(context_router)

--- a/cli/analyze.py
+++ b/cli/analyze.py
@@ -36,6 +36,7 @@ from services.analysis_service import (
     build_advisory_summary,
     build_share_summary,
 )
+from services.deployment_outcome_service import record_deployment_outcome
 from services.project_service import create_project, list_projects
 from services.project_service import resolve_project_reference
 from services.intake_service import (
@@ -379,6 +380,39 @@ def _run_project_list() -> int:
     return 0
 
 
+def _run_outcome_record(args: argparse.Namespace) -> int:
+    try:
+        recorded = record_deployment_outcome(
+            analysis_id=args.analysis_id,
+            outcome=args.outcome,
+            deployed_at=args.deployed_at,
+            linked_incident_id=args.linked_incident_id,
+            environment=args.environment,
+            summary=args.summary,
+            project_id=args.project_id,
+            project_key=args.project_key,
+            source_interface="cli",
+        )
+    except ValueError as exc:
+        _emit_json(
+            build_error(
+                code=getattr(exc, "code", "invalid_deployment_request"),
+                message=str(exc),
+            ),
+            stream=sys.stderr,
+        )
+        return 2
+
+    _emit_json(
+        {
+            "data": recorded,
+            "meta": build_meta(interface="cli", id=recorded["id"]),
+        },
+        stream=sys.stdout,
+    )
+    return 0
+
+
 def _run_topology_import(args: argparse.Namespace) -> int:
     try:
         project = resolve_project_reference(
@@ -554,6 +588,55 @@ def build_parser() -> argparse.ArgumentParser:
     )
     project_subparsers.add_parser("list", help="List known project/workspace records.")
 
+    outcome_parser = subparsers.add_parser(
+        "outcome", help="Record post-deployment outcomes for persisted analyses."
+    )
+    outcome_subparsers = outcome_parser.add_subparsers(dest="outcome_command")
+    outcome_subparsers.required = True
+    outcome_record_parser = outcome_subparsers.add_parser(
+        "record",
+        help="Capture a deployment outcome for a persisted analysis report.",
+    )
+    outcome_record_parser.add_argument(
+        "--analysis-id",
+        required=True,
+        type=int,
+        help="Persisted analysis report identifier.",
+    )
+    outcome_record_parser.add_argument(
+        "--outcome",
+        required=True,
+        help="Deployment result: success, failure, or rolled_back.",
+    )
+    outcome_record_parser.add_argument(
+        "--deployed-at",
+        help="Optional ISO 8601 deployment timestamp. Defaults to now.",
+    )
+    outcome_record_parser.add_argument(
+        "--linked-incident-id",
+        type=int,
+        help="Optional linked incident identifier.",
+    )
+    outcome_record_parser.add_argument(
+        "--environment",
+        help="Optional environment label such as prod or staging.",
+    )
+    outcome_record_parser.add_argument(
+        "--summary",
+        help="Optional operator summary for the deployment outcome.",
+    )
+    outcome_record_parser.add_argument(
+        "--project",
+        dest="project_key",
+        help="Optional project/workspace key for validation.",
+    )
+    outcome_record_parser.add_argument(
+        "--project-id",
+        dest="project_id",
+        type=int,
+        help="Optional numeric project/workspace id for validation.",
+    )
+
     topology_parser = subparsers.add_parser(
         "topology", help="Manage project-scoped topology context."
     )
@@ -673,6 +756,8 @@ def main() -> None:
         raise SystemExit(_run_project_create(args))
     if args.command == "project" and args.project_command == "list":
         raise SystemExit(_run_project_list())
+    if args.command == "outcome" and args.outcome_command == "record":
+        raise SystemExit(_run_outcome_record(args))
     if args.command == "topology" and args.topology_command == "import":
         raise SystemExit(_run_topology_import(args))
     if args.command == "github" and args.github_command == "init":

--- a/config.py
+++ b/config.py
@@ -28,6 +28,9 @@ class Settings:
     share_management_token: str | None = os.getenv(
         "DEPLOYWHISPER_SHARE_TOKEN"
     ) or os.getenv("APP_SHARE_MANAGEMENT_TOKEN")
+    deployment_outcome_token: str | None = os.getenv(
+        "DEPLOYWHISPER_OUTCOME_TOKEN"
+    ) or os.getenv("APP_DEPLOYMENT_OUTCOME_TOKEN")
     github_app_enabled: bool = (
         os.getenv("DEPLOYWHISPER_GITHUB_APP_ENABLED", "false").lower() == "true"
     )

--- a/docs/deployment-history.md
+++ b/docs/deployment-history.md
@@ -1,0 +1,50 @@
+# Deployment Outcome Capture
+
+DeployWhisper can now capture post-deployment results for persisted analyses so teams can audit deployment history per project/workspace and feed later calibration work.
+
+## API
+
+Record an outcome with the deployment webhook endpoint:
+
+```bash
+curl -X POST http://localhost:8080/api/v1/deployments/outcomes \
+  -H 'Content-Type: application/json' \
+  -H 'X-DeployWhisper-Outcome-Token: change-me' \
+  -d '{
+    "analysis_id": 42,
+    "outcome": "success",
+    "deployed_at": "2026-04-30T08:15:00Z",
+    "environment": "prod"
+  }'
+```
+
+Query stored outcome history:
+
+```bash
+curl "http://localhost:8080/api/v1/deployments/outcomes?analysis_id=42"
+```
+
+Supported outcome values are `success`, `failure`, and `rolled_back`.
+Set `DEPLOYWHISPER_OUTCOME_TOKEN` (or `APP_DEPLOYMENT_OUTCOME_TOKEN`) on the server before using the ingestion endpoint.
+
+## CLI
+
+Record an outcome from the shared CLI surface:
+
+```bash
+deploywhisper outcome record \
+  --analysis-id 42 \
+  --outcome success \
+  --deployed-at 2026-04-30T08:15:00Z \
+  --environment prod
+```
+
+`--deployed-at` is optional for the CLI path; when omitted, DeployWhisper records the current UTC timestamp.
+
+## Rollout Notes
+
+- Migration `011_add_deployment_outcome_fields` adds `deployed_at` and `linked_incident_id` to the existing `deployment_outcomes` table.
+- Migration `011_add_deployment_outcome_fields` also backfills the previously metadata-only `incident_records` table into the Alembic chain so `alembic upgrade head` produces a complete schema.
+- Outcome capture stays project-scoped by deriving the owning workspace from the referenced `analysis_id`.
+- Incident linkage is optional and validates against the existing `incident_records` table when provided.
+- The webhook-style ingestion path now requires `X-DeployWhisper-Outcome-Token`, aligned with the repo's existing explicit token-based mutation pattern.

--- a/migrations/versions/011_add_deployment_outcome_fields.py
+++ b/migrations/versions/011_add_deployment_outcome_fields.py
@@ -1,0 +1,102 @@
+"""Add deployment outcome timestamps and incident linkage.
+
+Revision ID: 011_add_deployment_outcome_fields
+Revises: 010_add_project_workspaces
+Create Date: 2026-04-30
+"""
+
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "011_add_deployment_outcome_fields"
+down_revision = "010_add_project_workspaces"
+branch_labels = None
+depends_on = None
+_INCIDENT_RECORDS_CREATED_MARKER = "migration:011:created_incident_records"
+
+
+def upgrade() -> None:
+    connection = op.get_bind()
+    inspector = sa.inspect(connection)
+    if not inspector.has_table("incident_records"):
+        op.create_table(
+            "incident_records",
+            sa.Column("id", sa.Integer(), primary_key=True, autoincrement=True),
+            sa.Column("title", sa.String(length=255), nullable=False),
+            sa.Column(
+                "severity",
+                sa.String(length=20),
+                nullable=False,
+                server_default="unknown",
+            ),
+            sa.Column("source_file", sa.String(length=255), nullable=False),
+            sa.Column("incident_date", sa.String(length=40), nullable=True),
+            sa.Column("content", sa.Text(), nullable=False),
+            sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        )
+        connection.execute(
+            sa.text(
+                """
+                INSERT INTO app_settings (key, value, updated_at)
+                VALUES (:key, :value, CURRENT_TIMESTAMP)
+                """
+            ),
+            {
+                "key": _INCIDENT_RECORDS_CREATED_MARKER,
+                "value": "true",
+            },
+        )
+    op.add_column(
+        "deployment_outcomes",
+        sa.Column("deployed_at", sa.DateTime(timezone=True), nullable=True),
+    )
+    op.add_column(
+        "deployment_outcomes",
+        sa.Column("linked_incident_id", sa.Integer(), nullable=True),
+    )
+    connection.execute(
+        sa.text(
+            """
+            UPDATE deployment_outcomes
+            SET deployed_at = created_at
+            WHERE deployed_at IS NULL
+            """
+        )
+    )
+    with op.batch_alter_table("deployment_outcomes") as batch_op:
+        batch_op.alter_column(
+            "deployed_at",
+            existing_type=sa.DateTime(timezone=True),
+            nullable=False,
+        )
+        batch_op.create_foreign_key(
+            "fk_deployment_outcomes_linked_incident_id_incident_records",
+            "incident_records",
+            ["linked_incident_id"],
+            ["id"],
+            ondelete="SET NULL",
+        )
+
+
+def downgrade() -> None:
+    connection = op.get_bind()
+    with op.batch_alter_table("deployment_outcomes") as batch_op:
+        batch_op.drop_constraint(
+            "fk_deployment_outcomes_linked_incident_id_incident_records",
+            type_="foreignkey",
+        )
+        batch_op.drop_column("linked_incident_id")
+        batch_op.drop_column("deployed_at")
+    marker_present = connection.execute(
+        sa.text("SELECT value FROM app_settings WHERE key = :key LIMIT 1"),
+        {"key": _INCIDENT_RECORDS_CREATED_MARKER},
+    ).scalar()
+    if marker_present is not None:
+        connection.execute(
+            sa.text("DELETE FROM app_settings WHERE key = :key"),
+            {"key": _INCIDENT_RECORDS_CREATED_MARKER},
+        )
+        op.drop_table("incident_records")

--- a/models/database.py
+++ b/models/database.py
@@ -39,6 +39,7 @@ _KNOWN_ALEMBIC_REVISIONS = {
     "008_add_rollback_plan_payload",
     "009_add_report_share_settings",
     "010_add_project_workspaces",
+    "011_add_deployment_outcome_fields",
 }
 _BASELINE_TABLES = {"analysis_reports", "app_settings"}
 _EVIDENCE_TABLES = {
@@ -129,6 +130,13 @@ def _analysis_report_columns(connection) -> set[str]:
     }
 
 
+def _deployment_outcome_columns(connection) -> set[str]:
+    return {
+        column["name"]
+        for column in inspect(connection).get_columns("deployment_outcomes")
+    }
+
+
 def _bootstrap_brownfield_revision() -> None:
     with engine.begin() as connection:
         tables = set(inspect(connection).get_table_names())
@@ -153,6 +161,17 @@ def _bootstrap_brownfield_revision() -> None:
             if "analysis_reports" in tables
             else set()
         )
+        deployment_outcome_columns = (
+            _deployment_outcome_columns(connection)
+            if "deployment_outcomes" in tables
+            else set()
+        )
+        if {
+            "deployed_at",
+            "linked_incident_id",
+        }.issubset(deployment_outcome_columns):
+            _write_alembic_revision(connection, "011_add_deployment_outcome_fields")
+            return
         if (
             "projects" in tables
             and "topology_versions" in tables

--- a/models/repositories/deployment_outcomes.py
+++ b/models/repositories/deployment_outcomes.py
@@ -1,0 +1,70 @@
+"""Deployment outcome repository."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session, selectinload
+
+from models.tables import DeploymentOutcome
+
+
+def _deployment_outcome_load_options() -> list:
+    return [
+        selectinload(DeploymentOutcome.project),
+    ]
+
+
+def create_deployment_outcome(
+    session: Session,
+    *,
+    project_id: int,
+    analysis_id: int,
+    outcome_label: str,
+    deployed_at: datetime,
+    linked_incident_id: int | None = None,
+    environment: str | None = None,
+    summary: str | None = None,
+) -> DeploymentOutcome:
+    outcome = DeploymentOutcome(
+        project_id=project_id,
+        analysis_id=analysis_id,
+        outcome_label=outcome_label,
+        deployed_at=deployed_at,
+        linked_incident_id=linked_incident_id,
+        environment=environment,
+        summary=summary,
+    )
+    session.add(outcome)
+    session.commit()
+    session.refresh(outcome)
+    return session.execute(
+        select(DeploymentOutcome)
+        .options(*_deployment_outcome_load_options())
+        .where(DeploymentOutcome.id == outcome.id)
+    ).scalar_one()
+
+
+def list_deployment_outcomes(
+    session: Session,
+    *,
+    project_id: int | None = None,
+    analysis_id: int | None = None,
+    outcome_label: str | None = None,
+    limit: int = 100,
+) -> list[DeploymentOutcome]:
+    stmt = (
+        select(DeploymentOutcome)
+        .options(*_deployment_outcome_load_options())
+        .order_by(DeploymentOutcome.deployed_at.desc(), DeploymentOutcome.id.desc())
+        .limit(max(1, limit))
+    )
+    if project_id is not None:
+        stmt = stmt.where(DeploymentOutcome.project_id == project_id)
+    if analysis_id is not None:
+        stmt = stmt.where(DeploymentOutcome.analysis_id == analysis_id)
+    if outcome_label:
+        stmt = stmt.where(DeploymentOutcome.outcome_label == outcome_label)
+    result = session.execute(stmt)
+    return list(result.scalars().all())

--- a/models/tables.py
+++ b/models/tables.py
@@ -36,6 +36,9 @@ if "IncidentRecord" not in globals():
         created_at: Mapped[datetime] = mapped_column(
             DateTime(timezone=True), default=lambda: datetime.now(UTC)
         )
+        deployment_outcomes: Mapped[list["DeploymentOutcome"]] = relationship(
+            back_populates="incident"
+        )
 
 
 if "Project" not in globals():
@@ -64,6 +67,10 @@ if "Project" not in globals():
             onupdate=lambda: datetime.now(UTC),
         )
         reports: Mapped[list["AnalysisReport"]] = relationship(back_populates="project")
+        deployment_outcomes: Mapped[list["DeploymentOutcome"]] = relationship(
+            back_populates="project",
+            cascade="all, delete-orphan",
+        )
         topology_versions: Mapped[list["TopologyVersion"]] = relationship(
             back_populates="project",
             cascade="all, delete-orphan",
@@ -127,6 +134,9 @@ if "AnalysisReport" not in globals():
             back_populates="report",
             cascade="all, delete-orphan",
             uselist=False,
+        )
+        deployment_outcomes: Mapped[list["DeploymentOutcome"]] = relationship(
+            back_populates="report"
         )
         project: Mapped["Project"] = relationship(back_populates="reports")
         created_at: Mapped[datetime] = mapped_column(
@@ -327,11 +337,25 @@ if "DeploymentOutcome" not in globals():
             ForeignKey("analysis_reports.id", ondelete="SET NULL"),
             nullable=True,
         )
+        linked_incident_id: Mapped[int | None] = mapped_column(
+            ForeignKey("incident_records.id", ondelete="SET NULL"),
+            nullable=True,
+        )
         environment: Mapped[str | None] = mapped_column(String(80), nullable=True)
         outcome_label: Mapped[str] = mapped_column(String(40), default="unknown")
         summary: Mapped[str | None] = mapped_column(Text, nullable=True)
+        deployed_at: Mapped[datetime] = mapped_column(
+            DateTime(timezone=True), default=lambda: datetime.now(UTC)
+        )
         created_at: Mapped[datetime] = mapped_column(
             DateTime(timezone=True), default=lambda: datetime.now(UTC)
+        )
+        project: Mapped["Project"] = relationship(back_populates="deployment_outcomes")
+        report: Mapped["AnalysisReport | None"] = relationship(
+            back_populates="deployment_outcomes"
+        )
+        incident: Mapped["IncidentRecord | None"] = relationship(
+            back_populates="deployment_outcomes"
         )
 
 

--- a/services/deployment_outcome_service.py
+++ b/services/deployment_outcome_service.py
@@ -1,0 +1,253 @@
+"""Deployment outcome capture and retrieval helpers."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+
+from models.database import SessionLocal
+from models.repositories.analysis_reports import get_analysis_report
+from models.repositories.deployment_outcomes import (
+    create_deployment_outcome as create_deployment_outcome_record,
+)
+from models.repositories.deployment_outcomes import (
+    list_deployment_outcomes as list_deployment_outcome_records,
+)
+from models.repositories.incident_records import get_incident_record
+from models.repositories.projects import get_project, get_project_by_key
+from services.project_service import ensure_default_project, normalize_project_key
+
+ALLOWED_DEPLOYMENT_OUTCOMES = {"success", "failure", "rolled_back"}
+
+
+class DeploymentOutcomeError(ValueError):
+    """Raised when a deployment outcome request is invalid."""
+
+    def __init__(self, code: str, message: str) -> None:
+        super().__init__(message)
+        self.code = code
+        self.message = message
+
+
+def _normalize_outcome(value: str) -> str:
+    normalized = str(value or "").strip().lower().replace("-", "_")
+    if normalized not in ALLOWED_DEPLOYMENT_OUTCOMES:
+        raise DeploymentOutcomeError(
+            "invalid_deployment_outcome",
+            "Outcome must be one of: success, failure, rolled_back.",
+        )
+    return normalized
+
+
+def _normalize_optional_text(value: str | None) -> str | None:
+    text = str(value or "").strip()
+    return text or None
+
+
+def _coerce_timestamp(value: str | datetime | None) -> datetime:
+    if value is None or (isinstance(value, str) and not value.strip()):
+        return datetime.now(UTC)
+    if isinstance(value, datetime):
+        timestamp = value
+    else:
+        candidate = str(value).strip()
+        try:
+            timestamp = datetime.fromisoformat(candidate.replace("Z", "+00:00"))
+        except ValueError as exc:
+            raise DeploymentOutcomeError(
+                "invalid_deployed_at",
+                "deployed_at must be a valid ISO 8601 timestamp.",
+            ) from exc
+    if timestamp.tzinfo is None:
+        timestamp = timestamp.replace(tzinfo=UTC)
+    return timestamp.astimezone(UTC)
+
+
+def _serialize_project(project) -> dict[str, Any]:
+    created_at = project.created_at
+    updated_at = project.updated_at
+    return {
+        "id": project.id,
+        "project_key": project.project_key,
+        "display_name": project.display_name,
+        "description": project.description,
+        "repository_url": project.repository_url,
+        "default_branch": project.default_branch,
+        "is_default": bool(project.is_default),
+        "created_at": _isoformat_utc(created_at),
+        "updated_at": _isoformat_utc(updated_at),
+    }
+
+
+def _serialize_deployment_outcome(outcome) -> dict[str, Any]:
+    deployed_at = outcome.deployed_at or outcome.created_at
+    return {
+        "id": outcome.id,
+        "project": _serialize_project(outcome.project),
+        "analysis_id": outcome.analysis_id,
+        "outcome": outcome.outcome_label,
+        "deployed_at": _isoformat_utc(deployed_at),
+        "linked_incident_id": outcome.linked_incident_id,
+        "environment": outcome.environment,
+        "summary": outcome.summary,
+        "created_at": _isoformat_utc(outcome.created_at),
+    }
+
+
+def _isoformat_utc(value: datetime) -> str:
+    if value.tzinfo is None:
+        value = value.replace(tzinfo=UTC)
+    else:
+        value = value.astimezone(UTC)
+    return value.isoformat()
+
+
+def _resolve_requested_project(
+    session,
+    *,
+    project_id: int | None,
+    project_key: str | None,
+):
+    try:
+        normalized_key = normalize_project_key(project_key) if project_key else None
+    except ValueError as exc:
+        raise DeploymentOutcomeError(
+            "invalid_project_request",
+            str(exc),
+        ) from exc
+    project_by_id = get_project(session, project_id) if project_id is not None else None
+    project_by_key = (
+        get_project_by_key(session, normalized_key)
+        if normalized_key is not None
+        else None
+    )
+    if project_id is not None and project_by_id is None:
+        detail = (
+            f"project_id={project_id}, project_key={normalized_key}"
+            if normalized_key is not None
+            else f"project_id={project_id}"
+        )
+        raise DeploymentOutcomeError(
+            "project_not_found",
+            f"Unknown project reference: {detail}.",
+        )
+    if normalized_key is not None and project_by_key is None:
+        detail = (
+            f"project_id={project_id}, project_key={normalized_key}"
+            if project_id is not None
+            else f"project_key={normalized_key}"
+        )
+        raise DeploymentOutcomeError(
+            "project_not_found",
+            f"Unknown project reference: {detail}.",
+        )
+    if (
+        project_by_id is not None
+        and project_by_key is not None
+        and project_by_id.id != project_by_key.id
+    ):
+        raise DeploymentOutcomeError(
+            "conflicting_project_reference",
+            "The supplied project_id and project_key refer to different projects.",
+        )
+    return project_by_id or project_by_key
+
+
+def record_deployment_outcome(
+    *,
+    analysis_id: int,
+    outcome: str,
+    deployed_at: str | datetime | None = None,
+    linked_incident_id: int | None = None,
+    environment: str | None = None,
+    summary: str | None = None,
+    project_id: int | None = None,
+    project_key: str | None = None,
+    source_interface: str | None = None,
+) -> dict[str, Any]:
+    del source_interface
+    normalized_outcome = _normalize_outcome(outcome)
+    normalized_timestamp = _coerce_timestamp(deployed_at)
+
+    with SessionLocal() as session:
+        report = get_analysis_report(session, analysis_id, include_evidence=False)
+        if report is None:
+            raise DeploymentOutcomeError(
+                "analysis_not_found",
+                f"Analysis report not found: {analysis_id}.",
+            )
+        requested_project = _resolve_requested_project(
+            session,
+            project_id=project_id,
+            project_key=project_key,
+        )
+        if requested_project is not None and requested_project.id != report.project_id:
+            raise DeploymentOutcomeError(
+                "conflicting_project_reference",
+                "The supplied project reference does not match the analysis report project.",
+            )
+        if (
+            linked_incident_id is not None
+            and get_incident_record(session, linked_incident_id) is None
+        ):
+            raise DeploymentOutcomeError(
+                "incident_not_found",
+                f"Incident record not found: {linked_incident_id}.",
+            )
+        recorded = create_deployment_outcome_record(
+            session,
+            project_id=report.project_id,
+            analysis_id=analysis_id,
+            outcome_label=normalized_outcome,
+            deployed_at=normalized_timestamp,
+            linked_incident_id=linked_incident_id,
+            environment=_normalize_optional_text(environment),
+            summary=_normalize_optional_text(summary),
+        )
+        return _serialize_deployment_outcome(recorded)
+
+
+def list_deployment_outcomes(
+    *,
+    analysis_id: int | None = None,
+    outcome: str | None = None,
+    project_id: int | None = None,
+    project_key: str | None = None,
+    limit: int = 100,
+) -> list[dict[str, Any]]:
+    normalized_outcome = _normalize_outcome(outcome) if outcome is not None else None
+    with SessionLocal() as session:
+        requested_project = _resolve_requested_project(
+            session,
+            project_id=project_id,
+            project_key=project_key,
+        )
+        resolved_project_id = (
+            requested_project.id if requested_project is not None else None
+        )
+        if analysis_id is not None:
+            report = get_analysis_report(session, analysis_id, include_evidence=False)
+            if report is None:
+                raise DeploymentOutcomeError(
+                    "analysis_not_found",
+                    f"Analysis report not found: {analysis_id}.",
+                )
+            if (
+                requested_project is not None
+                and requested_project.id != report.project_id
+            ):
+                raise DeploymentOutcomeError(
+                    "conflicting_project_reference",
+                    "The supplied project reference does not match the analysis report project.",
+                )
+            resolved_project_id = report.project_id
+        if resolved_project_id is None:
+            resolved_project_id = ensure_default_project().id
+        outcomes = list_deployment_outcome_records(
+            session,
+            project_id=resolved_project_id,
+            analysis_id=analysis_id,
+            outcome_label=normalized_outcome,
+            limit=limit,
+        )
+        return [_serialize_deployment_outcome(item) for item in outcomes]

--- a/tests/test_api/test_deployments.py
+++ b/tests/test_api/test_deployments.py
@@ -1,0 +1,135 @@
+"""Tests for deployment outcome API routes."""
+
+from __future__ import annotations
+
+import os
+import tempfile
+import unittest
+from importlib import reload
+from pathlib import Path
+
+import config as config_module
+import models.database as database_module
+import models.repositories.analysis_reports as analysis_reports_repository_module
+import models.tables as tables_module
+import services.project_service as project_service_module
+import services.report_service as report_service_module
+from analysis.risk_scorer import RiskAssessment
+from app import create_app
+from fastapi.testclient import TestClient
+from llm.narrator import NarrativeResult
+from parsers.base import ParseBatchResult, ParsedFileResult
+
+
+class DeploymentOutcomesApiTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tempdir = tempfile.TemporaryDirectory()
+        self.db_path = Path(self.tempdir.name) / "deployments.db"
+        os.environ["DATABASE_URL"] = f"sqlite:///{self.db_path}"
+        os.environ["DEPLOYWHISPER_OUTCOME_TOKEN"] = "outcome-secret"
+        reload(config_module)
+        reload(tables_module)
+        reload(database_module)
+        reload(analysis_reports_repository_module)
+        reload(project_service_module)
+        reload(report_service_module)
+        database_module.init_db()
+        self.client = TestClient(create_app())
+        self.project = project_service_module.create_project(
+            project_key="payments",
+            display_name="Payments",
+        )
+        self.persisted_report = report_service_module.persist_analysis_report(
+            ParseBatchResult(
+                files=[
+                    ParsedFileResult(
+                        file_name="payments.tf",
+                        tool="terraform",
+                        status="parsed",
+                        changes=[],
+                    )
+                ]
+            ),
+            RiskAssessment(
+                score=18,
+                severity="low",
+                recommendation="go",
+                top_risk="Scoped deployment history test report.",
+                contributors=[],
+                interaction_risks=[],
+                partial_context=False,
+                warnings=[],
+            ),
+            NarrativeResult(
+                opening_sentence="GO: deployment history test report.",
+                explanation="Deployment history test report.",
+                guidance=[],
+                degraded=False,
+                warnings=[],
+            ),
+            project_id=self.project.id,
+            audit_context={"source_interface": "api"},
+        )
+
+    def tearDown(self) -> None:
+        database_module.engine.dispose()
+        os.environ.pop("DATABASE_URL", None)
+        os.environ.pop("DEPLOYWHISPER_OUTCOME_TOKEN", None)
+        self.tempdir.cleanup()
+
+    def test_webhook_endpoint_records_and_lists_deployment_outcomes(self) -> None:
+        response = self.client.post(
+            "/api/v1/deployments/outcomes",
+            headers={"X-DeployWhisper-Outcome-Token": "outcome-secret"},
+            json={
+                "analysis_id": self.persisted_report["id"],
+                "outcome": "success",
+                "deployed_at": "2026-04-30T08:15:00Z",
+                "environment": "prod",
+            },
+        )
+
+        self.assertEqual(response.status_code, 200)
+        payload = response.json()
+        self.assertEqual(payload["data"]["analysis_id"], self.persisted_report["id"])
+        self.assertEqual(payload["data"]["project"]["project_key"], "payments")
+        self.assertEqual(payload["data"]["outcome"], "success")
+
+        list_response = self.client.get(
+            "/api/v1/deployments/outcomes",
+            params={"analysis_id": self.persisted_report["id"]},
+        )
+        self.assertEqual(list_response.status_code, 200)
+        list_payload = list_response.json()
+        self.assertEqual(list_payload["meta"]["count"], 1)
+        self.assertEqual(list_payload["data"][0]["outcome"], "success")
+
+    def test_webhook_endpoint_returns_standard_error_for_unknown_analysis(self) -> None:
+        response = self.client.post(
+            "/api/v1/deployments/outcomes",
+            headers={"X-DeployWhisper-Outcome-Token": "outcome-secret"},
+            json={
+                "analysis_id": 999,
+                "outcome": "failure",
+                "deployed_at": "2026-04-30T08:15:00Z",
+            },
+        )
+
+        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.json()["error"]["code"], "analysis_not_found")
+
+    def test_webhook_endpoint_rejects_missing_token(self) -> None:
+        response = self.client.post(
+            "/api/v1/deployments/outcomes",
+            json={
+                "analysis_id": self.persisted_report["id"],
+                "outcome": "success",
+                "deployed_at": "2026-04-30T08:15:00Z",
+            },
+        )
+
+        self.assertEqual(response.status_code, 403)
+        self.assertEqual(
+            response.json()["error"]["code"],
+            "deployment_outcome_ingest_forbidden",
+        )

--- a/tests/test_cli/test_analyze.py
+++ b/tests/test_cli/test_analyze.py
@@ -24,6 +24,7 @@ from cli.analyze import main
 from importlib import reload
 from integrations.github.init_service import GitHubInitOptions, GitHubInitResult
 from llm.narrator import NarrativeResult
+from parsers.base import ParseBatchResult, ParsedFileResult
 from services.skill_installer_service import InstalledSkillEntry, SkillInstallResult
 from services.skill_registry_service import SkillRegistryEntry
 from services.skill_test_harness_service import (
@@ -725,6 +726,101 @@ class AnalyzeCliTests(unittest.TestCase):
         self.assertEqual(
             payload["data"]["persisted_report"]["project"]["project_key"], "payments"
         )
+
+    def test_outcome_record_command_records_deployment_result(self) -> None:
+        project = project_service_module.create_project(
+            project_key="payments",
+            display_name="Payments",
+        )
+        persisted = report_service_module.persist_analysis_report(
+            ParseBatchResult(
+                files=[
+                    ParsedFileResult(
+                        file_name="payments.tf",
+                        tool="terraform",
+                        status="parsed",
+                        changes=[],
+                    )
+                ]
+            ),
+            RiskAssessment(
+                score=12,
+                severity="low",
+                recommendation="go",
+                top_risk="Outcome capture test report.",
+                contributors=[],
+                interaction_risks=[],
+                partial_context=False,
+                warnings=[],
+            ),
+            NarrativeResult(
+                opening_sentence="GO: outcome capture test report.",
+                explanation="Outcome capture test report.",
+                guidance=[],
+                degraded=False,
+                warnings=[],
+            ),
+            project_id=project.id,
+            audit_context={"source_interface": "cli"},
+        )
+        output = io.StringIO()
+
+        with (
+            patch(
+                "sys.argv",
+                [
+                    "deploywhisper",
+                    "outcome",
+                    "record",
+                    "--analysis-id",
+                    str(persisted["id"]),
+                    "--outcome",
+                    "success",
+                    "--deployed-at",
+                    "2026-04-30T08:15:00Z",
+                ],
+            ),
+            redirect_stdout(output),
+        ):
+            with self.assertRaises(SystemExit) as ctx:
+                main()
+
+        self.assertEqual(ctx.exception.code, 0)
+        payload = json.loads(output.getvalue())
+        self.assertEqual(payload["meta"]["interface"], "cli")
+        self.assertEqual(payload["data"]["analysis_id"], persisted["id"])
+        self.assertEqual(payload["data"]["project"]["project_key"], "payments")
+        self.assertEqual(payload["data"]["outcome"], "success")
+
+    def test_outcome_record_command_reports_unknown_analysis_with_structured_error(
+        self,
+    ) -> None:
+        stdout = io.StringIO()
+        stderr = io.StringIO()
+
+        with (
+            patch(
+                "sys.argv",
+                [
+                    "deploywhisper",
+                    "outcome",
+                    "record",
+                    "--analysis-id",
+                    "999",
+                    "--outcome",
+                    "success",
+                ],
+            ),
+            redirect_stdout(stdout),
+            redirect_stderr(stderr),
+        ):
+            with self.assertRaises(SystemExit) as ctx:
+                main()
+
+        self.assertEqual(ctx.exception.code, 2)
+        self.assertEqual(stdout.getvalue(), "")
+        payload = json.loads(stderr.getvalue())
+        self.assertEqual(payload["error"]["code"], "analysis_not_found")
 
     def test_analyze_command_reports_unsupported_inputs_with_structured_error(
         self,

--- a/tests/test_infra/test_container_contract.py
+++ b/tests/test_infra/test_container_contract.py
@@ -24,6 +24,7 @@ class ContainerContractTests(unittest.TestCase):
                 "008_add_rollback_plan_payload.py",
                 "009_add_report_share_settings.py",
                 "010_add_project_workspaces.py",
+                "011_add_deployment_outcome_fields.py",
             ],
         )
         baseline_content = migrations[0].read_text(encoding="utf-8")
@@ -33,6 +34,7 @@ class ContainerContractTests(unittest.TestCase):
         rollback_content = migrations[4].read_text(encoding="utf-8")
         share_content = migrations[5].read_text(encoding="utf-8")
         project_content = migrations[6].read_text(encoding="utf-8")
+        deployment_outcomes_content = migrations[7].read_text(encoding="utf-8")
         self.assertIn("down_revision = None", baseline_content)
         self.assertIn('"app_settings"', baseline_content)
         self.assertIn(
@@ -56,6 +58,12 @@ class ContainerContractTests(unittest.TestCase):
         )
         self.assertIn('"projects"', project_content)
         self.assertIn('"project_id"', project_content)
+        self.assertIn(
+            'down_revision = "010_add_project_workspaces"',
+            deployment_outcomes_content,
+        )
+        self.assertIn('"deployed_at"', deployment_outcomes_content)
+        self.assertIn('"linked_incident_id"', deployment_outcomes_content)
 
     def test_dockerfile_exists(self) -> None:
         self.assertTrue(Path("Dockerfile").exists())

--- a/tests/test_infra/test_migrations.py
+++ b/tests/test_infra/test_migrations.py
@@ -62,7 +62,10 @@ class MigrationTests(unittest.TestCase):
         self.assertIn("analysis_id", self._table_columns("context_snapshots"))
         self.assertIn("project_id", self._table_columns("analysis_reports"))
         self.assertIn("project_key", self._table_columns("projects"))
+        self.assertIn("title", self._table_columns("incident_records"))
         self.assertIn("payload_json", self._table_columns("topology_versions"))
+        self.assertIn("deployed_at", self._table_columns("deployment_outcomes"))
+        self.assertIn("linked_incident_id", self._table_columns("deployment_outcomes"))
         self.assertIn("report_schema_version", self._table_columns("analysis_reports"))
         self.assertIn("blast_radius_json", self._table_columns("analysis_reports"))
         self.assertIn("rollback_plan_json", self._table_columns("analysis_reports"))
@@ -180,6 +183,70 @@ class MigrationTests(unittest.TestCase):
         self.assertTrue(any(row[2] == "analysis_reports" for row in finding_fks))
         self.assertTrue(any(row[2] == "findings" for row in evidence_fks))
 
+    def test_downgrade_to_010_drops_incident_records_when_011_created_it(self) -> None:
+        command.upgrade(self._config(), "head")
+
+        command.downgrade(self._config(), "010_add_project_workspaces")
+
+        sqlite_conn = sqlite3.connect(self.db_path)
+        try:
+            tables = {
+                row[0]
+                for row in sqlite_conn.execute(
+                    "SELECT name FROM sqlite_master WHERE type='table'"
+                ).fetchall()
+            }
+            marker = sqlite_conn.execute(
+                "SELECT value FROM app_settings WHERE key = ? LIMIT 1",
+                ("migration:011:created_incident_records",),
+            ).fetchone()
+        finally:
+            sqlite_conn.close()
+
+        self.assertNotIn("incident_records", tables)
+        self.assertIsNone(marker)
+
+    def test_downgrade_to_010_preserves_preexisting_incident_records(self) -> None:
+        command.upgrade(self._config(), "010_add_project_workspaces")
+
+        sqlite_conn = sqlite3.connect(self.db_path)
+        sqlite_conn.execute(
+            """
+            CREATE TABLE incident_records (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                title VARCHAR(255) NOT NULL,
+                severity VARCHAR(20) NOT NULL,
+                source_file VARCHAR(255) NOT NULL,
+                incident_date VARCHAR(40),
+                content TEXT NOT NULL,
+                created_at DATETIME NOT NULL
+            )
+            """
+        )
+        sqlite_conn.commit()
+        sqlite_conn.close()
+
+        command.upgrade(self._config(), "head")
+        command.downgrade(self._config(), "010_add_project_workspaces")
+
+        sqlite_conn = sqlite3.connect(self.db_path)
+        try:
+            tables = {
+                row[0]
+                for row in sqlite_conn.execute(
+                    "SELECT name FROM sqlite_master WHERE type='table'"
+                ).fetchall()
+            }
+            marker = sqlite_conn.execute(
+                "SELECT value FROM app_settings WHERE key = ? LIMIT 1",
+                ("migration:011:created_incident_records",),
+            ).fetchone()
+        finally:
+            sqlite_conn.close()
+
+        self.assertIn("incident_records", tables)
+        self.assertIsNone(marker)
+
     def test_init_db_upgrades_brownfield_database_without_alembic_version(self) -> None:
         command.upgrade(self._config(), "0001_create_analysis_reports")
         sqlite_conn = sqlite3.connect(self.db_path)
@@ -224,7 +291,7 @@ class MigrationTests(unittest.TestCase):
         self.assertIn("evidence_items", tables)
         self.assertIn("projects", tables)
         self.assertIn("topology_versions", tables)
-        self.assertEqual(revision, "010_add_project_workspaces")
+        self.assertEqual(revision, "011_add_deployment_outcome_fields")
 
     def test_init_db_repairs_partial_evidence_schema_without_alembic_version(
         self,
@@ -273,7 +340,7 @@ class MigrationTests(unittest.TestCase):
         self.assertIn("findings", tables)
         self.assertIn("evidence_items", tables)
         self.assertIn("projects", tables)
-        self.assertEqual(revision, "010_add_project_workspaces")
+        self.assertEqual(revision, "011_add_deployment_outcome_fields")
 
     def test_init_db_repairs_current_schema_without_alembic_version(self) -> None:
         command.upgrade(self._config(), "head")
@@ -299,7 +366,7 @@ class MigrationTests(unittest.TestCase):
         finally:
             sqlite_conn.close()
 
-        self.assertEqual(revision, "010_add_project_workspaces")
+        self.assertEqual(revision, "011_add_deployment_outcome_fields")
         self.assertIn("report_schema_version", columns)
         self.assertIn("blast_radius_json", columns)
         self.assertIn("project_id", columns)
@@ -325,7 +392,7 @@ class MigrationTests(unittest.TestCase):
         finally:
             sqlite_conn.close()
 
-        self.assertEqual(revision, "010_add_project_workspaces")
+        self.assertEqual(revision, "011_add_deployment_outcome_fields")
 
 
 if __name__ == "__main__":

--- a/tests/test_services/test_deployment_outcome_service.py
+++ b/tests/test_services/test_deployment_outcome_service.py
@@ -1,0 +1,188 @@
+"""Tests for deployment outcome capture and retrieval."""
+
+from __future__ import annotations
+
+import os
+import tempfile
+import unittest
+from importlib import reload
+from pathlib import Path
+
+import config as config_module
+import models.database as database_module
+import models.repositories.analysis_reports as analysis_reports_repository_module
+import models.tables as tables_module
+import services.deployment_outcome_service as deployment_outcome_service_module
+import services.project_service as project_service_module
+import services.report_service as report_service_module
+from analysis.risk_scorer import RiskAssessment
+from llm.narrator import NarrativeResult
+from models.database import SessionLocal
+from models.repositories.incident_records import create_incident_record
+from parsers.base import ParseBatchResult, ParsedFileResult
+
+
+class DeploymentOutcomeServiceTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tempdir = tempfile.TemporaryDirectory()
+        self.db_path = Path(self.tempdir.name) / "outcomes.db"
+        os.environ["DATABASE_URL"] = f"sqlite:///{self.db_path}"
+        reload(config_module)
+        reload(tables_module)
+        reload(database_module)
+        reload(analysis_reports_repository_module)
+        reload(project_service_module)
+        reload(report_service_module)
+        reload(deployment_outcome_service_module)
+        database_module.init_db()
+
+        self.project = project_service_module.create_project(
+            project_key="payments",
+            display_name="Payments",
+        )
+        self.persisted_report = report_service_module.persist_analysis_report(
+            ParseBatchResult(
+                files=[
+                    ParsedFileResult(
+                        file_name="payments.tf",
+                        tool="terraform",
+                        status="parsed",
+                        changes=[],
+                    )
+                ]
+            ),
+            RiskAssessment(
+                score=18,
+                severity="low",
+                recommendation="go",
+                top_risk="Scoped deployment history test report.",
+                contributors=[],
+                interaction_risks=[],
+                partial_context=False,
+                warnings=[],
+            ),
+            NarrativeResult(
+                opening_sentence="GO: deployment history test report.",
+                explanation="Deployment history test report.",
+                guidance=[],
+                degraded=False,
+                warnings=[],
+            ),
+            project_id=self.project.id,
+            audit_context={"source_interface": "api"},
+        )
+
+    def tearDown(self) -> None:
+        database_module.engine.dispose()
+        os.environ.pop("DATABASE_URL", None)
+        self.tempdir.cleanup()
+
+    def test_record_deployment_outcome_uses_report_project_and_returns_payload(
+        self,
+    ) -> None:
+        with SessionLocal() as session:
+            incident = create_incident_record(
+                session,
+                title="Checkout degraded",
+                severity="high",
+                source_file="incident.md",
+                incident_date="2026-04-30",
+                content="Rollback needed after checkout deployment.",
+            )
+
+        recorded = deployment_outcome_service_module.record_deployment_outcome(
+            analysis_id=self.persisted_report["id"],
+            outcome="rolled_back",
+            deployed_at="2026-04-30T08:15:00Z",
+            linked_incident_id=incident.id,
+            environment="prod",
+            summary="Rollback completed after checkout errors.",
+            source_interface="api",
+        )
+
+        self.assertEqual(recorded["analysis_id"], self.persisted_report["id"])
+        self.assertEqual(recorded["project"]["project_key"], "payments")
+        self.assertEqual(recorded["outcome"], "rolled_back")
+        self.assertEqual(recorded["linked_incident_id"], incident.id)
+        self.assertEqual(recorded["environment"], "prod")
+        self.assertEqual(
+            recorded["summary"], "Rollback completed after checkout errors."
+        )
+        self.assertEqual(recorded["deployed_at"], "2026-04-30T08:15:00+00:00")
+
+    def test_record_deployment_outcome_rejects_mismatched_project_reference(
+        self,
+    ) -> None:
+        other_project = project_service_module.create_project(
+            project_key="platform",
+            display_name="Platform",
+        )
+
+        with self.assertRaises(
+            deployment_outcome_service_module.DeploymentOutcomeError
+        ) as ctx:
+            deployment_outcome_service_module.record_deployment_outcome(
+                analysis_id=self.persisted_report["id"],
+                outcome="success",
+                project_id=other_project.id,
+            )
+
+        self.assertEqual(ctx.exception.code, "conflicting_project_reference")
+
+    def test_list_deployment_outcomes_filters_by_analysis_id(self) -> None:
+        deployment_outcome_service_module.record_deployment_outcome(
+            analysis_id=self.persisted_report["id"],
+            outcome="success",
+            deployed_at="2026-04-30T08:15:00Z",
+            source_interface="api",
+        )
+
+        other_project = project_service_module.create_project(
+            project_key="platform",
+            display_name="Platform",
+        )
+        other_report = report_service_module.persist_analysis_report(
+            ParseBatchResult(
+                files=[
+                    ParsedFileResult(
+                        file_name="platform.tf",
+                        tool="terraform",
+                        status="parsed",
+                        changes=[],
+                    )
+                ]
+            ),
+            RiskAssessment(
+                score=20,
+                severity="low",
+                recommendation="go",
+                top_risk="Other project report.",
+                contributors=[],
+                interaction_risks=[],
+                partial_context=False,
+                warnings=[],
+            ),
+            NarrativeResult(
+                opening_sentence="GO: other project report.",
+                explanation="Other project report.",
+                guidance=[],
+                degraded=False,
+                warnings=[],
+            ),
+            project_id=other_project.id,
+            audit_context={"source_interface": "api"},
+        )
+        deployment_outcome_service_module.record_deployment_outcome(
+            analysis_id=other_report["id"],
+            outcome="failure",
+            deployed_at="2026-04-30T09:30:00Z",
+            source_interface="api",
+        )
+
+        results = deployment_outcome_service_module.list_deployment_outcomes(
+            analysis_id=self.persisted_report["id"]
+        )
+
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0]["analysis_id"], self.persisted_report["id"])
+        self.assertEqual(results[0]["project"]["project_key"], "payments")


### PR DESCRIPTION
This adds a shared deployment outcome capture path across the API and CLI, completes the Alembic chain for incident linkage, and protects webhook-style ingestion with an explicit token so post-deploy history can support later trend and calibration work without weakening trust boundaries.

Constraint: Outcome history must remain project-scoped and keyed off persisted analyses
Constraint: Pure Alembic upgrade and downgrade must work without relying on ORM metadata side effects
Rejected: Reuse report-history endpoints | mixes deployment outcomes with report browsing and complicates later calibration work
Rejected: Leave outcome ingestion unauthenticated | allows unauthorized history tampering
Confidence: high
Scope-risk: moderate
Reversibility: clean
Directive: Keep deployment outcome writes behind explicit auth and preserve downgrade symmetry when extending migration 011
Tested: Ruff check, Ruff format --check, focused deployment outcome unittest suites, unittest discover -q, scripts/ci-local.sh
Not-tested: Bandit local security scan (tool not installed)

## What does this PR do?

<!-- Brief description of changes -->

## Type of change
- [ ] Feature (new functionality)
- [ ] Bugfix (non-breaking fix)
- [ ] Release preparation
- [ ] Hotfix (critical production fix)
- [ ] Docs / refactor / chore

## Checklist
- [ ] I have followed the branch naming convention
- [ ] Tests pass locally (`pytest tests/ -v`)
- [ ] Linting passes (`ruff check .`)
- [ ] Docker build succeeds
- [ ] I have updated docs if needed
- [ ] No secrets or .env values committed

## Related issue
Closes #