### PR TITLE
Keep governance promises enforceable at closeout

### DIFF
--- a/_bmad-output/implementation-artifacts/0-1-publish-core-governance-files.md
+++ b/_bmad-output/implementation-artifacts/0-1-publish-core-governance-files.md
@@ -1,0 +1,131 @@
+# Story 0.1: Publish Core Governance Files
+
+Status: done
+
+## Story
+
+As a project maintainer,
+I want public governance, support, security, conduct, contributing, and roadmap files,
+so that users and contributors understand how the project operates.
+
+## Acceptance Criteria
+
+1. Given a new contributor or user visits the repository, when they inspect governance and community files, then they can find `GOVERNANCE.md`, `CONTRIBUTING.md`, `CODE_OF_CONDUCT.md`, `SECURITY.md`, `SUPPORT.md`, and `ROADMAP.md`.
+2. Given a new contributor or user reads those documents, when they evaluate project access and roadmap posture, then the documents do not imply SaaS, open-core, paid feature gating, vendor-controlled roadmap priority, or proprietary plugins required for major supported platforms.
+
+### Requirement Traceability
+
+- Primary PRD requirements: `GOV-01`, `GOV-03`, `GOV-04`, `GOV-05`, `GOV-06`, `NFR-OSS-01`.
+- Supporting PRD / NFR / differentiation requirements: `DOC-15`, `DOC-19`, `DOC-20`, `NFR-OSS-02`, `NFR-OSS-04`.
+- Coverage intent: Baseline.
+- Story alignment note: This story publishes the root community files required for open-source trust. It does not implement maintainer ownership, CODEOWNERS routing, RFC mechanics, contributor ladder, release process, or adopters tracking; those are covered by later Epic 0 and Epic 14 stories.
+
+## Tasks / Subtasks
+
+- [x] Audit existing repository community files and identify missing required files. (AC: 1)
+  - [x] Confirm whether root `CONTRIBUTING.md` already exists and can be reused.
+  - [x] Confirm missing root `GOVERNANCE.md`, `CODE_OF_CONDUCT.md`, `SECURITY.md`, `SUPPORT.md`, and `ROADMAP.md`.
+- [x] Add missing root community files with self-hosted, advisory-first, open-source posture. (AC: 1, 2)
+  - [x] Add `GOVERNANCE.md` that defines public governance principles and references future maintainer/RFC artifacts without inventing completed maturity.
+  - [x] Add `CODE_OF_CONDUCT.md` with clear participation standards and reporting path.
+  - [x] Add `SECURITY.md` with supported reporting process, sensitive data guidance, and local-first security boundary.
+  - [x] Add `SUPPORT.md` with community support channels and no paid support guarantees.
+  - [x] Add `ROADMAP.md` with public roadmap phases and honest non-guarantees.
+- [x] Add documentation guardrail tests for the required files and forbidden posture claims. (AC: 1, 2)
+  - [x] Test that all six required root files exist.
+  - [x] Test that required files do not contain SaaS/open-core/paid feature-gating claims.
+  - [x] Test that required files guard against vendor-controlled roadmap priority and proprietary plugin prerequisites.
+- [x] Run focused validation and update story status. (AC: 1, 2)
+  - [x] Run the new docs test.
+  - [x] Run the relevant repository validation for docs-only changes.
+
+### Review Findings
+
+- [x] [Review][Patch] Guardrail coverage does not enforce all AC2 posture constraints [tests/test_infra/test_governance_files.py:20] — fixed by expanding forbidden posture patterns and adding positive assertions for vendor roadmap control, hosted-control-plane, and proprietary-prerequisite guardrails.
+- [x] [Review][Patch] Sprint status changes exceed the Story 0.1 docs-only scope [_bmad-output/implementation-artifacts/sprint-status.yaml:44] — fixed for this follow-up by leaving the existing 2026-05-01 planning baseline intact and avoiding any new broad sprint-status rewrite; Story 0.1 remains `review`.
+- [x] [Review][Patch] Proprietary-plugin regex misses singular `plugin is required` phrasing [tests/test_infra/test_governance_files.py:35] — fixed with singular/plural coverage and regression examples.
+- [x] [Review][Patch] Forbidden-posture scan flags explicit negations such as `not open-core` as violations [tests/test_infra/test_governance_files.py:21] — fixed with negation-aware pattern matching and regression examples.
+- [x] [Review][Patch] Required posture assertion depends on exact sentence text and unguarded file reads [tests/test_infra/test_governance_files.py:102] — fixed with intent regexes and missing-file-safe failures.
+- [x] [Review][Patch] Placeholder guard only rejects blank files, not placeholder-only docs [tests/test_infra/test_governance_files.py:76] — fixed with minimum meaningful content and placeholder term checks.
+- [x] [Review][Patch] Forbidden patterns miss typographic dash variants from pasted Markdown [tests/test_infra/test_governance_files.py:21] — fixed by normalizing typographic dash variants before matching.
+- [x] [Review][Patch] Forbidden patterns miss common equivalent hosted-control-plane and private-roadmap-priority wording [tests/test_infra/test_governance_files.py:21] — fixed with expanded hosted-control-plane and roadmap-priority patterns plus regression examples.
+
+## Dev Notes
+
+### Scope
+
+- Create or update root-level documentation only, plus a small docs guardrail test.
+- Do not edit `.github/CODEOWNERS`; Story 0.2 owns maintainer areas and CODEOWNERS.
+- Do not create `MAINTAINERS.md`, `CONTRIBUTOR_LADDER.md`, `RELEASE_PROCESS.md`, `ADOPTERS.md`, or an RFC directory in this story; architecture and PRD list them as required governance artifacts, but this story's acceptance criteria names only six root files.
+- Do not imply DeployWhisper has CNCF status, production adopters, paid support, proprietary plugins, or vendor-controlled roadmap priority.
+
+### Existing Repository Context
+
+- `CONTRIBUTING.md` already exists and includes Git Flow, branch naming, PR process, code standards, testing, and release guidance.
+- `.github/CODEOWNERS` already exists but is outside this story's acceptance criteria.
+- `LICENSE` exists and is MIT.
+- Required missing files before implementation: `GOVERNANCE.md`, `CODE_OF_CONDUCT.md`, `SECURITY.md`, `SUPPORT.md`, and `ROADMAP.md`.
+
+### Architecture and Product Guardrails
+
+- Documentation and governance are architectural surfaces because DeployWhisper is self-hosted and open-source. Required governance artifacts are listed in the architecture's documentation and governance section.
+- The PRD requires public governance documentation, public roadmap, contributor guide, code of conduct, security policy, and public open-source processes.
+- Preserve the product posture: local-first, advisory-first, self-hosted, evidence-backed, and benchmark-honest.
+
+### Testing Requirements
+
+- Use standard-library `unittest` style consistent with project context.
+- Put the docs guardrail test under `tests/test_infra/` because it validates repository packaging/community metadata rather than runtime behavior.
+- Keep tests deterministic and local; do not call network services.
+
+### References
+
+- `_bmad-output/planning-artifacts/epics.md` - Epic 0, Story 0.1 acceptance criteria.
+- `_bmad-output/planning-artifacts/prd.md` - Open Governance and CNCF readiness requirements.
+- `_bmad-output/planning-artifacts/architecture.md` - Documentation and Governance Architecture.
+- `_bmad-output/project-context.md` - testing and workflow rules.
+- `CONTRIBUTING.md` - existing contributor guide to preserve and reuse.
+
+## Dev Agent Record
+
+### Agent Model Used
+
+GPT-5
+
+### Debug Log References
+
+- `./.venv/bin/python -m unittest tests.test_infra.test_governance_files -q` failed before implementation because five required root files were missing.
+- `./.venv/bin/python -m unittest tests.test_infra.test_governance_files -q` passed after adding governance files.
+- `./.venv/bin/ruff check tests/test_infra/test_governance_files.py` passed.
+- `./.venv/bin/ruff format --check tests/test_infra/test_governance_files.py` initially required formatting; passed after `./.venv/bin/ruff format tests/test_infra/test_governance_files.py`.
+- `./.venv/bin/python -m unittest discover -q` passed: 211 tests, 1 skipped.
+- 2026-05-01 dev-story verification rerun: `./.venv/bin/python -m unittest tests.test_infra.test_governance_files -q` passed: 2 tests.
+- 2026-05-01 dev-story verification rerun: `./.venv/bin/ruff check .` passed.
+- 2026-05-01 dev-story verification rerun: `./.venv/bin/ruff format --check .` passed: 250 files already formatted.
+- 2026-05-01 dev-story verification rerun: `./.venv/bin/python -m unittest discover -q` passed: 211 tests, 1 skipped.
+
+### Completion Notes List
+
+- Added required root governance/community files for Story 0.1: `GOVERNANCE.md`, `CODE_OF_CONDUCT.md`, `SECURITY.md`, `SUPPORT.md`, and `ROADMAP.md`.
+- Reused the existing root `CONTRIBUTING.md`.
+- Added a deterministic docs guardrail test that verifies all six required root files exist and that they avoid forbidden SaaS/open-core/feature-gating posture claims.
+- Preserved Story 0.1 scope: did not change CODEOWNERS or add maintainer/RFC/release/adopters artifacts owned by later stories.
+- Re-ran `bmad-dev-story` verification from the validation-report request; no implementation gaps remained and Story 0.1 stays ready for code review.
+
+### File List
+
+- `_bmad-output/implementation-artifacts/0-1-publish-core-governance-files.md`
+- `_bmad-output/implementation-artifacts/0-1-publish-core-governance-files-validation-report.md`
+- `_bmad-output/implementation-artifacts/sprint-status.yaml`
+- `CODE_OF_CONDUCT.md`
+- `GOVERNANCE.md`
+- `ROADMAP.md`
+- `SECURITY.md`
+- `SUPPORT.md`
+- `tests/test_infra/test_governance_files.py`
+
+## Change Log
+
+- 2026-05-01: Story created from corrected Epic 0.1 context.
+- 2026-05-01: Implemented core governance files and docs guardrail test; story moved to review.
+- 2026-05-01: Re-ran dev-story verification from validation report; focused governance test, Ruff check, Ruff format check, and full unittest suite passed.

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -1,5 +1,5 @@
 # generated: 2026-05-01
-# last_updated: 2026-05-01
+# last_updated: 2026-05-04
 # project: deploywhisper
 # project_key: NOKEY
 # tracking_system: file-system
@@ -35,7 +35,7 @@
 # - Dev moves story to review, then runs code-review
 
 generated: 2026-05-01
-last_updated: 2026-05-01
+last_updated: 2026-05-04
 project: deploywhisper
 project_key: NOKEY
 tracking_system: file-system
@@ -43,7 +43,7 @@ story_location: _bmad-output/implementation-artifacts
 
 development_status:
   epic-0: in-progress
-  0-1-publish-core-governance-files: review
+  0-1-publish-core-governance-files: done
   0-2-define-maintainer-ownership-and-codeowners: ready-for-dev
   0-3-create-requirements-traceability-matrix: ready-for-dev
   0-4-establish-rfc-and-decision-process: ready-for-dev

--- a/tests/test_infra/test_governance_files.py
+++ b/tests/test_infra/test_governance_files.py
@@ -3,10 +3,13 @@
 from __future__ import annotations
 
 from pathlib import Path
+import re
 import unittest
 
 
 ROOT = Path(__file__).resolve().parents[2]
+
+TYPOGRAPHIC_DASHES = "\u2010\u2011\u2012\u2013\u2014\u2212"
 
 REQUIRED_COMMUNITY_FILES = (
     "GOVERNANCE.md",
@@ -17,16 +20,108 @@ REQUIRED_COMMUNITY_FILES = (
     "ROADMAP.md",
 )
 
-FORBIDDEN_POSTURE_CLAIMS = (
-    "saas-only",
-    "hosted-only",
-    "open core",
-    "open-core",
-    "enterprise-only",
-    "paid feature",
-    "proprietary plugin required",
-    "commercial edition required",
+FORBIDDEN_POSTURE_PATTERNS = (
+    ("SaaS-only posture", re.compile(r"\bsaas[-\s]?only\b")),
+    ("SaaS mandate", re.compile(r"\bsaas\s+(?:deployment\s+)?(?:is\s+)?mandatory\b")),
+    ("hosted-only posture", re.compile(r"\bhosted[-\s]?only\b")),
+    (
+        "hosted exclusivity",
+        re.compile(r"\bavailable\s+exclusively\s+via\s+the\s+hosted\s+service\b"),
+    ),
+    ("open-core posture", re.compile(r"\bopen[-\s]?core\b")),
+    ("enterprise-only posture", re.compile(r"\benterprise[-\s]?only\b")),
+    ("paid feature gating", re.compile(r"\bpaid\s+(?:feature|tier|plan|edition)\b")),
+    (
+        "hosted control-plane requirement",
+        re.compile(
+            r"\b(?:core\s+analysis|main\s+workflow|deployment-risk\s+briefing)"
+            r"\s+requires\s+(?:a\s+)?(?:cloud|hosted)\s+control\s+plane\b"
+        ),
+    ),
+    (
+        "vendor-controlled roadmap priority",
+        re.compile(
+            r"\b(?:vendor|sponsor|commercial|customer)[-\s]+controlled\s+roadmap\b"
+            r"|\broadmap\s+(?:is\s+)?(?:vendor|sponsor|commercial|customer)[-\s]+controlled\b"
+            r"|\broadmap\s+priority\s+(?:is|will\s+be)\s+controlled\b"
+            r"|\b(?:sponsors?|vendors?|commercial\s+customers?|customers?)"
+            r"\s+(?:set|determine|control)\s+roadmap\s+(?:priorities|priority|order)\b"
+            r"|\bcustomer[-\s]+driven\s+roadmap\s+priorities\b"
+        ),
+    ),
+    (
+        "proprietary plugin requirement",
+        re.compile(
+            r"\bproprietary\s+plugins?\s+(?:(?:is|are)\s+)?required\b"
+            r"|\brequired\s+proprietary\s+plugins?\b"
+            r"|\bmajor\s+(?:supported\s+)?platforms?\s+require\s+proprietary\s+plugins?\b"
+        ),
+    ),
+    (
+        "commercial edition requirement",
+        re.compile(r"\bcommercial\s+edition\s+(?:is\s+)?required\b"),
+    ),
 )
+
+REQUIRED_POSTURE_PATTERNS = (
+    (
+        "GOVERNANCE.md",
+        "roadmap priority must remain public",
+        re.compile(
+            r"\b(?:external\s+funding|sponsorship|cloud\s+credits|foundation\s+support)"
+            r".{0,120}\bmust\s+not\s+grant\s+private\s+control\b"
+            r".{0,80}\broadmap\s+priority\b"
+        ),
+    ),
+    (
+        "GOVERNANCE.md",
+        "optional hosted/vendor services must not become prerequisites",
+        re.compile(
+            r"\b(?:optional\s+services|hosted\s+deployments|vendor-specific\s+adapters)"
+            r".{0,160}\bmust\s+not\s+become\s+prerequisites\b"
+            r".{0,100}\bdeployment-risk\s+briefing\s+workflow\b"
+        ),
+    ),
+    (
+        "ROADMAP.md",
+        "core analysis must not require a hosted control plane",
+        re.compile(
+            r"\bshould\s+not\s+require\s+a\s+hosted\s+control\s+plane\b.{0,80}\bcore\s+analysis\b"
+        ),
+    ),
+)
+
+PLACEHOLDER_TERMS = ("todo", "tbd", "coming soon", "placeholder", "lorem ipsum")
+
+
+def _normalize_markdown(content: str) -> str:
+    """Return lowercase text normalized for policy-pattern matching."""
+
+    dash_translation = str.maketrans({dash: "-" for dash in TYPOGRAPHIC_DASHES})
+    content = content.translate(dash_translation).lower()
+    return re.sub(r"\s+", " ", content)
+
+
+def _is_negated(content: str, match: re.Match[str]) -> bool:
+    prefix = content[max(0, match.start() - 40) : match.start()]
+    return bool(
+        re.search(
+            r"\b(?:not|never|no|without|does\s+not|do\s+not|must\s+not|should\s+not)"
+            r"(?:\s+\w+){0,4}\s*$",
+            prefix,
+        )
+    )
+
+
+def _has_forbidden_posture(content: str, pattern: re.Pattern[str]) -> bool:
+    return any(not _is_negated(content, match) for match in pattern.finditer(content))
+
+
+def _is_placeholder_document(content: str) -> bool:
+    normalized = _normalize_markdown(content)
+    body = re.sub(r"(?m)^#+\s*", "", content).strip().lower()
+    word_count = len(re.findall(r"[a-z0-9]+", body))
+    return word_count < 20 or any(term in normalized for term in PLACEHOLDER_TERMS)
 
 
 class GovernanceFilesTests(unittest.TestCase):
@@ -39,6 +134,18 @@ class GovernanceFilesTests(unittest.TestCase):
 
         self.assertEqual([], missing)
 
+    def test_required_community_files_are_not_placeholders(self) -> None:
+        placeholders: list[str] = []
+
+        for name in REQUIRED_COMMUNITY_FILES:
+            path = ROOT / name
+            if path.is_file() and _is_placeholder_document(
+                path.read_text(encoding="utf-8")
+            ):
+                placeholders.append(name)
+
+        self.assertEqual([], placeholders)
+
     def test_community_files_do_not_imply_feature_gating(self) -> None:
         violations: list[tuple[str, str]] = []
 
@@ -46,12 +153,65 @@ class GovernanceFilesTests(unittest.TestCase):
             path = ROOT / name
             if not path.exists():
                 continue
-            content = path.read_text(encoding="utf-8").lower()
-            for phrase in FORBIDDEN_POSTURE_CLAIMS:
-                if phrase in content:
-                    violations.append((name, phrase))
+            content = _normalize_markdown(path.read_text(encoding="utf-8"))
+            for label, pattern in FORBIDDEN_POSTURE_PATTERNS:
+                if _has_forbidden_posture(content, pattern):
+                    violations.append((name, label))
 
         self.assertEqual([], violations)
+
+    def test_community_files_explicitly_reject_closed_posture(self) -> None:
+        missing: list[tuple[str, str]] = []
+
+        for name, label, pattern in REQUIRED_POSTURE_PATTERNS:
+            path = ROOT / name
+            if not path.is_file():
+                missing.append((name, label))
+                continue
+            content = _normalize_markdown(path.read_text(encoding="utf-8"))
+            if not pattern.search(content):
+                missing.append((name, label))
+
+        self.assertEqual([], missing)
+
+    def test_forbidden_posture_patterns_cover_reviewed_phrasings(self) -> None:
+        forbidden_examples = (
+            "Proprietary plugin is required for Kubernetes.",
+            "The core analysis requires a cloud control plane.",
+            "Available exclusively via the hosted service.",
+            "Sponsors set roadmap priorities.",
+            "This is an open-core distribution.",
+            "The product is hosted-only.",
+            "The roadmap is vendor-controlled.",
+        )
+
+        for example in forbidden_examples:
+            normalized = _normalize_markdown(example)
+            self.assertTrue(
+                any(
+                    _has_forbidden_posture(normalized, pattern)
+                    for _, pattern in FORBIDDEN_POSTURE_PATTERNS
+                ),
+                example,
+            )
+
+    def test_forbidden_posture_patterns_allow_explicit_negations(self) -> None:
+        allowed_examples = (
+            "DeployWhisper is not open-core.",
+            "This project is not SaaS-only.",
+            "Core analysis should not require a hosted control plane.",
+            "The roadmap must not grant private control to sponsors.",
+        )
+
+        for example in allowed_examples:
+            normalized = _normalize_markdown(example)
+            self.assertFalse(
+                any(
+                    _has_forbidden_posture(normalized, pattern)
+                    for _, pattern in FORBIDDEN_POSTURE_PATTERNS
+                ),
+                example,
+            )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Story 0.1 publishes the core governance files and needs a deterministic guardrail that protects the open, self-hosted posture without blocking ordinary wording improvements. The guardrail now normalizes Markdown, handles negated policy statements, catches equivalent closed-posture phrasing, and records the story closeout state.

Constraint: Story 0.1 scope is root governance documentation plus a small docs guardrail test
Rejected: Leave exact-string posture checks | too brittle for normal documentation edits
Rejected: Broad sprint-status regeneration in this closeout | unrelated to the single Story 0.1 lifecycle update
Confidence: high
Scope-risk: narrow
Directive: Keep these tests deterministic and local; do not replace them with LLM or network-based policy checks
Tested: ./.venv/bin/python -m unittest tests.test_infra.test_governance_files -q
Tested: ./.venv/bin/ruff check .
Tested: ./.venv/bin/ruff format --check .
Tested: ./.venv/bin/python -m unittest discover -q
Not-tested: External GitHub PR rendering or repository community-profile UI

## What does this PR do?

<!-- Brief description of changes -->

## Type of change
- [ ] Feature (new functionality)
- [ ] Bugfix (non-breaking fix)
- [ ] Release preparation
- [ ] Hotfix (critical production fix)
- [ ] Docs / refactor / chore

## Checklist
- [ ] I have followed the branch naming convention
- [ ] Tests pass locally (`pytest tests/ -v`)
- [ ] Linting passes (`ruff check .`)
- [ ] Docker build succeeds
- [ ] I have updated docs if needed
- [ ] No secrets or .env values committed

## Related issue
Closes #