### PR TITLE
Make project workspace scoping durable

### DIFF
--- a/_bmad-output/implementation-artifacts/1-1-project-and-workspace-records.md
+++ b/_bmad-output/implementation-artifacts/1-1-project-and-workspace-records.md
@@ -1,0 +1,148 @@
+# Story 1.1: Project and Workspace Records
+
+Status: done
+
+<!-- Generated from updated PRD/architecture/epics plus implementation-readiness-report-2026-05-01.md. -->
+
+## Story
+
+As a platform admin,
+I want first-class project and workspace records,
+So that analysis, reports, and future context can be scoped before shared usage expands.
+
+## Acceptance Criteria
+
+1. Given a self-hosted DeployWhisper instance, When an admin creates projects and workspaces, Then project and workspace/environment records are represented with stable keys, display names, descriptions, and timestamps. And migrations only add the entities needed for project/workspace selection and lookup.
+2. Given a duplicate, missing, or invalid project key is submitted, When project or workspace validation runs, Then the user receives an explicit error and no partial project/workspace record is created.
+
+### Requirement Traceability
+
+- Primary PRD requirements: Epic 1 coverage: PRJ-01..10, HIS-08, NFR-SEC-07, DOC-22.
+- Supporting PRD / NFR / differentiation requirements: See `_bmad-output/planning-artifacts/prd.md`, `_bmad-output/planning-artifacts/architecture.md`, and `_bmad-output/planning-artifacts/implementation-readiness-report-2026-05-01.md`.
+- Coverage intent: Baseline + Delta.
+- Story alignment note: This story was created from the updated Epic 1 plan after the 2026-05-01 readiness rerun. The readiness report verified 187/187 PRD functional requirement IDs in the epics artifact, 38 NFR IDs present, and no critical or major readiness defects.
+
+## Tasks / Subtasks
+
+- [x] Implement and verify acceptance criterion 1. (AC: 1)
+- [x] Implement and verify acceptance criterion 2. (AC: 2)
+- [x] Reuse existing services, repositories, schemas, and UI/CLI/API helpers before adding new abstractions. (AC: all)
+- [x] Add or update deterministic regression coverage for the changed behavior. (AC: all)
+- [x] Update relevant docs or examples if the story changes user-visible, operator, API, CLI, integration, or contribution behavior. (AC: all)
+- [x] Run required validation and record commands/results in the Dev Agent Record. (AC: all)
+
+### Review Findings
+
+- [x] [Review][Patch] Duplicate workspace creation can raise an uncaught database `IntegrityError` instead of the explicit duplicate-key error contract [services/project_service.py:222]
+- [x] [Review][Patch] Explicit workspace list calls validate the requested project only after `ensure_default_project()` can mutate the database [services/project_service.py:251]
+- [x] [Review][Patch] Workspace API routes return `400` for `project_not_found` instead of the existing project-aware `404` contract [api/routes/projects.py:65]
+- [x] [Review][Patch] Workspace persistence and API expose an unused `is_default` field outside Story 1.1's represented-record scope [migrations/versions/014_add_project_workspace_records.py:29]
+- [x] [Review][Patch] Brownfield migration repair can stamp revision `014` without verifying the full `project_workspaces` schema contract [models/database.py:216]
+- [x] [Review][Patch] Omitted `project_key` workspace listing returns all project workspaces instead of the default project's workspaces [services/project_service.py:255]
+- [x] [Review][Patch] Explicit blank workspace list project key is treated as omitted and can still create the default project [services/project_service.py:255]
+- [x] [Review][Patch] Brownfield workspace schema validation does not verify required non-null column semantics before stamping revision `014` [models/database.py:177]
+- [x] [Review][Patch] Brownfield init can skip a stray partial `project_workspaces` table when baseline tables are absent [models/database.py:220]
+- [x] [Review][Patch] Workspace creation maps every `IntegrityError` to a duplicate workspace key error [services/project_service.py:230]
+- [x] [Review][Patch] Concurrent duplicate project creation can raise uncaught database `IntegrityError` instead of the explicit duplicate project-key error contract [services/project_service.py:204]
+- [x] [Review][Patch] Workspace creation can surface raw foreign-key `IntegrityError` if the project disappears between validation and insert [services/project_service.py:259]
+- [x] [Review][Patch] Brownfield workspace schema validation does not verify `id` primary-key or workspace column type compatibility before stamping revision `014` [models/database.py:177]
+- [x] [Review][Patch] Workspace migration file is untracked and would be omitted from commit/push unless explicitly added [migrations/versions/014_add_project_workspace_records.py]
+
+## Dev Notes
+
+### Epic Context
+
+- Epic: 1. Project, Workspace, and RBAC Foundation
+- Epic goal: Make DeployWhisper project-aware before reports, incidents, topology, scanner imports, and feedback become harder to migrate.
+- Epic coverage: PRJ-01..10, HIS-08, NFR-SEC-07, DOC-22
+
+### Architecture and Product Guardrails
+
+- Preserve DeployWhisper's local-first raw artifact boundary: raw IaC, scanner artifacts, incident exports, and sensitive context stay in the user's infrastructure by default.
+- Preserve the advisory-first core. Optional adapters may interpret report outputs, but canonical report semantics remain advisory unless explicit story scope says otherwise.
+- Reuse the shared analysis core and service layer before adapting UI, API, CLI, GitHub, or future workflow surfaces.
+- Keep Evidence Law behavior intact: no high or critical finding without deterministic evidence.
+- Keep project/workspace scope explicit for reports, incidents, topology, outcomes, feedback, scanner imports, and connector-related data.
+- Do not introduce new dependencies unless the active story explicitly requires and justifies them.
+
+### Source Tree Guidance
+
+- API routes belong under `api/routes/` and should use existing `ApiRoute` / `ApiError` envelope patterns.
+- Shared orchestration belongs in `services/`; parsers normalize input, analysis modules score/derive risk, and surfaces adapt outputs.
+- UI work belongs under `ui/routes/` and `ui/components/`, following the existing NiceGUI composition style.
+- CLI behavior belongs under `cli/` and must call the same service-layer paths as UI/API flows.
+- Persistence work belongs under `models/` with Alembic migrations when schema changes are required.
+- Documentation required by a story should be updated in the same workstream.
+
+### Testing Requirements
+
+- Use standard-library `unittest` in the existing `tests/test_*` layout.
+- Add focused regression tests for the layer changed by the story before broad refactors.
+- For Python changes, run `./.venv/bin/ruff check .`, `./.venv/bin/ruff format --check .`, and `./.venv/bin/python -m unittest discover -q` before closing implementation.
+- Use `bash scripts/ci-local.sh` for broader or cross-layer changes.
+
+### Project Structure Notes
+
+- Follow the current repository shape documented in `_bmad-output/project-context.md` and `AGENTS.md`.
+- If implementation reveals a conflict between this story and the current code baseline, keep the smallest compatible change and update the story notes rather than silently drifting from the PRD.
+
+### References
+
+- `_bmad-output/planning-artifacts/epics.md` - source Epic 1 / Story 1.1 definition.
+- `_bmad-output/planning-artifacts/prd.md` - functional and non-functional requirements.
+- `_bmad-output/planning-artifacts/architecture.md` - target architecture, boundaries, and guardrails.
+- `_bmad-output/planning-artifacts/ux-design-specification.md` - UX expectations for user-facing stories.
+- `_bmad-output/planning-artifacts/implementation-readiness-report-2026-05-01.md` - readiness verdict and residual story-format concern.
+- `_bmad-output/project-context.md` - repository-specific implementation rules.
+
+## Dev Agent Record
+
+### Agent Model Used
+
+GPT-5 Codex
+
+### Debug Log References
+
+- 2026-05-04: Added failing service/API coverage for workspace creation, duplicate keys, invalid keys, and no partial record creation; confirmed failures before implementation.
+- 2026-05-04: Added `ProjectWorkspace` persistence, migration `014_add_project_workspace_records`, repository/service helpers, API schemas/routes, CLI workspace subcommands, and project-workspaces documentation updates.
+- 2026-05-04: Updated migration repair and container contract tests for the new migration head.
+- 2026-05-05: Fixed code-review findings for workspace duplicate race handling, explicit lookup side effects, project-not-found API status, unused workspace default state, and brownfield schema validation.
+- 2026-05-05: Fixed code-review rerun findings for default-only workspace listing, blank explicit project-key validation, non-null workspace schema validation, stray workspace-table detection, and narrowed integrity-error translation.
+- 2026-05-05: Fixed remaining code-review findings for duplicate project insert races, workspace foreign-key insert races, and primary-key/type validation for brownfield workspace schemas.
+- 2026-05-05: Fixed code-review rerun finding by explicitly staging the new workspace migration file for commit inclusion.
+
+### Completion Notes List
+
+- Project records continue to use the existing project service/repository/API path.
+- Workspace/environment records are now first-class project-local rows with stable keys, display names, optional descriptions, optional environment labels, timestamps, and duplicate protection per project.
+- Invalid or duplicate workspace requests fail before insertion, preserving the no-partial-record guarantee.
+- Admin creation/listing is available through API and CLI; docs now list the new workspace endpoints and CLI commands.
+- Code-review follow-up now translates database duplicate races into explicit workspace validation errors, keeps explicit workspace reads side-effect-free, returns `404` for unknown project-scoped workspace routes, removes unused workspace default state, and verifies the full workspace schema before brownfield revision stamping.
+- Code-review rerun follow-up now scopes omitted workspace listings to the default project, treats blank explicit project keys as invalid input, rejects nullable/stray workspace schemas during brownfield startup, and only rewrites unique workspace-key integrity failures as duplicate-key validation errors.
+- Remaining review follow-up now translates duplicate project insert races to the explicit project-key validation contract, maps workspace project foreign-key races to `project_not_found`, and rejects brownfield workspace tables with a missing primary key or incompatible reflected column types.
+- Code-review rerun follow-up now has the `014_add_project_workspace_records` migration staged so Git closeout includes the migration required by the story.
+
+### File List
+
+- `api/routes/projects.py`
+- `api/schemas.py`
+- `cli/analyze.py`
+- `docs/project-workspaces.md`
+- `migrations/versions/014_add_project_workspace_records.py`
+- `models/database.py`
+- `models/repositories/projects.py`
+- `models/tables.py`
+- `services/project_service.py`
+- `tests/test_api/test_projects.py`
+- `tests/test_cli/test_analyze.py`
+- `tests/test_infra/test_container_contract.py`
+- `tests/test_infra/test_migrations.py`
+- `tests/test_services/test_project_service.py`
+- `_bmad-output/implementation-artifacts/sprint-status.yaml`
+
+## Change Log
+
+- 2026-05-01: Story created/aligned from updated PRD, architecture, epics, sprint status, and readiness report.
+- 2026-05-04: Implemented first-class workspace records with API/CLI surfaces, migration support, docs, and regression coverage.
+- 2026-05-05: Addressed code-review findings for project/workspace race handling and stricter brownfield workspace schema validation.
+- 2026-05-05: Addressed code-review rerun finding by staging the workspace migration file for Git closeout.

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -1,5 +1,5 @@
 # generated: 2026-05-01
-# last_updated: 2026-05-04
+# last_updated: 2026-05-05
 # project: deploywhisper
 # project_key: NOKEY
 # tracking_system: file-system
@@ -35,7 +35,7 @@
 # - Dev moves story to review, then runs code-review
 
 generated: 2026-05-01
-last_updated: 2026-05-04
+last_updated: 2026-05-05
 project: deploywhisper
 project_key: NOKEY
 tracking_system: file-system
@@ -50,7 +50,7 @@ development_status:
   epic-0-retrospective: optional
 
   epic-1: in-progress
-  1-1-project-and-workspace-records: ready-for-dev
+  1-1-project-and-workspace-records: done
   1-2-project-aware-analysis-submission: ready-for-dev
   1-3-project-scoped-report-persistence: ready-for-dev
   1-4-project-scoped-learning-and-context-records: ready-for-dev

--- a/api/routes/projects.py
+++ b/api/routes/projects.py
@@ -10,15 +10,35 @@ from api.schemas import (
     ProjectData,
     ProjectListResponse,
     ProjectResponse,
+    WorkspaceCreateRequest,
+    WorkspaceData,
+    WorkspaceListResponse,
+    WorkspaceResponse,
     build_meta,
 )
 from services.project_service import (
     ProjectResolutionError,
     create_project,
+    create_workspace,
     list_projects,
+    list_workspaces,
 )
 
 router = APIRouter(prefix="/api/v1/projects", tags=["projects"], route_class=ApiRoute)
+
+
+def _project_api_error(
+    exc: ValueError,
+    *,
+    default_code: str = "invalid_project_request",
+) -> ApiError:
+    code = getattr(exc, "code", default_code)
+    status_code = 404 if code == "project_not_found" else 400
+    return ApiError(
+        status_code=status_code,
+        code=code,
+        message=str(exc),
+    )
 
 
 @router.get("", response_model=ProjectListResponse)
@@ -48,5 +68,38 @@ def create_project_route(payload: ProjectCreateRequest) -> ProjectResponse:
         ) from exc
     return ProjectResponse(
         data=ProjectData(**created.model_dump()),
+        meta=build_meta(id=created.id),
+    )
+
+
+@router.get("/{project_key}/workspaces", response_model=WorkspaceListResponse)
+def get_workspaces(project_key: str) -> WorkspaceListResponse:
+    try:
+        workspaces = list_workspaces(project_key=project_key)
+    except (ProjectResolutionError, ValueError) as exc:
+        raise _project_api_error(exc, default_code="invalid_workspace_request") from exc
+    return WorkspaceListResponse(
+        data=[WorkspaceData(**workspace.model_dump()) for workspace in workspaces],
+        meta=build_meta(count=len(workspaces)),
+    )
+
+
+@router.post("/{project_key}/workspaces", response_model=WorkspaceResponse)
+def create_workspace_route(
+    project_key: str,
+    payload: WorkspaceCreateRequest,
+) -> WorkspaceResponse:
+    try:
+        created = create_workspace(
+            project_key=project_key,
+            workspace_key=payload.workspace_key,
+            display_name=payload.display_name,
+            description=payload.description,
+            environment=payload.environment,
+        )
+    except (ProjectResolutionError, ValueError) as exc:
+        raise _project_api_error(exc, default_code="invalid_workspace_request") from exc
+    return WorkspaceResponse(
+        data=WorkspaceData(**created.model_dump()),
         meta=build_meta(id=created.id),
     )

--- a/api/schemas.py
+++ b/api/schemas.py
@@ -268,6 +268,29 @@ class ProjectCreateRequest(BaseModel):
     )
 
 
+class WorkspaceCreateRequest(BaseModel):
+    workspace_key: str = Field(..., description="Stable workspace/environment key")
+    display_name: str = Field(..., description="Human-readable workspace name")
+    description: str | None = Field(default=None, description="Optional description")
+    environment: str | None = Field(
+        default=None, description="Optional environment label such as prod or staging"
+    )
+
+
+class WorkspaceData(BaseModel):
+    id: int = Field(..., description="Stable workspace identifier")
+    project_id: int = Field(..., description="Owning project identifier")
+    project_key: str = Field(..., description="Owning stable project key")
+    workspace_key: str = Field(..., description="Stable workspace/environment key")
+    display_name: str = Field(..., description="Human-readable workspace name")
+    description: str | None = Field(default=None, description="Optional description")
+    environment: str | None = Field(
+        default=None, description="Optional environment label"
+    )
+    created_at: str = Field(..., description="Creation timestamp")
+    updated_at: str = Field(..., description="Last update timestamp")
+
+
 class ProjectListResponse(BaseModel):
     data: list[ProjectData]
     meta: ListMetaPayload
@@ -275,6 +298,16 @@ class ProjectListResponse(BaseModel):
 
 class ProjectResponse(BaseModel):
     data: ProjectData
+    meta: ResourceOnlyMetaPayload
+
+
+class WorkspaceListResponse(BaseModel):
+    data: list[WorkspaceData]
+    meta: ListMetaPayload
+
+
+class WorkspaceResponse(BaseModel):
+    data: WorkspaceData
     meta: ResourceOnlyMetaPayload
 
 

--- a/cli/analyze.py
+++ b/cli/analyze.py
@@ -37,7 +37,8 @@ from services.analysis_service import (
     build_share_summary,
 )
 from services.deployment_outcome_service import record_deployment_outcome
-from services.project_service import create_project, list_projects
+from services.project_service import create_project, create_workspace
+from services.project_service import list_projects, list_workspaces
 from services.project_service import resolve_project_reference
 from services.intake_service import (
     MAX_TOTAL_UPLOAD_BYTES,
@@ -380,6 +381,43 @@ def _run_project_list() -> int:
     return 0
 
 
+def _run_project_workspace_create(args: argparse.Namespace) -> int:
+    try:
+        created = create_workspace(
+            project_key=args.project_key,
+            workspace_key=args.workspace_key,
+            display_name=args.display_name,
+            description=args.description,
+            environment=args.environment,
+        )
+    except ValueError as exc:
+        sys.stderr.write(f"{exc}\n")
+        return 2
+    print(
+        f"Created workspace {created.workspace_key} "
+        f"({created.display_name}) for project {created.project_key} "
+        f"[id={created.id}]"
+    )
+    return 0
+
+
+def _run_project_workspace_list(args: argparse.Namespace) -> int:
+    try:
+        workspaces = list_workspaces(project_key=args.project_key)
+    except ValueError as exc:
+        sys.stderr.write(f"{exc}\n")
+        return 2
+    for workspace in workspaces:
+        environment = (
+            f" ({workspace.environment})" if workspace.environment is not None else ""
+        )
+        print(
+            f"{workspace.project_key}/{workspace.workspace_key}: "
+            f"{workspace.display_name}{environment}"
+        )
+    return 0
+
+
 def _run_outcome_record(args: argparse.Namespace) -> int:
     try:
         recorded = record_deployment_outcome(
@@ -587,6 +625,33 @@ def build_parser() -> argparse.ArgumentParser:
         help="Optional default branch name.",
     )
     project_subparsers.add_parser("list", help="List known project/workspace records.")
+    project_workspace_parser = project_subparsers.add_parser(
+        "workspace", help="Manage workspace/environment records for a project."
+    )
+    workspace_subparsers = project_workspace_parser.add_subparsers(
+        dest="workspace_command"
+    )
+    workspace_subparsers.required = True
+    workspace_create_parser = workspace_subparsers.add_parser(
+        "create", help="Create a workspace/environment record."
+    )
+    workspace_create_parser.add_argument("project_key", help="Owning project key.")
+    workspace_create_parser.add_argument("workspace_key", help="Stable workspace key.")
+    workspace_create_parser.add_argument(
+        "display_name", help="Human-readable workspace name."
+    )
+    workspace_create_parser.add_argument(
+        "--description",
+        help="Optional workspace description.",
+    )
+    workspace_create_parser.add_argument(
+        "--environment",
+        help="Optional environment label such as prod or staging.",
+    )
+    workspace_list_parser = workspace_subparsers.add_parser(
+        "list", help="List workspace/environment records for a project."
+    )
+    workspace_list_parser.add_argument("project_key", help="Owning project key.")
 
     outcome_parser = subparsers.add_parser(
         "outcome", help="Record post-deployment outcomes for persisted analyses."
@@ -756,6 +821,11 @@ def main() -> None:
         raise SystemExit(_run_project_create(args))
     if args.command == "project" and args.project_command == "list":
         raise SystemExit(_run_project_list())
+    if args.command == "project" and args.project_command == "workspace":
+        if args.workspace_command == "create":
+            raise SystemExit(_run_project_workspace_create(args))
+        if args.workspace_command == "list":
+            raise SystemExit(_run_project_workspace_list(args))
     if args.command == "outcome" and args.outcome_command == "record":
         raise SystemExit(_run_outcome_record(args))
     if args.command == "topology" and args.topology_command == "import":

--- a/docs/project-workspaces.md
+++ b/docs/project-workspaces.md
@@ -5,6 +5,7 @@ DeployWhisper now scopes analyses and topology context to lightweight project/wo
 ### What Changed
 
 - Projects have a stable `project_key`, display name, optional description, repository URL, and default branch.
+- Workspaces have a stable project-local `workspace_key`, display name, optional description, optional environment label, and timestamps.
 - New analyses can attach to a project through the UI, API, CLI, or GitHub integration path.
 - Persisted reports now carry project metadata and history filters can scope by project.
 - Topology uploads are stored per project, with legacy file-based topology continuing to resolve through the default `unassigned` project.
@@ -16,12 +17,16 @@ DeployWhisper now scopes analyses and topology context to lightweight project/wo
 - Web UI: choose an existing project or create one before running a manual analysis, and switch the active project from the searchable full-width `Active Project` card directly below the fixed header when moving between dashboard, history, and other routed pages.
 - API:
   - `POST /api/v1/projects` creates a project
+  - `GET /api/v1/projects/<project_key>/workspaces` lists workspace/environment records for a project
+  - `POST /api/v1/projects/<project_key>/workspaces` creates a workspace/environment record
   - `POST /api/v1/analyses` accepts multipart `project_key` or `project_id`
   - `GET /api/v1/context/topology?project_key=<key>` reads project-scoped topology status
   - `POST /api/v1/context/topology` stores project-scoped topology JSON with `project_key` or `project_id`
 - CLI:
   - `deploywhisper project create <key> <display-name>`
   - `deploywhisper project list`
+  - `deploywhisper project workspace create <project-key> <workspace-key> <display-name>`
+  - `deploywhisper project workspace list <project-key>`
   - `deploywhisper analyze --project <key> <artifact...>`
   - `deploywhisper topology import --from custom --source <topology.json> --project <key>`
   - `deploywhisper topology import --from terraform --source <state-or-uri> --project <key>`
@@ -40,6 +45,7 @@ DeployWhisper now scopes analyses and topology context to lightweight project/wo
 ### Legacy Mapping
 
 - Existing persisted reports are backfilled into the default `unassigned` project during migration `010_add_project_workspaces`.
+- First-class workspace/environment records are introduced by migration `014_add_project_workspace_records`.
 - Existing file-based topology remains readable through the default project and new default-project topology updates continue to mirror the legacy file path for compatibility.
 
 ### Non-Goals

--- a/migrations/versions/014_add_project_workspace_records.py
+++ b/migrations/versions/014_add_project_workspace_records.py
@@ -1,0 +1,58 @@
+"""Add first-class project workspace records.
+
+Revision ID: 014_add_project_workspace_records
+Revises: 013_add_incident_analysis_reference
+Create Date: 2026-05-04
+"""
+
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "014_add_project_workspace_records"
+down_revision = "013_add_incident_analysis_reference"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "project_workspaces",
+        sa.Column("id", sa.Integer(), primary_key=True, autoincrement=True),
+        sa.Column("project_id", sa.Integer(), nullable=False),
+        sa.Column("workspace_key", sa.String(length=120), nullable=False),
+        sa.Column("display_name", sa.String(length=255), nullable=False),
+        sa.Column("description", sa.Text(), nullable=True),
+        sa.Column("environment", sa.String(length=80), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.ForeignKeyConstraint(["project_id"], ["projects.id"], ondelete="CASCADE"),
+        sa.UniqueConstraint(
+            "project_id",
+            "workspace_key",
+            name="uq_project_workspaces_project_key",
+        ),
+    )
+    op.create_index(
+        "ix_project_workspaces_project_id",
+        "project_workspaces",
+        ["project_id"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_project_workspaces_workspace_key",
+        "project_workspaces",
+        ["workspace_key"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ix_project_workspaces_workspace_key",
+        table_name="project_workspaces",
+    )
+    op.drop_index("ix_project_workspaces_project_id", table_name="project_workspaces")
+    op.drop_table("project_workspaces")

--- a/models/database.py
+++ b/models/database.py
@@ -7,7 +7,7 @@ from pathlib import Path
 
 from alembic import command
 from alembic.config import Config
-from sqlalchemy import create_engine
+from sqlalchemy import DateTime, Integer, String, create_engine
 from sqlalchemy import event
 from sqlalchemy.engine import make_url
 from sqlalchemy import inspect
@@ -42,6 +42,7 @@ _KNOWN_ALEMBIC_REVISIONS = {
     "011_add_deployment_outcome_fields",
     "012_add_feedback_event_fields",
     "013_add_incident_analysis_reference",
+    "014_add_project_workspace_records",
 }
 _BASELINE_TABLES = {"analysis_reports", "app_settings"}
 _EVIDENCE_TABLES = {
@@ -166,6 +167,83 @@ def _incident_record_has_analysis_link(connection) -> bool:
     return has_foreign_key and has_index
 
 
+def _project_workspace_columns(connection) -> set[str]:
+    return {
+        column["name"]
+        for column in inspect(connection).get_columns("project_workspaces")
+    }
+
+
+def _project_workspace_schema_complete(connection) -> bool:
+    inspector = inspect(connection)
+    column_map = {
+        column["name"]: column
+        for column in inspect(connection).get_columns("project_workspaces")
+    }
+    columns = set(column_map)
+    required_columns = {
+        "id",
+        "project_id",
+        "workspace_key",
+        "display_name",
+        "description",
+        "environment",
+        "created_at",
+        "updated_at",
+    }
+    required_non_nullable_columns = {
+        "project_id",
+        "workspace_key",
+        "display_name",
+        "created_at",
+        "updated_at",
+    }
+    has_required_nullability = all(
+        column_name in column_map and column_map[column_name].get("nullable") is False
+        for column_name in required_non_nullable_columns
+    )
+    has_primary_key = bool(column_map.get("id", {}).get("primary_key"))
+    required_type_affinities = {
+        "id": Integer,
+        "project_id": Integer,
+        "workspace_key": String,
+        "display_name": String,
+        "description": String,
+        "environment": String,
+        "created_at": DateTime,
+        "updated_at": DateTime,
+    }
+    has_required_types = all(
+        column_name in column_map
+        and column_map[column_name]["type"]._type_affinity is expected_affinity
+        for column_name, expected_affinity in required_type_affinities.items()
+    )
+    has_unique_key = any(
+        set(constraint.get("column_names") or []) == {"project_id", "workspace_key"}
+        for constraint in inspector.get_unique_constraints("project_workspaces")
+    )
+    has_project_fk = any(
+        foreign_key.get("referred_table") == "projects"
+        and "project_id" in (foreign_key.get("constrained_columns") or [])
+        and (foreign_key.get("options") or {}).get("ondelete") == "CASCADE"
+        for foreign_key in inspector.get_foreign_keys("project_workspaces")
+    )
+    indexed_columns = {
+        tuple(index.get("column_names") or [])
+        for index in inspector.get_indexes("project_workspaces")
+    }
+    return (
+        required_columns.issubset(columns)
+        and has_required_nullability
+        and has_primary_key
+        and has_required_types
+        and has_unique_key
+        and has_project_fk
+        and ("project_id",) in indexed_columns
+        and ("workspace_key",) in indexed_columns
+    )
+
+
 def _bootstrap_brownfield_revision() -> None:
     with engine.begin() as connection:
         tables = set(inspect(connection).get_table_names())
@@ -173,6 +251,19 @@ def _bootstrap_brownfield_revision() -> None:
 
         has_baseline_tables = _BASELINE_TABLES.issubset(tables)
         has_evidence_tables = _EVIDENCE_TABLES.issubset(tables)
+        has_project_workspace_table = "project_workspaces" in tables
+        has_complete_workspace_records = (
+            has_project_workspace_table
+            and _project_workspace_schema_complete(connection)
+            and has_baseline_tables
+            and "projects" in tables
+            and "topology_versions" in tables
+        )
+        if has_project_workspace_table and not has_complete_workspace_records:
+            raise RuntimeError(
+                "Detected a partial project workspace schema without a complete "
+                "migration history. Manual recovery is required."
+            )
         if not has_baseline_tables and "alembic_version" not in tables:
             return
 
@@ -212,6 +303,14 @@ def _bootstrap_brownfield_revision() -> None:
         has_complete_incident_link = {"analysis_id"}.issubset(
             incident_record_columns
         ) and _incident_record_has_analysis_link(connection)
+        if (
+            has_complete_workspace_records
+            and "projects" in tables
+            and "topology_versions" in tables
+            and "project_id" in report_columns
+        ):
+            _write_alembic_revision(connection, "014_add_project_workspace_records")
+            return
         if has_complete_incident_link and has_feedback_fields:
             _write_alembic_revision(connection, "013_add_incident_analysis_reference")
             return

--- a/models/repositories/projects.py
+++ b/models/repositories/projects.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 
-from models.tables import Project
+from models.tables import Project, ProjectWorkspace
 
 
 def create_project(
@@ -53,3 +53,53 @@ def get_default_project(session: Session) -> Project | None:
         select(Project).where(Project.is_default.is_(True)).order_by(Project.id.asc())
     )
     return session.execute(stmt).scalars().first()
+
+
+def create_workspace(
+    session: Session,
+    *,
+    project_id: int,
+    workspace_key: str,
+    display_name: str,
+    description: str | None = None,
+    environment: str | None = None,
+) -> ProjectWorkspace:
+    record = ProjectWorkspace(
+        project_id=project_id,
+        workspace_key=workspace_key,
+        display_name=display_name,
+        description=description,
+        environment=environment,
+    )
+    session.add(record)
+    session.commit()
+    session.refresh(record)
+    return record
+
+
+def list_workspaces(
+    session: Session,
+    *,
+    project_id: int | None = None,
+) -> list[ProjectWorkspace]:
+    stmt = select(ProjectWorkspace)
+    if project_id is not None:
+        stmt = stmt.where(ProjectWorkspace.project_id == project_id)
+    stmt = stmt.order_by(
+        ProjectWorkspace.project_id.asc(),
+        ProjectWorkspace.workspace_key.asc(),
+    )
+    return list(session.execute(stmt).scalars().all())
+
+
+def get_workspace_by_key(
+    session: Session,
+    *,
+    project_id: int,
+    workspace_key: str,
+) -> ProjectWorkspace | None:
+    stmt = select(ProjectWorkspace).where(
+        ProjectWorkspace.project_id == project_id,
+        ProjectWorkspace.workspace_key == workspace_key,
+    )
+    return session.execute(stmt).scalar_one_or_none()

--- a/models/tables.py
+++ b/models/tables.py
@@ -72,6 +72,10 @@ if "Project" not in globals():
             onupdate=lambda: datetime.now(UTC),
         )
         reports: Mapped[list["AnalysisReport"]] = relationship(back_populates="project")
+        workspaces: Mapped[list["ProjectWorkspace"]] = relationship(
+            back_populates="project",
+            cascade="all, delete-orphan",
+        )
         deployment_outcomes: Mapped[list["DeploymentOutcome"]] = relationship(
             back_populates="project",
             cascade="all, delete-orphan",
@@ -80,6 +84,40 @@ if "Project" not in globals():
             back_populates="project",
             cascade="all, delete-orphan",
         )
+
+
+if "ProjectWorkspace" not in globals():
+
+    class ProjectWorkspace(Base):
+        """First-class workspace/environment scope within a project."""
+
+        __tablename__ = "project_workspaces"
+        __table_args__ = (
+            UniqueConstraint(
+                "project_id",
+                "workspace_key",
+                name="uq_project_workspaces_project_key",
+            ),
+        )
+
+        id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+        project_id: Mapped[int] = mapped_column(
+            ForeignKey("projects.id", ondelete="CASCADE"),
+            index=True,
+        )
+        workspace_key: Mapped[str] = mapped_column(String(120), index=True)
+        display_name: Mapped[str] = mapped_column(String(255))
+        description: Mapped[str | None] = mapped_column(Text, nullable=True)
+        environment: Mapped[str | None] = mapped_column(String(80), nullable=True)
+        created_at: Mapped[datetime] = mapped_column(
+            DateTime(timezone=True), default=lambda: datetime.now(UTC)
+        )
+        updated_at: Mapped[datetime] = mapped_column(
+            DateTime(timezone=True),
+            default=lambda: datetime.now(UTC),
+            onupdate=lambda: datetime.now(UTC),
+        )
+        project: Mapped["Project"] = relationship(back_populates="workspaces")
 
 
 if "AnalysisReport" not in globals():

--- a/services/project_service.py
+++ b/services/project_service.py
@@ -6,15 +6,18 @@ import re
 from typing import Any
 
 from pydantic import BaseModel
-from sqlalchemy.exc import OperationalError
+from sqlalchemy.exc import IntegrityError, OperationalError
 
 from models.database import SessionLocal, init_db
 from models.repositories.projects import (
     create_project as create_project_record,
+    create_workspace as create_workspace_record,
     get_default_project,
     get_project,
     get_project_by_key,
+    get_workspace_by_key,
     list_projects as list_project_records,
+    list_workspaces as list_workspace_records,
 )
 from models.repositories.settings import get_setting, upsert_setting
 
@@ -45,6 +48,18 @@ class ProjectRecord(BaseModel):
     updated_at: str
 
 
+class WorkspaceRecord(BaseModel):
+    id: int
+    project_id: int
+    project_key: str
+    workspace_key: str
+    display_name: str
+    description: str | None = None
+    environment: str | None = None
+    created_at: str
+    updated_at: str
+
+
 def _serialize(record) -> ProjectRecord:
     created_at = record.created_at.isoformat()
     updated_at = record.updated_at.isoformat()
@@ -61,12 +76,87 @@ def _serialize(record) -> ProjectRecord:
     )
 
 
+def _serialize_workspace(record) -> WorkspaceRecord:
+    project_key = record.project.project_key if record.project is not None else ""
+    return WorkspaceRecord(
+        id=record.id,
+        project_id=record.project_id,
+        project_key=project_key,
+        workspace_key=record.workspace_key,
+        display_name=record.display_name,
+        description=record.description,
+        environment=record.environment,
+        created_at=record.created_at.isoformat(),
+        updated_at=record.updated_at.isoformat(),
+    )
+
+
 def normalize_project_key(value: str) -> str:
     normalized = _PROJECT_KEY_PATTERN.sub("-", value.strip().lower()).strip("-")
     normalized = re.sub(r"-{2,}", "-", normalized)
     if not normalized:
         raise ValueError("Project key must contain at least one letter or number.")
     return normalized
+
+
+def normalize_workspace_key(value: str) -> str:
+    try:
+        return normalize_project_key(value)
+    except ValueError as exc:
+        raise ValueError(
+            "Workspace key must contain at least one letter or number."
+        ) from exc
+
+
+def _is_workspace_unique_integrity_error(exc: IntegrityError) -> bool:
+    constraint_name = getattr(getattr(exc.orig, "diag", None), "constraint_name", "")
+    if constraint_name == "uq_project_workspaces_project_key":
+        return True
+    message = str(exc.orig).lower()
+    return (
+        "uq_project_workspaces_project_key" in message
+        or (
+            "unique constraint failed" in message
+            and "project_workspaces.project_id" in message
+            and "project_workspaces.workspace_key" in message
+        )
+        or (
+            "duplicate key" in message
+            and "project_workspaces" in message
+            and "workspace_key" in message
+        )
+    )
+
+
+def _is_project_unique_integrity_error(exc: IntegrityError) -> bool:
+    constraint_name = getattr(getattr(exc.orig, "diag", None), "constraint_name", "")
+    if constraint_name in {"uq_projects_project_key", "projects_project_key_key"}:
+        return True
+    message = str(exc.orig).lower()
+    return (
+        "uq_projects_project_key" in message
+        or ("unique constraint failed" in message and "projects.project_key" in message)
+        or (
+            "duplicate key" in message
+            and "projects" in message
+            and "project_key" in message
+        )
+    )
+
+
+def _is_workspace_project_fk_integrity_error(exc: IntegrityError) -> bool:
+    constraint_name = getattr(getattr(exc.orig, "diag", None), "constraint_name", "")
+    if constraint_name in {
+        "project_workspaces_project_id_fkey",
+        "fk_project_workspaces_project_id_projects",
+    }:
+        return True
+    message = str(exc.orig).lower()
+    return "foreign key constraint failed" in message or (
+        "violates foreign key constraint" in message
+        and "project_workspaces" in message
+        and "project_id" in message
+    )
 
 
 def _display_name_from_key(project_key: str) -> str:
@@ -146,22 +236,102 @@ def create_project(
         existing = get_project_by_key(session, normalized_key)
         if existing is not None:
             raise ValueError(f"Project key already exists: {normalized_key}")
-        created = create_project_record(
-            session,
-            project_key=normalized_key,
-            display_name=normalized_display_name,
-            description=(description or None),
-            repository_url=(repository_url or None),
-            default_branch=(default_branch or None),
-            is_default=False,
-        )
+        try:
+            created = create_project_record(
+                session,
+                project_key=normalized_key,
+                display_name=normalized_display_name,
+                description=(description or None),
+                repository_url=(repository_url or None),
+                default_branch=(default_branch or None),
+                is_default=False,
+            )
+        except IntegrityError as exc:
+            session.rollback()
+            if not _is_project_unique_integrity_error(exc):
+                raise
+            raise ValueError(f"Project key already exists: {normalized_key}") from exc
         return _serialize(created)
+
+
+def create_workspace(
+    *,
+    project_key: str,
+    workspace_key: str,
+    display_name: str,
+    description: str | None = None,
+    environment: str | None = None,
+) -> WorkspaceRecord:
+    normalized_project_key = normalize_project_key(project_key)
+    normalized_workspace_key = normalize_workspace_key(workspace_key)
+    normalized_display_name = str(display_name or "").strip()
+    if not normalized_display_name:
+        raise ValueError("Display name is required.")
+    with SessionLocal() as session:
+        project = get_project_by_key(session, normalized_project_key)
+        if project is None:
+            raise ProjectResolutionError(
+                "project_not_found",
+                f"Unknown project reference: project_key={normalized_project_key}.",
+            )
+        existing = get_workspace_by_key(
+            session,
+            project_id=project.id,
+            workspace_key=normalized_workspace_key,
+        )
+        if existing is not None:
+            raise ValueError(
+                f"Workspace key already exists for project "
+                f"{normalized_project_key}: {normalized_workspace_key}"
+            )
+        try:
+            created = create_workspace_record(
+                session,
+                project_id=project.id,
+                workspace_key=normalized_workspace_key,
+                display_name=normalized_display_name,
+                description=(description or None),
+                environment=(environment or None),
+            )
+        except IntegrityError as exc:
+            session.rollback()
+            if _is_workspace_unique_integrity_error(exc):
+                raise ValueError(
+                    f"Workspace key already exists for project "
+                    f"{normalized_project_key}: {normalized_workspace_key}"
+                ) from exc
+            if _is_workspace_project_fk_integrity_error(exc):
+                raise ProjectResolutionError(
+                    "project_not_found",
+                    f"Unknown project reference: project_key={normalized_project_key}.",
+                ) from exc
+            raise
+        created.project = project
+        return _serialize_workspace(created)
 
 
 def list_projects() -> list[ProjectRecord]:
     ensure_default_project()
     with SessionLocal() as session:
         return [_serialize(record) for record in list_project_records(session)]
+
+
+def list_workspaces(*, project_key: str | None = None) -> list[WorkspaceRecord]:
+    if project_key is None:
+        normalized_project_key = ensure_default_project().project_key
+    else:
+        normalized_project_key = normalize_project_key(project_key)
+    with SessionLocal() as session:
+        project = get_project_by_key(session, normalized_project_key)
+        if project is None:
+            raise ProjectResolutionError(
+                "project_not_found",
+                f"Unknown project reference: project_key={normalized_project_key}.",
+            )
+        return [
+            _serialize_workspace(record)
+            for record in list_workspace_records(session, project_id=project.id)
+        ]
 
 
 def get_project_by_id(project_id: int) -> ProjectRecord | None:
@@ -295,3 +465,11 @@ def build_project_payload(project: ProjectRecord | dict[str, Any]) -> dict[str, 
     if isinstance(project, ProjectRecord):
         return project.model_dump()
     return dict(project)
+
+
+def build_workspace_payload(
+    workspace: WorkspaceRecord | dict[str, Any],
+) -> dict[str, Any]:
+    if isinstance(workspace, WorkspaceRecord):
+        return workspace.model_dump()
+    return dict(workspace)

--- a/tests/test_api/test_projects.py
+++ b/tests/test_api/test_projects.py
@@ -56,3 +56,90 @@ class ProjectsApiTests(unittest.TestCase):
         payload = response.json()
         self.assertGreaterEqual(payload["meta"]["count"], 1)
         self.assertEqual(payload["data"][0]["project_key"], "unassigned")
+
+    def test_create_workspace_returns_structured_payload(self) -> None:
+        project_response = self.client.post(
+            "/api/v1/projects",
+            json={
+                "project_key": "payments-api",
+                "display_name": "Payments API",
+            },
+        )
+        self.assertEqual(project_response.status_code, 200)
+
+        response = self.client.post(
+            "/api/v1/projects/payments-api/workspaces",
+            json={
+                "workspace_key": "Production / US East",
+                "display_name": "Production US East",
+                "description": "Primary production environment",
+                "environment": "prod",
+            },
+        )
+
+        self.assertEqual(response.status_code, 200)
+        payload = response.json()
+        self.assertEqual(payload["data"]["project_key"], "payments-api")
+        self.assertEqual(payload["data"]["workspace_key"], "production-us-east")
+        self.assertEqual(payload["data"]["display_name"], "Production US East")
+        self.assertEqual(payload["data"]["environment"], "prod")
+
+    def test_duplicate_workspace_key_returns_explicit_error_without_partial_record(
+        self,
+    ) -> None:
+        project_response = self.client.post(
+            "/api/v1/projects",
+            json={
+                "project_key": "platform",
+                "display_name": "Platform",
+            },
+        )
+        self.assertEqual(project_response.status_code, 200)
+        first_response = self.client.post(
+            "/api/v1/projects/platform/workspaces",
+            json={
+                "workspace_key": "prod",
+                "display_name": "Production",
+            },
+        )
+        self.assertEqual(first_response.status_code, 200)
+
+        duplicate_response = self.client.post(
+            "/api/v1/projects/platform/workspaces",
+            json={
+                "workspace_key": "prod",
+                "display_name": "Production Duplicate",
+            },
+        )
+
+        self.assertEqual(duplicate_response.status_code, 400)
+        payload = duplicate_response.json()
+        self.assertEqual(payload["error"]["code"], "invalid_workspace_request")
+        self.assertIn("Workspace key already exists", payload["error"]["message"])
+
+        list_response = self.client.get("/api/v1/projects/platform/workspaces")
+        self.assertEqual(list_response.status_code, 200)
+        workspaces = list_response.json()["data"]
+        self.assertEqual(len(workspaces), 1)
+        self.assertEqual(workspaces[0]["display_name"], "Production")
+
+    def test_workspace_routes_return_not_found_for_unknown_project(self) -> None:
+        list_response = self.client.get("/api/v1/projects/missing/workspaces")
+        create_response = self.client.post(
+            "/api/v1/projects/missing/workspaces",
+            json={
+                "workspace_key": "prod",
+                "display_name": "Production",
+            },
+        )
+
+        self.assertEqual(list_response.status_code, 404)
+        self.assertEqual(create_response.status_code, 404)
+        self.assertEqual(
+            list_response.json()["error"]["code"],
+            "project_not_found",
+        )
+        self.assertEqual(
+            create_response.json()["error"]["code"],
+            "project_not_found",
+        )

--- a/tests/test_cli/test_analyze.py
+++ b/tests/test_cli/test_analyze.py
@@ -894,6 +894,53 @@ class AnalyzeCliTests(unittest.TestCase):
         self.assertEqual(ctx.exception.code, 0)
         self.assertIn("unassigned", output.getvalue())
 
+    def test_project_workspace_create_and_list_commands(self) -> None:
+        project_service_module.create_project(
+            project_key="payments",
+            display_name="Payments",
+        )
+        create_output = io.StringIO()
+
+        with (
+            patch(
+                "sys.argv",
+                [
+                    "deploywhisper",
+                    "project",
+                    "workspace",
+                    "create",
+                    "payments",
+                    "Production / US East",
+                    "Production US East",
+                    "--environment",
+                    "prod",
+                ],
+            ),
+            redirect_stdout(create_output),
+        ):
+            with self.assertRaises(SystemExit) as ctx:
+                main()
+
+        self.assertEqual(ctx.exception.code, 0)
+        self.assertIn("Created workspace production-us-east", create_output.getvalue())
+
+        list_output = io.StringIO()
+        with (
+            patch(
+                "sys.argv",
+                ["deploywhisper", "project", "workspace", "list", "payments"],
+            ),
+            redirect_stdout(list_output),
+        ):
+            with self.assertRaises(SystemExit) as ctx:
+                main()
+
+        self.assertEqual(ctx.exception.code, 0)
+        self.assertIn(
+            "payments/production-us-east: Production US East (prod)",
+            list_output.getvalue(),
+        )
+
     def test_project_command_requires_subcommand(self) -> None:
         stderr = io.StringIO()
 

--- a/tests/test_infra/test_container_contract.py
+++ b/tests/test_infra/test_container_contract.py
@@ -27,6 +27,7 @@ class ContainerContractTests(unittest.TestCase):
                 "011_add_deployment_outcome_fields.py",
                 "012_add_feedback_event_fields.py",
                 "013_add_incident_analysis_reference.py",
+                "014_add_project_workspace_records.py",
             ],
         )
         baseline_content = migrations[0].read_text(encoding="utf-8")
@@ -39,6 +40,7 @@ class ContainerContractTests(unittest.TestCase):
         deployment_outcomes_content = migrations[7].read_text(encoding="utf-8")
         feedback_content = migrations[8].read_text(encoding="utf-8")
         incident_link_content = migrations[9].read_text(encoding="utf-8")
+        workspace_content = migrations[10].read_text(encoding="utf-8")
         self.assertIn("down_revision = None", baseline_content)
         self.assertIn('"app_settings"', baseline_content)
         self.assertIn(
@@ -79,6 +81,12 @@ class ContainerContractTests(unittest.TestCase):
             incident_link_content,
         )
         self.assertIn('"analysis_id"', incident_link_content)
+        self.assertIn(
+            'down_revision = "013_add_incident_analysis_reference"',
+            workspace_content,
+        )
+        self.assertIn('"project_workspaces"', workspace_content)
+        self.assertIn('"workspace_key"', workspace_content)
 
     def test_dockerfile_exists(self) -> None:
         self.assertTrue(Path("Dockerfile").exists())

--- a/tests/test_infra/test_migrations.py
+++ b/tests/test_infra/test_migrations.py
@@ -53,6 +53,43 @@ class MigrationTests(unittest.TestCase):
         finally:
             sqlite_conn.close()
 
+    def _create_project_workspace_table(
+        self,
+        *,
+        id_definition: str = "id INTEGER PRIMARY KEY AUTOINCREMENT",
+        workspace_key_definition: str = "workspace_key VARCHAR(120) NOT NULL",
+    ) -> None:
+        sqlite_conn = sqlite3.connect(self.db_path)
+        try:
+            sqlite_conn.execute(
+                f"""
+                CREATE TABLE project_workspaces (
+                    {id_definition},
+                    project_id INTEGER NOT NULL,
+                    {workspace_key_definition},
+                    display_name VARCHAR(255) NOT NULL,
+                    description TEXT,
+                    environment VARCHAR(80),
+                    created_at DATETIME NOT NULL,
+                    updated_at DATETIME NOT NULL,
+                    FOREIGN KEY(project_id) REFERENCES projects(id) ON DELETE CASCADE,
+                    UNIQUE(project_id, workspace_key)
+                )
+                """
+            )
+            sqlite_conn.execute(
+                "CREATE INDEX ix_project_workspaces_project_id "
+                "ON project_workspaces (project_id)"
+            )
+            sqlite_conn.execute(
+                "CREATE INDEX ix_project_workspaces_workspace_key "
+                "ON project_workspaces (workspace_key)"
+            )
+            sqlite_conn.execute("DROP TABLE alembic_version")
+            sqlite_conn.commit()
+        finally:
+            sqlite_conn.close()
+
     def test_upgrade_head_creates_evidence_schema_on_clean_database(self) -> None:
         command.upgrade(self._config(), "head")
 
@@ -62,6 +99,9 @@ class MigrationTests(unittest.TestCase):
         self.assertIn("analysis_id", self._table_columns("context_snapshots"))
         self.assertIn("project_id", self._table_columns("analysis_reports"))
         self.assertIn("project_key", self._table_columns("projects"))
+        self.assertIn("workspace_key", self._table_columns("project_workspaces"))
+        self.assertIn("environment", self._table_columns("project_workspaces"))
+        self.assertNotIn("is_default", self._table_columns("project_workspaces"))
         self.assertIn("title", self._table_columns("incident_records"))
         self.assertIn("analysis_id", self._table_columns("incident_records"))
         self.assertIn("payload_json", self._table_columns("topology_versions"))
@@ -311,7 +351,7 @@ class MigrationTests(unittest.TestCase):
         self.assertIn("evidence_items", tables)
         self.assertIn("projects", tables)
         self.assertIn("topology_versions", tables)
-        self.assertEqual(revision, "013_add_incident_analysis_reference")
+        self.assertEqual(revision, "014_add_project_workspace_records")
 
     def test_init_db_repairs_partial_evidence_schema_without_alembic_version(
         self,
@@ -360,7 +400,7 @@ class MigrationTests(unittest.TestCase):
         self.assertIn("findings", tables)
         self.assertIn("evidence_items", tables)
         self.assertIn("projects", tables)
-        self.assertEqual(revision, "013_add_incident_analysis_reference")
+        self.assertEqual(revision, "014_add_project_workspace_records")
 
     def test_init_db_repairs_current_schema_without_alembic_version(self) -> None:
         command.upgrade(self._config(), "head")
@@ -386,7 +426,7 @@ class MigrationTests(unittest.TestCase):
         finally:
             sqlite_conn.close()
 
-        self.assertEqual(revision, "013_add_incident_analysis_reference")
+        self.assertEqual(revision, "014_add_project_workspace_records")
         self.assertIn("report_schema_version", columns)
         self.assertIn("blast_radius_json", columns)
         self.assertIn("project_id", columns)
@@ -410,6 +450,118 @@ class MigrationTests(unittest.TestCase):
         ):
             database_module.init_db()
 
+    def test_init_db_rejects_partial_project_workspace_schema(self) -> None:
+        command.upgrade(self._config(), "013_add_incident_analysis_reference")
+        sqlite_conn = sqlite3.connect(self.db_path)
+        sqlite_conn.execute(
+            """
+            CREATE TABLE project_workspaces (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                project_id INTEGER NOT NULL,
+                workspace_key VARCHAR(120) NOT NULL
+            )
+            """
+        )
+        sqlite_conn.execute("DROP TABLE alembic_version")
+        sqlite_conn.commit()
+        sqlite_conn.close()
+
+        reload(config_module)
+        reload(tables_module)
+        reload(database_module)
+
+        with self.assertRaisesRegex(RuntimeError, "partial project workspace schema"):
+            database_module.init_db()
+
+    def test_init_db_rejects_nullable_project_workspace_required_columns(self) -> None:
+        command.upgrade(self._config(), "013_add_incident_analysis_reference")
+        sqlite_conn = sqlite3.connect(self.db_path)
+        sqlite_conn.execute(
+            """
+            CREATE TABLE project_workspaces (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                project_id INTEGER,
+                workspace_key VARCHAR(120),
+                display_name VARCHAR(255),
+                description TEXT,
+                environment VARCHAR(80),
+                created_at DATETIME,
+                updated_at DATETIME,
+                FOREIGN KEY(project_id) REFERENCES projects(id) ON DELETE CASCADE,
+                UNIQUE(project_id, workspace_key)
+            )
+            """
+        )
+        sqlite_conn.execute(
+            "CREATE INDEX ix_project_workspaces_project_id "
+            "ON project_workspaces (project_id)"
+        )
+        sqlite_conn.execute(
+            "CREATE INDEX ix_project_workspaces_workspace_key "
+            "ON project_workspaces (workspace_key)"
+        )
+        sqlite_conn.execute("DROP TABLE alembic_version")
+        sqlite_conn.commit()
+        sqlite_conn.close()
+
+        reload(config_module)
+        reload(tables_module)
+        reload(database_module)
+
+        with self.assertRaisesRegex(RuntimeError, "partial project workspace schema"):
+            database_module.init_db()
+
+    def test_init_db_rejects_project_workspace_schema_without_primary_key(
+        self,
+    ) -> None:
+        command.upgrade(self._config(), "013_add_incident_analysis_reference")
+        self._create_project_workspace_table(id_definition="id INTEGER NOT NULL")
+
+        reload(config_module)
+        reload(tables_module)
+        reload(database_module)
+
+        with self.assertRaisesRegex(RuntimeError, "partial project workspace schema"):
+            database_module.init_db()
+
+    def test_init_db_rejects_project_workspace_schema_with_wrong_key_type(
+        self,
+    ) -> None:
+        command.upgrade(self._config(), "013_add_incident_analysis_reference")
+        self._create_project_workspace_table(
+            workspace_key_definition="workspace_key INTEGER NOT NULL"
+        )
+
+        reload(config_module)
+        reload(tables_module)
+        reload(database_module)
+
+        with self.assertRaisesRegex(RuntimeError, "partial project workspace schema"):
+            database_module.init_db()
+
+    def test_init_db_rejects_stray_project_workspace_table_without_baseline(
+        self,
+    ) -> None:
+        sqlite_conn = sqlite3.connect(self.db_path)
+        sqlite_conn.execute(
+            """
+            CREATE TABLE project_workspaces (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                project_id INTEGER NOT NULL,
+                workspace_key VARCHAR(120) NOT NULL
+            )
+            """
+        )
+        sqlite_conn.commit()
+        sqlite_conn.close()
+
+        reload(config_module)
+        reload(tables_module)
+        reload(database_module)
+
+        with self.assertRaisesRegex(RuntimeError, "partial project workspace schema"):
+            database_module.init_db()
+
     def test_init_db_repairs_empty_alembic_revision_state(self) -> None:
         command.upgrade(self._config(), "0001_create_analysis_reports")
         sqlite_conn = sqlite3.connect(self.db_path)
@@ -431,7 +583,7 @@ class MigrationTests(unittest.TestCase):
         finally:
             sqlite_conn.close()
 
-        self.assertEqual(revision, "013_add_incident_analysis_reference")
+        self.assertEqual(revision, "014_add_project_workspace_records")
 
 
 if __name__ == "__main__":

--- a/tests/test_services/test_project_service.py
+++ b/tests/test_services/test_project_service.py
@@ -7,6 +7,9 @@ import tempfile
 import unittest
 from importlib import reload
 from pathlib import Path
+from unittest.mock import patch
+
+from sqlalchemy.exc import IntegrityError
 
 import config as config_module
 import models.database as database_module
@@ -51,6 +54,247 @@ class ProjectServiceTests(unittest.TestCase):
         self.assertEqual(project.display_name, "Payments API")
         self.assertEqual(project.repository_url, "https://github.com/acme/payments-api")
         self.assertEqual(project.default_branch, "main")
+
+    def test_project_duplicate_integrity_error_uses_explicit_validation_error(
+        self,
+    ) -> None:
+        project_service_module.create_project(
+            project_key="platform",
+            display_name="Platform",
+        )
+
+        with (
+            patch.object(
+                project_service_module, "get_project_by_key", return_value=None
+            ),
+            self.assertRaisesRegex(ValueError, "Project key already exists"),
+        ):
+            project_service_module.create_project(
+                project_key="platform",
+                display_name="Platform Duplicate",
+            )
+
+        projects = [
+            project
+            for project in project_service_module.list_projects()
+            if project.project_key == "platform"
+        ]
+        self.assertEqual(len(projects), 1)
+        self.assertEqual(projects[0].display_name, "Platform")
+
+    def test_create_workspace_normalizes_key_and_persists_metadata(self) -> None:
+        project = project_service_module.create_project(
+            project_key="payments-api",
+            display_name="Payments API",
+        )
+
+        workspace = project_service_module.create_workspace(
+            project_key=project.project_key,
+            workspace_key="Production / US East",
+            display_name="Production US East",
+            description="Primary production environment",
+            environment="prod",
+        )
+
+        self.assertEqual(workspace.project_id, project.id)
+        self.assertEqual(workspace.project_key, "payments-api")
+        self.assertEqual(workspace.workspace_key, "production-us-east")
+        self.assertEqual(workspace.display_name, "Production US East")
+        self.assertEqual(workspace.description, "Primary production environment")
+        self.assertEqual(workspace.environment, "prod")
+        self.assertTrue(workspace.created_at)
+        self.assertTrue(workspace.updated_at)
+
+        workspaces = project_service_module.list_workspaces(project_key="payments-api")
+        self.assertEqual(
+            [item.workspace_key for item in workspaces], ["production-us-east"]
+        )
+
+    def test_invalid_workspace_key_does_not_create_partial_record(self) -> None:
+        project = project_service_module.create_project(
+            project_key="platform",
+            display_name="Platform",
+        )
+
+        with self.assertRaisesRegex(ValueError, "Workspace key"):
+            project_service_module.create_workspace(
+                project_key=project.project_key,
+                workspace_key=" !!! ",
+                display_name="Invalid",
+            )
+
+        self.assertEqual(
+            project_service_module.list_workspaces(project_key="platform"), []
+        )
+
+    def test_duplicate_workspace_key_does_not_create_partial_record(self) -> None:
+        project = project_service_module.create_project(
+            project_key="platform",
+            display_name="Platform",
+        )
+        project_service_module.create_workspace(
+            project_key=project.project_key,
+            workspace_key="prod",
+            display_name="Production",
+        )
+
+        with self.assertRaisesRegex(ValueError, "Workspace key already exists"):
+            project_service_module.create_workspace(
+                project_key=project.project_key,
+                workspace_key="prod",
+                display_name="Production Duplicate",
+            )
+
+        workspaces = project_service_module.list_workspaces(project_key="platform")
+        self.assertEqual(len(workspaces), 1)
+        self.assertEqual(workspaces[0].display_name, "Production")
+
+    def test_workspace_duplicate_integrity_error_uses_explicit_validation_error(
+        self,
+    ) -> None:
+        project = project_service_module.create_project(
+            project_key="platform",
+            display_name="Platform",
+        )
+        project_service_module.create_workspace(
+            project_key=project.project_key,
+            workspace_key="prod",
+            display_name="Production",
+        )
+
+        with (
+            patch.object(
+                project_service_module, "get_workspace_by_key", return_value=None
+            ),
+            self.assertRaisesRegex(ValueError, "Workspace key already exists"),
+        ):
+            project_service_module.create_workspace(
+                project_key=project.project_key,
+                workspace_key="prod",
+                display_name="Production Duplicate",
+            )
+
+        workspaces = project_service_module.list_workspaces(project_key="platform")
+        self.assertEqual(len(workspaces), 1)
+        self.assertEqual(workspaces[0].display_name, "Production")
+
+    def test_workspace_project_fk_integrity_error_uses_project_not_found(
+        self,
+    ) -> None:
+        project = project_service_module.create_project(
+            project_key="platform",
+            display_name="Platform",
+        )
+        integrity_error = IntegrityError(
+            "insert",
+            {},
+            Exception("FOREIGN KEY constraint failed"),
+        )
+
+        with (
+            patch.object(
+                project_service_module, "get_workspace_by_key", return_value=None
+            ),
+            patch.object(
+                project_service_module,
+                "create_workspace_record",
+                side_effect=integrity_error,
+            ),
+            self.assertRaises(
+                project_service_module.ProjectResolutionError
+            ) as exc_info,
+        ):
+            project_service_module.create_workspace(
+                project_key=project.project_key,
+                workspace_key="prod",
+                display_name="Production",
+            )
+
+        self.assertEqual(exc_info.exception.code, "project_not_found")
+
+    def test_non_duplicate_workspace_integrity_error_is_not_rewritten(self) -> None:
+        project = project_service_module.create_project(
+            project_key="platform",
+            display_name="Platform",
+        )
+        integrity_error = IntegrityError(
+            "insert",
+            {},
+            Exception("CHECK constraint failed: project_workspaces_environment"),
+        )
+
+        with (
+            patch.object(
+                project_service_module, "get_workspace_by_key", return_value=None
+            ),
+            patch.object(
+                project_service_module,
+                "create_workspace_record",
+                side_effect=integrity_error,
+            ),
+            self.assertRaises(IntegrityError),
+        ):
+            project_service_module.create_workspace(
+                project_key=project.project_key,
+                workspace_key="prod",
+                display_name="Production",
+            )
+
+    def test_list_workspaces_without_project_key_uses_default_project_only(
+        self,
+    ) -> None:
+        default_project = project_service_module.ensure_default_project()
+        project_service_module.create_workspace(
+            project_key=default_project.project_key,
+            workspace_key="legacy",
+            display_name="Legacy",
+        )
+        other_project = project_service_module.create_project(
+            project_key="platform",
+            display_name="Platform",
+        )
+        project_service_module.create_workspace(
+            project_key=other_project.project_key,
+            workspace_key="prod",
+            display_name="Production",
+        )
+
+        workspaces = project_service_module.list_workspaces()
+
+        self.assertEqual(
+            [workspace.workspace_key for workspace in workspaces], ["legacy"]
+        )
+        self.assertEqual(workspaces[0].project_key, default_project.project_key)
+
+    def test_invalid_workspace_list_project_key_does_not_create_default_project(
+        self,
+    ) -> None:
+        with database_module.engine.begin() as connection:
+            connection.exec_driver_sql(
+                "DELETE FROM projects WHERE project_key = ?",
+                ("unassigned",),
+            )
+
+        with self.assertRaisesRegex(ValueError, "Project key"):
+            project_service_module.list_workspaces(project_key=" !!! ")
+
+        with database_module.SessionLocal() as session:
+            self.assertIsNone(project_service_module.get_default_project(session))
+
+    def test_blank_workspace_list_project_key_does_not_create_default_project(
+        self,
+    ) -> None:
+        with database_module.engine.begin() as connection:
+            connection.exec_driver_sql(
+                "DELETE FROM projects WHERE project_key = ?",
+                ("unassigned",),
+            )
+
+        with self.assertRaisesRegex(ValueError, "Project key"):
+            project_service_module.list_workspaces(project_key="")
+
+        with database_module.SessionLocal() as session:
+            self.assertIsNone(project_service_module.get_default_project(session))
 
     def test_resolve_project_reference_derives_stable_repository_key(self) -> None:
         project = project_service_module.resolve_project_reference(


### PR DESCRIPTION
Story 1.1 needs first-class workspace records so future project-aware analysis, history, topology, and access-control work can rely on stable project-local workspace identifiers. This change adds the workspace table, service/API/CLI surfaces, brownfield migration guards, docs, and regression coverage for duplicate and missing-project validation paths.

Constraint: Preserve local-first advisory behavior while adding only the project/workspace entities needed for selection and lookup
Rejected: Defer workspace records to later stories | downstream Epic 1 stories need stable workspace scope before shared usage expands
Confidence: high
Scope-risk: moderate
Directive: Do not relax brownfield revision stamping without verifying the full project_workspaces schema contract
Tested: ./.venv/bin/ruff check .; ./.venv/bin/ruff format --check .; ./.venv/bin/python -m unittest discover -q; bash scripts/ci-local.sh
Not-tested: Bandit local security scan because bandit is not installed locally

## What does this PR do?

<!-- Brief description of changes -->

## Type of change
- [ ] Feature (new functionality)
- [ ] Bugfix (non-breaking fix)
- [ ] Release preparation
- [ ] Hotfix (critical production fix)
- [ ] Docs / refactor / chore

## Checklist
- [ ] I have followed the branch naming convention
- [ ] Tests pass locally (`pytest tests/ -v`)
- [ ] Linting passes (`ruff check .`)
- [ ] Docker build succeeds
- [ ] I have updated docs if needed
- [ ] No secrets or .env values committed

## Related issue
Closes #