### PR TITLE
Capture reviewer feedback as auditable learning-loop state

### DIFF
--- a/_bmad-output/implementation-artifacts/5-6-reviewer-feedback-capture.md
+++ b/_bmad-output/implementation-artifacts/5-6-reviewer-feedback-capture.md
@@ -1,0 +1,107 @@
+# Story 5.6: Reviewer feedback capture
+
+Status: review
+
+<!-- Note: Validation is optional. Run validate-create-story for quality check before dev-story. -->
+
+## Story
+
+As a reviewer,
+I want to rate findings as useful/false-positive/missed,
+so that the product learns from my expertise.
+
+## Acceptance Criteria
+
+1. Thumbs up/down on each finding in the UI
+2. False positive flag with optional reason
+3. False negative note for missed findings
+4. Feedback stored in FeedbackEvent table
+5. Feedback summary visible to admins
+
+### Requirement Traceability
+
+- Primary PRD requirements: `HIS-05`
+- Supporting PRD / NFR / differentiation requirements: `DIF-05`
+- Coverage intent: `Delta`
+- Story alignment note: Reviewer feedback is the first explicit learning-loop feature and should be stored in an auditable form.
+
+## Tasks / Subtasks
+
+- [x] Implement AC1: Thumbs up/down on each finding in the UI (AC: 1)
+- [x] Implement AC2: False positive flag with optional reason (AC: 2)
+- [x] Implement AC3: False negative note for missed findings (AC: 3)
+- [x] Implement AC4: Feedback stored in FeedbackEvent table (AC: 4)
+- [x] Implement AC5: Feedback summary visible to admins (AC: 5)
+- [x] Add or update automated verification, fixtures, docs, and rollout notes required for this story (AC: 1, 2, 3, 4, 5)
+
+## Dev Notes
+
+- Epic context: Context Moat (2, 15-22 (overlaps Epics 3-4), P1).
+- Epic goal: Automate topology discovery across supported infrastructure sources. Capture deployment outcomes. Build the feedback loop. This epic turns DeployWhisper from "smart on day 1" to "measurably smarter every month".
+- This story starts the human-in-the-loop learning loop; the feedback model should support later calibration work directly.
+- Epic 5 is the feedback/context moat. Topology freshness, deployment outcomes, and reviewer feedback are first-class context signals that must remain auditable.
+- Capture history and feedback in a way that can support later calibration and backtesting without rewriting the persistence model again.
+- Outcome and feedback ingestion should be explicit and operator-visible; hidden heuristics will undermine trust.
+- Preserve the project-context guardrails: shared analysis core, local-first handling of raw IaC, advisory-first outputs, and deterministic tests over flaky integration assumptions.
+
+### Project Structure Notes
+
+- Likely implementation surfaces: services/topology_service.py, services/report_service.py, api/routes/, models/, ui/routes/, cli/, tests/, ui/components/.
+- Keep new capabilities in the correct layer instead of duplicating logic across UI, API, CLI, integrations, or docs.
+- If this story introduces a new top-level folder or runtime surface, align it with the architecture document before implementation starts.
+
+### References
+
+- [Epics](../planning-artifacts/epics.md)
+- [PRD](../planning-artifacts/prd.md)
+- [Architecture](../planning-artifacts/architecture.md)
+- [Project Context](../project-context.md)
+
+## Dev Agent Record
+
+### Agent Model Used
+
+GPT-5 (Codex)
+
+### Debug Log References
+
+- `./.venv/bin/python -m unittest -q tests.test_services.test_feedback_service tests.test_infra.test_migrations tests.test_infra.test_container_contract tests.test_ui.test_history_page tests.test_ui.test_settings_page`
+- `./.venv/bin/python -m unittest -q tests.test_ui.test_history_page tests.test_ui.test_settings_page tests.test_ui.test_app_shell tests.test_services.test_feedback_service`
+- `./.venv/bin/ruff check .`
+- `./.venv/bin/ruff format --check .`
+- `./.venv/bin/python -m unittest discover -q`
+- `bash scripts/ci-local.sh`
+
+### Completion Notes List
+
+- Added migration `012_add_feedback_event_fields` so reviewer feedback can persist `finding_id` and `false_positive_reason` in the existing `feedback_events` table.
+- Added shared reviewer-feedback persistence and summary helpers in `services/feedback_service.py` and `models/repositories/feedback_events.py`, including report/finding validation and project-scoped summary aggregation.
+- Added reviewer feedback controls to the full history report detail page and the active dashboard review surface, covering thumbs up/down, false-positive reason capture, and missed-finding notes.
+- Added an admin-facing reviewer feedback summary card to the settings page for the active project.
+- Added rollout documentation in `docs/reviewer-feedback.md` and expanded migration/UI/service regression coverage for the new learning-loop path.
+- Validation passed with repo-wide Ruff checks, focused feedback/migration/UI suites, full `unittest discover -q`, and `bash scripts/ci-local.sh`. Local CI still skipped Bandit because it is not installed in this environment.
+
+### File List
+
+- `_bmad-output/implementation-artifacts/5-6-reviewer-feedback-capture.md`
+- `_bmad-output/implementation-artifacts/sprint-status.yaml`
+- `docs/reviewer-feedback.md`
+- `migrations/versions/012_add_feedback_event_fields.py`
+- `models/database.py`
+- `models/repositories/feedback_events.py`
+- `models/tables.py`
+- `services/feedback_service.py`
+- `tests/test_infra/test_container_contract.py`
+- `tests/test_infra/test_migrations.py`
+- `tests/test_services/test_feedback_service.py`
+- `tests/test_ui/test_app_shell.py`
+- `tests/test_ui/test_history_page.py`
+- `tests/test_ui/test_settings_page.py`
+- `ui/components/report_detail_page.py`
+- `ui/components/upload_panel.py`
+- `ui/routes/history.py`
+- `ui/routes/settings.py`
+
+### Change Log
+
+- 2026-04-30: Implemented Story 5.6 reviewer feedback capture across migration, shared service, history/dashboard reviewer UI, admin summary, tests, and rollout documentation.

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -99,7 +99,7 @@ development_status:
   5-3-topology-drift-detection: done
   5-4-topology-freshness-badge: review
   5-5-deployment-history-capture: review
-  5-6-reviewer-feedback-capture: ready-for-dev
+  5-6-reviewer-feedback-capture: review
   5-7-outcome-linking: ready-for-dev
   5-8-calibration-dashboard: ready-for-dev
   5-9-trend-analysis: ready-for-dev

--- a/docs/reviewer-feedback.md
+++ b/docs/reviewer-feedback.md
@@ -1,0 +1,35 @@
+# Reviewer Feedback Capture
+
+DeployWhisper now captures reviewer feedback for persisted analysis reports so teams can start building an auditable learning loop around finding quality.
+
+## Reviewer Workflow
+
+- Open a saved report in the main review UI.
+- Use the **Reviewer feedback** section to record:
+  - `Thumbs up` when a finding was useful
+  - `Thumbs down` when a finding was not useful
+  - `Mark false positive` with an optional reason when the finding should not have been surfaced
+  - `Missed finding note` when the report failed to call out an important risk
+
+The live dashboard review surface and the full history detail page both expose the same feedback controls.
+
+## Storage Model
+
+- Feedback is stored in the `feedback_events` table.
+- Migration `012_add_feedback_event_fields` adds:
+  - `finding_id`
+  - `false_positive_reason`
+- Feedback stays project-scoped by deriving the owning workspace from the persisted `analysis_id`.
+- Finding feedback is validated against the findings stored on the target report before persistence.
+
+## Admin Summary
+
+- The **Settings** page now shows a **Reviewer feedback summary** card for the active project.
+- The summary reports:
+  - useful findings
+  - not useful findings
+  - false positives
+  - missed findings
+  - recent reviewer notes
+
+The summary uses the latest feedback state per finding while still retaining the underlying feedback events for auditability.

--- a/migrations/versions/012_add_feedback_event_fields.py
+++ b/migrations/versions/012_add_feedback_event_fields.py
@@ -1,0 +1,34 @@
+"""Add finding-level reviewer feedback fields.
+
+Revision ID: 012_add_feedback_event_fields
+Revises: 011_add_deployment_outcome_fields
+Create Date: 2026-04-30
+"""
+
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "012_add_feedback_event_fields"
+down_revision = "011_add_deployment_outcome_fields"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "feedback_events",
+        sa.Column("finding_id", sa.String(length=64), nullable=True),
+    )
+    op.add_column(
+        "feedback_events",
+        sa.Column("false_positive_reason", sa.Text(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("feedback_events") as batch_op:
+        batch_op.drop_column("false_positive_reason")
+        batch_op.drop_column("finding_id")

--- a/models/database.py
+++ b/models/database.py
@@ -40,6 +40,7 @@ _KNOWN_ALEMBIC_REVISIONS = {
     "009_add_report_share_settings",
     "010_add_project_workspaces",
     "011_add_deployment_outcome_fields",
+    "012_add_feedback_event_fields",
 }
 _BASELINE_TABLES = {"analysis_reports", "app_settings"}
 _EVIDENCE_TABLES = {
@@ -137,6 +138,12 @@ def _deployment_outcome_columns(connection) -> set[str]:
     }
 
 
+def _feedback_event_columns(connection) -> set[str]:
+    return {
+        column["name"] for column in inspect(connection).get_columns("feedback_events")
+    }
+
+
 def _bootstrap_brownfield_revision() -> None:
     with engine.begin() as connection:
         tables = set(inspect(connection).get_table_names())
@@ -166,6 +173,17 @@ def _bootstrap_brownfield_revision() -> None:
             if "deployment_outcomes" in tables
             else set()
         )
+        feedback_event_columns = (
+            _feedback_event_columns(connection)
+            if "feedback_events" in tables
+            else set()
+        )
+        if {
+            "finding_id",
+            "false_positive_reason",
+        }.issubset(feedback_event_columns):
+            _write_alembic_revision(connection, "012_add_feedback_event_fields")
+            return
         if {
             "deployed_at",
             "linked_incident_id",

--- a/models/repositories/feedback_events.py
+++ b/models/repositories/feedback_events.py
@@ -1,0 +1,60 @@
+"""Reviewer feedback repository."""
+
+from __future__ import annotations
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from models.tables import FeedbackEvent
+
+
+def create_feedback_event(
+    session: Session,
+    *,
+    project_id: int,
+    analysis_id: int,
+    finding_id: str | None = None,
+    reviewer_role: str | None = None,
+    useful: bool | None = None,
+    correctness_rating: int | None = None,
+    false_positive_flag: bool = False,
+    false_positive_reason: str | None = None,
+    false_negative_note: str | None = None,
+    outcome_label: str | None = None,
+) -> FeedbackEvent:
+    event = FeedbackEvent(
+        project_id=project_id,
+        analysis_id=analysis_id,
+        finding_id=finding_id,
+        reviewer_role=reviewer_role,
+        useful=useful,
+        correctness_rating=correctness_rating,
+        false_positive_flag=false_positive_flag,
+        false_positive_reason=false_positive_reason,
+        false_negative_note=false_negative_note,
+        outcome_label=outcome_label,
+    )
+    session.add(event)
+    session.commit()
+    session.refresh(event)
+    return event
+
+
+def list_feedback_events(
+    session: Session,
+    *,
+    project_id: int | None = None,
+    analysis_id: int | None = None,
+    limit: int | None = None,
+) -> list[FeedbackEvent]:
+    stmt = select(FeedbackEvent).order_by(
+        FeedbackEvent.created_at.desc(), FeedbackEvent.id.desc()
+    )
+    if project_id is not None:
+        stmt = stmt.where(FeedbackEvent.project_id == project_id)
+    if analysis_id is not None:
+        stmt = stmt.where(FeedbackEvent.analysis_id == analysis_id)
+    if limit is not None:
+        stmt = stmt.limit(max(1, limit))
+    result = session.execute(stmt)
+    return list(result.scalars().all())

--- a/models/tables.py
+++ b/models/tables.py
@@ -375,10 +375,12 @@ if "FeedbackEvent" not in globals():
             ForeignKey("analysis_reports.id", ondelete="SET NULL"),
             nullable=True,
         )
+        finding_id: Mapped[str | None] = mapped_column(String(64), nullable=True)
         reviewer_role: Mapped[str | None] = mapped_column(String(80), nullable=True)
         useful: Mapped[bool | None] = mapped_column(Boolean, nullable=True)
         correctness_rating: Mapped[int | None] = mapped_column(Integer, nullable=True)
         false_positive_flag: Mapped[bool] = mapped_column(Boolean, default=False)
+        false_positive_reason: Mapped[str | None] = mapped_column(Text, nullable=True)
         false_negative_note: Mapped[str | None] = mapped_column(Text, nullable=True)
         outcome_label: Mapped[str | None] = mapped_column(String(80), nullable=True)
         created_at: Mapped[datetime] = mapped_column(

--- a/services/feedback_service.py
+++ b/services/feedback_service.py
@@ -1,0 +1,240 @@
+"""Reviewer feedback capture and summary helpers."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+
+from models.database import SessionLocal
+from models.repositories.analysis_reports import get_analysis_report
+from models.repositories.feedback_events import (
+    create_feedback_event,
+    list_feedback_events,
+)
+from services.project_service import (
+    build_project_payload,
+    ensure_default_project,
+    resolve_project_reference,
+)
+
+
+class FeedbackError(ValueError):
+    """Raised when reviewer feedback input is invalid."""
+
+    def __init__(self, code: str, message: str) -> None:
+        super().__init__(message)
+        self.code = code
+        self.message = message
+
+
+def _serialize_timestamp(value: datetime) -> str:
+    if value.tzinfo is None:
+        value = value.replace(tzinfo=UTC)
+    else:
+        value = value.astimezone(UTC)
+    return value.isoformat()
+
+
+def _normalize_optional_text(value: str | None) -> str | None:
+    text = str(value or "").strip()
+    return text or None
+
+
+def _serialize_event(event) -> dict[str, Any]:
+    return {
+        "id": event.id,
+        "project_id": event.project_id,
+        "analysis_id": event.analysis_id,
+        "finding_id": event.finding_id,
+        "reviewer_role": event.reviewer_role,
+        "useful": event.useful,
+        "correctness_rating": event.correctness_rating,
+        "false_positive_flag": bool(event.false_positive_flag),
+        "false_positive_reason": event.false_positive_reason,
+        "false_negative_note": event.false_negative_note,
+        "outcome_label": event.outcome_label,
+        "created_at": _serialize_timestamp(event.created_at),
+    }
+
+
+def _project_payload(
+    project_id: int | None = None, project_key: str | None = None
+) -> dict[str, Any]:
+    if project_id is None and project_key is None:
+        return build_project_payload(ensure_default_project())
+    return build_project_payload(
+        resolve_project_reference(project_id=project_id, project_key=project_key)
+    )
+
+
+def record_finding_feedback(
+    *,
+    analysis_id: int,
+    finding_id: str,
+    useful: bool,
+    false_positive_flag: bool = False,
+    false_positive_reason: str | None = None,
+    reviewer_role: str = "reviewer",
+) -> dict[str, Any]:
+    normalized_finding_id = str(finding_id or "").strip()
+    if not normalized_finding_id:
+        raise FeedbackError("invalid_feedback_request", "finding_id is required.")
+    normalized_reason = _normalize_optional_text(false_positive_reason)
+    if normalized_reason is not None and not false_positive_flag:
+        raise FeedbackError(
+            "invalid_feedback_request",
+            "False positive reason requires false_positive_flag=True.",
+        )
+    with SessionLocal() as session:
+        report = get_analysis_report(session, analysis_id, include_evidence=False)
+        if report is None:
+            raise FeedbackError(
+                "analysis_not_found",
+                f"Analysis report not found: {analysis_id}.",
+            )
+        finding_ids = {finding.finding_id for finding in report.findings}
+        if normalized_finding_id not in finding_ids:
+            raise FeedbackError(
+                "finding_not_found",
+                f"Finding not found on analysis report {analysis_id}: {normalized_finding_id}.",
+            )
+        outcome_label = (
+            "false_positive"
+            if false_positive_flag
+            else "useful"
+            if useful
+            else "not_useful"
+        )
+        event = create_feedback_event(
+            session,
+            project_id=report.project_id,
+            analysis_id=analysis_id,
+            finding_id=normalized_finding_id,
+            reviewer_role=reviewer_role,
+            useful=bool(useful),
+            correctness_rating=1 if useful else 0,
+            false_positive_flag=false_positive_flag,
+            false_positive_reason=normalized_reason,
+            outcome_label=outcome_label,
+        )
+        return _serialize_event(event)
+
+
+def record_false_negative_feedback(
+    *,
+    analysis_id: int,
+    note: str,
+    reviewer_role: str = "reviewer",
+) -> dict[str, Any]:
+    normalized_note = _normalize_optional_text(note)
+    if normalized_note is None:
+        raise FeedbackError(
+            "invalid_feedback_request",
+            "False negative note is required.",
+        )
+    with SessionLocal() as session:
+        report = get_analysis_report(session, analysis_id, include_evidence=False)
+        if report is None:
+            raise FeedbackError(
+                "analysis_not_found",
+                f"Analysis report not found: {analysis_id}.",
+            )
+        event = create_feedback_event(
+            session,
+            project_id=report.project_id,
+            analysis_id=analysis_id,
+            reviewer_role=reviewer_role,
+            false_negative_note=normalized_note,
+            outcome_label="missed",
+        )
+        return _serialize_event(event)
+
+
+def fetch_report_feedback_state(analysis_id: int) -> dict[str, Any]:
+    with SessionLocal() as session:
+        report = get_analysis_report(session, analysis_id, include_evidence=False)
+        if report is None:
+            raise FeedbackError(
+                "analysis_not_found",
+                f"Analysis report not found: {analysis_id}.",
+            )
+        events = list_feedback_events(session, analysis_id=analysis_id)
+    finding_feedback: dict[str, dict[str, Any]] = {}
+    false_negative_notes: list[dict[str, Any]] = []
+    for event in events:
+        serialized = _serialize_event(event)
+        if event.finding_id is not None and event.finding_id not in finding_feedback:
+            finding_feedback[event.finding_id] = serialized
+        if event.false_negative_note:
+            false_negative_notes.append(serialized)
+    return {
+        "finding_feedback": finding_feedback,
+        "false_negative_notes": false_negative_notes,
+    }
+
+
+def fetch_feedback_summary(
+    *,
+    project_id: int | None = None,
+    project_key: str | None = None,
+) -> dict[str, Any]:
+    if project_id is None and project_key is None:
+        project = ensure_default_project()
+    else:
+        project = resolve_project_reference(
+            project_id=project_id, project_key=project_key
+        )
+    with SessionLocal() as session:
+        events = list_feedback_events(session, project_id=project.id)
+
+    latest_finding_feedback: dict[tuple[int | None, str], Any] = {}
+    latest_false_negative_by_report: dict[int | None, Any] = {}
+    recent_notes: list[dict[str, Any]] = []
+    for event in events:
+        if event.finding_id is not None:
+            latest_finding_feedback.setdefault(
+                (event.analysis_id, event.finding_id), event
+            )
+            if event.false_positive_reason:
+                recent_notes.append(
+                    {
+                        "type": "false_positive",
+                        "text": event.false_positive_reason,
+                        "analysis_id": event.analysis_id,
+                        "finding_id": event.finding_id,
+                        "created_at": _serialize_timestamp(event.created_at),
+                    }
+                )
+        if event.false_negative_note:
+            latest_false_negative_by_report.setdefault(event.analysis_id, event)
+            recent_notes.append(
+                {
+                    "type": "missed_finding",
+                    "text": event.false_negative_note,
+                    "analysis_id": event.analysis_id,
+                    "finding_id": event.finding_id,
+                    "created_at": _serialize_timestamp(event.created_at),
+                }
+            )
+
+    latest_events = list(latest_finding_feedback.values())
+    useful_count = sum(1 for event in latest_events if event.useful is True)
+    not_useful_count = sum(1 for event in latest_events if event.useful is False)
+    false_positive_count = sum(
+        1 for event in latest_events if bool(event.false_positive_flag)
+    )
+
+    recent_notes.sort(key=lambda item: item["created_at"], reverse=True)
+    return {
+        "project": build_project_payload(project),
+        "current_state": {
+            "useful_count": useful_count,
+            "not_useful_count": not_useful_count,
+            "false_positive_count": false_positive_count,
+            "missed_finding_count": len(latest_false_negative_by_report),
+        },
+        "totals": {
+            "events_recorded": len(events),
+        },
+        "recent_notes": recent_notes[:5],
+    }

--- a/tests/test_infra/test_container_contract.py
+++ b/tests/test_infra/test_container_contract.py
@@ -25,6 +25,7 @@ class ContainerContractTests(unittest.TestCase):
                 "009_add_report_share_settings.py",
                 "010_add_project_workspaces.py",
                 "011_add_deployment_outcome_fields.py",
+                "012_add_feedback_event_fields.py",
             ],
         )
         baseline_content = migrations[0].read_text(encoding="utf-8")
@@ -35,6 +36,7 @@ class ContainerContractTests(unittest.TestCase):
         share_content = migrations[5].read_text(encoding="utf-8")
         project_content = migrations[6].read_text(encoding="utf-8")
         deployment_outcomes_content = migrations[7].read_text(encoding="utf-8")
+        feedback_content = migrations[8].read_text(encoding="utf-8")
         self.assertIn("down_revision = None", baseline_content)
         self.assertIn('"app_settings"', baseline_content)
         self.assertIn(
@@ -64,6 +66,12 @@ class ContainerContractTests(unittest.TestCase):
         )
         self.assertIn('"deployed_at"', deployment_outcomes_content)
         self.assertIn('"linked_incident_id"', deployment_outcomes_content)
+        self.assertIn(
+            'down_revision = "011_add_deployment_outcome_fields"',
+            feedback_content,
+        )
+        self.assertIn('"finding_id"', feedback_content)
+        self.assertIn('"false_positive_reason"', feedback_content)
 
     def test_dockerfile_exists(self) -> None:
         self.assertTrue(Path("Dockerfile").exists())

--- a/tests/test_infra/test_migrations.py
+++ b/tests/test_infra/test_migrations.py
@@ -66,6 +66,8 @@ class MigrationTests(unittest.TestCase):
         self.assertIn("payload_json", self._table_columns("topology_versions"))
         self.assertIn("deployed_at", self._table_columns("deployment_outcomes"))
         self.assertIn("linked_incident_id", self._table_columns("deployment_outcomes"))
+        self.assertIn("finding_id", self._table_columns("feedback_events"))
+        self.assertIn("false_positive_reason", self._table_columns("feedback_events"))
         self.assertIn("report_schema_version", self._table_columns("analysis_reports"))
         self.assertIn("blast_radius_json", self._table_columns("analysis_reports"))
         self.assertIn("rollback_plan_json", self._table_columns("analysis_reports"))
@@ -183,6 +185,15 @@ class MigrationTests(unittest.TestCase):
         self.assertTrue(any(row[2] == "analysis_reports" for row in finding_fks))
         self.assertTrue(any(row[2] == "findings" for row in evidence_fks))
 
+    def test_downgrade_to_011_removes_feedback_event_fields(self) -> None:
+        command.upgrade(self._config(), "head")
+
+        command.downgrade(self._config(), "011_add_deployment_outcome_fields")
+
+        columns = self._table_columns("feedback_events")
+        self.assertNotIn("finding_id", columns)
+        self.assertNotIn("false_positive_reason", columns)
+
     def test_downgrade_to_010_drops_incident_records_when_011_created_it(self) -> None:
         command.upgrade(self._config(), "head")
 
@@ -291,7 +302,7 @@ class MigrationTests(unittest.TestCase):
         self.assertIn("evidence_items", tables)
         self.assertIn("projects", tables)
         self.assertIn("topology_versions", tables)
-        self.assertEqual(revision, "011_add_deployment_outcome_fields")
+        self.assertEqual(revision, "012_add_feedback_event_fields")
 
     def test_init_db_repairs_partial_evidence_schema_without_alembic_version(
         self,
@@ -340,7 +351,7 @@ class MigrationTests(unittest.TestCase):
         self.assertIn("findings", tables)
         self.assertIn("evidence_items", tables)
         self.assertIn("projects", tables)
-        self.assertEqual(revision, "011_add_deployment_outcome_fields")
+        self.assertEqual(revision, "012_add_feedback_event_fields")
 
     def test_init_db_repairs_current_schema_without_alembic_version(self) -> None:
         command.upgrade(self._config(), "head")
@@ -366,7 +377,7 @@ class MigrationTests(unittest.TestCase):
         finally:
             sqlite_conn.close()
 
-        self.assertEqual(revision, "011_add_deployment_outcome_fields")
+        self.assertEqual(revision, "012_add_feedback_event_fields")
         self.assertIn("report_schema_version", columns)
         self.assertIn("blast_radius_json", columns)
         self.assertIn("project_id", columns)
@@ -392,7 +403,7 @@ class MigrationTests(unittest.TestCase):
         finally:
             sqlite_conn.close()
 
-        self.assertEqual(revision, "011_add_deployment_outcome_fields")
+        self.assertEqual(revision, "012_add_feedback_event_fields")
 
 
 if __name__ == "__main__":

--- a/tests/test_services/test_feedback_service.py
+++ b/tests/test_services/test_feedback_service.py
@@ -1,0 +1,169 @@
+"""Tests for reviewer feedback capture and summaries."""
+
+from __future__ import annotations
+
+import os
+import tempfile
+import unittest
+from importlib import reload
+from pathlib import Path
+
+import config as config_module
+import models.database as database_module
+import models.repositories.analysis_reports as analysis_reports_repository_module
+import models.tables as tables_module
+import services.feedback_service as feedback_service_module
+import services.project_service as project_service_module
+import services.report_service as report_service_module
+from analysis.risk_scorer import RiskAssessment
+from evidence.models import Finding
+from llm.narrator import NarrativeResult
+from parsers.base import ParseBatchResult, ParsedFileResult
+
+
+class FeedbackServiceTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tempdir = tempfile.TemporaryDirectory()
+        self.db_path = Path(self.tempdir.name) / "feedback.db"
+        os.environ["DATABASE_URL"] = f"sqlite:///{self.db_path}"
+        reload(config_module)
+        reload(tables_module)
+        reload(database_module)
+        reload(analysis_reports_repository_module)
+        reload(project_service_module)
+        reload(report_service_module)
+        reload(feedback_service_module)
+        database_module.init_db()
+
+        self.project = project_service_module.create_project(
+            project_key="payments",
+            display_name="Payments",
+        )
+        self.report = report_service_module.persist_analysis_report(
+            ParseBatchResult(
+                files=[
+                    ParsedFileResult(
+                        file_name="payments.tf",
+                        tool="terraform",
+                        status="parsed",
+                        changes=[],
+                    )
+                ]
+            ),
+            RiskAssessment(
+                score=44,
+                severity="medium",
+                recommendation="caution",
+                top_risk="Payments report for feedback tests.",
+                contributors=[],
+                interaction_risks=[],
+                partial_context=False,
+                warnings=[],
+            ),
+            NarrativeResult(
+                opening_sentence="CAUTION: payments feedback test report.",
+                explanation="Feedback test report.",
+                guidance=[],
+                degraded=False,
+                warnings=[],
+            ),
+            findings=[
+                Finding(
+                    finding_id="finding-001",
+                    analysis_id=0,
+                    title="MEDIUM: payments security group",
+                    description="Security group needs review.",
+                    severity="medium",
+                    category="networking/ingress",
+                    deterministic=True,
+                    confidence=1.0,
+                    uncertainty_note=None,
+                    evidence_refs=[],
+                    skill_id=None,
+                )
+            ],
+            project_id=self.project.id,
+            audit_context={"source_interface": "ui"},
+        )
+        self.finding_id = self.report["findings"][0]["finding_id"]
+
+    def tearDown(self) -> None:
+        database_module.engine.dispose()
+        os.environ.pop("DATABASE_URL", None)
+        self.tempdir.cleanup()
+
+    def test_record_finding_feedback_persists_useful_and_false_positive_reason(
+        self,
+    ) -> None:
+        event = feedback_service_module.record_finding_feedback(
+            analysis_id=self.report["id"],
+            finding_id=self.finding_id,
+            useful=False,
+            false_positive_flag=True,
+            false_positive_reason="Known compensating control already covers this.",
+        )
+
+        self.assertEqual(event["analysis_id"], self.report["id"])
+        self.assertEqual(event["finding_id"], self.finding_id)
+        self.assertFalse(event["useful"])
+        self.assertTrue(event["false_positive_flag"])
+        self.assertEqual(
+            event["false_positive_reason"],
+            "Known compensating control already covers this.",
+        )
+
+    def test_record_false_negative_feedback_persists_report_level_note(self) -> None:
+        event = feedback_service_module.record_false_negative_feedback(
+            analysis_id=self.report["id"],
+            note="Missed the lack of rollback alarms on the payments API.",
+        )
+
+        self.assertEqual(event["analysis_id"], self.report["id"])
+        self.assertIsNone(event["finding_id"])
+        self.assertEqual(
+            event["false_negative_note"],
+            "Missed the lack of rollback alarms on the payments API.",
+        )
+        self.assertEqual(event["outcome_label"], "missed")
+
+    def test_feedback_summary_uses_latest_finding_feedback_state(self) -> None:
+        feedback_service_module.record_finding_feedback(
+            analysis_id=self.report["id"],
+            finding_id=self.finding_id,
+            useful=True,
+        )
+        feedback_service_module.record_finding_feedback(
+            analysis_id=self.report["id"],
+            finding_id=self.finding_id,
+            useful=False,
+            false_positive_flag=True,
+            false_positive_reason="Flagged after reviewer confirmation.",
+        )
+        feedback_service_module.record_false_negative_feedback(
+            analysis_id=self.report["id"],
+            note="Missed a payments failover prerequisite.",
+        )
+
+        summary = feedback_service_module.fetch_feedback_summary(
+            project_id=self.project.id
+        )
+
+        self.assertEqual(summary["project"]["project_key"], "payments")
+        self.assertEqual(summary["current_state"]["useful_count"], 0)
+        self.assertEqual(summary["current_state"]["not_useful_count"], 1)
+        self.assertEqual(summary["current_state"]["false_positive_count"], 1)
+        self.assertEqual(summary["current_state"]["missed_finding_count"], 1)
+        self.assertEqual(summary["totals"]["events_recorded"], 3)
+        self.assertIn(
+            "payments failover prerequisite", summary["recent_notes"][0]["text"]
+        )
+
+    def test_record_finding_feedback_rejects_unknown_finding(self) -> None:
+        with self.assertRaises(feedback_service_module.FeedbackError) as ctx:
+            feedback_service_module.record_finding_feedback(
+                analysis_id=self.report["id"],
+                finding_id="missing-finding",
+                useful=True,
+            )
+
+        self.assertEqual(ctx.exception.code, "finding_not_found")

--- a/tests/test_ui/test_app_shell.py
+++ b/tests/test_ui/test_app_shell.py
@@ -235,6 +235,10 @@ class DashboardShellTests(unittest.TestCase):
             "1 saved briefing is shaping the current advisory view.", response.text
         )
         self.assertIn("Findings table", response.text)
+        self.assertIn("Reviewer feedback", response.text)
+        self.assertIn("Thumbs up", response.text)
+        self.assertIn("Thumbs down", response.text)
+        self.assertIn("Missed finding note", response.text)
         self.assertIn("Severity", response.text)
         self.assertIn("Evidence", response.text)
         self.assertIn("View evidence", response.text)

--- a/tests/test_ui/test_history_page.py
+++ b/tests/test_ui/test_history_page.py
@@ -278,6 +278,18 @@ class HistoryPageRenderingTests(unittest.TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertIn("Operational narrative", response.text)
         self.assertIn("What changed?", response.text)
+
+    def test_history_detail_route_shows_reviewer_feedback_controls(self) -> None:
+        self._persist_report()
+
+        response = self.client.get("/history/1")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("Reviewer feedback", response.text)
+        self.assertIn("Thumbs up", response.text)
+        self.assertIn("Thumbs down", response.text)
+        self.assertIn("False positive reason", response.text)
+        self.assertIn("Missed finding note", response.text)
         self.assertIn("Why is it risky?", response.text)
         self.assertIn("Exact resource/file", response.text)
         self.assertIn("Verify before deploying", response.text)

--- a/tests/test_ui/test_settings_page.py
+++ b/tests/test_ui/test_settings_page.py
@@ -67,6 +67,7 @@ class SettingsPageTests(unittest.TestCase):
         )
         self.assertIn("Drift check cadence", response.text)
         self.assertIn("Topology drift", response.text)
+        self.assertIn("Reviewer feedback summary", response.text)
 
     def test_settings_page_lists_drift_resource_names(self) -> None:
         project = project_service_module.create_project(

--- a/ui/components/report_detail_page.py
+++ b/ui/components/report_detail_page.py
@@ -9,6 +9,12 @@ from nicegui import ui
 
 from analysis.blast_radius import BlastRadiusResult
 from analysis.rollback_planner import RollbackPlan
+from services.feedback_service import (
+    FeedbackError,
+    fetch_report_feedback_state,
+    record_false_negative_feedback,
+    record_finding_feedback,
+)
 from ui.components.blast_radius_graph import render_blast_radius_panel
 from ui.components.context_completeness_panel import (
     render_context_completeness_panel,
@@ -336,7 +342,160 @@ def _render_audit_metadata(report: dict[str, Any]) -> None:
                     ).classes("text-sm dw-muted")
 
 
-def render_report_detail_page(report: dict[str, Any]) -> None:
+def render_reviewer_feedback_panel(
+    report: dict[str, Any],
+    *,
+    on_feedback_change=None,
+) -> None:
+    feedback_state = fetch_report_feedback_state(int(report["id"]))
+    latest_finding_feedback = feedback_state["finding_feedback"]
+    latest_false_negative = (
+        feedback_state["false_negative_notes"][0]
+        if feedback_state["false_negative_notes"]
+        else None
+    )
+
+    def submit_finding_feedback(
+        *,
+        finding_id: str,
+        useful: bool,
+        false_positive_flag: bool = False,
+        reason_input=None,
+    ) -> None:
+        try:
+            record_finding_feedback(
+                analysis_id=int(report["id"]),
+                finding_id=finding_id,
+                useful=useful,
+                false_positive_flag=false_positive_flag,
+                false_positive_reason=(
+                    reason_input.value if reason_input is not None else None
+                ),
+            )
+        except FeedbackError as exc:
+            ui.notify(str(exc), color="warning")
+            return
+        ui.notify("Reviewer feedback saved.", color="positive")
+        if on_feedback_change is not None:
+            on_feedback_change()
+
+    def submit_false_negative(note_input) -> None:
+        try:
+            record_false_negative_feedback(
+                analysis_id=int(report["id"]),
+                note=note_input.value,
+            )
+        except FeedbackError as exc:
+            ui.notify(str(exc), color="warning")
+            return
+        ui.notify("Missed-finding note saved.", color="positive")
+        if on_feedback_change is not None:
+            on_feedback_change()
+
+    with ui.card().classes("w-full dw-panel shadow-none p-5") as feedback_card:
+        decorate_review_section(
+            feedback_card,
+            section="feedback",
+            label="Reviewer feedback",
+        )
+        with ui.column().classes("gap-4"):
+            with ui.column().classes("gap-1"):
+                ui.label("Reviewer feedback").classes("text-lg font-medium dw-text")
+                ui.label(
+                    "Capture whether each finding was useful, flag false positives with a reason, and record anything the report missed."
+                ).classes("text-sm dw-muted leading-6")
+            for finding in report.get("findings", []):
+                finding_id = str(finding["finding_id"])
+                current_feedback = latest_finding_feedback.get(finding_id)
+                with ui.card().classes("w-full dw-panel-soft shadow-none"):
+                    with ui.column().classes("gap-3 p-4"):
+                        ui.label(finding["title"]).classes(
+                            "text-sm font-semibold dw-text"
+                        )
+                        if current_feedback is not None:
+                            status_bits = []
+                            if current_feedback.get("useful") is True:
+                                status_bits.append("Latest vote: useful")
+                            elif current_feedback.get("useful") is False:
+                                status_bits.append("Latest vote: not useful")
+                            if current_feedback.get("false_positive_flag"):
+                                status_bits.append("Marked false positive")
+                            ui.label(" · ".join(status_bits)).classes(
+                                "text-xs dw-muted"
+                            )
+                        with ui.row().classes("w-full gap-3 flex-wrap"):
+                            ui.button(
+                                "Thumbs up",
+                                on_click=lambda fid=finding_id: submit_finding_feedback(
+                                    finding_id=fid,
+                                    useful=True,
+                                ),
+                            ).props("outline no-caps").classes("dw-theme-button")
+                            ui.button(
+                                "Thumbs down",
+                                on_click=lambda fid=finding_id: submit_finding_feedback(
+                                    finding_id=fid,
+                                    useful=False,
+                                ),
+                            ).props("outline no-caps").classes("dw-theme-button")
+                        false_positive_reason = (
+                            ui.textarea(
+                                label="False positive reason",
+                                value=(
+                                    current_feedback.get("false_positive_reason")
+                                    if current_feedback is not None
+                                    else ""
+                                ),
+                            )
+                            .props("outlined autogrow")
+                            .classes("w-full")
+                        )
+                        ui.button(
+                            "Mark false positive",
+                            on_click=lambda fid=finding_id, reason_input=false_positive_reason: (
+                                submit_finding_feedback(
+                                    finding_id=fid,
+                                    useful=False,
+                                    false_positive_flag=True,
+                                    reason_input=reason_input,
+                                )
+                            ),
+                        ).props("outline no-caps").classes("dw-danger-button")
+            with ui.card().classes("w-full dw-panel-soft shadow-none"):
+                with ui.column().classes("gap-3 p-4"):
+                    ui.label("Missed finding note").classes(
+                        "text-sm font-semibold dw-text"
+                    )
+                    if latest_false_negative is not None:
+                        ui.label(
+                            "Latest note: "
+                            + str(latest_false_negative["false_negative_note"])
+                        ).classes("text-xs dw-muted")
+                    missed_note = (
+                        ui.textarea(
+                            label="Missed finding note",
+                            value=(
+                                latest_false_negative.get("false_negative_note")
+                                if latest_false_negative is not None
+                                else ""
+                            ),
+                        )
+                        .props("outlined autogrow")
+                        .classes("w-full")
+                    )
+                    ui.button(
+                        "Save missed finding note",
+                        on_click=lambda note_input=missed_note: submit_false_negative(
+                            note_input
+                        ),
+                    ).props("outline no-caps").classes("dw-theme-button")
+
+
+def render_report_detail_page(
+    report: dict[str, Any],
+    *,
+    on_feedback_change=None,
+) -> None:
     """Render one report as a dedicated, single-column detail page."""
     findings = report.get("findings", [])
     evidence_items = report.get("evidence_items", [])
@@ -402,6 +561,7 @@ def render_report_detail_page(report: dict[str, Any]) -> None:
         artifact_names=artifact_names,
         report_id=int(report["id"]),
     )
+    render_reviewer_feedback_panel(report, on_feedback_change=on_feedback_change)
     render_context_completeness_panel(context)
     if (
         blast_radius.get("affected")

--- a/ui/components/upload_panel.py
+++ b/ui/components/upload_panel.py
@@ -34,6 +34,7 @@ from ui.components.project_workspace_switcher import (
     open_create_project_dialog as show_create_project_dialog,
 )
 from ui.components.blast_radius_graph import render_blast_radius_panel
+from ui.components.report_detail_page import render_reviewer_feedback_panel
 from ui.components.rollback_plan import render_rollback_plan
 from ui.components.review_accessibility import (
     decorate_modal_card,
@@ -376,6 +377,14 @@ def build_upload_panel(
                             title="Findings table",
                             artifact_names=artifact_names,
                             report_id=int(report["id"]),
+                        )
+                        render_reviewer_feedback_panel(
+                            report,
+                            on_feedback_change=lambda current_report=report: (
+                                render_result_card(
+                                    current_report, timer_state["remaining"]
+                                )
+                            ),
                         )
                 render_context_completeness_panel(context)
                 blast_radius = report.get("blast_radius") or {}

--- a/ui/routes/history.py
+++ b/ui/routes/history.py
@@ -513,7 +513,10 @@ def build_history_detail_page(report_id: int, *, show_comparison: bool = False) 
                                 f"/history/{report_id}/compare#report-comparison"
                             ),
                         ).props("flat no-caps").classes("dw-theme-button")
-            render_report_detail_page(report)
+            render_report_detail_page(
+                report,
+                on_feedback_change=render_history_detail_content.refresh,
+            )
 
     content_refresh["fn"] = lambda *_: render_history_detail_content.refresh()
     render_history_detail_content()

--- a/ui/routes/settings.py
+++ b/ui/routes/settings.py
@@ -7,6 +7,7 @@ from typing import Any
 from nicegui import events, ui
 
 from llm.skill_context import get_custom_skill_statuses, save_custom_skill
+from services.feedback_service import fetch_feedback_summary
 from services.project_service import get_active_project
 from services.settings_service import (
     activate_local_mode,
@@ -132,6 +133,9 @@ def build_settings_page() -> None:
         dashboard_duration_seconds = get_dashboard_result_display_duration_seconds()
         drift_interval_hours = get_topology_drift_check_interval_hours()
         topology_status = get_topology_status(
+            project_id=active_project.id if active_project is not None else None
+        )
+        feedback_summary = fetch_feedback_summary(
             project_id=active_project.id if active_project is not None else None
         )
         custom_skill_statuses = get_custom_skill_statuses()
@@ -562,6 +566,54 @@ def build_settings_page() -> None:
                         lambda event: save_drift_interval(event)
                     )
                     render_topology_feedback(topology_status)
+
+            with ui.card().classes("w-full dw-panel shadow-none"):
+                ui.label("Reviewer feedback summary").classes(
+                    "text-lg font-medium dw-text"
+                )
+                ui.label(
+                    "Admin-facing summary of the latest reviewer feedback state for the active project."
+                ).classes("text-sm dw-muted")
+                with ui.row().classes("w-full items-stretch gap-2 flex-wrap mt-3"):
+                    metrics = [
+                        ("Useful", feedback_summary["current_state"]["useful_count"]),
+                        (
+                            "Not useful",
+                            feedback_summary["current_state"]["not_useful_count"],
+                        ),
+                        (
+                            "False positives",
+                            feedback_summary["current_state"]["false_positive_count"],
+                        ),
+                        (
+                            "Missed findings",
+                            feedback_summary["current_state"]["missed_finding_count"],
+                        ),
+                    ]
+                    for label, value in metrics:
+                        with ui.card().classes(
+                            "dw-panel-soft shadow-none min-w-[120px] flex-1"
+                        ):
+                            with ui.column().classes("gap-1 p-3"):
+                                ui.label(str(value)).classes(
+                                    "text-2xl font-semibold dw-text"
+                                )
+                                ui.label(label).classes(
+                                    "text-[11px] font-semibold uppercase tracking-[0.08em] dw-muted"
+                                )
+                ui.label(
+                    f"Recorded feedback events: {feedback_summary['totals']['events_recorded']}"
+                ).classes("text-sm dw-muted mt-3")
+                with ui.column().classes("w-full gap-2 mt-2"):
+                    ui.label("Recent notes").classes("text-sm font-semibold dw-text")
+                    if not feedback_summary["recent_notes"]:
+                        ui.label(
+                            "No reviewer notes have been captured for the active project yet."
+                        ).classes("text-sm dw-muted")
+                    for item in feedback_summary["recent_notes"]:
+                        ui.label(
+                            f"{item['type'].replace('_', ' ').title()}: {item['text']}"
+                        ).classes("text-sm dw-muted leading-6")
 
             with ui.card().classes("w-full dw-panel shadow-none"):
                 ui.label("Custom AI Skills").classes("text-lg font-medium dw-text")


### PR DESCRIPTION
This adds a shared reviewer feedback path for persisted findings, stores finding-level false-positive context in the existing feedback event history, and surfaces both reviewer controls and an admin summary on the project-scoped review surfaces.

Constraint: Feedback must remain project-scoped and validate against persisted report findings
Constraint: New migration state must remain compatible with brownfield repair logic and downgrade paths
Rejected: Add a separate feedback table | unnecessary schema sprawl when the existing feedback event history can be extended additively
Rejected: Limit feedback to history-only UI | misses the live dashboard review flow where reviewers first inspect findings
Confidence: high
Scope-risk: moderate
Reversibility: clean
Directive: Keep reviewer feedback storage append-only and preserve latest-state summaries without discarding event history
Tested: Ruff check, Ruff format --check, focused feedback/migration/UI unittest suites, unittest discover -q, scripts/ci-local.sh
Not-tested: Bandit local security scan (tool not installed)

## What does this PR do?

<!-- Brief description of changes -->

## Type of change
- [ ] Feature (new functionality)
- [ ] Bugfix (non-breaking fix)
- [ ] Release preparation
- [ ] Hotfix (critical production fix)
- [ ] Docs / refactor / chore

## Checklist
- [ ] I have followed the branch naming convention
- [ ] Tests pass locally (`pytest tests/ -v`)
- [ ] Linting passes (`ruff check .`)
- [ ] Docker build succeeds
- [ ] I have updated docs if needed
- [ ] No secrets or .env values committed

## Related issue
Closes #