### PR TITLE
Require project scope before analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -370,7 +370,9 @@ Response shape:
 POST /api/v1/analyses
 ```
 
-Upload one or more artifact files as multipart form-data.
+Upload one or more artifact files as multipart form-data. New analysis submissions
+must include either `project_key` or `project_id`; missing scope returns a
+structured `missing_project_scope` error before artifact parsing.
 
 Response includes:
 

--- a/_bmad-output/implementation-artifacts/1-2-project-aware-analysis-submission.md
+++ b/_bmad-output/implementation-artifacts/1-2-project-aware-analysis-submission.md
@@ -1,0 +1,277 @@
+# Story 1.2: Project-Aware Analysis Submission
+
+Status: review
+
+<!-- Generated from updated PRD/architecture/epics plus implementation-readiness-report-2026-05-01.md. -->
+
+## Story
+
+As a platform engineer,
+I want to provide or derive a project key during analysis,
+So that reports are saved under the correct project.
+
+## Acceptance Criteria
+
+1. Given a user submits artifacts through UI, API, CLI, or GitHub flow, When a project key is provided or derivable, Then the analysis run and report are associated with that project. And missing or ambiguous project scope produces an explicit, actionable message.
+2. Given a project key references an unknown, conflicting, or otherwise invalid project in the current local/admin phase, When analysis submission is attempted, Then the request is rejected before parsing artifacts. And no report, incident, outcome, feedback, topology, or scanner data is associated with that unauthorized project reference. Full project membership and role enforcement remains deferred to the lightweight RBAC story.
+
+### Requirement Traceability
+
+- Primary PRD requirements: Epic 1 coverage: PRJ-01..10, HIS-08, NFR-SEC-07, DOC-22.
+- Supporting PRD / NFR / differentiation requirements: See `_bmad-output/planning-artifacts/prd.md`, `_bmad-output/planning-artifacts/architecture.md`, and `_bmad-output/planning-artifacts/implementation-readiness-report-2026-05-01.md`.
+- Coverage intent: Baseline + Delta.
+- Story alignment note: This story was created from the updated Epic 1 plan after the 2026-05-01 readiness rerun. The readiness report verified 187/187 PRD functional requirement IDs in the epics artifact, 38 NFR IDs present, and no critical or major readiness defects.
+
+## Tasks / Subtasks
+
+- [x] Implement and verify acceptance criterion 1. (AC: 1)
+- [x] Implement and verify acceptance criterion 2. (AC: 2)
+- [x] Reuse existing services, repositories, schemas, and UI/CLI/API helpers before adding new abstractions. (AC: all)
+- [x] Add or update deterministic regression coverage for the changed behavior. (AC: all)
+- [x] Update relevant docs or examples if the story changes user-visible, operator, API, CLI, integration, or contribution behavior. (AC: all)
+- [x] Run required validation and record commands/results in the Dev Agent Record. (AC: all)
+
+### Review Findings
+
+- [x] [Review][Decision] Missing analysis scope still falls back to the default project — Fixed by requiring explicit or derived project scope in the shared analysis submission path before parsing, returning `missing_project_scope` for API/CLI submissions without `project_key` or `project_id`, and updating docs/tests to preserve `unassigned` only as a legacy/default topology mapping.
+- [x] [Review][Decision] Story AC2 requires unauthorized-project rejection but the current codebase has no caller access model — Resolved by clarifying the Story 1.2 local/admin phase scope: invalid/unknown/conflicting project references are rejected before parsing, while full project membership and role checks remain deferred to the lightweight RBAC story. Evidence: `_bmad-output/implementation-artifacts/1-2-project-aware-analysis-submission.md`, `docs/project-workspaces.md`.
+- [x] [Review][Patch] Stale UI active-project selection can fall back to `unassigned` for new manual uploads — Fixed by validating saved active-project settings against existing project records before treating them as a selected project. [`services/project_service.py:449`]
+- [x] [Review][Patch] `POST /api/v1/analyses` can return `404 project_not_found` but the route response contract omits 404 — Fixed by adding `404` to the route response model declaration. [`api/routes/analyses.py:153`]
+- [x] [Review][Patch] Documented `project_id` analysis submission path lacks a direct success regression after the pre-parse resolution change — Fixed with direct API and CLI `project_id` success regressions. [`tests/test_api/test_analyses.py:330`]
+- [x] [Review][Patch] UI and GitHub derivation handoffs are not covered by tests that exercise the new shared missing-scope guard end-to-end — Fixed with UI missing-scope guard coverage and a GitHub webhook test that runs the real shared analysis path with a repository-derived project. [`tests/test_ui/test_upload_panel.py:35`]
+- [x] [Review][Patch] Explicit GitHub project override still auto-creates unknown scope — Fixed by treating `DEPLOYWHISPER_GITHUB_PROJECT_KEY` as an explicit existing-project reference while preserving auto-create only for repository-derived keys. [`integrations/github/app_service.py:384`]
+- [x] [Review][Patch] Malformed GitHub project override is not normalized into a configuration error — Fixed by normalizing `ProjectResolutionError` and project-key validation `ValueError` into `GitHubAppConfigurationError` before analysis execution. [`integrations/github/app_service.py:391`]
+- [x] [Review][Patch] Public API/CLI contract still advertises analysis project scope as optional — Fixed FastAPI field descriptions and CLI help text to state that either `project_key`/`--project` or `project_id`/`--project-id` is required. [`api/routes/analyses.py:169`, `cli/analyze.py:589`]
+- [x] [Review][Patch] GitHub webhook masks invalid project scope as generic app misconfiguration — Fixed by adding a project-scope-specific GitHub App exception and mapping it to project error codes/statuses in the webhook route. [`api/routes/github_app.py:109`, `integrations/github/app_service.py:391`]
+- [x] [Review][Patch] Conflicting project references are not regression-locked as pre-parse failures on API/CLI — Fixed by adding no-parse/no-report assertions to the API and CLI conflicting-reference regressions. [`tests/test_api/test_analyses.py:581`, `tests/test_cli/test_analyze.py:1254`]
+- [x] [Review][Patch] Whitespace `project_key` breaks otherwise valid `project_id` submissions — Fixed by trimming blank project keys before project resolution and adding API, CLI, and service regressions for `project_id` plus blank `project_key`. [`services/analysis_service.py:682`, `services/project_service.py:357`]
+- [x] [Review][Patch] Missing-scope fast-fail is still masked by API/CLI artifact preflight — Fixed by resolving required analysis scope before API/CLI artifact read/classification and adding unsupported-input regressions that now return `missing_project_scope` when scope is absent. [`api/routes/analyses.py:189`, `cli/analyze.py:283`]
+- [x] [Review][Patch] Stale active-project recovery is inconsistent across pages — Fixed by making history list/detail pages use the same valid-saved-selection check as uploads before applying active project scope. [`ui/components/upload_panel.py:142`, `ui/routes/history.py:39`]
+- [x] [Review][Decision] GitHub webhook project-scope failures now return non-2xx responses and may trigger repeated webhook retries — Fixed by acknowledging project-scope failures as handled webhook results, surfacing the project error in the response/check-run note, and skipping analysis/report creation. [`api/routes/github_app.py:109`, `integrations/github/app_service.py:391`]
+- [x] [Review][Patch] Whitespace-only `project_key` can still resolve to the default project in the generic resolver — Fixed by rejecting blank-key-only references while still allowing valid `project_id` plus blank `project_key` form submissions. [`services/project_service.py:357`]
+- [x] [Review][Patch] Stale deleted project selection makes `/history` unscoped while the shell can still advertise `Unassigned` — Fixed by scoping stale/no-saved-selection history views to `get_active_project()`'s default-project fallback instead of passing no project filter. [`ui/routes/history.py:39`]
+- [x] [Review][Patch] Repository-derived GitHub project keys can collide across distinct repositories and silently reuse the wrong project — Fixed by canonicalizing repository references, checking existing repository ownership before reuse, and adding a deterministic hash suffix for derived-key collisions. [`services/project_service.py:175`, `integrations/github/app_service.py:392`]
+- [x] [Review][Patch] GitHub project-scope errors are only wrapped before the second shared-scope resolution, leaving a possible 500 if the project changes between lookup and analysis — Fixed by catching late shared-analysis project resolution failures and returning the same handled webhook result as initial project-scope failures. [`integrations/github/app_service.py:391`, `services/analysis_service.py:712`]
+- [x] [Review][Patch] Repository-collision fallback still merges unrelated repositories when the existing matching project has no stored `repository_url` — Fixed by treating missing stored repository URLs as unconfirmed matches for repository-derived scope and forcing the collision-safe hashed key path. [`services/project_service.py:207`, `tests/test_services/test_project_service.py:325`]
+- [x] [Review][Patch] GitHub webhook downgrades arbitrary analysis `ValueError`s into neutral project-scope no-ops — Fixed by allowing only known project-scope `ValueError` codes to become handled webhook results; unrelated analysis `ValueError`s now propagate as operational failures. [`integrations/github/app_service.py:459`, `tests/test_services/test_github_app_service.py:373`]
+- [x] [Review][Patch] GitHub explicit project-scope failures do not fail fast before artifact download/classification — Fixed by resolving explicit GitHub project overrides immediately after webhook metadata/token validation and before PR artifact download or classification, with regressions asserting artifact loading is skipped. [`integrations/github/app_service.py:341`, `tests/test_services/test_github_app_service.py:247`]
+- [x] [Review][Patch] Repository-derived project resolution ignores an existing project already bound to the same `repository_url` when its project key is custom — Fixed by preferring canonical repository-url matches before derived-key creation, preserving custom project keys for repository-derived submissions. [`services/project_service.py:399`, `tests/test_services/test_project_service.py:348`]
+- [x] [Review][Patch] Legacy repository-backed projects with the derived project key and missing `repository_url` can silently fork into a new suffixed project instead of being reused and backfilled — Superseded by the later data-isolation decision: missing `repository_url` is treated as unconfirmed ownership, so repository-derived submissions use the collision-safe hashed key instead of display-name-based backfill. [`services/project_service.py:207`, `tests/test_services/test_project_service.py:362`]
+- [x] [Review][Patch] Whitespace-only explicit project keys are normalized as missing scope, and a blank GitHub override is treated as unset instead of invalid explicit scope — Fixed by preserving blank-explicit state through shared analysis scope resolution and GitHub env override handling, returning `invalid_project_reference` before parsing or artifact download. [`services/analysis_service.py:688`, `integrations/github/app_service.py:347`, `tests/test_services/test_github_app_service.py:332`]
+- [x] [Review][Decision] Repository-collision legacy backfill can silently bind a manually created project — Resolved in favor of data isolation: removed the display-name-based backfill heuristic, and records without `repository_url` now remain unconfirmed collisions that route repository-derived submissions to a deterministic hashed key. [`services/project_service.py:469`, `tests/test_services/test_project_service.py:362`]
+- [x] [Review][Patch] Repository canonicalization misses common SSH/SCP-style Git remotes — Fixed by normalizing SCP-style Git remotes like `git@github.com:owner/repo.git` to the same canonical `owner/repo` form used by HTTPS remotes. [`services/project_service.py:189`, `tests/test_services/test_project_service.py:386`]
+- [x] [Review][Patch] Repository matching drops the SCM host, so different remotes with the same owner/repo path can merge into the same project — Fixed by preserving the SCM host in canonical repository identity while keeping user-facing derived project keys path-based, and by passing host-aware GitHub repository references from webhook handling. [`services/project_service.py:188`, `integrations/github/app_service.py:530`, `tests/test_services/test_project_service.py:407`]
+
+## Dev Notes
+
+### Epic Context
+
+- Epic: 1. Project, Workspace, and RBAC Foundation
+- Epic goal: Make DeployWhisper project-aware before reports, incidents, topology, scanner imports, and feedback become harder to migrate.
+- Epic coverage: PRJ-01..10, HIS-08, NFR-SEC-07, DOC-22
+
+### Architecture and Product Guardrails
+
+- Preserve DeployWhisper's local-first raw artifact boundary: raw IaC, scanner artifacts, incident exports, and sensitive context stay in the user's infrastructure by default.
+- Preserve the advisory-first core. Optional adapters may interpret report outputs, but canonical report semantics remain advisory unless explicit story scope says otherwise.
+- Reuse the shared analysis core and service layer before adapting UI, API, CLI, GitHub, or future workflow surfaces.
+- Keep Evidence Law behavior intact: no high or critical finding without deterministic evidence.
+- Keep project/workspace scope explicit for reports, incidents, topology, outcomes, feedback, scanner imports, and connector-related data.
+- Do not introduce new dependencies unless the active story explicitly requires and justifies them.
+
+### Source Tree Guidance
+
+- API routes belong under `api/routes/` and should use existing `ApiRoute` / `ApiError` envelope patterns.
+- Shared orchestration belongs in `services/`; parsers normalize input, analysis modules score/derive risk, and surfaces adapt outputs.
+- UI work belongs under `ui/routes/` and `ui/components/`, following the existing NiceGUI composition style.
+- CLI behavior belongs under `cli/` and must call the same service-layer paths as UI/API flows.
+- Persistence work belongs under `models/` with Alembic migrations when schema changes are required.
+- Documentation required by a story should be updated in the same workstream.
+
+### Testing Requirements
+
+- Use standard-library `unittest` in the existing `tests/test_*` layout.
+- Add focused regression tests for the layer changed by the story before broad refactors.
+- For Python changes, run `./.venv/bin/ruff check .`, `./.venv/bin/ruff format --check .`, and `./.venv/bin/python -m unittest discover -q` before closing implementation.
+- Use `bash scripts/ci-local.sh` for broader or cross-layer changes.
+
+### Project Structure Notes
+
+- Follow the current repository shape documented in `_bmad-output/project-context.md` and `AGENTS.md`.
+- If implementation reveals a conflict between this story and the current code baseline, keep the smallest compatible change and update the story notes rather than silently drifting from the PRD.
+
+### References
+
+- `_bmad-output/planning-artifacts/epics.md` - source Epic 1 / Story 1.2 definition.
+- `_bmad-output/planning-artifacts/prd.md` - functional and non-functional requirements.
+- `_bmad-output/planning-artifacts/architecture.md` - target architecture, boundaries, and guardrails.
+- `_bmad-output/planning-artifacts/ux-design-specification.md` - UX expectations for user-facing stories.
+- `_bmad-output/planning-artifacts/implementation-readiness-report-2026-05-01.md` - readiness verdict and residual story-format concern.
+- `_bmad-output/project-context.md` - repository-specific implementation rules.
+
+## Dev Agent Record
+
+### Agent Model Used
+
+GPT-5
+
+### Debug Log References
+
+- `./.venv/bin/python -m unittest tests.test_api.test_analyses.AnalysesApiTests.test_create_analysis_rejects_unknown_project_before_parsing tests.test_cli.test_analyze.AnalyzeCliTests.test_analyze_command_rejects_unknown_project_before_parsing` - failed before implementation, proving the regressions reached parsing.
+- `./.venv/bin/python -m unittest tests.test_api.test_analyses.AnalysesApiTests.test_create_analysis_rejects_unknown_project_before_parsing tests.test_cli.test_analyze.AnalyzeCliTests.test_analyze_command_rejects_unknown_project_before_parsing` - passed after moving project resolution earlier.
+- `./.venv/bin/python -m unittest tests.test_api.test_analyses tests.test_cli.test_analyze tests.test_ui.test_upload_panel tests.test_services.test_github_app_service tests.test_services.test_analysis_service -q` - passed, 90 tests.
+- `./.venv/bin/ruff check .` - passed.
+- `./.venv/bin/ruff format --check .` - passed, 254 files already formatted.
+- `./.venv/bin/python -m bandit --version` - Bandit unavailable in the virtualenv.
+- `./.venv/bin/python -m unittest discover -q` - passed, 238 tests, 1 skipped.
+- `bash scripts/ci-local.sh` - passed; local CI skipped Bandit because it is not installed.
+- `./.venv/bin/python -m unittest tests.test_services.test_analysis_service.AnalysisServiceTests.test_analyze_uploaded_files_requires_explicit_project_scope_before_parsing tests.test_api.test_analyses tests.test_cli.test_analyze tests.test_ui.test_upload_panel tests.test_services.test_github_app_service -q` - passed, 81 tests.
+- `./.venv/bin/ruff check .` - passed after review fix.
+- `./.venv/bin/ruff format --check .` - failed on `tests/test_cli/test_analyze.py`; `./.venv/bin/ruff format tests/test_cli/test_analyze.py` formatted the file.
+- `./.venv/bin/ruff check .` - passed after formatting.
+- `./.venv/bin/ruff format --check .` - passed, 254 files already formatted.
+- `./.venv/bin/python -m unittest discover -q` - passed after review fix, 239 tests, 1 skipped.
+- `bash scripts/ci-local.sh` - passed after review fix; local CI skipped Bandit because it is not installed.
+- `bmad-code-review` rerun - found 1 decision-needed item and 4 patch items; story returned to in-progress for follow-up.
+- `./.venv/bin/python -m unittest tests.test_services.test_project_service.ProjectServiceTests.test_active_project_selection_flag_ignores_stale_saved_project tests.test_api.test_analyses.AnalysesApiTests.test_create_analysis_accepts_project_id tests.test_cli.test_analyze.AnalyzeCliTests.test_analyze_command_accepts_project_id tests.test_ui.test_upload_panel.UploadPanelTests.test_run_uploaded_analysis_requires_project_scope_before_parsing tests.test_services.test_github_app_service.GitHubAppServiceTests.test_handle_github_app_webhook_derives_project_for_real_analysis -q` - passed, 5 tests.
+- `./.venv/bin/python -m unittest tests.test_services.test_project_service tests.test_api.test_analyses tests.test_cli.test_analyze tests.test_ui.test_upload_panel tests.test_services.test_github_app_service -q` - passed, 104 tests.
+- `./.venv/bin/ruff check .` - passed after rerun-review fixes.
+- `./.venv/bin/ruff format --check .` - passed, 254 files already formatted.
+- `./.venv/bin/python -m unittest discover -q` - passed after rerun-review fixes, 241 tests, 1 skipped.
+- `bash scripts/ci-local.sh` - passed after rerun-review fixes; local CI skipped Bandit because it is not installed.
+- `bmad-code-review` rerun - found 3 patch items; story returned to in-progress for follow-up.
+- `./.venv/bin/ruff check integrations/github/app_service.py api/routes/analyses.py cli/analyze.py tests/test_services/test_github_app_service.py` - passed after latest review-finding fixes.
+- `./.venv/bin/ruff format --check integrations/github/app_service.py api/routes/analyses.py cli/analyze.py tests/test_services/test_github_app_service.py` - passed, 4 files already formatted.
+- `./.venv/bin/python -m unittest tests.test_services.test_github_app_service.GitHubAppServiceTests.test_handle_github_app_webhook_prefers_explicit_project_key_override tests.test_services.test_github_app_service.GitHubAppServiceTests.test_handle_github_app_webhook_rejects_unknown_explicit_project_override tests.test_services.test_github_app_service.GitHubAppServiceTests.test_handle_github_app_webhook_rejects_malformed_project_override -q` - passed, 3 tests.
+- `./.venv/bin/python -m unittest tests.test_services.test_github_app_service tests.test_api.test_analyses tests.test_cli.test_analyze -q` - passed, 80 tests.
+- `./.venv/bin/ruff check .` - passed after latest review-finding fixes.
+- `./.venv/bin/ruff format --check .` - passed, 254 files already formatted.
+- `./.venv/bin/python -m unittest discover -q` - passed after latest review-finding fixes, 241 tests, 1 skipped.
+- `bash scripts/ci-local.sh` - passed after latest review-finding fixes; local CI skipped Bandit because it is not installed.
+- `bmad-code-review` rerun - Blind Hunter reported 2 intentional compatibility changes that were dismissed against Story 1.2 scope; Acceptance Auditor found 2 patch items; Edge Case Hunter found 3 patch items.
+- `./.venv/bin/ruff check services/project_service.py services/analysis_service.py api/routes/analyses.py cli/analyze.py integrations/github/app_service.py api/routes/github_app.py ui/routes/history.py tests/test_api/test_analyses.py tests/test_cli/test_analyze.py tests/test_services/test_project_service.py tests/test_api/test_github_app.py tests/test_services/test_github_app_service.py tests/test_ui/test_history_page.py` - passed after latest review-finding fixes.
+- `./.venv/bin/ruff format --check services/project_service.py services/analysis_service.py api/routes/analyses.py cli/analyze.py integrations/github/app_service.py api/routes/github_app.py ui/routes/history.py tests/test_api/test_analyses.py tests/test_cli/test_analyze.py tests/test_services/test_project_service.py tests/test_api/test_github_app.py tests/test_services/test_github_app_service.py tests/test_ui/test_history_page.py` - passed, 13 files already formatted.
+- `./.venv/bin/python -m unittest tests.test_api.test_analyses tests.test_cli.test_analyze tests.test_services.test_project_service tests.test_api.test_github_app tests.test_services.test_github_app_service tests.test_ui.test_history_page -q` - passed, 129 tests.
+- `./.venv/bin/ruff check .` - passed after latest review-finding fixes.
+- `./.venv/bin/ruff format --check .` - passed, 254 files already formatted.
+- `./.venv/bin/python -m unittest discover -q` - passed after latest review-finding fixes, 245 tests, 1 skipped.
+- `bash scripts/ci-local.sh` - passed after latest review-finding fixes; local CI skipped Bandit because it is not installed.
+- `bmad-code-review` rerun - Acceptance Auditor found no findings; Blind Hunter and Edge Case Hunter found 1 decision-needed item and 4 patch items; story returned to in-progress for follow-up.
+- `./.venv/bin/python -m unittest tests.test_services.test_project_service tests.test_services.test_github_app_service tests.test_api.test_github_app tests.test_ui.test_history_page -q` - failed before final collision canonicalization; repository URL and owner/repo forms created different project keys.
+- `./.venv/bin/python -m unittest tests.test_services.test_project_service tests.test_services.test_github_app_service tests.test_api.test_github_app tests.test_ui.test_history_page -q` - passed after reviewer-finding fixes, 63 tests.
+- `./.venv/bin/ruff check services/project_service.py integrations/github/app_service.py api/routes/github_app.py ui/routes/history.py tests/test_services/test_project_service.py tests/test_services/test_github_app_service.py tests/test_api/test_github_app.py tests/test_ui/test_history_page.py` - passed.
+- `./.venv/bin/ruff format --check services/project_service.py integrations/github/app_service.py api/routes/github_app.py ui/routes/history.py tests/test_services/test_project_service.py tests/test_services/test_github_app_service.py tests/test_api/test_github_app.py tests/test_ui/test_history_page.py` - failed; `services/project_service.py` and `tests/test_services/test_github_app_service.py` needed formatting.
+- `./.venv/bin/ruff format services/project_service.py tests/test_services/test_github_app_service.py` - reformatted 2 files.
+- `./.venv/bin/ruff check services/project_service.py integrations/github/app_service.py api/routes/github_app.py ui/routes/history.py tests/test_services/test_project_service.py tests/test_services/test_github_app_service.py tests/test_api/test_github_app.py tests/test_ui/test_history_page.py` - passed after formatting.
+- `./.venv/bin/ruff format --check services/project_service.py integrations/github/app_service.py api/routes/github_app.py ui/routes/history.py tests/test_services/test_project_service.py tests/test_services/test_github_app_service.py tests/test_api/test_github_app.py tests/test_ui/test_history_page.py` - passed, 8 files already formatted.
+- `./.venv/bin/ruff check .` - passed after reviewer-finding fixes.
+- `./.venv/bin/ruff format --check .` - passed, 254 files already formatted.
+- `./.venv/bin/python -m unittest discover -q` - passed after reviewer-finding fixes, 245 tests, 1 skipped.
+- `bash scripts/ci-local.sh` - passed after reviewer-finding fixes; local CI skipped Bandit because it is not installed.
+- `bmad-code-review` rerun - found 3 patch items across Blind Hunter, Edge Case Hunter, and Acceptance Auditor; story returned to in-progress for follow-up.
+- `./.venv/bin/python -m unittest tests.test_services.test_project_service tests.test_services.test_github_app_service tests.test_api.test_github_app tests.test_ui.test_history_page -q` - passed after latest reviewer-finding fixes, 66 tests.
+- `./.venv/bin/ruff check services/project_service.py integrations/github/app_service.py tests/test_services/test_project_service.py tests/test_services/test_github_app_service.py` - passed.
+- `./.venv/bin/ruff format --check services/project_service.py integrations/github/app_service.py tests/test_services/test_project_service.py tests/test_services/test_github_app_service.py` - passed, 4 files already formatted.
+- `./.venv/bin/ruff check .` - passed after latest reviewer-finding fixes.
+- `./.venv/bin/ruff format --check .` - passed, 254 files already formatted.
+- `./.venv/bin/python -m unittest discover -q` - passed after latest reviewer-finding fixes, 245 tests, 1 skipped.
+- `bash scripts/ci-local.sh` - passed after latest reviewer-finding fixes; local CI skipped Bandit because it is not installed.
+- `bmad-code-review` rerun - Acceptance Auditor found no findings; Blind Hunter and Edge Case Hunter found 3 patch items; story returned to in-progress for follow-up.
+- `./.venv/bin/python -m unittest tests.test_services.test_project_service.ProjectServiceTests.test_resolve_project_reference_reuses_custom_key_repository_match tests.test_services.test_project_service.ProjectServiceTests.test_resolve_project_reference_backfills_legacy_repository_match tests.test_services.test_project_service.ProjectServiceTests.test_resolve_project_reference_disambiguates_manual_key_collision tests.test_services.test_analysis_service.AnalysisServiceTests.test_resolve_analysis_project_scope_rejects_blank_explicit_key tests.test_api.test_analyses.AnalysesApiTests.test_create_analysis_rejects_blank_explicit_project_key_before_parsing tests.test_cli.test_analyze.AnalyzeCliTests.test_analyze_command_rejects_blank_explicit_project_key_before_parsing tests.test_services.test_github_app_service.GitHubAppServiceTests.test_handle_github_app_webhook_handles_blank_project_override -q` - failed before reviewer-finding fixes, proving repository reuse/backfill and blank-explicit-scope regressions.
+- `./.venv/bin/python -m unittest tests.test_services.test_project_service.ProjectServiceTests.test_resolve_project_reference_reuses_custom_key_repository_match tests.test_services.test_project_service.ProjectServiceTests.test_resolve_project_reference_backfills_legacy_repository_match tests.test_services.test_project_service.ProjectServiceTests.test_resolve_project_reference_disambiguates_manual_key_collision tests.test_services.test_analysis_service.AnalysisServiceTests.test_resolve_analysis_project_scope_rejects_blank_explicit_key tests.test_api.test_analyses.AnalysesApiTests.test_create_analysis_rejects_blank_explicit_project_key_before_parsing tests.test_cli.test_analyze.AnalyzeCliTests.test_analyze_command_rejects_blank_explicit_project_key_before_parsing tests.test_services.test_github_app_service.GitHubAppServiceTests.test_handle_github_app_webhook_handles_blank_project_override -q` - passed after reviewer-finding fixes, 7 tests.
+- `./.venv/bin/python -m unittest tests.test_services.test_project_service tests.test_services.test_analysis_service tests.test_api.test_analyses tests.test_cli.test_analyze tests.test_services.test_github_app_service -q` - passed after reviewer-finding fixes, 131 tests.
+- `./.venv/bin/ruff check services/project_service.py services/analysis_service.py integrations/github/app_service.py tests/test_services/test_project_service.py tests/test_services/test_analysis_service.py tests/test_api/test_analyses.py tests/test_cli/test_analyze.py tests/test_services/test_github_app_service.py` - passed after reviewer-finding fixes.
+- `./.venv/bin/ruff format --check services/project_service.py services/analysis_service.py integrations/github/app_service.py tests/test_services/test_project_service.py tests/test_services/test_analysis_service.py tests/test_api/test_analyses.py tests/test_cli/test_analyze.py tests/test_services/test_github_app_service.py` - passed after formatting, 8 files already formatted.
+- `./.venv/bin/ruff check .` - passed after reviewer-finding fixes.
+- `./.venv/bin/ruff format --check .` - passed after reviewer-finding fixes, 254 files already formatted.
+- `./.venv/bin/python -m unittest discover -q` - passed after reviewer-finding fixes, 246 tests, 1 skipped.
+- `bash scripts/ci-local.sh` - passed after reviewer-finding fixes; local CI skipped Bandit because it is not installed.
+- `bmad-code-review` rerun - Blind Hunter found 1 decision-needed item and 1 patch item after dismissing the blank GitHub override concern as intentional explicit-scope behavior from the prior Story 1.2 review; Acceptance Auditor found no findings; Edge Case Hunter timed out twice, so the layer was marked failed and the story returned to in-progress.
+- `./.venv/bin/python -m unittest tests.test_services.test_project_service.ProjectServiceTests.test_resolve_project_reference_disambiguates_missing_repository_url_collision tests.test_services.test_project_service.ProjectServiceTests.test_resolve_project_reference_reuses_scp_style_repository_remote tests.test_services.test_project_service.ProjectServiceTests.test_resolve_project_reference_reuses_same_repository_key tests.test_services.test_project_service.ProjectServiceTests.test_resolve_project_reference_disambiguates_manual_key_collision tests.test_services.test_project_service.ProjectServiceTests.test_resolve_project_reference_reuses_custom_key_repository_match -q` - passed after latest reviewer-finding fixes, 5 tests.
+- `./.venv/bin/python -m unittest tests.test_services.test_project_service tests.test_services.test_github_app_service -q` - passed after latest reviewer-finding fixes, 46 tests.
+- `./.venv/bin/ruff check services/project_service.py tests/test_services/test_project_service.py` - passed after latest reviewer-finding fixes.
+- `./.venv/bin/ruff format --check services/project_service.py tests/test_services/test_project_service.py` - passed after latest reviewer-finding fixes, 2 files already formatted.
+- `./.venv/bin/ruff check .` - passed after latest reviewer-finding fixes.
+- `./.venv/bin/ruff format --check .` - passed after latest reviewer-finding fixes, 254 files already formatted.
+- `./.venv/bin/python -m unittest discover -q` - passed after latest reviewer-finding fixes, 246 tests, 1 skipped.
+- `bash scripts/ci-local.sh` - passed after latest reviewer-finding fixes; local CI skipped Bandit because it is not installed.
+- `bmad-code-review` rerun - Blind Hunter found 1 patch item after dismissing the UI scope handoff concern as already handled in `ui/components/upload_panel.py` and the blank GitHub override concern as intentional explicit-scope behavior from prior Story 1.2 review; Edge Case Hunter and Acceptance Auditor timed out twice, so those layers were marked failed and the story returned to in-progress.
+- `./.venv/bin/python -m unittest tests.test_services.test_project_service.ProjectServiceTests.test_resolve_project_reference_disambiguates_same_path_cross_host_remote tests.test_services.test_project_service.ProjectServiceTests.test_resolve_project_reference_reuses_scp_style_repository_remote tests.test_services.test_project_service.ProjectServiceTests.test_resolve_project_reference_reuses_same_repository_key tests.test_services.test_project_service.ProjectServiceTests.test_resolve_project_reference_reuses_custom_key_repository_match tests.test_services.test_project_service.ProjectServiceTests.test_resolve_project_reference_disambiguates_repository_key_collision tests.test_services.test_project_service.ProjectServiceTests.test_resolve_project_reference_disambiguates_missing_repository_url_collision -q` - passed after latest reviewer-finding fixes, 6 tests.
+- `./.venv/bin/python -m unittest tests.test_services.test_github_app_service -q` - passed after latest reviewer-finding fixes, 18 tests.
+- `./.venv/bin/python -m unittest tests.test_services.test_project_service tests.test_services.test_github_app_service -q` - passed after latest reviewer-finding fixes, 47 tests.
+- `./.venv/bin/ruff check services/project_service.py integrations/github/app_service.py tests/test_services/test_project_service.py` - passed after latest reviewer-finding fixes.
+- `./.venv/bin/ruff format --check services/project_service.py integrations/github/app_service.py tests/test_services/test_project_service.py` - failed before formatting; `services/project_service.py` and `integrations/github/app_service.py` needed formatting.
+- `./.venv/bin/ruff format services/project_service.py integrations/github/app_service.py` - reformatted 2 files.
+- `./.venv/bin/ruff check services/project_service.py integrations/github/app_service.py tests/test_services/test_project_service.py` - passed after formatting.
+- `./.venv/bin/ruff format --check services/project_service.py integrations/github/app_service.py tests/test_services/test_project_service.py` - passed after formatting, 3 files already formatted.
+- `./.venv/bin/ruff check .` - passed after latest reviewer-finding fixes.
+- `./.venv/bin/ruff format --check .` - passed after latest reviewer-finding fixes, 254 files already formatted.
+- `./.venv/bin/python -m unittest discover -q` - passed after latest reviewer-finding fixes, 246 tests, 1 skipped.
+- `bash scripts/ci-local.sh` - passed after latest reviewer-finding fixes; local CI skipped Bandit because it is not installed.
+
+### Completion Notes List
+
+- Resolved analysis project scope once at the start of the shared `analyze_uploaded_files` pipeline and passed the resolved project ID through context building and report persistence.
+- Preserved the existing UI, API, CLI, and GitHub project-aware flows while ensuring invalid explicit project references fail before parser execution.
+- Added API and CLI regression tests that assert unknown project references return structured project errors, do not invoke parsing, and do not create reports.
+- Fixed review finding by rejecting missing project scope before parser execution in the shared analysis pipeline.
+- Added service, API, and CLI regression tests for `missing_project_scope`, and updated existing API/CLI success-path tests to pass explicit project scope.
+- Updated workspace and CI advisory docs plus the README analysis endpoint notes to document required project scope for new API/CLI analysis submissions.
+- Resolved the AC2 phase-scope decision by clarifying that Story 1.2 rejects invalid local/admin project references before parsing while full membership and role checks are deferred to Story 1.5.
+- Fixed stale active-project selection so missing saved project records no longer enable manual UI uploads under the fallback `unassigned` project.
+- Added the missing API `404` response contract and direct API/CLI `project_id` success regressions.
+- Added UI and GitHub integration tests that exercise the shared missing-scope guard and repository-derived project handoff.
+- Fixed explicit GitHub project override handling so unknown or malformed configured project keys fail as configuration errors and do not create projects or start analysis.
+- Updated API and CLI contract text so generated metadata and help output match the required project-scope behavior.
+- Fixed GitHub webhook project-scope errors so invalid project references return project-specific API error codes instead of generic app-unconfigured errors.
+- Added pre-parse/no-report regression coverage for conflicting API/CLI project references.
+- Normalized blank `project_key` values so valid `project_id` submissions are accepted even when form clients send empty project-key fields.
+- Moved API/CLI analysis scope checks ahead of artifact read/classification so missing scope is the first actionable failure for submissions with artifacts.
+- Aligned history page active-project recovery with upload behavior when a saved project selection becomes stale.
+- Fixed blank-key-only project references so they cannot fall through to the default project.
+- Fixed stale history project recovery so stale/no-saved selection scopes history to the default project instead of all reports.
+- Fixed repository-derived GitHub project collisions by canonicalizing repository references and suffixing colliding derived keys with a deterministic repository hash.
+- Fixed GitHub webhook project-scope failures so initial and late failures are handled as acknowledged no-analysis results with neutral check-run notes instead of non-2xx delivery failures or generic 500s.
+- Fixed repository-derived collision handling for preexisting manual projects without repository URLs.
+- Moved explicit GitHub project override resolution ahead of artifact download/classification.
+- Narrowed GitHub analysis error handling so only actual project-scope errors are converted into neutral handled webhook results.
+- Fixed repository matching so canonical identity includes the SCM host, preventing same owner/repo paths on different hosts from reusing the same project while preserving path-derived display keys.
+
+### File List
+
+- `_bmad-output/implementation-artifacts/1-2-project-aware-analysis-submission.md`
+- `_bmad-output/implementation-artifacts/sprint-status.yaml`
+- `README.md`
+- `api/routes/analyses.py`
+- `api/routes/github_app.py`
+- `docs/ci-advisory-consumption.md`
+- `docs/project-workspaces.md`
+- `integrations/github/app_service.py`
+- `services/analysis_service.py`
+- `services/project_service.py`
+- `tests/test_api/test_analyses.py`
+- `tests/test_api/test_github_app.py`
+- `tests/test_cli/test_analyze.py`
+- `tests/test_services/test_github_app_service.py`
+- `tests/test_services/test_analysis_service.py`
+- `tests/test_services/test_project_service.py`
+- `tests/test_ui/test_history_page.py`
+- `tests/test_ui/test_upload_panel.py`
+- `ui/routes/history.py`
+
+## Change Log
+
+- 2026-05-01: Story created/aligned from updated PRD, architecture, epics, sprint status, and readiness report.
+- 2026-05-05: Implemented project-scope fast-fail behavior for analysis submission and moved story to review.
+- 2026-05-05: Fixed review finding by rejecting missing analysis project scope before parsing and updating API/CLI docs and regression coverage.
+- 2026-05-05: Re-ran code review; unresolved decision and patch findings moved story back to in-progress.
+- 2026-05-05: Fixed rerun review findings and moved story back to review.
+- 2026-05-05: Re-ran code review; unresolved GitHub override and public contract findings moved story back to in-progress.
+- 2026-05-05: Fixed latest review findings for GitHub explicit project overrides and API/CLI contract text; moved story back to review.
+- 2026-05-05: Re-ran code review; unresolved GitHub webhook error-contract and conflicting-reference regression findings moved story back to in-progress.
+- 2026-05-05: Fixed latest review findings for GitHub project-scope errors, API/CLI preflight, blank keys, conflicting-reference regressions, and stale history scope; moved story back to review.
+- 2026-05-05: Re-ran code review; unresolved GitHub webhook delivery decision and project-scope edge-case findings moved story back to in-progress.
+- 2026-05-05: Fixed latest reviewer findings for webhook project-scope handling, blank-key fallback, stale history scope, repository-key collisions, and late GitHub scope errors; moved story back to review.
+- 2026-05-05: Re-ran code review; unresolved GitHub project-scope fast-fail and repository collision findings moved story back to in-progress.
+- 2026-05-05: Fixed latest reviewer findings for manual repository-key collisions, explicit GitHub scope fast-fail ordering, and non-project analysis ValueError handling; moved story back to review.
+- 2026-05-06: Fixed latest reviewer finding for SCM host-aware repository identity; moved story back to review.

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -51,7 +51,7 @@ development_status:
 
   epic-1: in-progress
   1-1-project-and-workspace-records: done
-  1-2-project-aware-analysis-submission: ready-for-dev
+  1-2-project-aware-analysis-submission: review
   1-3-project-scoped-report-persistence: ready-for-dev
   1-4-project-scoped-learning-and-context-records: ready-for-dev
   1-5-lightweight-rbac-role-model: ready-for-dev

--- a/api/routes/analyses.py
+++ b/api/routes/analyses.py
@@ -25,6 +25,7 @@ from services.analysis_service import (
     analyze_uploaded_files,
     build_advisory_summary,
     build_share_summary,
+    resolve_analysis_project_scope,
 )
 from services.intake_service import (
     MAX_TOTAL_UPLOAD_BYTES,
@@ -155,6 +156,7 @@ def list_analyses(
     response_model=AnalysisRunResponse,
     responses={
         400: {"model": ErrorResponse},
+        404: {"model": ErrorResponse},
         413: {"model": ErrorResponse},
         405: {"model": ErrorResponse},
         422: {"model": ErrorResponse},
@@ -165,8 +167,14 @@ async def create_analysis(
     files: list[UploadFile] | None = File(
         default=None, description="Supported deployment artifacts to analyze."
     ),
-    project_id: int | None = Form(default=None),
-    project_key: str | None = Form(default=None),
+    project_id: int | None = Form(
+        default=None,
+        description="Required unless project_key is provided; numeric project id for the analysis.",
+    ),
+    project_key: str | None = Form(
+        default=None,
+        description="Required unless project_id is provided; project key for the analysis.",
+    ),
     trigger_type: str | None = Header(
         default=None, alias="X-DeployWhisper-Trigger-Type"
     ),
@@ -178,6 +186,11 @@ async def create_analysis(
             code="missing_artifacts",
             message="At least one artifact file is required.",
         )
+
+    try:
+        resolve_analysis_project_scope(project_id=project_id, project_key=project_key)
+    except ValueError as exc:
+        raise _project_api_error(exc) from exc
 
     raw_files = await _read_upload_files_with_limit(files)
     pending_analysis = build_pending_analysis(raw_files)

--- a/api/routes/github_app.py
+++ b/api/routes/github_app.py
@@ -11,6 +11,7 @@ from api.errors import ApiError, ApiRoute
 from config import settings
 from integrations.github.app_service import (
     GitHubAppConfigurationError,
+    GitHubAppProjectScopeError,
     GitHubAppRequestError,
     build_github_app_oauth_url,
     complete_github_app_oauth,
@@ -106,6 +107,27 @@ async def github_app_webhook(request: Request) -> dict[str, object]:
             payload=payload,
             config=config,
         )
+    except GitHubAppProjectScopeError as exc:
+        code = getattr(exc, "code", "invalid_project_reference")
+        return {
+            "data": {
+                "event": event_name,
+                "action": str(payload.get("action") or "").strip() or None,
+                "handled": True,
+                "automatic_analysis_triggered": False,
+                "check_run_id": None,
+                "report_id": None,
+                "report_url": None,
+                "marketplace_url": config.marketplace_url,
+                "install_url": config.install_url,
+                "advisory_only": True,
+                "note": f"{code}: {exc}",
+            },
+            "meta": {
+                "api_version": "v1",
+                "app_name": settings.app_name,
+            },
+        }
     except GitHubAppConfigurationError as exc:
         raise ApiError(
             status_code=405,

--- a/cli/analyze.py
+++ b/cli/analyze.py
@@ -35,6 +35,7 @@ from services.analysis_service import (
     analyze_uploaded_files,
     build_advisory_summary,
     build_share_summary,
+    resolve_analysis_project_scope,
 )
 from services.deployment_outcome_service import record_deployment_outcome
 from services.project_service import create_project, create_workspace
@@ -274,6 +275,18 @@ def _run_analyze(
             build_error(
                 code="missing_artifacts",
                 message="At least one artifact file is required.",
+            ),
+            stream=sys.stderr,
+        )
+        return 2
+
+    try:
+        resolve_analysis_project_scope(project_id=project_id, project_key=project_key)
+    except ValueError as exc:
+        _emit_json(
+            build_error(
+                code=getattr(exc, "code", "invalid_project_request"),
+                message=str(exc),
             ),
             stream=sys.stderr,
         )
@@ -588,13 +601,13 @@ def build_parser() -> argparse.ArgumentParser:
     analyze_parser.add_argument(
         "--project",
         dest="project_key",
-        help="Optional project/workspace key for the analysis.",
+        help="Project/workspace key for the analysis. Required unless --project-id is provided.",
     )
     analyze_parser.add_argument(
         "--project-id",
         dest="project_id",
         type=int,
-        help="Optional numeric project/workspace id for the analysis.",
+        help="Numeric project/workspace id for the analysis. Required unless --project is provided.",
     )
     analyze_parser.add_argument(
         "paths", nargs="*", help="Artifact file paths to analyze."

--- a/docs/ci-advisory-consumption.md
+++ b/docs/ci-advisory-consumption.md
@@ -11,12 +11,12 @@ DeployWhisper remains advisory in automation contexts.
 - Sensitive shared reports can opt into password protection and file-name redaction through `POST /api/v1/analyses/{id}/share`
 - The share-configuration API is disabled unless `DEPLOYWHISPER_SHARE_TOKEN` is set; callers must send that value in `X-DeployWhisper-Share-Token`
 - CLI and API responses preserve `severity`, `recommendation`, `partial_context`, and `narrative_degraded` for machine-readable uncertainty handling
-- High-risk or degraded analyses still return success payloads; non-zero CLI exit codes are reserved for operational failures such as unreadable files or shared-analysis crashes
+- High-risk or degraded analyses still return success payloads; non-zero CLI exit codes are reserved for operational failures such as unreadable files, missing project scope, or shared-analysis crashes
 
 ## CLI Example
 
 ```bash
-deploywhisper analyze plan.json > advisory.json
+deploywhisper analyze --project payments plan.json > advisory.json
 python - <<'PY'
 import json
 payload = json.load(open("advisory.json", encoding="utf-8"))
@@ -28,6 +28,7 @@ PY
 
 ```bash
 curl -sS -X POST http://localhost:8080/api/v1/analyses \
+  -F "project_key=payments" \
   -F "files=@plan.json" \
   > advisory.json
 python - <<'PY'

--- a/docs/project-workspaces.md
+++ b/docs/project-workspaces.md
@@ -6,7 +6,7 @@ DeployWhisper now scopes analyses and topology context to lightweight project/wo
 
 - Projects have a stable `project_key`, display name, optional description, repository URL, and default branch.
 - Workspaces have a stable project-local `workspace_key`, display name, optional description, optional environment label, and timestamps.
-- New analyses can attach to a project through the UI, API, CLI, or GitHub integration path.
+- New analyses must attach to a project through the UI, API, CLI, or GitHub integration path.
 - Persisted reports now carry project metadata and history filters can scope by project.
 - Topology uploads are stored per project, with legacy file-based topology continuing to resolve through the default `unassigned` project.
 - Topology drift checks now run on a persisted cadence (daily by default), reuse the imported source reference when available, and surface per-project added/removed/modified resource reports in settings.
@@ -19,7 +19,7 @@ DeployWhisper now scopes analyses and topology context to lightweight project/wo
   - `POST /api/v1/projects` creates a project
   - `GET /api/v1/projects/<project_key>/workspaces` lists workspace/environment records for a project
   - `POST /api/v1/projects/<project_key>/workspaces` creates a workspace/environment record
-  - `POST /api/v1/analyses` accepts multipart `project_key` or `project_id`
+  - `POST /api/v1/analyses` requires multipart `project_key` or `project_id`
   - `GET /api/v1/context/topology?project_key=<key>` reads project-scoped topology status
   - `POST /api/v1/context/topology` stores project-scoped topology JSON with `project_key` or `project_id`
 - CLI:
@@ -27,7 +27,7 @@ DeployWhisper now scopes analyses and topology context to lightweight project/wo
   - `deploywhisper project list`
   - `deploywhisper project workspace create <project-key> <workspace-key> <display-name>`
   - `deploywhisper project workspace list <project-key>`
-  - `deploywhisper analyze --project <key> <artifact...>`
+  - `deploywhisper analyze --project <key> <artifact...>` or `deploywhisper analyze --project-id <id> <artifact...>`
   - `deploywhisper topology import --from custom --source <topology.json> --project <key>`
   - `deploywhisper topology import --from terraform --source <state-or-uri> --project <key>`
   - The topology import command now routes through a shared source registry and returns a normalized import result with accepted, skipped, partially parsed, and unsupported resources.
@@ -37,14 +37,16 @@ DeployWhisper now scopes analyses and topology context to lightweight project/wo
 
 - Shared workspace chrome now keeps project switching in a dedicated global card below the header, with searchable filtering, keyboard navigation, and current/default project context shown consistently across pages.
 - Explicit `project_key` / `project_id` references now fail fast when they are unknown instead of silently falling back to `unassigned`.
+- New API and CLI analysis submissions without a project reference fail fast with `missing_project_scope` instead of silently falling back to `unassigned`.
 - Conflicting `project_key` and `project_id` inputs are rejected.
+- In the current local/admin phase, unauthorized analysis scope means an unknown, conflicting, or otherwise invalid project reference. Full membership and role enforcement is intentionally deferred to the lightweight RBAC story.
 - Repository-derived project keys include the owner segment when available to avoid collisions between unrelated repositories with the same leaf name.
 - Topology import stores normalized graph metadata only. Raw source artifacts are not persisted, and unsupported resources degrade to explicit warnings instead of aborting the whole import.
 - Drift cadence is persisted through the settings UI, and scheduled drift checks warn when more than 10% of mapped resources changed since the last import.
 
 ### Legacy Mapping
 
-- Existing persisted reports are backfilled into the default `unassigned` project during migration `010_add_project_workspaces`.
+- Existing persisted reports are backfilled into the default `unassigned` project during migration `010_add_project_workspaces`; this legacy mapping does not apply to new API or CLI analysis submissions.
 - First-class workspace/environment records are introduced by migration `014_add_project_workspace_records`.
 - Existing file-based topology remains readable through the default project and new default-project topology updates continue to mirror the legacy file path for compatibility.
 

--- a/integrations/github/app_service.py
+++ b/integrations/github/app_service.py
@@ -37,10 +37,24 @@ _STATE_MAX_AGE_SECONDS = 600
 _UPLOAD_LIMIT_MESSAGE = (
     "Total artifact payload exceeds the 50 MB analysis-session limit."
 )
+_PROJECT_SCOPE_ERROR_CODES = {
+    "missing_project_scope",
+    "project_not_found",
+    "conflicting_project_reference",
+    "invalid_project_reference",
+}
 
 
 class GitHubAppConfigurationError(RuntimeError):
     """Raised when required GitHub App configuration is missing."""
+
+
+class GitHubAppProjectScopeError(RuntimeError):
+    """Raised when GitHub analysis cannot resolve an explicit project scope."""
+
+    def __init__(self, code: str, message: str) -> None:
+        super().__init__(message)
+        self.code = code
 
 
 class GitHubAppRequestError(RuntimeError):
@@ -330,6 +344,43 @@ def handle_github_app_webhook(
         installation_id,
         config=config,
     )
+    raw_explicit_project_key = os.getenv("DEPLOYWHISPER_GITHUB_PROJECT_KEY")
+    explicit_project_key = (
+        raw_explicit_project_key.strip()
+        if raw_explicit_project_key is not None
+        else None
+    )
+    project = None
+    if explicit_project_key is not None:
+        try:
+            project = resolve_project_reference(project_key=explicit_project_key)
+        except ProjectResolutionError as exc:
+            return _project_scope_failure_result(
+                event_name=event_name,
+                action=action,
+                owner=owner,
+                repo_name=repo_name,
+                head_sha=head_sha,
+                installation_token=installation_token,
+                code=exc.code,
+                message=str(exc),
+                config=config,
+            )
+        except ValueError as exc:
+            return _project_scope_failure_result(
+                event_name=event_name,
+                action=action,
+                owner=owner,
+                repo_name=repo_name,
+                head_sha=head_sha,
+                installation_token=installation_token,
+                code=getattr(exc, "code", "invalid_project_reference"),
+                message=str(exc),
+                config=config,
+            )
+        except RuntimeError as exc:
+            raise GitHubAppConfigurationError(str(exc)) from exc
+
     raw_files = _load_pull_request_artifacts(
         owner=owner,
         repo_name=repo_name,
@@ -377,29 +428,76 @@ def handle_github_app_webhook(
     if config.checks_enabled:
         _require_check_run_report_url_config(config)
 
-    explicit_project_key = (
-        os.getenv("DEPLOYWHISPER_GITHUB_PROJECT_KEY") or ""
-    ).strip() or None
+    if project is None:
+        try:
+            project = resolve_project_reference(
+                repository_name=_repository_reference(owner, repo_name, config=config),
+                allow_create=True,
+            )
+        except ProjectResolutionError as exc:
+            return _project_scope_failure_result(
+                event_name=event_name,
+                action=action,
+                owner=owner,
+                repo_name=repo_name,
+                head_sha=head_sha,
+                installation_token=installation_token,
+                code=exc.code,
+                message=str(exc),
+                config=config,
+            )
+        except ValueError as exc:
+            return _project_scope_failure_result(
+                event_name=event_name,
+                action=action,
+                owner=owner,
+                repo_name=repo_name,
+                head_sha=head_sha,
+                installation_token=installation_token,
+                code=getattr(exc, "code", "invalid_project_reference"),
+                message=str(exc),
+                config=config,
+            )
+        except RuntimeError as exc:
+            raise GitHubAppConfigurationError(str(exc)) from exc
+
     try:
-        project = resolve_project_reference(
-            project_key=explicit_project_key,
-            repository_name=f"{owner}/{repo_name}"
-            if explicit_project_key is None
-            else None,
-            allow_create=True,
+        result = analyze_uploaded_files(
+            accepted_files,
+            project_key=project.project_key,
+            audit_context={
+                "source_interface": "github_app",
+                "trigger_type": "github_app_pull_request",
+                "trigger_id": f"{owner}/{repo_name}#PR-{pull_number}",
+            },
         )
     except ProjectResolutionError as exc:
-        raise GitHubAppConfigurationError(str(exc)) from exc
-
-    result = analyze_uploaded_files(
-        accepted_files,
-        project_key=project.project_key,
-        audit_context={
-            "source_interface": "github_app",
-            "trigger_type": "github_app_pull_request",
-            "trigger_id": f"{owner}/{repo_name}#PR-{pull_number}",
-        },
-    )
+        return _project_scope_failure_result(
+            event_name=event_name,
+            action=action,
+            owner=owner,
+            repo_name=repo_name,
+            head_sha=head_sha,
+            installation_token=installation_token,
+            code=exc.code,
+            message=str(exc),
+            config=config,
+        )
+    except ValueError as exc:
+        code = getattr(exc, "code", None)
+        if code not in _PROJECT_SCOPE_ERROR_CODES:
+            raise
+        return _project_scope_failure_result(
+            event_name=event_name,
+            action=action,
+            owner=owner,
+            repo_name=repo_name,
+            head_sha=head_sha,
+            installation_token=installation_token,
+            code=code,
+            message=str(exc),
+            config=config,
+        )
     report_id = int(result.persisted_report["id"])
     report_url = build_share_report_link(report_id)
     check_run_id = None
@@ -426,6 +524,58 @@ def handle_github_app_webhook(
         report_id=report_id,
         report_url=report_url,
         note="GitHub App webhook processed and advisory analysis completed.",
+    )
+
+
+def _repository_reference(
+    owner: str, repo_name: str, *, config: GitHubAppConfig
+) -> str:
+    host = parse.urlparse(config.authorize_url).netloc.strip().lower()
+    if not host:
+        host = parse.urlparse(config.api_base_url).netloc.strip().lower()
+    if host == "api.github.com":
+        host = "github.com"
+    return f"{host}/{owner}/{repo_name}" if host else f"{owner}/{repo_name}"
+
+
+def _project_scope_failure_result(
+    *,
+    event_name: str,
+    action: str | None,
+    owner: str,
+    repo_name: str,
+    head_sha: str,
+    installation_token: str,
+    code: str,
+    message: str,
+    config: GitHubAppConfig,
+) -> GitHubWebhookResult:
+    note = f"{code}: {message}"
+    check_run_id = (
+        _create_check_run(
+            owner=owner,
+            repo_name=repo_name,
+            head_sha=head_sha,
+            installation_token=installation_token,
+            conclusion="neutral",
+            title=DEFAULT_CHECK_RUN_NAME,
+            summary=note,
+            details_url=None,
+            text=_check_run_text(details_url=None),
+            api_base_url=config.api_base_url,
+        )
+        if config.checks_enabled
+        else None
+    )
+    return GitHubWebhookResult(
+        event=event_name,
+        action=action,
+        handled=True,
+        automatic_analysis_triggered=False,
+        check_run_id=check_run_id,
+        report_id=None,
+        report_url=None,
+        note=note,
     )
 
 

--- a/services/analysis_service.py
+++ b/services/analysis_service.py
@@ -13,18 +13,18 @@ from analysis.incident_matcher import (
     load_incident_candidates,
 )
 from analysis.risk_engine import score_evidence
-from analysis.rollback_planner import RollbackPlan, generate_rollback_plan
-from evidence.mappers import build_findings
 from analysis.risk_scorer import RiskAssessment
-from evidence.models import ContextCompleteness, EvidenceItem, Finding
+from analysis.rollback_planner import RollbackPlan, generate_rollback_plan
 from evidence.extractor import extract_batch_evidence
+from evidence.mappers import build_findings
+from evidence.models import ContextCompleteness, EvidenceItem, Finding
 from llm.narrator import NarrativeResult, generate_narrative
 from llm.providers import generate_completion_with_settings
 from parsers.base import ParseBatchResult, UnifiedChange
 from services.intake_service import build_parse_batch
-from services.report_service import persist_analysis_report
+from services.project_service import ProjectResolutionError, resolve_project_reference
+from services.report_service import build_share_report_link, persist_analysis_report
 from services.settings_service import resolve_provider_runtime
-from services.report_service import build_share_report_link
 from services.topology_service import (
     STALE_AFTER_DAYS,
     get_topology_status,
@@ -679,6 +679,36 @@ def build_analysis_artifacts(
     )
 
 
+def resolve_analysis_project_scope(
+    *,
+    project_id: int | None = None,
+    project_key: str | None = None,
+):
+    """Resolve the required analysis project before artifact parsing."""
+    raw_project_key = str(project_key) if project_key is not None else None
+    cleaned_project_key = (
+        raw_project_key.strip() if raw_project_key is not None else None
+    )
+    if project_id is None and raw_project_key is not None and not cleaned_project_key:
+        raise ProjectResolutionError(
+            "invalid_project_reference",
+            "Project key must contain at least one letter or number.",
+        )
+    if project_id is None and not cleaned_project_key:
+        raise ProjectResolutionError(
+            "missing_project_scope",
+            (
+                "Project scope is required for analysis submission. "
+                "Provide a project_key or project_id, select a project in the UI, "
+                "or use a workflow integration that derives one."
+            ),
+        )
+    return resolve_project_reference(
+        project_id=project_id,
+        project_key=cleaned_project_key or None,
+    )
+
+
 def analyze_uploaded_files(
     files: list[tuple[str, bytes | None]],
     completion_client=None,
@@ -687,10 +717,13 @@ def analyze_uploaded_files(
     audit_context: dict | None = None,
 ) -> AnalysisRunResult:
     """Run the shared parse -> assess -> persist pipeline."""
-    artifacts = build_analysis_artifacts(
-        files,
+    resolved_project = resolve_analysis_project_scope(
         project_id=project_id,
         project_key=project_key,
+    )
+    artifacts = build_analysis_artifacts(
+        files,
+        project_id=resolved_project.id,
         completion_client=completion_client,
     )
     persisted_report = persist_analysis_report(
@@ -702,8 +735,7 @@ def analyze_uploaded_files(
         findings=artifacts.findings,
         evidence_items=artifacts.evidence_items,
         artifact_snapshots={name: raw_content for name, raw_content in files},
-        project_id=project_id,
-        project_key=project_key,
+        project_id=resolved_project.id,
         audit_context=audit_context,
     )
     return AnalysisRunResult(

--- a/services/project_service.py
+++ b/services/project_service.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
+import hashlib
 import re
 from typing import Any
+from urllib.parse import urlparse
 
 from pydantic import BaseModel
 from sqlalchemy.exc import IntegrityError, OperationalError
@@ -173,13 +175,87 @@ def _display_name_from_key(project_key: str) -> str:
 
 
 def derive_project_key_from_repository(repository_name: str) -> str:
-    trimmed = str(repository_name or "").strip().rstrip("/")
+    _, repository_path = _parse_repository_reference(repository_name)
+    trimmed = repository_path or str(repository_name or "").strip().rstrip("/")
     if trimmed.endswith(".git"):
         trimmed = trimmed[:-4]
     if "/" not in trimmed:
         return normalize_project_key(trimmed)
     owner, leaf = trimmed.split("/", maxsplit=1)
     return normalize_project_key(f"{owner}-{leaf}")
+
+
+def _parse_repository_reference(
+    repository_name: str | None,
+) -> tuple[str | None, str | None]:
+    trimmed = str(repository_name or "").strip().rstrip("/")
+    if not trimmed:
+        return None, None
+    parsed = urlparse(trimmed)
+    host: str | None = None
+    path = trimmed
+    if parsed.scheme or parsed.netloc:
+        host = parsed.netloc.rsplit("@", maxsplit=1)[-1].lower() or None
+        path = parsed.path
+    elif ":" in trimmed:
+        host_part, path_part = trimmed.split(":", maxsplit=1)
+        if "@" in host_part or "." in host_part:
+            host = host_part.rsplit("@", maxsplit=1)[-1].lower() or None
+            path = path_part
+    else:
+        parts = trimmed.split("/", maxsplit=1)
+        if len(parts) == 2 and "." in parts[0]:
+            host = parts[0].lower() or None
+            path = parts[1]
+    canonical_path = path.strip("/")
+    if canonical_path.endswith(".git"):
+        canonical_path = canonical_path[:-4]
+    return host, canonical_path.lower() or None
+
+
+def _canonical_repository_name(repository_name: str | None) -> str | None:
+    host, repository_path = _parse_repository_reference(repository_name)
+    if repository_path is None:
+        return None
+    if host is None:
+        return repository_path
+    return f"{host}/{repository_path}"
+
+
+def _repository_project_key(repository_name: str) -> str:
+    canonical = _canonical_repository_name(repository_name) or str(repository_name)
+    digest = hashlib.sha256(canonical.encode("utf-8")).hexdigest()[:8]
+    return f"{derive_project_key_from_repository(repository_name)}-{digest}"
+
+
+def _repository_matches_project(record, repository_name: str | None) -> bool:
+    record_repository = _canonical_repository_name(
+        getattr(record, "repository_url", None)
+    )
+    requested_repository = _canonical_repository_name(repository_name)
+    if requested_repository is None:
+        return True
+    if record_repository is None:
+        return False
+    return record_repository == requested_repository
+
+
+def _repository_storage_value(repository_name: str | None) -> str | None:
+    return _canonical_repository_name(repository_name) or (
+        str(repository_name).strip() if repository_name is not None else None
+    )
+
+
+def _find_project_by_repository(session, repository_name: str | None):
+    requested_repository = _canonical_repository_name(repository_name)
+    if requested_repository is None:
+        return None
+    for record in list_project_records(session):
+        if _canonical_repository_name(getattr(record, "repository_url", None)) == (
+            requested_repository
+        ):
+            return record
+    return None
 
 
 def display_name_from_repository(repository_name: str) -> str:
@@ -353,6 +429,13 @@ def resolve_project_reference(
     repository_name: str | None = None,
     allow_create: bool = False,
 ) -> ProjectRecord:
+    raw_project_key = str(project_key) if project_key is not None else None
+    project_key = raw_project_key.strip() if raw_project_key is not None else None
+    if project_id is None and raw_project_key is not None and not project_key:
+        raise ProjectResolutionError(
+            "invalid_project_reference",
+            "Project key must contain at least one letter or number.",
+        )
     ensure_default_project()
     normalized_key = normalize_project_key(project_key) if project_key else None
     derived_key = (
@@ -398,7 +481,14 @@ def resolve_project_reference(
 
         record = record_by_id or record_by_key
         if record is None and derived_key is not None:
-            record = get_project_by_key(session, derived_key)
+            record = _find_project_by_repository(session, repository_name)
+            if record is None:
+                record = get_project_by_key(session, derived_key)
+                if record is not None and not _repository_matches_project(
+                    record, repository_name
+                ):
+                    derived_key = _repository_project_key(str(repository_name))
+                    record = get_project_by_key(session, derived_key)
 
         if record is None and allow_create:
             if normalized_key is not None:
@@ -414,7 +504,7 @@ def resolve_project_reference(
                     display_name=display_name_from_repository(
                         repository_name or derived_key
                     ),
-                    repository_url=repository_name,
+                    repository_url=_repository_storage_value(repository_name),
                 )
         elif record is None and (project_id is not None or normalized_key is not None):
             detail = (
@@ -449,7 +539,11 @@ def get_active_project() -> ProjectRecord | None:
         setting = get_setting(session, ACTIVE_PROJECT_SETTING_KEY)
         if setting is None:
             return _serialize(get_default_project(session))
-        record = get_project(session, int(setting.value))
+        try:
+            project_id = int(setting.value)
+        except (TypeError, ValueError):
+            project_id = 0
+        record = get_project(session, project_id)
         if record is None:
             return _serialize(get_default_project(session))
         return _serialize(record)
@@ -458,7 +552,14 @@ def get_active_project() -> ProjectRecord | None:
 def has_active_project_selection() -> bool:
     ensure_default_project()
     with SessionLocal() as session:
-        return get_setting(session, ACTIVE_PROJECT_SETTING_KEY) is not None
+        setting = get_setting(session, ACTIVE_PROJECT_SETTING_KEY)
+        if setting is None:
+            return False
+        try:
+            project_id = int(setting.value)
+        except (TypeError, ValueError):
+            return False
+        return get_project(session, project_id) is not None
 
 
 def build_project_payload(project: ProjectRecord | dict[str, Any]) -> dict[str, Any]:

--- a/tests/test_api/test_analyses.py
+++ b/tests/test_api/test_analyses.py
@@ -406,6 +406,96 @@ class AnalysesApiTests(unittest.TestCase):
         )
         self.assertEqual(payload["data"]["persisted_report"]["id"], 2)
 
+    def test_create_analysis_accepts_project_id(self) -> None:
+        project = project_service_module.create_project(
+            project_key="payments",
+            display_name="Payments",
+        )
+        files = [
+            (
+                "files",
+                (
+                    "plan.json",
+                    b'{"resource_changes": [{"address": "aws_security_group.main", "change": {"actions": ["modify"]}}]}',
+                    "application/json",
+                ),
+            )
+        ]
+        narrative = NarrativeResult(
+            opening_sentence="CAUTION: review the security group update.",
+            explanation="The deployment widens database access and should be reviewed.",
+            guidance=["Review the security group change before deploy."],
+            degraded=False,
+            warnings=[],
+        )
+
+        with (
+            patch(
+                "services.analysis_service.evaluate_parse_batch",
+                return_value=self._analysis_assessment(),
+            ),
+            patch(
+                "services.analysis_service.generate_narrative", return_value=narrative
+            ),
+            patch("services.analysis_service.find_incident_matches", return_value=[]),
+        ):
+            response = self.client.post(
+                "/api/v1/analyses",
+                files=files,
+                data={"project_id": str(project.id)},
+            )
+
+        self.assertEqual(response.status_code, 200)
+        payload = response.json()
+        self.assertEqual(
+            payload["data"]["persisted_report"]["project"]["project_key"], "payments"
+        )
+
+    def test_create_analysis_accepts_project_id_with_blank_project_key(self) -> None:
+        project = project_service_module.create_project(
+            project_key="payments",
+            display_name="Payments",
+        )
+        files = [
+            (
+                "files",
+                (
+                    "plan.json",
+                    b'{"resource_changes": [{"address": "aws_security_group.main", "change": {"actions": ["modify"]}}]}',
+                    "application/json",
+                ),
+            )
+        ]
+        narrative = NarrativeResult(
+            opening_sentence="CAUTION: review the security group update.",
+            explanation="The deployment widens database access and should be reviewed.",
+            guidance=[],
+            degraded=False,
+            warnings=[],
+        )
+
+        with (
+            patch(
+                "services.analysis_service.evaluate_parse_batch",
+                return_value=self._analysis_assessment(),
+            ),
+            patch(
+                "services.analysis_service.generate_narrative", return_value=narrative
+            ),
+            patch("services.analysis_service.find_incident_matches", return_value=[]),
+        ):
+            response = self.client.post(
+                "/api/v1/analyses",
+                files=files,
+                data={"project_id": str(project.id), "project_key": "   "},
+            )
+
+        self.assertEqual(response.status_code, 200)
+        payload = response.json()
+        self.assertEqual(
+            payload["data"]["persisted_report"]["project"]["project_key"], "payments"
+        )
+
     def test_create_analysis_rejects_unknown_project_reference(self) -> None:
         files = [
             (
@@ -426,6 +516,86 @@ class AnalysesApiTests(unittest.TestCase):
 
         self.assertEqual(response.status_code, 404)
         self.assertEqual(response.json()["error"]["code"], "project_not_found")
+
+    def test_create_analysis_rejects_unknown_project_before_parsing(self) -> None:
+        files = [
+            (
+                "files",
+                (
+                    "plan.json",
+                    b'{"resource_changes": [{"address": "aws_security_group.main", "change": {"actions": ["modify"]}}]}',
+                    "application/json",
+                ),
+            )
+        ]
+
+        with patch(
+            "services.analysis_service.build_parse_batch",
+            side_effect=AssertionError("project must resolve before parsing"),
+        ) as build_parse_batch:
+            response = self.client.post(
+                "/api/v1/analyses",
+                files=files,
+                data={"project_key": "missing"},
+            )
+
+        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.json()["error"]["code"], "project_not_found")
+        build_parse_batch.assert_not_called()
+        list_response = self.client.get("/api/v1/analyses")
+        self.assertEqual(list_response.json()["meta"]["total_count"], 1)
+
+    def test_create_analysis_rejects_missing_project_scope_before_parsing(
+        self,
+    ) -> None:
+        files = [
+            (
+                "files",
+                (
+                    "plan.json",
+                    b'{"resource_changes": [{"address": "aws_security_group.main", "change": {"actions": ["modify"]}}]}',
+                    "application/json",
+                ),
+            )
+        ]
+
+        with patch(
+            "services.analysis_service.build_parse_batch",
+            side_effect=AssertionError("project must resolve before parsing"),
+        ) as build_parse_batch:
+            response = self.client.post("/api/v1/analyses", files=files)
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.json()["error"]["code"], "missing_project_scope")
+        build_parse_batch.assert_not_called()
+
+    def test_create_analysis_rejects_blank_explicit_project_key_before_parsing(
+        self,
+    ) -> None:
+        files = [
+            (
+                "files",
+                (
+                    "plan.json",
+                    b'{"resource_changes": [{"address": "aws_security_group.main", "change": {"actions": ["modify"]}}]}',
+                    "application/json",
+                ),
+            )
+        ]
+
+        with patch(
+            "services.analysis_service.build_parse_batch",
+            side_effect=AssertionError("project must resolve before parsing"),
+        ) as build_parse_batch:
+            response = self.client.post(
+                "/api/v1/analyses",
+                files=files,
+                data={"project_key": "   "},
+            )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.json()["error"]["code"], "invalid_project_reference")
+        build_parse_batch.assert_not_called()
 
     def test_list_analyses_rejects_unknown_project_reference(self) -> None:
         response = self.client.get(
@@ -456,19 +626,30 @@ class AnalysesApiTests(unittest.TestCase):
             )
         ]
 
-        response = self.client.post(
-            "/api/v1/analyses",
-            files=files,
-            data={"project_id": str(first.id), "project_key": second.project_key},
-        )
+        with patch(
+            "services.analysis_service.build_parse_batch",
+            side_effect=AssertionError("project must resolve before parsing"),
+        ) as build_parse_batch:
+            response = self.client.post(
+                "/api/v1/analyses",
+                files=files,
+                data={"project_id": str(first.id), "project_key": second.project_key},
+            )
 
         self.assertEqual(response.status_code, 400)
         self.assertEqual(
             response.json()["error"]["code"],
             "conflicting_project_reference",
         )
+        build_parse_batch.assert_not_called()
+        list_response = self.client.get("/api/v1/analyses")
+        self.assertEqual(list_response.json()["meta"]["total_count"], 1)
 
     def test_create_analysis_captures_trigger_headers_when_present(self) -> None:
+        project_service_module.create_project(
+            project_key="payments",
+            display_name="Payments",
+        )
         files = [
             (
                 "files",
@@ -505,6 +686,7 @@ class AnalysesApiTests(unittest.TestCase):
             response = self.client.post(
                 "/api/v1/analyses",
                 files=files,
+                data={"project_key": "payments"},
                 headers={
                     "X-DeployWhisper-Trigger-Type": "user_session",
                     "X-DeployWhisper-Trigger-Id": "sess-456",
@@ -523,6 +705,10 @@ class AnalysesApiTests(unittest.TestCase):
     def test_create_analysis_preserves_distinct_artifacts_with_same_basename(
         self,
     ) -> None:
+        project_service_module.create_project(
+            project_key="payments",
+            display_name="Payments",
+        )
         files = [
             (
                 "files",
@@ -566,7 +752,11 @@ class AnalysesApiTests(unittest.TestCase):
             ),
             patch("services.analysis_service.find_incident_matches", return_value=[]),
         ):
-            response = self.client.post("/api/v1/analyses", files=files)
+            response = self.client.post(
+                "/api/v1/analyses",
+                files=files,
+                data={"project_key": "payments"},
+            )
 
         self.assertEqual(response.status_code, 200)
         payload = response.json()
@@ -574,19 +764,35 @@ class AnalysesApiTests(unittest.TestCase):
         self.assertEqual(intake_names, ["plan.json", "plan#2.json"])
 
     def test_create_analysis_rejects_payloads_over_50_mb(self) -> None:
+        project_service_module.create_project(
+            project_key="payments",
+            display_name="Payments",
+        )
         oversized = b"x" * 50_000_001
         files = [("files", ("plan.json", oversized, "application/json"))]
 
-        response = self.client.post("/api/v1/analyses", files=files)
+        response = self.client.post(
+            "/api/v1/analyses",
+            files=files,
+            data={"project_key": "payments"},
+        )
 
         self.assertEqual(response.status_code, 413)
         payload = response.json()
         self.assertEqual(payload["error"]["code"], "upload_limit_exceeded")
 
     def test_create_analysis_rejects_requests_without_supported_artifacts(self) -> None:
+        project_service_module.create_project(
+            project_key="payments",
+            display_name="Payments",
+        )
         files = [("files", ("README.txt", b"hello", "text/plain"))]
 
-        response = self.client.post("/api/v1/analyses", files=files)
+        response = self.client.post(
+            "/api/v1/analyses",
+            files=files,
+            data={"project_key": "payments"},
+        )
 
         self.assertEqual(response.status_code, 400)
         payload = response.json()
@@ -594,6 +800,16 @@ class AnalysesApiTests(unittest.TestCase):
         self.assertEqual(
             payload["error"]["details"]["items"][0]["status"], "unsupported"
         )
+
+    def test_create_analysis_rejects_missing_scope_before_unsupported_preflight(
+        self,
+    ) -> None:
+        files = [("files", ("README.txt", b"hello", "text/plain"))]
+
+        response = self.client.post("/api/v1/analyses", files=files)
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.json()["error"]["code"], "missing_project_scope")
 
     def test_get_analysis_returns_standard_error_envelope_for_missing_report(
         self,
@@ -624,6 +840,10 @@ class AnalysesApiTests(unittest.TestCase):
         self.assertEqual(payload["error"]["message"], "Method Not Allowed")
 
     def test_analysis_pipeline_failure_uses_standard_error_envelope(self) -> None:
+        project_service_module.create_project(
+            project_key="payments",
+            display_name="Payments",
+        )
         files = [
             (
                 "files",
@@ -661,7 +881,11 @@ class AnalysesApiTests(unittest.TestCase):
                 side_effect=RuntimeError("boom"),
             ),
         ):
-            response = client.post("/api/v1/analyses", files=files)
+            response = client.post(
+                "/api/v1/analyses",
+                files=files,
+                data={"project_key": "payments"},
+            )
 
         self.assertEqual(response.status_code, 500)
         payload = response.json()

--- a/tests/test_api/test_github_app.py
+++ b/tests/test_api/test_github_app.py
@@ -14,6 +14,7 @@ import app as app_module
 import config as config_module
 import models.database as database_module
 import models.tables as tables_module
+from integrations.github.app_service import GitHubAppProjectScopeError
 from fastapi.testclient import TestClient
 
 
@@ -121,3 +122,37 @@ class GitHubAppRouteTests(unittest.TestCase):
         self.assertTrue(body["data"]["automatic_analysis_triggered"])
         self.assertEqual(body["data"]["check_run_id"], 7)
         self.assertEqual(body["data"]["report_id"], 17)
+
+    @patch("api.routes.github_app.handle_github_app_webhook")
+    def test_webhook_acknowledges_project_scope_error(
+        self, handle_github_app_webhook
+    ) -> None:
+        payload = b'{"action":"opened"}'
+        signature = (
+            "sha256="
+            + hmac.new(
+                b"webhook-secret",
+                payload,
+                hashlib.sha256,
+            ).hexdigest()
+        )
+        handle_github_app_webhook.side_effect = GitHubAppProjectScopeError(
+            "project_not_found",
+            "Unknown project reference: project_key=missing.",
+        )
+
+        response = self.client.post(
+            "/api/v1/github/app/webhook",
+            headers={
+                "X-GitHub-Event": "pull_request",
+                "X-Hub-Signature-256": signature,
+                "Content-Type": "application/json",
+            },
+            content=payload,
+        )
+
+        self.assertEqual(response.status_code, 200)
+        body = response.json()
+        self.assertFalse(body["data"]["automatic_analysis_triggered"])
+        self.assertTrue(body["data"]["handled"])
+        self.assertIn("project_not_found", body["data"]["note"])

--- a/tests/test_cli/test_analyze.py
+++ b/tests/test_cli/test_analyze.py
@@ -566,6 +566,10 @@ class AnalyzeCliTests(unittest.TestCase):
     def test_analyze_command_runs_shared_analysis_and_prints_structured_output(
         self,
     ) -> None:
+        project_service_module.create_project(
+            project_key="payments",
+            display_name="Payments",
+        )
         artifact_path = Path(self.tempdir.name) / "plan.json"
         artifact_path.write_text(
             '{"resource_changes": [{"address": "aws_security_group.main", "change": {"actions": ["modify"]}}]}',
@@ -585,7 +589,16 @@ class AnalyzeCliTests(unittest.TestCase):
                 "services.analysis_service.generate_narrative", return_value=narrative
             ),
             patch("services.analysis_service.find_incident_matches", return_value=[]),
-            patch("sys.argv", ["deploywhisper", "analyze", str(artifact_path)]),
+            patch(
+                "sys.argv",
+                [
+                    "deploywhisper",
+                    "analyze",
+                    "--project",
+                    "payments",
+                    str(artifact_path),
+                ],
+            ),
             redirect_stdout(output),
         ):
             with self.assertRaises(SystemExit) as ctx:
@@ -632,6 +645,10 @@ class AnalyzeCliTests(unittest.TestCase):
     def test_analyze_command_captures_trigger_context_from_environment_when_available(
         self,
     ) -> None:
+        project_service_module.create_project(
+            project_key="payments",
+            display_name="Payments",
+        )
         artifact_path = Path(self.tempdir.name) / "plan.json"
         artifact_path.write_text(
             '{"resource_changes": [{"address": "aws_security_group.main", "change": {"actions": ["modify"]}}]}',
@@ -659,7 +676,16 @@ class AnalyzeCliTests(unittest.TestCase):
                 },
                 clear=False,
             ),
-            patch("sys.argv", ["deploywhisper", "analyze", str(artifact_path)]),
+            patch(
+                "sys.argv",
+                [
+                    "deploywhisper",
+                    "analyze",
+                    "--project",
+                    "payments",
+                    str(artifact_path),
+                ],
+            ),
             redirect_stdout(output),
         ):
             with self.assertRaises(SystemExit) as ctx:
@@ -713,6 +739,114 @@ class AnalyzeCliTests(unittest.TestCase):
                     "analyze",
                     "--project",
                     "payments",
+                    str(artifact_path),
+                ],
+            ),
+            redirect_stdout(output),
+        ):
+            with self.assertRaises(SystemExit) as ctx:
+                main()
+
+        self.assertEqual(ctx.exception.code, 0)
+        payload = json.loads(output.getvalue())
+        self.assertEqual(
+            payload["data"]["persisted_report"]["project"]["project_key"], "payments"
+        )
+
+    def test_analyze_command_accepts_project_id(self) -> None:
+        project = project_service_module.create_project(
+            project_key="payments",
+            display_name="Payments",
+        )
+        artifact_path = Path(self.tempdir.name) / "plan.json"
+        artifact_path.write_text(
+            '{"resource_changes": [{"address": "aws_security_group.main", "change": {"actions": ["modify"]}}]}',
+            encoding="utf-8",
+        )
+        output = io.StringIO()
+
+        def passthrough_analyze_uploaded_files(
+            files,
+            completion_client=None,
+            audit_context=None,
+            project_id=None,
+            project_key=None,
+        ):
+            return analysis_service_module.analyze_uploaded_files(
+                files,
+                completion_client=completion_client,
+                audit_context=audit_context,
+                project_id=project_id,
+                project_key=project_key,
+            )
+
+        with (
+            patch(
+                "cli.analyze.analyze_uploaded_files",
+                side_effect=passthrough_analyze_uploaded_files,
+            ),
+            patch(
+                "sys.argv",
+                [
+                    "deploywhisper",
+                    "analyze",
+                    "--project-id",
+                    str(project.id),
+                    str(artifact_path),
+                ],
+            ),
+            redirect_stdout(output),
+        ):
+            with self.assertRaises(SystemExit) as ctx:
+                main()
+
+        self.assertEqual(ctx.exception.code, 0)
+        payload = json.loads(output.getvalue())
+        self.assertEqual(
+            payload["data"]["persisted_report"]["project"]["project_key"], "payments"
+        )
+
+    def test_analyze_command_accepts_project_id_with_blank_project_key(self) -> None:
+        project = project_service_module.create_project(
+            project_key="payments",
+            display_name="Payments",
+        )
+        artifact_path = Path(self.tempdir.name) / "plan.json"
+        artifact_path.write_text(
+            '{"resource_changes": [{"address": "aws_security_group.main", "change": {"actions": ["modify"]}}]}',
+            encoding="utf-8",
+        )
+        output = io.StringIO()
+
+        def passthrough_analyze_uploaded_files(
+            files,
+            completion_client=None,
+            audit_context=None,
+            project_id=None,
+            project_key=None,
+        ):
+            return analysis_service_module.analyze_uploaded_files(
+                files,
+                completion_client=completion_client,
+                audit_context=audit_context,
+                project_id=project_id,
+                project_key=project_key,
+            )
+
+        with (
+            patch(
+                "cli.analyze.analyze_uploaded_files",
+                side_effect=passthrough_analyze_uploaded_files,
+            ),
+            patch(
+                "sys.argv",
+                [
+                    "deploywhisper",
+                    "analyze",
+                    "--project-id",
+                    str(project.id),
+                    "--project",
+                    "   ",
                     str(artifact_path),
                 ],
             ),
@@ -825,6 +959,43 @@ class AnalyzeCliTests(unittest.TestCase):
     def test_analyze_command_reports_unsupported_inputs_with_structured_error(
         self,
     ) -> None:
+        project_service_module.create_project(
+            project_key="payments",
+            display_name="Payments",
+        )
+        artifact_path = Path(self.tempdir.name) / "README.txt"
+        artifact_path.write_text("hello", encoding="utf-8")
+        stdout = io.StringIO()
+        stderr = io.StringIO()
+
+        with (
+            patch(
+                "sys.argv",
+                [
+                    "deploywhisper",
+                    "analyze",
+                    "--project",
+                    "payments",
+                    str(artifact_path),
+                ],
+            ),
+            redirect_stdout(stdout),
+            redirect_stderr(stderr),
+        ):
+            with self.assertRaises(SystemExit) as ctx:
+                main()
+
+        self.assertEqual(ctx.exception.code, 2)
+        self.assertEqual(stdout.getvalue(), "")
+        payload = json.loads(stderr.getvalue())
+        self.assertEqual(payload["error"]["code"], "no_supported_artifacts")
+        self.assertEqual(
+            payload["error"]["details"]["items"][0]["status"], "unsupported"
+        )
+
+    def test_analyze_command_rejects_missing_scope_before_unsupported_preflight(
+        self,
+    ) -> None:
         artifact_path = Path(self.tempdir.name) / "README.txt"
         artifact_path.write_text("hello", encoding="utf-8")
         stdout = io.StringIO()
@@ -841,18 +1012,28 @@ class AnalyzeCliTests(unittest.TestCase):
         self.assertEqual(ctx.exception.code, 2)
         self.assertEqual(stdout.getvalue(), "")
         payload = json.loads(stderr.getvalue())
-        self.assertEqual(payload["error"]["code"], "no_supported_artifacts")
-        self.assertEqual(
-            payload["error"]["details"]["items"][0]["status"], "unsupported"
-        )
+        self.assertEqual(payload["error"]["code"], "missing_project_scope")
 
     def test_analyze_command_reports_missing_files_with_structured_error(self) -> None:
+        project_service_module.create_project(
+            project_key="payments",
+            display_name="Payments",
+        )
         missing_path = Path(self.tempdir.name) / "missing-plan.json"
         stdout = io.StringIO()
         stderr = io.StringIO()
 
         with (
-            patch("sys.argv", ["deploywhisper", "analyze", str(missing_path)]),
+            patch(
+                "sys.argv",
+                [
+                    "deploywhisper",
+                    "analyze",
+                    "--project",
+                    "payments",
+                    str(missing_path),
+                ],
+            ),
             redirect_stdout(stdout),
             redirect_stderr(stderr),
         ):
@@ -1108,6 +1289,10 @@ class AnalyzeCliTests(unittest.TestCase):
 
         with (
             patch(
+                "services.analysis_service.build_parse_batch",
+                side_effect=AssertionError("project must resolve before parsing"),
+            ) as build_parse_batch,
+            patch(
                 "sys.argv",
                 [
                     "deploywhisper",
@@ -1128,8 +1313,131 @@ class AnalyzeCliTests(unittest.TestCase):
         self.assertEqual(ctx.exception.code, 2)
         payload = json.loads(stderr.getvalue())
         self.assertEqual(payload["error"]["code"], "conflicting_project_reference")
+        build_parse_batch.assert_not_called()
+        with database_module.SessionLocal() as session:
+            self.assertEqual(
+                analysis_reports_repository_module.count_analysis_reports(session),
+                0,
+            )
+
+    def test_analyze_command_rejects_unknown_project_before_parsing(self) -> None:
+        artifact_path = Path(self.tempdir.name) / "plan.json"
+        artifact_path.write_text(
+            '{"resource_changes": [{"address": "aws_security_group.main", "change": {"actions": ["modify"]}}]}',
+            encoding="utf-8",
+        )
+        stdout = io.StringIO()
+        stderr = io.StringIO()
+
+        with (
+            patch(
+                "services.analysis_service.build_parse_batch",
+                side_effect=AssertionError("project must resolve before parsing"),
+            ) as build_parse_batch,
+            patch(
+                "sys.argv",
+                [
+                    "deploywhisper",
+                    "analyze",
+                    "--project",
+                    "missing",
+                    str(artifact_path),
+                ],
+            ),
+            redirect_stdout(stdout),
+            redirect_stderr(stderr),
+        ):
+            with self.assertRaises(SystemExit) as ctx:
+                main()
+
+        self.assertEqual(ctx.exception.code, 2)
+        self.assertEqual(stdout.getvalue(), "")
+        payload = json.loads(stderr.getvalue())
+        self.assertEqual(payload["error"]["code"], "project_not_found")
+        build_parse_batch.assert_not_called()
+        with database_module.SessionLocal() as session:
+            self.assertEqual(
+                analysis_reports_repository_module.count_analysis_reports(session),
+                0,
+            )
+
+    def test_analyze_command_rejects_missing_project_scope_before_parsing(
+        self,
+    ) -> None:
+        artifact_path = Path(self.tempdir.name) / "plan.json"
+        artifact_path.write_text(
+            '{"resource_changes": [{"address": "aws_security_group.main", "change": {"actions": ["modify"]}}]}',
+            encoding="utf-8",
+        )
+        stdout = io.StringIO()
+        stderr = io.StringIO()
+
+        with (
+            patch(
+                "services.analysis_service.build_parse_batch",
+                side_effect=AssertionError("project must resolve before parsing"),
+            ) as build_parse_batch,
+            patch("sys.argv", ["deploywhisper", "analyze", str(artifact_path)]),
+            redirect_stdout(stdout),
+            redirect_stderr(stderr),
+        ):
+            with self.assertRaises(SystemExit) as ctx:
+                main()
+
+        self.assertEqual(ctx.exception.code, 2)
+        self.assertEqual(stdout.getvalue(), "")
+        payload = json.loads(stderr.getvalue())
+        self.assertEqual(payload["error"]["code"], "missing_project_scope")
+        build_parse_batch.assert_not_called()
+        with database_module.SessionLocal() as session:
+            self.assertEqual(
+                analysis_reports_repository_module.count_analysis_reports(session),
+                0,
+            )
+
+    def test_analyze_command_rejects_blank_explicit_project_key_before_parsing(
+        self,
+    ) -> None:
+        artifact_path = Path(self.tempdir.name) / "plan.json"
+        artifact_path.write_text(
+            '{"resource_changes": [{"address": "aws_security_group.main", "change": {"actions": ["modify"]}}]}',
+            encoding="utf-8",
+        )
+        stdout = io.StringIO()
+        stderr = io.StringIO()
+
+        with (
+            patch(
+                "services.analysis_service.build_parse_batch",
+                side_effect=AssertionError("project must resolve before parsing"),
+            ) as build_parse_batch,
+            patch(
+                "sys.argv",
+                [
+                    "deploywhisper",
+                    "analyze",
+                    "--project",
+                    "   ",
+                    str(artifact_path),
+                ],
+            ),
+            redirect_stdout(stdout),
+            redirect_stderr(stderr),
+        ):
+            with self.assertRaises(SystemExit) as ctx:
+                main()
+
+        self.assertEqual(ctx.exception.code, 2)
+        self.assertEqual(stdout.getvalue(), "")
+        payload = json.loads(stderr.getvalue())
+        self.assertEqual(payload["error"]["code"], "invalid_project_reference")
+        build_parse_batch.assert_not_called()
 
     def test_analyze_command_preserves_distinct_files_with_same_basename(self) -> None:
+        project_service_module.create_project(
+            project_key="payments",
+            display_name="Payments",
+        )
         first_dir = Path(self.tempdir.name) / "first"
         second_dir = Path(self.tempdir.name) / "second"
         first_dir.mkdir(parents=True, exist_ok=True)
@@ -1160,7 +1468,14 @@ class AnalyzeCliTests(unittest.TestCase):
             patch("services.analysis_service.find_incident_matches", return_value=[]),
             patch(
                 "sys.argv",
-                ["deploywhisper", "analyze", str(first_path), str(second_path)],
+                [
+                    "deploywhisper",
+                    "analyze",
+                    "--project",
+                    "payments",
+                    str(first_path),
+                    str(second_path),
+                ],
             ),
             redirect_stdout(output),
         ):
@@ -1185,6 +1500,10 @@ class AnalyzeCliTests(unittest.TestCase):
     def test_analyze_command_reports_shared_analysis_failures_with_structured_error(
         self,
     ) -> None:
+        project_service_module.create_project(
+            project_key="payments",
+            display_name="Payments",
+        )
         artifact_path = Path(self.tempdir.name) / "plan.json"
         artifact_path.write_text(
             '{"resource_changes": [{"address": "aws_security_group.main", "change": {"actions": ["modify"]}}]}',
@@ -1197,7 +1516,16 @@ class AnalyzeCliTests(unittest.TestCase):
             patch(
                 "cli.analyze.analyze_uploaded_files", side_effect=RuntimeError("boom")
             ),
-            patch("sys.argv", ["deploywhisper", "analyze", str(artifact_path)]),
+            patch(
+                "sys.argv",
+                [
+                    "deploywhisper",
+                    "analyze",
+                    "--project",
+                    "payments",
+                    str(artifact_path),
+                ],
+            ),
             redirect_stdout(stdout),
             redirect_stderr(stderr),
         ):
@@ -1214,6 +1542,10 @@ class AnalyzeCliTests(unittest.TestCase):
     def test_analyze_command_rejects_payloads_over_limit_before_reading_all_bytes(
         self,
     ) -> None:
+        project_service_module.create_project(
+            project_key="payments",
+            display_name="Payments",
+        )
         artifact_path = Path(self.tempdir.name) / "large-plan.json"
         artifact_path.write_text("x" * 11, encoding="utf-8")
         stdout = io.StringIO()
@@ -1221,7 +1553,16 @@ class AnalyzeCliTests(unittest.TestCase):
 
         with (
             patch("cli.analyze.MAX_TOTAL_UPLOAD_BYTES", 10),
-            patch("sys.argv", ["deploywhisper", "analyze", str(artifact_path)]),
+            patch(
+                "sys.argv",
+                [
+                    "deploywhisper",
+                    "analyze",
+                    "--project",
+                    "payments",
+                    str(artifact_path),
+                ],
+            ),
             redirect_stdout(stdout),
             redirect_stderr(stderr),
         ):
@@ -1236,6 +1577,10 @@ class AnalyzeCliTests(unittest.TestCase):
     def test_analyze_command_preserves_advisory_output_for_high_risk_results(
         self,
     ) -> None:
+        project_service_module.create_project(
+            project_key="payments",
+            display_name="Payments",
+        )
         artifact_path = Path(self.tempdir.name) / "plan.json"
         artifact_path.write_text(
             '{"resource_changes": [{"address": "aws_security_group.main", "change": {"actions": ["delete"]}}]}',
@@ -1282,7 +1627,16 @@ class AnalyzeCliTests(unittest.TestCase):
                 "services.analysis_service.generate_narrative", return_value=narrative
             ),
             patch("services.analysis_service.find_incident_matches", return_value=[]),
-            patch("sys.argv", ["deploywhisper", "analyze", str(artifact_path)]),
+            patch(
+                "sys.argv",
+                [
+                    "deploywhisper",
+                    "analyze",
+                    "--project",
+                    "payments",
+                    str(artifact_path),
+                ],
+            ),
             redirect_stdout(output),
         ):
             with self.assertRaises(SystemExit) as ctx:
@@ -1316,6 +1670,10 @@ class AnalyzeCliTests(unittest.TestCase):
         )
 
     def test_analyze_command_suppresses_non_json_stream_noise_on_success(self) -> None:
+        project_service_module.create_project(
+            project_key="payments",
+            display_name="Payments",
+        )
         artifact_path = Path(self.tempdir.name) / "plan.json"
         artifact_path.write_text(
             '{"resource_changes": [{"address": "aws_security_group.main", "change": {"actions": ["modify"]}}]}',
@@ -1357,7 +1715,16 @@ class AnalyzeCliTests(unittest.TestCase):
                 "cli.analyze.analyze_uploaded_files",
                 side_effect=noisy_analyze_uploaded_files,
             ),
-            patch("sys.argv", ["deploywhisper", "analyze", str(artifact_path)]),
+            patch(
+                "sys.argv",
+                [
+                    "deploywhisper",
+                    "analyze",
+                    "--project",
+                    "payments",
+                    str(artifact_path),
+                ],
+            ),
             redirect_stdout(stdout),
             redirect_stderr(stderr),
         ):

--- a/tests/test_services/test_analysis_service.py
+++ b/tests/test_services/test_analysis_service.py
@@ -14,13 +14,40 @@ from analysis.rollback_planner import RollbackPlan
 from llm.narrator import NarrativeResult
 from parsers.base import ParseBatchResult, ParsedFileResult, UnifiedChange
 from services.analysis_service import (
+    analyze_uploaded_files,
     build_advisory_summary,
     build_analysis_artifacts,
     build_share_summary,
+    resolve_analysis_project_scope,
 )
 
 
 class AnalysisServiceTests(unittest.TestCase):
+    def test_analyze_uploaded_files_requires_explicit_project_scope_before_parsing(
+        self,
+    ) -> None:
+        with (
+            patch(
+                "services.analysis_service.build_parse_batch",
+                side_effect=AssertionError("project must resolve before parsing"),
+            ) as build_parse_batch,
+            self.assertRaisesRegex(ValueError, "Project scope is required") as exc_info,
+        ):
+            analyze_uploaded_files([("plan.json", b'{"resource_changes": []}')])
+
+        self.assertEqual(
+            getattr(exc_info.exception, "code", ""), "missing_project_scope"
+        )
+        build_parse_batch.assert_not_called()
+
+    def test_resolve_analysis_project_scope_rejects_blank_explicit_key(self) -> None:
+        with self.assertRaisesRegex(ValueError, "Project key") as exc_info:
+            resolve_analysis_project_scope(project_key="   ")
+
+        self.assertEqual(
+            getattr(exc_info.exception, "code", ""), "invalid_project_reference"
+        )
+
     def _share_report_payload(self) -> dict:
         return {
             "id": 17,

--- a/tests/test_services/test_github_app_service.py
+++ b/tests/test_services/test_github_app_service.py
@@ -17,6 +17,7 @@ import models.database as database_module
 import models.tables as tables_module
 import services.project_service as project_service_module
 from integrations.github import app_service
+from llm.narrator import NarrativeResult
 
 
 class GitHubAppServiceTests(unittest.TestCase):
@@ -199,6 +200,10 @@ class GitHubAppServiceTests(unittest.TestCase):
         create_check_run,
     ) -> None:
         os.environ["DEPLOYWHISPER_GITHUB_PROJECT_KEY"] = "platform-core"
+        project_service_module.create_project(
+            project_key="platform-core",
+            display_name="Platform Core",
+        )
         generate_installation_access_token.return_value = "installation-token"
         load_pull_request_artifacts.return_value = [("plan.tf", b'resource "x" "y" {}')]
         analyze_uploaded_files.return_value = type(
@@ -234,6 +239,323 @@ class GitHubAppServiceTests(unittest.TestCase):
         self.assertEqual(
             analyze_uploaded_files.call_args.kwargs["project_key"], "platform-core"
         )
+
+    @patch("integrations.github.app_service._create_check_run")
+    @patch("integrations.github.app_service.analyze_uploaded_files")
+    @patch("integrations.github.app_service._load_pull_request_artifacts")
+    @patch("integrations.github.app_service._generate_installation_access_token")
+    def test_handle_github_app_webhook_handles_unknown_explicit_project_override(
+        self,
+        generate_installation_access_token,
+        load_pull_request_artifacts,
+        analyze_uploaded_files,
+        create_check_run,
+    ) -> None:
+        os.environ["DEPLOYWHISPER_GITHUB_PROJECT_KEY"] = "wrong-project"
+        generate_installation_access_token.return_value = "installation-token"
+        load_pull_request_artifacts.return_value = [("plan.tf", b'resource "x" "y" {}')]
+        create_check_run.return_value = 994
+
+        try:
+            result = app_service.handle_github_app_webhook(
+                event_name="pull_request",
+                payload={
+                    "action": "opened",
+                    "number": 3,
+                    "installation": {"id": 42},
+                    "repository": {
+                        "name": "deploywhisper",
+                        "owner": {"login": "deploywhisper"},
+                    },
+                    "pull_request": {
+                        "number": 3,
+                        "head": {"sha": "abc123"},
+                    },
+                },
+            )
+        finally:
+            os.environ.pop("DEPLOYWHISPER_GITHUB_PROJECT_KEY", None)
+
+        load_pull_request_artifacts.assert_not_called()
+        analyze_uploaded_files.assert_not_called()
+        self.assertTrue(result.handled)
+        self.assertFalse(result.automatic_analysis_triggered)
+        self.assertEqual(result.check_run_id, 994)
+        self.assertIn("project_not_found", result.note)
+        self.assertIsNone(
+            project_service_module.get_project_by_project_key("wrong-project")
+        )
+
+    @patch("integrations.github.app_service._create_check_run")
+    @patch("integrations.github.app_service.analyze_uploaded_files")
+    @patch("integrations.github.app_service._load_pull_request_artifacts")
+    @patch("integrations.github.app_service._generate_installation_access_token")
+    def test_handle_github_app_webhook_handles_malformed_project_override(
+        self,
+        generate_installation_access_token,
+        load_pull_request_artifacts,
+        analyze_uploaded_files,
+        create_check_run,
+    ) -> None:
+        os.environ["DEPLOYWHISPER_GITHUB_PROJECT_KEY"] = "!!!"
+        generate_installation_access_token.return_value = "installation-token"
+        load_pull_request_artifacts.return_value = [("plan.tf", b'resource "x" "y" {}')]
+        create_check_run.return_value = 995
+
+        try:
+            result = app_service.handle_github_app_webhook(
+                event_name="pull_request",
+                payload={
+                    "action": "opened",
+                    "number": 3,
+                    "installation": {"id": 42},
+                    "repository": {
+                        "name": "deploywhisper",
+                        "owner": {"login": "deploywhisper"},
+                    },
+                    "pull_request": {
+                        "number": 3,
+                        "head": {"sha": "abc123"},
+                    },
+                },
+            )
+        finally:
+            os.environ.pop("DEPLOYWHISPER_GITHUB_PROJECT_KEY", None)
+
+        load_pull_request_artifacts.assert_not_called()
+        analyze_uploaded_files.assert_not_called()
+        self.assertTrue(result.handled)
+        self.assertFalse(result.automatic_analysis_triggered)
+        self.assertEqual(result.check_run_id, 995)
+        self.assertIn("invalid_project_reference", result.note)
+
+    @patch("integrations.github.app_service._create_check_run")
+    @patch("integrations.github.app_service.analyze_uploaded_files")
+    @patch("integrations.github.app_service._load_pull_request_artifacts")
+    @patch("integrations.github.app_service._generate_installation_access_token")
+    def test_handle_github_app_webhook_handles_blank_project_override(
+        self,
+        generate_installation_access_token,
+        load_pull_request_artifacts,
+        analyze_uploaded_files,
+        create_check_run,
+    ) -> None:
+        os.environ["DEPLOYWHISPER_GITHUB_PROJECT_KEY"] = "   "
+        generate_installation_access_token.return_value = "installation-token"
+        load_pull_request_artifacts.return_value = [("plan.tf", b'resource "x" "y" {}')]
+        create_check_run.return_value = 996
+
+        try:
+            result = app_service.handle_github_app_webhook(
+                event_name="pull_request",
+                payload={
+                    "action": "opened",
+                    "number": 3,
+                    "installation": {"id": 42},
+                    "repository": {
+                        "name": "deploywhisper",
+                        "owner": {"login": "deploywhisper"},
+                    },
+                    "pull_request": {
+                        "number": 3,
+                        "head": {"sha": "abc123"},
+                    },
+                },
+            )
+        finally:
+            os.environ.pop("DEPLOYWHISPER_GITHUB_PROJECT_KEY", None)
+
+        load_pull_request_artifacts.assert_not_called()
+        analyze_uploaded_files.assert_not_called()
+        self.assertTrue(result.handled)
+        self.assertFalse(result.automatic_analysis_triggered)
+        self.assertEqual(result.check_run_id, 996)
+        self.assertIn("invalid_project_reference", result.note)
+
+    @patch("integrations.github.app_service._create_check_run")
+    @patch("integrations.github.app_service.analyze_uploaded_files")
+    @patch("integrations.github.app_service._load_pull_request_artifacts")
+    @patch("integrations.github.app_service._generate_installation_access_token")
+    def test_handle_github_app_webhook_handles_late_project_scope_error(
+        self,
+        generate_installation_access_token,
+        load_pull_request_artifacts,
+        analyze_uploaded_files,
+        create_check_run,
+    ) -> None:
+        generate_installation_access_token.return_value = "installation-token"
+        load_pull_request_artifacts.return_value = [("plan.tf", b'resource "x" "y" {}')]
+        analyze_uploaded_files.side_effect = (
+            project_service_module.ProjectResolutionError(
+                "project_not_found",
+                "Unknown project reference: project_key=deploywhisper-deploywhisper.",
+            )
+        )
+        create_check_run.return_value = 996
+
+        result = app_service.handle_github_app_webhook(
+            event_name="pull_request",
+            payload={
+                "action": "opened",
+                "number": 3,
+                "installation": {"id": 42},
+                "repository": {
+                    "name": "deploywhisper",
+                    "owner": {"login": "deploywhisper"},
+                },
+                "pull_request": {
+                    "number": 3,
+                    "head": {"sha": "abc123"},
+                },
+            },
+        )
+
+        self.assertTrue(result.handled)
+        self.assertFalse(result.automatic_analysis_triggered)
+        self.assertEqual(result.check_run_id, 996)
+        self.assertIn("project_not_found", result.note)
+
+    @patch("integrations.github.app_service._create_check_run")
+    @patch("integrations.github.app_service.analyze_uploaded_files")
+    @patch("integrations.github.app_service._load_pull_request_artifacts")
+    @patch("integrations.github.app_service._generate_installation_access_token")
+    def test_handle_github_app_webhook_propagates_non_project_analysis_value_error(
+        self,
+        generate_installation_access_token,
+        load_pull_request_artifacts,
+        analyze_uploaded_files,
+        create_check_run,
+    ) -> None:
+        generate_installation_access_token.return_value = "installation-token"
+        load_pull_request_artifacts.return_value = [("plan.tf", b'resource "x" "y" {}')]
+        analyze_uploaded_files.side_effect = ValueError("analysis exploded")
+
+        with self.assertRaisesRegex(ValueError, "analysis exploded"):
+            app_service.handle_github_app_webhook(
+                event_name="pull_request",
+                payload={
+                    "action": "opened",
+                    "number": 3,
+                    "installation": {"id": 42},
+                    "repository": {
+                        "name": "deploywhisper",
+                        "owner": {"login": "deploywhisper"},
+                    },
+                    "pull_request": {
+                        "number": 3,
+                        "head": {"sha": "abc123"},
+                    },
+                },
+            )
+
+        create_check_run.assert_not_called()
+
+    @patch("integrations.github.app_service._create_check_run")
+    @patch("integrations.github.app_service.analyze_uploaded_files")
+    @patch("integrations.github.app_service._load_pull_request_artifacts")
+    @patch("integrations.github.app_service._generate_installation_access_token")
+    def test_handle_github_app_webhook_disambiguates_manual_repository_key_collision(
+        self,
+        generate_installation_access_token,
+        load_pull_request_artifacts,
+        analyze_uploaded_files,
+        create_check_run,
+    ) -> None:
+        project_service_module.create_project(
+            project_key="deploywhisper-deploywhisper",
+            display_name="Manual DeployWhisper Project",
+        )
+        generate_installation_access_token.return_value = "installation-token"
+        load_pull_request_artifacts.return_value = [("plan.tf", b'resource "x" "y" {}')]
+        analyze_uploaded_files.return_value = type(
+            "Result",
+            (),
+            {
+                "assessment": type("Assessment", (), {"recommendation": "caution"})(),
+                "persisted_report": {"id": 19},
+            },
+        )()
+        create_check_run.return_value = 997
+
+        result = app_service.handle_github_app_webhook(
+            event_name="pull_request",
+            payload={
+                "action": "opened",
+                "number": 3,
+                "installation": {"id": 42},
+                "repository": {
+                    "name": "deploywhisper",
+                    "owner": {"login": "deploywhisper"},
+                },
+                "pull_request": {
+                    "number": 3,
+                    "head": {"sha": "abc123"},
+                },
+            },
+        )
+
+        self.assertTrue(result.automatic_analysis_triggered)
+        project_key = analyze_uploaded_files.call_args.kwargs["project_key"]
+        self.assertNotEqual(project_key, "deploywhisper-deploywhisper")
+        self.assertTrue(project_key.startswith("deploywhisper-deploywhisper-"))
+
+    @patch("integrations.github.app_service._create_check_run")
+    @patch("services.analysis_service.find_incident_matches", return_value=[])
+    @patch("services.analysis_service.generate_narrative")
+    @patch("integrations.github.app_service._load_pull_request_artifacts")
+    @patch("integrations.github.app_service._generate_installation_access_token")
+    def test_handle_github_app_webhook_derives_project_for_real_analysis(
+        self,
+        generate_installation_access_token,
+        load_pull_request_artifacts,
+        generate_narrative,
+        find_incident_matches,
+        create_check_run,
+    ) -> None:
+        generate_installation_access_token.return_value = "installation-token"
+        load_pull_request_artifacts.return_value = [
+            (
+                "plan.json",
+                b'{"resource_changes": [{"address": "aws_security_group.main", "change": {"actions": ["modify"]}}]}',
+            )
+        ]
+        generate_narrative.return_value = NarrativeResult(
+            opening_sentence="CAUTION: review the security group update.",
+            explanation="The deployment widens database access and should be reviewed.",
+            guidance=[],
+            degraded=False,
+            warnings=[],
+        )
+        create_check_run.return_value = 993
+
+        result = app_service.handle_github_app_webhook(
+            event_name="pull_request",
+            payload={
+                "action": "opened",
+                "number": 3,
+                "installation": {"id": 42},
+                "repository": {
+                    "name": "deploywhisper",
+                    "owner": {"login": "deploywhisper"},
+                },
+                "pull_request": {
+                    "number": 3,
+                    "head": {"sha": "abc123"},
+                },
+            },
+        )
+
+        self.assertTrue(result.automatic_analysis_triggered)
+        self.assertEqual(result.check_run_id, 993)
+        project = project_service_module.get_project_by_project_key(
+            "deploywhisper-deploywhisper"
+        )
+        self.assertIsNotNone(project)
+        self.assertEqual(
+            result.report_url, "https://deploywhisper.example.com/reports/1"
+        )
+        find_incident_matches.assert_called_once()
+        create_check_run.assert_called_once()
 
     @patch("integrations.github.app_service.analyze_uploaded_files")
     @patch("integrations.github.app_service._load_pull_request_artifacts")

--- a/tests/test_services/test_project_service.py
+++ b/tests/test_services/test_project_service.py
@@ -305,6 +305,122 @@ class ProjectServiceTests(unittest.TestCase):
         self.assertEqual(project.project_key, "acmecorp-payments-api")
         self.assertEqual(project.display_name, "Payments API")
 
+    def test_resolve_project_reference_disambiguates_repository_key_collision(
+        self,
+    ) -> None:
+        first = project_service_module.resolve_project_reference(
+            repository_name="foo/bar-baz",
+            allow_create=True,
+        )
+        second = project_service_module.resolve_project_reference(
+            repository_name="foo-bar/baz",
+            allow_create=True,
+        )
+
+        self.assertEqual(first.project_key, "foo-bar-baz")
+        self.assertNotEqual(second.project_key, first.project_key)
+        self.assertTrue(second.project_key.startswith("foo-bar-baz-"))
+        self.assertEqual(second.repository_url, "foo-bar/baz")
+
+    def test_resolve_project_reference_disambiguates_manual_key_collision(
+        self,
+    ) -> None:
+        manual = project_service_module.create_project(
+            project_key="foo-bar-baz",
+            display_name="Manual Project",
+        )
+
+        resolved = project_service_module.resolve_project_reference(
+            repository_name="foo-bar/baz",
+            allow_create=True,
+        )
+
+        self.assertNotEqual(resolved.id, manual.id)
+        self.assertTrue(resolved.project_key.startswith("foo-bar-baz-"))
+        self.assertEqual(resolved.repository_url, "foo-bar/baz")
+
+    def test_resolve_project_reference_reuses_custom_key_repository_match(
+        self,
+    ) -> None:
+        existing = project_service_module.create_project(
+            project_key="platform-core",
+            display_name="Platform Core",
+            repository_url="https://github.com/acme/platform-core",
+        )
+
+        resolved = project_service_module.resolve_project_reference(
+            repository_name="github.com/acme/platform-core",
+            allow_create=True,
+        )
+
+        self.assertEqual(resolved.id, existing.id)
+        self.assertEqual(resolved.project_key, "platform-core")
+        self.assertEqual(
+            resolved.repository_url, "https://github.com/acme/platform-core"
+        )
+
+    def test_resolve_project_reference_disambiguates_missing_repository_url_collision(
+        self,
+    ) -> None:
+        existing = project_service_module.create_project(
+            project_key="foo-bar-baz",
+            display_name="BAR BAZ",
+        )
+
+        resolved = project_service_module.resolve_project_reference(
+            repository_name="foo/bar-baz",
+            allow_create=True,
+        )
+
+        self.assertNotEqual(resolved.id, existing.id)
+        self.assertTrue(resolved.project_key.startswith("foo-bar-baz-"))
+        self.assertEqual(resolved.repository_url, "foo/bar-baz")
+
+    def test_resolve_project_reference_reuses_same_repository_key(self) -> None:
+        first = project_service_module.resolve_project_reference(
+            repository_name="https://github.com/Foo/Bar-Baz.git",
+            allow_create=True,
+        )
+        second = project_service_module.resolve_project_reference(
+            repository_name="github.com/foo/bar-baz",
+            allow_create=True,
+        )
+
+        self.assertEqual(second.id, first.id)
+        self.assertEqual(second.project_key, "foo-bar-baz")
+
+    def test_resolve_project_reference_reuses_scp_style_repository_remote(
+        self,
+    ) -> None:
+        first = project_service_module.resolve_project_reference(
+            repository_name="https://github.com/Foo/Bar-Baz.git",
+            allow_create=True,
+        )
+        second = project_service_module.resolve_project_reference(
+            repository_name="git@github.com:Foo/Bar-Baz.git",
+            allow_create=True,
+        )
+
+        self.assertEqual(second.id, first.id)
+        self.assertEqual(second.project_key, "foo-bar-baz")
+
+    def test_resolve_project_reference_disambiguates_same_path_cross_host_remote(
+        self,
+    ) -> None:
+        first = project_service_module.resolve_project_reference(
+            repository_name="https://github.com/acme/api.git",
+            allow_create=True,
+        )
+        second = project_service_module.resolve_project_reference(
+            repository_name="https://gitlab.example.com/acme/api.git",
+            allow_create=True,
+        )
+
+        self.assertEqual(first.project_key, "acme-api")
+        self.assertNotEqual(second.id, first.id)
+        self.assertTrue(second.project_key.startswith("acme-api-"))
+        self.assertEqual(second.repository_url, "gitlab.example.com/acme/api")
+
     def test_active_project_setting_round_trips(self) -> None:
         created = project_service_module.create_project(
             project_key="network-core",
@@ -382,3 +498,42 @@ class ProjectServiceTests(unittest.TestCase):
         project_service_module.set_active_project(created.id)
 
         self.assertTrue(project_service_module.has_active_project_selection())
+
+    def test_active_project_selection_flag_ignores_stale_saved_project(self) -> None:
+        created = project_service_module.create_project(
+            project_key="core",
+            display_name="Core",
+        )
+        project_service_module.set_active_project(created.id)
+        with database_module.engine.begin() as connection:
+            connection.exec_driver_sql(
+                "DELETE FROM projects WHERE id = ?",
+                (created.id,),
+            )
+
+        self.assertFalse(project_service_module.has_active_project_selection())
+        active = project_service_module.get_active_project()
+        self.assertIsNotNone(active)
+        assert active is not None
+        self.assertEqual(active.project_key, project_service_module.DEFAULT_PROJECT_KEY)
+
+    def test_resolve_project_reference_ignores_blank_key_when_id_provided(self) -> None:
+        project = project_service_module.create_project(
+            project_key="payments",
+            display_name="Payments",
+        )
+
+        resolved = project_service_module.resolve_project_reference(
+            project_id=project.id,
+            project_key="   ",
+        )
+
+        self.assertEqual(resolved.project_key, "payments")
+
+    def test_resolve_project_reference_rejects_blank_key_without_id(self) -> None:
+        with self.assertRaises(
+            project_service_module.ProjectResolutionError
+        ) as exc_info:
+            project_service_module.resolve_project_reference(project_key="   ")
+
+        self.assertEqual(exc_info.exception.code, "invalid_project_reference")

--- a/tests/test_ui/test_history_page.py
+++ b/tests/test_ui/test_history_page.py
@@ -314,6 +314,24 @@ class HistoryPageRenderingTests(unittest.TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertIn("Analysis report not found", response.text)
 
+    def test_history_active_project_ignores_stale_saved_selection(self) -> None:
+        project = project_service_module.create_project(
+            project_key="payments",
+            display_name="Payments",
+        )
+        project_service_module.set_active_project(project.id)
+        with database_module.engine.begin() as connection:
+            connection.exec_driver_sql(
+                "DELETE FROM projects WHERE id = ?",
+                (project.id,),
+            )
+
+        active = history_module.resolve_history_active_project()
+
+        self.assertIsNotNone(active)
+        assert active is not None
+        self.assertEqual(active.project_key, project_service_module.DEFAULT_PROJECT_KEY)
+
     def test_public_report_route_blocks_compare_view_when_previous_report_is_protected(
         self,
     ) -> None:

--- a/tests/test_ui/test_upload_panel.py
+++ b/tests/test_ui/test_upload_panel.py
@@ -55,6 +55,21 @@ class UploadPanelTests(unittest.TestCase):
             },
         )
 
+    def test_run_uploaded_analysis_requires_project_scope_before_parsing(self) -> None:
+        with (
+            patch(
+                "services.analysis_service.build_parse_batch",
+                side_effect=AssertionError("project must resolve before parsing"),
+            ) as build_parse_batch,
+            self.assertRaisesRegex(ValueError, "Project scope is required") as exc_info,
+        ):
+            run_uploaded_analysis([("plan.json", b'{"resource_changes": []}')])
+
+        self.assertEqual(
+            getattr(exc_info.exception, "code", ""), "missing_project_scope"
+        )
+        build_parse_batch.assert_not_called()
+
     def test_resolve_initial_project_selection_requires_saved_choice(self) -> None:
         project_id, project_key = resolve_initial_project_selection(
             has_saved_selection=False,

--- a/ui/routes/history.py
+++ b/ui/routes/history.py
@@ -36,6 +36,11 @@ def page_selection_state(
     return selected_on_page == len(visible_ids), selected_on_page
 
 
+def resolve_history_active_project():
+    """Return the saved project or the default project when the saved selection is stale."""
+    return get_active_project()
+
+
 def build_history_page() -> None:
     """Render a scanable history view with direct report retrieval."""
     apply_theme()
@@ -52,7 +57,7 @@ def build_history_page() -> None:
 
     @ui.refreshable
     def render_history_content() -> None:
-        active_project = get_active_project()
+        active_project = resolve_history_active_project()
         active_project_id = active_project.id if active_project is not None else None
         reports_page = fetch_filtered_analysis_history_page(
             project_id=active_project_id,
@@ -481,7 +486,7 @@ def build_history_detail_page(report_id: int, *, show_comparison: bool = False) 
 
     @ui.refreshable
     def render_history_detail_content() -> None:
-        active_project = get_active_project()
+        active_project = resolve_history_active_project()
         active_project_id = active_project.id if active_project is not None else None
         report = fetch_analysis_report(report_id, project_id=active_project_id)
         comparison = (


### PR DESCRIPTION
Story 1.2 makes analysis submission project-aware across API, CLI, UI, and GitHub App entry points. Scope is resolved before artifact parsing so invalid or missing project references fail early, and repository-derived GitHub analysis now preserves canonical repository ownership to avoid cross-project reuse.

Constraint: Preserve DeployWhisper local-first and advisory-first posture while keeping one shared analysis core.

Constraint: BMad Story 1.2 required implementation artifacts and sprint status to reflect review readiness.

Rejected: Let API/CLI/GitHub fall back to the default project | would preserve silent unscoped analysis drift.

Rejected: Match repository projects by owner/repo path only | different SCM hosts can share owner/repo paths.

Confidence: high

Scope-risk: moderate

Directive: Do not move artifact parsing ahead of project-scope resolution without re-checking missing/invalid scope regressions.

Tested: ./.venv/bin/ruff check .

Tested: ./.venv/bin/ruff format --check .

Tested: ./.venv/bin/python -m unittest discover -q

Tested: bash scripts/ci-local.sh

Not-tested: Bandit security scan; scripts/ci-local.sh skipped it because Bandit is not installed.

## What does this PR do?

<!-- Brief description of changes -->

## Type of change
- [ ] Feature (new functionality)
- [ ] Bugfix (non-breaking fix)
- [ ] Release preparation
- [ ] Hotfix (critical production fix)
- [ ] Docs / refactor / chore

## Checklist
- [ ] I have followed the branch naming convention
- [ ] Tests pass locally (`pytest tests/ -v`)
- [ ] Linting passes (`ruff check .`)
- [ ] Docker build succeeds
- [ ] I have updated docs if needed
- [ ] No secrets or .env values committed

## Related issue
Closes #