### PR TITLE
Route governance reviews to accountable maintainers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,12 +1,36 @@
 # Default owner for everything
 * @pramodksahoo
 
-# Critical paths need explicit review
-/parsers/       @pramodksahoo
-/llm/           @pramodksahoo
-/analysis/      @pramodksahoo
+# Maintainer areas
+/.agents/       @pramodksahoo
+/_bmad/         @pramodksahoo
+/_bmad-output/  @pramodksahoo
 /.github/       @pramodksahoo
+/api/           @pramodksahoo
+/analysis/      @pramodksahoo
+/cli/           @pramodksahoo
+/data/          @pramodksahoo
+/docs/          @pramodksahoo
+/evidence/      @pramodksahoo
+/integrations/  @pramodksahoo
+/llm/           @pramodksahoo
+/migrations/    @pramodksahoo
+/models/        @pramodksahoo
+/parsers/       @pramodksahoo
+/samples/       @pramodksahoo
+/schemas/       @pramodksahoo
+/scripts/       @pramodksahoo
+/services/      @pramodksahoo
 /skills/        @pramodksahoo
+/tests/         @pramodksahoo
+/ui/            @pramodksahoo
+
+# High-signal contribution workflow files
 /tests/skill-tests/ @pramodksahoo
-/docs/contributing/skills.md @pramodksahoo
+/MAINTAINERS.md @pramodksahoo
+/CONTRIBUTING.md @pramodksahoo
+/GOVERNANCE.md @pramodksahoo
+/SECURITY.md @pramodksahoo
+/ROADMAP.md @pramodksahoo
 /.github/PULL_REQUEST_TEMPLATE/skill.md @pramodksahoo
+/docs/contributing/skills.md @pramodksahoo

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,0 +1,75 @@
+# DeployWhisper Maintainers
+
+DeployWhisper maintainership is public so contributors can see who reviews major
+project areas, which responsibilities maintainers carry, and where ownership
+coverage is still thin.
+
+## Current Maintainers
+
+| Maintainer | GitHub handle | Current role |
+| --- | --- | --- |
+| Pramoda Sahoo | `@pramodksahoo` | Project owner and current maintainer for all major repository areas |
+
+## Maintainer Responsibilities
+
+Maintainers are expected to:
+
+- Review pull requests for correctness, security posture, test coverage, and fit
+  with the advisory-first and local-first product boundaries.
+- Keep governance, contribution, security, support, roadmap, and ownership
+  documents aligned with current project behavior.
+- Protect sensitive artifacts by rejecting real credentials, raw production state,
+  private incident data, and unsafe infrastructure samples.
+- Route changes to area owners through CODEOWNERS and request additional review
+  when a change crosses multiple ownership areas.
+- Record meaningful decisions in planning artifacts, pull request descriptions,
+  or future RFCs when changes affect architecture, security, governance, roadmap,
+  or compatibility.
+
+## Maintainer Areas
+
+| Area | CODEOWNERS path | Primary maintainer | Review focus |
+| --- | --- | --- | --- |
+| `.agents` | `/.agents/` | `@pramodksahoo` | Local agent skills, workflow helpers, and project-specific automation surfaces |
+| `_bmad` | `/_bmad/` | `@pramodksahoo` | BMad module configuration, workflow registration, and method metadata |
+| `_bmad-output` | `/_bmad-output/` | `@pramodksahoo` | Planning, implementation, test architecture, and story lifecycle artifacts |
+| `.github` | `/.github/` | `@pramodksahoo` | CI, pull request templates, release automation, repository workflows |
+| `api` | `/api/` | `@pramodksahoo` | FastAPI route contracts, response envelopes, OpenAPI behavior |
+| `analysis` | `/analysis/` | `@pramodksahoo` | Risk scoring, evidence rules, blast radius, rollback, incident matching |
+| `cli` | `/cli/` | `@pramodksahoo` | Command-line workflows and shared-service integration |
+| `data` | `/data/` | `@pramodksahoo` | Seeded local data, analytics snapshots, and topology examples |
+| `docs` | `/docs/` | `@pramodksahoo` | User, operator, contributor, governance, and integration documentation |
+| `evidence` | `/evidence/` | `@pramodksahoo` | Evidence models, extractors, and mapper contracts |
+| `integrations` | `/integrations/` | `@pramodksahoo` | External integration boundaries and GitHub app services |
+| `llm` | `/llm/` | `@pramodksahoo` | Provider adapters, prompt boundaries, narrative fallback behavior |
+| `migrations` | `/migrations/` | `@pramodksahoo` | Alembic migrations and schema evolution history |
+| `models` | `/models/` | `@pramodksahoo` | Database models, repositories, persistence contracts |
+| `parsers` | `/parsers/` | `@pramodksahoo` | IaC parsing behavior and supported artifact boundaries |
+| `samples` | `/samples/` | `@pramodksahoo` | Synthetic examples and non-sensitive demonstration artifacts |
+| `schemas` | `/schemas/` | `@pramodksahoo` | JSON schemas and machine-readable contract definitions |
+| `scripts` | `/scripts/` | `@pramodksahoo` | Local CI, registry publishing, analytics, and helper automation |
+| `services` | `/services/` | `@pramodksahoo` | Shared orchestration and business logic used by UI, API, and CLI |
+| `skills` | `/skills/` | `@pramodksahoo` | Skill manifests, registry content, harness scenarios, contribution flow |
+| `tests` | `/tests/` | `@pramodksahoo` | Regression coverage, fixtures, infrastructure guardrails |
+| `ui` | `/ui/` | `@pramodksahoo` | NiceGUI routes, review surfaces, accessibility-sensitive flows |
+
+## Known Coverage Gaps
+
+- DeployWhisper currently has one public maintainer for all major areas.
+- There is no separate security-response maintainer group yet.
+- There is no independent release manager or docs maintainer yet.
+- Maintainer promotion, inactivity handling, and contributor ladder rules are
+  planned for later governance stories.
+
+Until those gaps are closed, contributors should expect `@pramodksahoo` to be
+requested on major-area changes through CODEOWNERS.
+
+## Ownership Updates
+
+Ownership changes should be made in the same pull request when CODEOWNERS and
+this file diverge. A valid ownership update should explain:
+
+- The repository area being added, removed, or transferred.
+- The maintainer handle responsible for review.
+- Any remaining coverage gap or temporary fallback.
+- Whether the change affects governance, security, release, or RFC expectations.

--- a/_bmad-output/implementation-artifacts/0-2-define-maintainer-ownership-and-codeowners.md
+++ b/_bmad-output/implementation-artifacts/0-2-define-maintainer-ownership-and-codeowners.md
@@ -1,0 +1,129 @@
+# Story 0.2: Define Maintainer Ownership and CODEOWNERS
+
+Status: done
+
+<!-- Generated from updated PRD/architecture/epics plus implementation-readiness-report-2026-05-01.md. -->
+
+## Story
+
+As a maintainer,
+I want maintainer areas and CODEOWNERS documented,
+So that reviews route to accountable project owners.
+
+## Acceptance Criteria
+
+1. Given a PR changes a major repository area, When CODEOWNERS evaluates the change, Then the appropriate maintainership area is requested for review. And `MAINTAINERS.md` explains owner responsibilities and known coverage gaps.
+
+### Requirement Traceability
+
+- Primary PRD requirements: Epic 0 coverage: GOV-01..15, NFR-OSS-01..05, DOC-15, DOC-19, DOC-20.
+- Supporting PRD / NFR / differentiation requirements: See `_bmad-output/planning-artifacts/prd.md`, `_bmad-output/planning-artifacts/architecture.md`, and `_bmad-output/planning-artifacts/implementation-readiness-report-2026-05-01.md`.
+- Coverage intent: Baseline + Delta.
+- Story alignment note: This story was created from the updated Epic 0 plan after the 2026-05-01 readiness rerun. The readiness report verified 187/187 PRD functional requirement IDs in the epics artifact, 38 NFR IDs present, and no critical or major readiness defects.
+
+## Tasks / Subtasks
+
+- [x] Implement and verify acceptance criterion 1. (AC: 1)
+- [x] Reuse existing services, repositories, schemas, and UI/CLI/API helpers before adding new abstractions. (AC: all)
+- [x] Add or update deterministic regression coverage for the changed behavior. (AC: all)
+- [x] Update relevant docs or examples if the story changes user-visible, operator, API, CLI, integration, or contribution behavior. (AC: all)
+- [x] Run required validation and record commands/results in the Dev Agent Record. (AC: all)
+
+### Review Findings
+
+- [x] [Review][Patch] Add explicit CODEOWNERS and MAINTAINERS coverage for current top-level repo areas such as `evidence/`, `integrations/`, `scripts/`, and `schemas/` [`.github/CODEOWNERS:5`]
+- [x] [Review][Patch] Add explicit CODEOWNERS, MAINTAINERS, and guardrail-test coverage for tracked top-level `_bmad/` project configuration area [`.github/CODEOWNERS:4`]
+
+## Dev Notes
+
+### Epic Context
+
+- Epic: 0. Open Governance, Traceability, and Maintainer Ownership
+- Epic goal: Establish the public project foundation needed for open-source trust, contribution, and roadmap accountability.
+- Epic coverage: GOV-01..15, NFR-OSS-01..05, DOC-15, DOC-19, DOC-20
+
+### Architecture and Product Guardrails
+
+- Preserve DeployWhisper's local-first raw artifact boundary: raw IaC, scanner artifacts, incident exports, and sensitive context stay in the user's infrastructure by default.
+- Preserve the advisory-first core. Optional adapters may interpret report outputs, but canonical report semantics remain advisory unless explicit story scope says otherwise.
+- Reuse the shared analysis core and service layer before adapting UI, API, CLI, GitHub, or future workflow surfaces.
+- Keep Evidence Law behavior intact: no high or critical finding without deterministic evidence.
+- Keep project/workspace scope explicit for reports, incidents, topology, outcomes, feedback, scanner imports, and connector-related data.
+- Do not introduce new dependencies unless the active story explicitly requires and justifies them.
+
+### Source Tree Guidance
+
+- API routes belong under `api/routes/` and should use existing `ApiRoute` / `ApiError` envelope patterns.
+- Shared orchestration belongs in `services/`; parsers normalize input, analysis modules score/derive risk, and surfaces adapt outputs.
+- UI work belongs under `ui/routes/` and `ui/components/`, following the existing NiceGUI composition style.
+- CLI behavior belongs under `cli/` and must call the same service-layer paths as UI/API flows.
+- Persistence work belongs under `models/` with Alembic migrations when schema changes are required.
+- Documentation required by a story should be updated in the same workstream.
+
+### Testing Requirements
+
+- Use standard-library `unittest` in the existing `tests/test_*` layout.
+- Add focused regression tests for the layer changed by the story before broad refactors.
+- For Python changes, run `./.venv/bin/ruff check .`, `./.venv/bin/ruff format --check .`, and `./.venv/bin/python -m unittest discover -q` before closing implementation.
+- Use `bash scripts/ci-local.sh` for broader or cross-layer changes.
+
+### Project Structure Notes
+
+- Follow the current repository shape documented in `_bmad-output/project-context.md` and `AGENTS.md`.
+- If implementation reveals a conflict between this story and the current code baseline, keep the smallest compatible change and update the story notes rather than silently drifting from the PRD.
+
+### References
+
+- `_bmad-output/planning-artifacts/epics.md` - source Epic 0 / Story 0.2 definition.
+- `_bmad-output/planning-artifacts/prd.md` - functional and non-functional requirements.
+- `_bmad-output/planning-artifacts/architecture.md` - target architecture, boundaries, and guardrails.
+- `_bmad-output/planning-artifacts/ux-design-specification.md` - UX expectations for user-facing stories.
+- `_bmad-output/planning-artifacts/implementation-readiness-report-2026-05-01.md` - readiness verdict and residual story-format concern.
+- `_bmad-output/project-context.md` - repository-specific implementation rules.
+
+## Dev Agent Record
+
+### Agent Model Used
+
+GPT-5
+
+### Debug Log References
+
+- `./.venv/bin/python -m unittest tests.test_infra.test_maintainer_ownership -q` initially failed before implementation because `MAINTAINERS.md` was missing and major repository areas were not explicitly routed in CODEOWNERS.
+- `./.venv/bin/python -m unittest tests.test_infra.test_maintainer_ownership -q` passed after adding maintainer ownership docs and CODEOWNERS area coverage.
+- `./.venv/bin/ruff check tests/test_infra/test_maintainer_ownership.py` passed.
+- `./.venv/bin/ruff format tests/test_infra/test_maintainer_ownership.py` reformatted the new test file.
+- `./.venv/bin/python -m unittest tests.test_infra.test_maintainer_ownership tests.test_infra.test_skill_contribution_workflow -q` passed after restoring the explicit `/tests/skill-tests/` CODEOWNERS route required by existing contribution workflow guardrails.
+- `./.venv/bin/ruff check .` passed.
+- `./.venv/bin/ruff format --check .` passed.
+- `./.venv/bin/python -m unittest discover -q` passed with 219 tests run and 1 skipped.
+- `bash scripts/ci-local.sh` passed; local Bandit scan was skipped because Bandit is not installed in the environment.
+- `./.venv/bin/python -m unittest tests.test_infra.test_maintainer_ownership tests.test_infra.test_skill_contribution_workflow -q` passed after fixing review findings.
+- `./.venv/bin/ruff check .` passed after fixing review findings.
+- `./.venv/bin/ruff format --check .` passed after fixing review findings.
+- `./.venv/bin/python -m unittest discover -q` passed with 219 tests run and 1 skipped after fixing review findings.
+- `./.venv/bin/python -m unittest tests.test_infra.test_maintainer_ownership tests.test_infra.test_skill_contribution_workflow -q` passed after adding `_bmad/` ownership coverage.
+- `./.venv/bin/ruff check .` passed after adding `_bmad/` ownership coverage.
+- `./.venv/bin/ruff format --check .` passed after adding `_bmad/` ownership coverage.
+- `./.venv/bin/python -m unittest discover -q` passed with 219 tests run and 1 skipped after adding `_bmad/` ownership coverage.
+
+### Completion Notes List
+
+- Added public `MAINTAINERS.md` with current maintainer, responsibilities, maintainer areas, known coverage gaps, and ownership update process.
+- Expanded `.github/CODEOWNERS` so major repository areas route to the current maintainer.
+- Added deterministic infrastructure guardrail coverage that verifies CODEOWNERS routes major areas and that `MAINTAINERS.md` explains responsibilities, area ownership, and coverage gaps.
+- Resolved review finding by adding explicit ownership coverage for all tracked top-level repository areas.
+- Resolved follow-up review finding by adding explicit `_bmad/` ownership coverage.
+
+### File List
+
+- `.github/CODEOWNERS`
+- `MAINTAINERS.md`
+- `_bmad-output/implementation-artifacts/0-2-define-maintainer-ownership-and-codeowners.md`
+- `_bmad-output/implementation-artifacts/sprint-status.yaml`
+- `tests/test_infra/test_maintainer_ownership.py`
+
+## Change Log
+
+- 2026-05-01: Story created/aligned from updated PRD, architecture, epics, sprint status, and readiness report.
+- 2026-05-04: Implemented maintainer ownership documentation, CODEOWNERS area routing, and infra guardrail tests.

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -44,7 +44,7 @@ story_location: _bmad-output/implementation-artifacts
 development_status:
   epic-0: in-progress
   0-1-publish-core-governance-files: done
-  0-2-define-maintainer-ownership-and-codeowners: ready-for-dev
+  0-2-define-maintainer-ownership-and-codeowners: done
   0-3-create-requirements-traceability-matrix: ready-for-dev
   0-4-establish-rfc-and-decision-process: ready-for-dev
   epic-0-retrospective: optional

--- a/tests/test_infra/test_maintainer_ownership.py
+++ b/tests/test_infra/test_maintainer_ownership.py
@@ -1,0 +1,100 @@
+"""Guardrails for maintainer ownership and CODEOWNERS coverage."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import re
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[2]
+CODEOWNERS = ROOT / ".github" / "CODEOWNERS"
+MAINTAINERS = ROOT / "MAINTAINERS.md"
+
+MAJOR_REPOSITORY_AREAS = {
+    ".agents": "/.agents/",
+    "_bmad": "/_bmad/",
+    "_bmad-output": "/_bmad-output/",
+    ".github": "/.github/",
+    "api": "/api/",
+    "analysis": "/analysis/",
+    "cli": "/cli/",
+    "data": "/data/",
+    "docs": "/docs/",
+    "evidence": "/evidence/",
+    "integrations": "/integrations/",
+    "llm": "/llm/",
+    "migrations": "/migrations/",
+    "models": "/models/",
+    "parsers": "/parsers/",
+    "samples": "/samples/",
+    "schemas": "/schemas/",
+    "scripts": "/scripts/",
+    "services": "/services/",
+    "skills": "/skills/",
+    "tests": "/tests/",
+    "ui": "/ui/",
+}
+
+REQUIRED_MAINTAINERS_SECTIONS = (
+    "## Current Maintainers",
+    "## Maintainer Responsibilities",
+    "## Maintainer Areas",
+    "## Known Coverage Gaps",
+    "## Ownership Updates",
+)
+
+
+def _codeowners_rules() -> dict[str, tuple[str, ...]]:
+    rules: dict[str, tuple[str, ...]] = {}
+    for line in CODEOWNERS.read_text(encoding="utf-8").splitlines():
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        pattern, *owners = stripped.split()
+        rules[pattern] = tuple(owners)
+    return rules
+
+
+class MaintainerOwnershipTests(unittest.TestCase):
+    """Verify public maintainer ownership stays actionable."""
+
+    def test_codeowners_routes_major_repository_areas(self) -> None:
+        rules = _codeowners_rules()
+        missing = [
+            area
+            for area, pattern in MAJOR_REPOSITORY_AREAS.items()
+            if pattern not in rules or not rules[pattern]
+        ]
+
+        self.assertEqual([], missing)
+
+    def test_maintainers_document_exists_and_explains_process(self) -> None:
+        self.assertTrue(MAINTAINERS.is_file())
+
+        content = MAINTAINERS.read_text(encoding="utf-8")
+        missing_sections = [
+            section
+            for section in REQUIRED_MAINTAINERS_SECTIONS
+            if section not in content
+        ]
+
+        self.assertEqual([], missing_sections)
+        self.assertIn("@pramodksahoo", content)
+        self.assertRegex(content.lower(), r"\breview\b")
+        self.assertRegex(content.lower(), r"\bsecurity\b")
+        self.assertRegex(content.lower(), r"\bcoverage gap")
+
+    def test_maintainers_document_maps_codeowners_areas(self) -> None:
+        content = MAINTAINERS.read_text(encoding="utf-8")
+        missing = [
+            area
+            for area in MAJOR_REPOSITORY_AREAS
+            if not re.search(rf"`{re.escape(area)}`|`/{re.escape(area)}/`", content)
+        ]
+
+        self.assertEqual([], missing)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Story 0.2 establishes explicit maintainer ownership so major repository areas request accountable review instead of relying on an implicit catch-all owner. The change documents current ownership responsibilities, known coverage gaps, and update rules while adding infrastructure tests that keep CODEOWNERS and MAINTAINERS aligned.

Constraint: Story 0.2 requires major repository areas to route through CODEOWNERS and MAINTAINERS.md to explain responsibilities and coverage gaps
Rejected: Rely only on the wildcard CODEOWNERS rule | it requests review but does not document maintainership areas or make gaps visible
Confidence: high
Scope-risk: narrow
Directive: Keep MAINTAINERS.md, CODEOWNERS, and tests/test_infra/test_maintainer_ownership.py synchronized when adding or renaming top-level ownership areas
Tested: ./.venv/bin/python -m unittest tests.test_infra.test_maintainer_ownership tests.test_infra.test_skill_contribution_workflow -q
Tested: ./.venv/bin/ruff check .
Tested: ./.venv/bin/ruff format --check .
Tested: ./.venv/bin/python -m unittest discover -q
Not-tested: GitHub-hosted CODEOWNERS review-request UI behavior on an opened pull request

## What does this PR do?

<!-- Brief description of changes -->

## Type of change
- [ ] Feature (new functionality)
- [ ] Bugfix (non-breaking fix)
- [ ] Release preparation
- [ ] Hotfix (critical production fix)
- [ ] Docs / refactor / chore

## Checklist
- [ ] I have followed the branch naming convention
- [ ] Tests pass locally (`pytest tests/ -v`)
- [ ] Linting passes (`ruff check .`)
- [ ] Docker build succeeds
- [ ] I have updated docs if needed
- [ ] No secrets or .env values committed

## Related issue
Closes #