### PR TITLE
Make major project decisions publicly traceable

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -12,9 +12,9 @@ DeployWhisper is an open-source, self-hosted project for evidence-backed pre-dep
 
 ## Decision Making
 
-Day-to-day changes are reviewed through pull requests. Larger changes that affect architecture, governance, security posture, public roadmap, supported interfaces, or compatibility expectations should use the RFC process once that process is published.
+Day-to-day changes are reviewed through pull requests. Larger changes that affect architecture, governance, security posture, public roadmap, supported interfaces, or compatibility expectations use the public RFC process in `docs/rfcs/README.md`.
 
-Until the full RFC process is available, maintainers should record major decisions in planning artifacts, pull request descriptions, or issue discussions and link them from the related work.
+Accepted RFCs must record the decision outcome and link back to relevant PRD or architecture sections. When an accepted RFC changes the current PRD or architecture, maintainers must track the required planning update in the RFC decision record.
 
 ## Maintainer Model
 
@@ -43,3 +43,4 @@ Core DeployWhisper capabilities should remain usable in a self-hosted environmen
 - `SECURITY.md` explains vulnerability reporting and security boundaries.
 - `SUPPORT.md` explains community support expectations.
 - `ROADMAP.md` publishes current roadmap direction.
+- `docs/rfcs/README.md` defines the public RFC and decision process for major changes.

--- a/_bmad-output/implementation-artifacts/0-4-establish-rfc-and-decision-process.md
+++ b/_bmad-output/implementation-artifacts/0-4-establish-rfc-and-decision-process.md
@@ -1,0 +1,118 @@
+# Story 0.4: Establish RFC and Decision Process
+
+Status: done
+
+<!-- Generated from updated PRD/architecture/epics plus implementation-readiness-report-2026-05-01.md. -->
+
+## Story
+
+As a maintainer,
+I want major design decisions to use a public RFC process,
+So that architecture, roadmap, and governance changes remain auditable.
+
+## Acceptance Criteria
+
+1. Given a change affects architecture, governance, security, or roadmap scope, When maintainers propose it, Then the RFC process defines required sections, review expectations, and decision recording. And accepted decisions link back to relevant PRD or architecture sections.
+
+### Requirement Traceability
+
+- Primary PRD requirements: Epic 0 coverage: GOV-01..15, NFR-OSS-01..05, DOC-15, DOC-19, DOC-20.
+- Supporting PRD / NFR / differentiation requirements: See `_bmad-output/planning-artifacts/prd.md`, `_bmad-output/planning-artifacts/architecture.md`, and `_bmad-output/planning-artifacts/implementation-readiness-report-2026-05-01.md`.
+- Coverage intent: Baseline + Delta.
+- Story alignment note: This story was created from the updated Epic 0 plan after the 2026-05-01 readiness rerun. The readiness report verified 187/187 PRD functional requirement IDs in the epics artifact, 38 NFR IDs present, and no critical or major readiness defects.
+
+## Tasks / Subtasks
+
+- [x] Implement and verify acceptance criterion 1. (AC: 1)
+- [x] Reuse existing services, repositories, schemas, and UI/CLI/API helpers before adding new abstractions. (AC: all)
+- [x] Add or update deterministic regression coverage for the changed behavior. (AC: all)
+- [x] Update relevant docs or examples if the story changes user-visible, operator, API, CLI, integration, or contribution behavior. (AC: all)
+- [x] Run required validation and record commands/results in the Dev Agent Record. (AC: all)
+
+## Dev Notes
+
+### Epic Context
+
+- Epic: 0. Open Governance, Traceability, and Maintainer Ownership
+- Epic goal: Establish the public project foundation needed for open-source trust, contribution, and roadmap accountability.
+- Epic coverage: GOV-01..15, NFR-OSS-01..05, DOC-15, DOC-19, DOC-20
+
+### Architecture and Product Guardrails
+
+- Preserve DeployWhisper's local-first raw artifact boundary: raw IaC, scanner artifacts, incident exports, and sensitive context stay in the user's infrastructure by default.
+- Preserve the advisory-first core. Optional adapters may interpret report outputs, but canonical report semantics remain advisory unless explicit story scope says otherwise.
+- Reuse the shared analysis core and service layer before adapting UI, API, CLI, GitHub, or future workflow surfaces.
+- Keep Evidence Law behavior intact: no high or critical finding without deterministic evidence.
+- Keep project/workspace scope explicit for reports, incidents, topology, outcomes, feedback, scanner imports, and connector-related data.
+- Do not introduce new dependencies unless the active story explicitly requires and justifies them.
+
+### Source Tree Guidance
+
+- API routes belong under `api/routes/` and should use existing `ApiRoute` / `ApiError` envelope patterns.
+- Shared orchestration belongs in `services/`; parsers normalize input, analysis modules score/derive risk, and surfaces adapt outputs.
+- UI work belongs under `ui/routes/` and `ui/components/`, following the existing NiceGUI composition style.
+- CLI behavior belongs under `cli/` and must call the same service-layer paths as UI/API flows.
+- Persistence work belongs under `models/` with Alembic migrations when schema changes are required.
+- Documentation required by a story should be updated in the same workstream.
+
+### Testing Requirements
+
+- Use standard-library `unittest` in the existing `tests/test_*` layout.
+- Add focused regression tests for the layer changed by the story before broad refactors.
+- For Python changes, run `./.venv/bin/ruff check .`, `./.venv/bin/ruff format --check .`, and `./.venv/bin/python -m unittest discover -q` before closing implementation.
+- Use `bash scripts/ci-local.sh` for broader or cross-layer changes.
+
+### Project Structure Notes
+
+- Follow the current repository shape documented in `_bmad-output/project-context.md` and `AGENTS.md`.
+- If implementation reveals a conflict between this story and the current code baseline, keep the smallest compatible change and update the story notes rather than silently drifting from the PRD.
+
+### References
+
+- `_bmad-output/planning-artifacts/epics.md` - source Epic 0 / Story 0.4 definition.
+- `_bmad-output/planning-artifacts/prd.md` - functional and non-functional requirements.
+- `_bmad-output/planning-artifacts/architecture.md` - target architecture, boundaries, and guardrails.
+- `_bmad-output/planning-artifacts/ux-design-specification.md` - UX expectations for user-facing stories.
+- `_bmad-output/planning-artifacts/implementation-readiness-report-2026-05-01.md` - readiness verdict and residual story-format concern.
+- `_bmad-output/project-context.md` - repository-specific implementation rules.
+
+## Dev Agent Record
+
+### Agent Model Used
+
+GPT-5
+
+### Debug Log References
+
+- `./.venv/bin/python -m unittest tests.test_infra.test_rfc_decision_process.RfcDecisionProcessTests.test_rfc_process_and_template_exist -v` failed before implementation because `docs/rfcs/README.md` and `docs/rfcs/0000-template.md` were missing.
+- `./.venv/bin/python -m unittest tests.test_infra.test_rfc_decision_process.RfcDecisionProcessTests -q` passed after adding the RFC process, template, and governance link.
+- `./.venv/bin/python -m unittest tests.test_infra.test_governance_files -q` passed after updating `GOVERNANCE.md`.
+- `./.venv/bin/ruff check .` passed.
+- `./.venv/bin/ruff format --check .` passed.
+- `./.venv/bin/python -m unittest discover -q` passed with 225 tests run and 1 skipped.
+- `bash scripts/ci-local.sh` passed; local Bandit scan was skipped because Bandit is not installed in the environment.
+- `bmad-code-review` found 0 decision-needed, 0 patch, and 0 deferred findings.
+- `./.venv/bin/python -m unittest tests.test_infra.test_rfc_decision_process.RfcDecisionProcessTests -q` passed during code review.
+- `./.venv/bin/python -m unittest tests.test_infra.test_governance_files -q` passed during code review.
+
+### Completion Notes List
+
+- Added a public RFC process under `docs/rfcs/README.md` defining when major architecture, governance, security, and roadmap changes require an RFC.
+- Added `docs/rfcs/0000-template.md` with required sections for summary, motivation, PRD and architecture links, design, security/privacy, compatibility, alternatives, review plan, and decision record.
+- Updated `GOVERNANCE.md` to point major decisions to the published RFC process and require accepted RFCs to link back to PRD or architecture sections.
+- Added deterministic infrastructure guardrails that verify the RFC process, template, review expectations, decision states, and governance cross-link remain present.
+- Code review completed cleanly with no new findings.
+
+### File List
+
+- `GOVERNANCE.md`
+- `_bmad-output/implementation-artifacts/0-4-establish-rfc-and-decision-process.md`
+- `_bmad-output/implementation-artifacts/sprint-status.yaml`
+- `docs/rfcs/0000-template.md`
+- `docs/rfcs/README.md`
+- `tests/test_infra/test_rfc_decision_process.py`
+
+## Change Log
+
+- 2026-05-01: Story created/aligned from updated PRD, architecture, epics, sprint status, and readiness report.
+- 2026-05-04: Implemented the public RFC process, RFC template, governance cross-link, and deterministic RFC guardrail tests.

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -46,7 +46,7 @@ development_status:
   0-1-publish-core-governance-files: done
   0-2-define-maintainer-ownership-and-codeowners: done
   0-3-create-requirements-traceability-matrix: ready-for-dev
-  0-4-establish-rfc-and-decision-process: ready-for-dev
+  0-4-establish-rfc-and-decision-process: done
   epic-0-retrospective: optional
 
   epic-1: in-progress

--- a/docs/rfcs/0000-template.md
+++ b/docs/rfcs/0000-template.md
@@ -1,0 +1,49 @@
+# RFC 0000: Short Title
+
+## Summary
+
+One or two paragraphs describing the proposed decision and the affected product or governance area.
+
+## Motivation
+
+Explain the user, maintainer, security, architecture, roadmap, or governance problem that makes this RFC necessary.
+
+## PRD and Architecture Links
+
+- PRD sections:
+- Architecture sections:
+- Related epics or stories:
+- Prior RFCs or decisions:
+
+Accepted RFCs must link the decision back to relevant PRD or architecture sections. If the proposal changes either planning artifact, list the required follow-up update.
+
+## Detailed Design
+
+Describe the proposed design, process, policy, API, workflow, or compatibility behavior in enough detail for maintainers and contributors to evaluate it.
+
+## Security and Privacy
+
+Explain impacts to raw artifact handling, credential handling, local-first boundaries, advisory-first behavior, vulnerability reporting, signing, provenance, or other security expectations.
+
+## Compatibility and Migration
+
+Document compatibility impacts, deprecations, migration steps, rollout order, and any user-visible behavior changes.
+
+## Alternatives Considered
+
+List meaningful alternatives and why they were rejected.
+
+## Review Plan
+
+- Required CODEOWNERS reviewers:
+- Required security, architecture, governance, or roadmap reviewers:
+- Minimum review window:
+- Public discussion links:
+
+## Decision Record
+
+- Status: Proposed
+- Decision date:
+- Approving maintainers:
+- Outcome rationale:
+- Follow-up issues, stories, or documentation updates:

--- a/docs/rfcs/README.md
+++ b/docs/rfcs/README.md
@@ -1,0 +1,82 @@
+# DeployWhisper RFC Process
+
+DeployWhisper uses public RFCs for major decisions that change project direction, trust boundaries, or long-lived contributor expectations. The process keeps architecture, roadmap, governance, and security decisions auditable and traceable to the PRD and architecture.
+
+## When An RFC Is Required
+
+Open an RFC before implementation when a proposed change affects any of these areas:
+
+- Architecture, runtime boundaries, persistence contracts, report schemas, API contracts, CLI contracts, or supported integration surfaces.
+- Governance, maintainer ownership, contribution policy, release policy, community process, or CNCF readiness posture.
+- Security posture, local-first boundaries, raw artifact handling, credential handling, signing, provenance, or vulnerability disclosure expectations.
+- Roadmap scope, supported platforms, compatibility guarantees, deprecations, or public project priorities.
+
+Routine bug fixes, small documentation updates, test-only changes, and implementation details that do not change public behavior usually do not need an RFC. Maintainers can request an RFC during issue or pull request review if the change is larger than it first appears.
+
+## RFC Lifecycle
+
+1. Copy `docs/rfcs/0000-template.md` to `docs/rfcs/NNNN-short-title.md`.
+2. Fill every required section before requesting review.
+3. Open a pull request that adds the RFC file and links any related issue, PRD section, architecture section, or prior decision.
+4. Keep the RFC in `Proposed` while discussion is active.
+5. Move the RFC to `Accepted`, `Rejected`, or `Withdrawn` when maintainers record the outcome.
+
+Accepted RFCs must link back to relevant PRD sections and architecture sections in the `PRD and Architecture Links` section. If the decision intentionally diverges from the current PRD or architecture, the RFC must identify the follow-up planning artifact update that brings them back into alignment.
+
+## Required Sections
+
+Every RFC must include:
+
+- Summary.
+- Motivation.
+- PRD and architecture links.
+- Detailed design.
+- Security and privacy considerations.
+- Compatibility and migration notes.
+- Alternatives considered.
+- Review plan.
+- Decision record.
+
+Use the template as the source of truth for the exact headings.
+
+## Review Expectations
+
+RFC review happens in public pull request discussion unless the topic requires private security handling under `SECURITY.md`.
+
+- The minimum review window is 7 calendar days for architecture, governance, security, roadmap, compatibility, or deprecation RFCs.
+- The pull request must request review from the relevant CODEOWNERS area.
+- Security-affecting RFCs must include a maintainer familiar with the local-first and raw-artifact boundaries.
+- Governance or roadmap RFCs must include maintainer review from the project governance owners.
+- Architecture RFCs must explain how the proposal preserves the shared analysis core and advisory-first posture.
+- Reviewers should check whether linked PRD and architecture sections are current and whether follow-up planning updates are required.
+
+Maintainers may extend the review window for high-impact or contested changes. Emergency security work may proceed faster, but the RFC must still be recorded after the private remediation path is complete.
+
+## Decision Recording
+
+The decision record must use one of these states:
+
+- `Proposed`: under active review.
+- `Accepted`: approved for implementation or already implemented.
+- `Rejected`: reviewed and declined.
+- `Withdrawn`: closed by the author before a final maintainer decision.
+
+Accepted decisions must record:
+
+- The approving maintainers.
+- The decision date.
+- The linked PRD and architecture sections.
+- Required follow-up issues, stories, documentation updates, or migration notes.
+- Any compatibility, security, or governance constraints future maintainers must preserve.
+
+Rejected and withdrawn RFCs should still keep their rationale so future contributors do not repeat the same proposal without new evidence.
+
+## File Naming
+
+Use `docs/rfcs/NNNN-short-title.md`.
+
+- `NNNN` is the next available four-digit number.
+- Use lowercase words separated by hyphens.
+- Keep the title short and descriptive.
+
+Example: `docs/rfcs/0001-report-schema-versioning.md`

--- a/tests/test_infra/test_rfc_decision_process.py
+++ b/tests/test_infra/test_rfc_decision_process.py
@@ -1,0 +1,89 @@
+"""Guardrails for the public RFC and decision process."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import re
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[2]
+RFC_PROCESS = ROOT / "docs" / "rfcs" / "README.md"
+RFC_TEMPLATE = ROOT / "docs" / "rfcs" / "0000-template.md"
+GOVERNANCE = ROOT / "GOVERNANCE.md"
+
+REQUIRED_PROCESS_TERMS = (
+    "architecture",
+    "governance",
+    "security",
+    "roadmap",
+)
+
+REQUIRED_TEMPLATE_HEADINGS = (
+    "## Summary",
+    "## Motivation",
+    "## PRD and Architecture Links",
+    "## Detailed Design",
+    "## Security and Privacy",
+    "## Compatibility and Migration",
+    "## Alternatives Considered",
+    "## Review Plan",
+    "## Decision Record",
+)
+
+REQUIRED_DECISION_STATES = ("proposed", "accepted", "rejected", "withdrawn")
+
+
+def _normalized(path: Path) -> str:
+    return re.sub(r"\s+", " ", path.read_text(encoding="utf-8").lower())
+
+
+class RfcDecisionProcessTests(unittest.TestCase):
+    """Verify major public decisions stay traceable to planning artifacts."""
+
+    def test_rfc_process_and_template_exist(self) -> None:
+        self.assertTrue(RFC_PROCESS.is_file())
+        self.assertTrue(RFC_TEMPLATE.is_file())
+
+    def test_rfc_process_defines_when_rfc_is_required(self) -> None:
+        content = _normalized(RFC_PROCESS)
+
+        missing_terms = [term for term in REQUIRED_PROCESS_TERMS if term not in content]
+
+        self.assertEqual([], missing_terms)
+        self.assertIn("major", content)
+        self.assertIn("rfc", content)
+
+    def test_rfc_template_defines_required_sections(self) -> None:
+        content = RFC_TEMPLATE.read_text(encoding="utf-8")
+        missing_headings = [
+            heading for heading in REQUIRED_TEMPLATE_HEADINGS if heading not in content
+        ]
+
+        self.assertEqual([], missing_headings)
+
+    def test_review_expectations_and_decision_recording_are_explicit(self) -> None:
+        content = _normalized(RFC_PROCESS)
+        missing_states = [
+            state for state in REQUIRED_DECISION_STATES if state not in content
+        ]
+
+        self.assertEqual([], missing_states)
+        self.assertIn("codeowners", content)
+        self.assertIn("review window", content)
+        self.assertIn("decision record", content)
+
+    def test_accepted_decisions_must_link_to_prd_or_architecture(self) -> None:
+        content = _normalized(RFC_PROCESS)
+
+        self.assertRegex(content, r"accepted.{0,160}prd")
+        self.assertRegex(content, r"accepted.{0,160}architecture")
+
+    def test_governance_links_to_rfc_process(self) -> None:
+        content = GOVERNANCE.read_text(encoding="utf-8")
+
+        self.assertIn("docs/rfcs/README.md", content)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Story 0.4 needed an auditable RFC path for architecture, governance, security, and roadmap changes. This publishes the RFC process, adds a reusable template, links governance to the process, and locks the required sections, review expectations, decision states, and PRD/architecture traceability with deterministic infra tests.

Constraint: Story 0.4 acceptance criteria require major decisions to define required sections, review expectations, decision recording, and accepted-decision links to PRD or architecture sections
Rejected: Keep major decisions only in PR descriptions or issues | not durable enough for public governance and CNCF-readiness evidence
Confidence: high
Scope-risk: narrow
Directive: Future major architecture, governance, security, roadmap, compatibility, or deprecation changes should update or add RFCs under docs/rfcs before implementation
Tested: ./.venv/bin/python -m unittest tests.test_infra.test_rfc_decision_process.RfcDecisionProcessTests -q
Tested: ./.venv/bin/python -m unittest tests.test_infra.test_governance_files -q
Tested: ./.venv/bin/ruff check .
Tested: ./.venv/bin/ruff format --check .
Tested: ./.venv/bin/python -m unittest discover -q
Tested: bash scripts/ci-local.sh
Not-tested: Bandit scan; local CI skipped it because Bandit is not installed

## What does this PR do?

<!-- Brief description of changes -->

## Type of change
- [ ] Feature (new functionality)
- [ ] Bugfix (non-breaking fix)
- [ ] Release preparation
- [ ] Hotfix (critical production fix)
- [ ] Docs / refactor / chore

## Checklist
- [ ] I have followed the branch naming convention
- [ ] Tests pass locally (`pytest tests/ -v`)
- [ ] Linting passes (`ruff check .`)
- [ ] Docker build succeeds
- [ ] I have updated docs if needed
- [ ] No secrets or .env values committed

## Related issue
Closes #