### PR TITLE
Preserve project boundaries for persisted reports

### DIFF
--- a/_bmad-output/implementation-artifacts/1-3-project-scoped-report-persistence.md
+++ b/_bmad-output/implementation-artifacts/1-3-project-scoped-report-persistence.md
@@ -1,0 +1,143 @@
+# Story 1.3: Project-Scoped Report Persistence
+
+Status: done
+
+<!-- Generated from updated PRD/architecture/epics plus implementation-readiness-report-2026-05-01.md. -->
+
+## Story
+
+As a platform admin,
+I want saved reports and analysis runs scoped to their project and optional workspace,
+So that teams do not see unrelated deployment reviews by accident.
+
+## Acceptance Criteria
+
+1. Given analysis runs and reports are created or queried, When persistence and retrieval run, Then records are scoped to project and optional workspace where applicable. And report repository queries and API responses prevent accidental cross-project leakage.
+2. Given a report lookup uses an ID from another project, When the caller's active project does not match the report scope, Then the response does not reveal report contents or metadata beyond an authorized error envelope.
+
+### Requirement Traceability
+
+- Primary PRD requirements: Epic 1 coverage: PRJ-01..10, HIS-08, NFR-SEC-07, DOC-22.
+- Supporting PRD / NFR / differentiation requirements: See `_bmad-output/planning-artifacts/prd.md`, `_bmad-output/planning-artifacts/architecture.md`, and `_bmad-output/planning-artifacts/implementation-readiness-report-2026-05-01.md`.
+- Coverage intent: Baseline + Delta.
+- Story alignment note: This story was created from the updated Epic 1 plan after the 2026-05-01 readiness rerun. The readiness report verified 187/187 PRD functional requirement IDs in the epics artifact, 38 NFR IDs present, and no critical or major readiness defects.
+
+## Tasks / Subtasks
+
+- [x] Implement and verify acceptance criterion 1. (AC: 1)
+- [x] Implement and verify acceptance criterion 2. (AC: 2)
+- [x] Reuse existing services, repositories, schemas, and UI/CLI/API helpers before adding new abstractions. (AC: all)
+- [x] Add or update deterministic regression coverage for the changed behavior. (AC: all)
+- [x] Update relevant docs or examples if the story changes user-visible, operator, API, CLI, integration, or contribution behavior. (AC: all)
+- [x] Run required validation and record commands/results in the Dev Agent Record. (AC: all)
+
+### Review Findings
+
+- [x] [Review][Patch] Require project scope when API retrieval filters by workspace_id [api/routes/analyses.py:131]
+- [x] [Review][Patch] Validate full report workspace schema before stamping brownfield revision 015 [models/database.py:307]
+
+## Dev Notes
+
+### Epic Context
+
+- Epic: 1. Project, Workspace, and RBAC Foundation
+- Epic goal: Make DeployWhisper project-aware before reports, incidents, topology, scanner imports, and feedback become harder to migrate.
+- Epic coverage: PRJ-01..10, HIS-08, NFR-SEC-07, DOC-22
+
+### Architecture and Product Guardrails
+
+- Preserve DeployWhisper's local-first raw artifact boundary: raw IaC, scanner artifacts, incident exports, and sensitive context stay in the user's infrastructure by default.
+- Preserve the advisory-first core. Optional adapters may interpret report outputs, but canonical report semantics remain advisory unless explicit story scope says otherwise.
+- Reuse the shared analysis core and service layer before adapting UI, API, CLI, GitHub, or future workflow surfaces.
+- Keep Evidence Law behavior intact: no high or critical finding without deterministic evidence.
+- Keep project/workspace scope explicit for reports, incidents, topology, outcomes, feedback, scanner imports, and connector-related data.
+- Do not introduce new dependencies unless the active story explicitly requires and justifies them.
+
+### Source Tree Guidance
+
+- API routes belong under `api/routes/` and should use existing `ApiRoute` / `ApiError` envelope patterns.
+- Shared orchestration belongs in `services/`; parsers normalize input, analysis modules score/derive risk, and surfaces adapt outputs.
+- UI work belongs under `ui/routes/` and `ui/components/`, following the existing NiceGUI composition style.
+- CLI behavior belongs under `cli/` and must call the same service-layer paths as UI/API flows.
+- Persistence work belongs under `models/` with Alembic migrations when schema changes are required.
+- Documentation required by a story should be updated in the same workstream.
+
+### Testing Requirements
+
+- Use standard-library `unittest` in the existing `tests/test_*` layout.
+- Add focused regression tests for the layer changed by the story before broad refactors.
+- For Python changes, run `./.venv/bin/ruff check .`, `./.venv/bin/ruff format --check .`, and `./.venv/bin/python -m unittest discover -q` before closing implementation.
+- Use `bash scripts/ci-local.sh` for broader or cross-layer changes.
+
+### Project Structure Notes
+
+- Follow the current repository shape documented in `_bmad-output/project-context.md` and `AGENTS.md`.
+- If implementation reveals a conflict between this story and the current code baseline, keep the smallest compatible change and update the story notes rather than silently drifting from the PRD.
+
+### References
+
+- `_bmad-output/planning-artifacts/epics.md` - source Epic 1 / Story 1.3 definition.
+- `_bmad-output/planning-artifacts/prd.md` - functional and non-functional requirements.
+- `_bmad-output/planning-artifacts/architecture.md` - target architecture, boundaries, and guardrails.
+- `_bmad-output/planning-artifacts/ux-design-specification.md` - UX expectations for user-facing stories.
+- `_bmad-output/planning-artifacts/implementation-readiness-report-2026-05-01.md` - readiness verdict and residual story-format concern.
+- `_bmad-output/project-context.md` - repository-specific implementation rules.
+
+## Dev Agent Record
+
+### Agent Model Used
+
+GPT-5.4 Codex
+
+### Debug Log References
+
+- `./.venv/bin/python -m unittest tests.test_services.test_report_service.ReportServiceTests.test_persist_analysis_report_stores_and_filters_workspace_scope tests.test_api.test_analyses.AnalysesApiTests.test_workspace_query_prevents_cross_workspace_report_lookup -q` - failed before implementation with `persist_analysis_report() got an unexpected keyword argument 'workspace_id'`.
+- `./.venv/bin/python -m unittest tests.test_services.test_report_service.ReportServiceTests.test_persist_analysis_report_stores_and_filters_workspace_scope tests.test_api.test_analyses.AnalysesApiTests.test_workspace_query_prevents_cross_workspace_report_lookup -q` - passed after workspace persistence and API scope filtering implementation.
+- `./.venv/bin/python -m unittest tests.test_services.test_report_service tests.test_api.test_analyses tests.test_infra.test_migrations tests.test_infra.test_container_contract -q` - passed, 69 tests.
+- `./.venv/bin/ruff check .` - passed.
+- `./.venv/bin/ruff format --check .` - initially reported `services/project_service.py`; passed after running `./.venv/bin/ruff format services/project_service.py`.
+- `./.venv/bin/python -m unittest discover -q` - passed, 247 tests, 1 skipped.
+- `bash scripts/ci-local.sh` - passed; Bandit skipped because it is not installed locally.
+- `git diff --check` - passed.
+- `./.venv/bin/python -m unittest tests.test_api.test_analyses.AnalysesApiTests.test_workspace_query_prevents_cross_workspace_report_lookup tests.test_infra.test_migrations.MigrationTests.test_init_db_rejects_partial_report_workspace_scope_schema tests.test_infra.test_migrations.MigrationTests.test_init_db_repairs_current_schema_without_alembic_version -q` - passed after review finding fixes.
+- `./.venv/bin/python -m unittest tests.test_services.test_report_service tests.test_api.test_analyses tests.test_infra.test_migrations tests.test_infra.test_container_contract -q` - passed, 70 tests.
+- `./.venv/bin/ruff check .` - passed after review finding fixes.
+- `./.venv/bin/ruff format --check .` - initially reported `tests/test_infra/test_migrations.py`; passed after running `./.venv/bin/ruff format tests/test_infra/test_migrations.py`.
+- `./.venv/bin/python -m unittest discover -q` - passed, 248 tests, 1 skipped.
+- `bash scripts/ci-local.sh` - passed; Bandit skipped because it is not installed locally.
+
+### Completion Notes List
+
+- Added nullable workspace scope to persisted analysis reports with Alembic migration `015_add_report_workspace_scope`.
+- Extended report persistence, serialization, history/detail retrieval, dashboard/trend helpers, API schemas/routes, CLI analysis options, and project/workspace resolution to validate and filter optional workspace scope.
+- Preserved unauthorized cross-scope behavior as standard not-found API envelopes so mismatched project/workspace lookups do not reveal report contents.
+- Closed review findings by rejecting API report/history retrieval requests that supply `workspace_id` without project scope, and by rejecting partial brownfield report workspace schemas before stamping revision 015.
+- Updated project workspace documentation with workspace-aware report submission and retrieval examples.
+
+### File List
+
+- `_bmad-output/implementation-artifacts/1-3-project-scoped-report-persistence.md`
+- `_bmad-output/implementation-artifacts/sprint-status.yaml`
+- `api/routes/analyses.py`
+- `api/schemas.py`
+- `cli/analyze.py`
+- `docs/project-workspaces.md`
+- `migrations/versions/015_add_report_workspace_scope.py`
+- `models/database.py`
+- `models/repositories/analysis_reports.py`
+- `models/repositories/projects.py`
+- `models/tables.py`
+- `services/analysis_service.py`
+- `services/project_service.py`
+- `services/report_service.py`
+- `tests/test_api/test_analyses.py`
+- `tests/test_infra/test_container_contract.py`
+- `tests/test_infra/test_migrations.py`
+- `tests/test_services/test_report_service.py`
+
+## Change Log
+
+- 2026-05-01: Story created/aligned from updated PRD, architecture, epics, sprint status, and readiness report.
+- 2026-05-06: Implemented project/workspace-scoped report persistence, retrieval filters, API/CLI contracts, migration, docs, and regression coverage.
+- 2026-05-06: Fixed code review findings for unscoped `workspace_id` API retrieval and partial brownfield revision 015 detection.
+- 2026-05-06: Re-ran BMad code review with no remaining findings; story marked done.

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -1,5 +1,5 @@
 # generated: 2026-05-01
-# last_updated: 2026-05-05
+# last_updated: 2026-05-06
 # project: deploywhisper
 # project_key: NOKEY
 # tracking_system: file-system
@@ -35,7 +35,7 @@
 # - Dev moves story to review, then runs code-review
 
 generated: 2026-05-01
-last_updated: 2026-05-05
+last_updated: 2026-05-06
 project: deploywhisper
 project_key: NOKEY
 tracking_system: file-system
@@ -52,7 +52,7 @@ development_status:
   epic-1: in-progress
   1-1-project-and-workspace-records: done
   1-2-project-aware-analysis-submission: review
-  1-3-project-scoped-report-persistence: ready-for-dev
+  1-3-project-scoped-report-persistence: done
   1-4-project-scoped-learning-and-context-records: ready-for-dev
   1-5-lightweight-rbac-role-model: ready-for-dev
   1-6-project-model-documentation: ready-for-dev

--- a/api/routes/analyses.py
+++ b/api/routes/analyses.py
@@ -44,11 +44,26 @@ READ_CHUNK_BYTES = 1024 * 1024
 
 def _project_api_error(exc: ValueError) -> ApiError:
     code = getattr(exc, "code", "invalid_project_request")
-    status_code = 404 if code == "project_not_found" else 400
+    status_code = 404 if code in {"project_not_found", "workspace_not_found"} else 400
     return ApiError(
         status_code=status_code,
         code=code,
         message=str(exc),
+    )
+
+
+def _reject_unscoped_workspace_id(
+    *,
+    project_id: int | None,
+    project_key: str | None,
+    workspace_id: int | None,
+) -> None:
+    if workspace_id is None or project_id is not None or project_key is not None:
+        return
+    raise ApiError(
+        status_code=400,
+        code="missing_project_scope",
+        message="Project scope is required when resolving workspace_id.",
     )
 
 
@@ -119,6 +134,8 @@ async def _read_upload_files_with_limit(
 def list_analyses(
     project_id: int | None = Query(default=None),
     project_key: str | None = Query(default=None),
+    workspace_id: int | None = Query(default=None),
+    workspace_key: str | None = Query(default=None),
     severity: str | None = Query(default=None),
     recommendation: str | None = Query(default=None),
     search: str | None = Query(default=None),
@@ -126,11 +143,23 @@ def list_analyses(
     page_size: int = Query(default=50, ge=1, le=100),
 ) -> AnalysisListResponse:
     try:
-        if project_id is None and project_key is None:
+        _reject_unscoped_workspace_id(
+            project_id=project_id,
+            project_key=project_key,
+            workspace_id=workspace_id,
+        )
+        if (
+            project_id is None
+            and project_key is None
+            and workspace_id is None
+            and workspace_key is None
+        ):
             project_id = ensure_default_project().id
         page_payload = fetch_filtered_analysis_history_page(
             project_id=project_id,
             project_key=project_key,
+            workspace_id=workspace_id,
+            workspace_key=workspace_key,
             severity=severity,
             recommendation=recommendation,
             search=search,
@@ -175,6 +204,14 @@ async def create_analysis(
         default=None,
         description="Required unless project_id is provided; project key for the analysis.",
     ),
+    workspace_id: int | None = Form(
+        default=None,
+        description="Optional numeric workspace/environment id for the analysis.",
+    ),
+    workspace_key: str | None = Form(
+        default=None,
+        description="Optional project-local workspace/environment key for the analysis.",
+    ),
     trigger_type: str | None = Header(
         default=None, alias="X-DeployWhisper-Trigger-Type"
     ),
@@ -188,7 +225,12 @@ async def create_analysis(
         )
 
     try:
-        resolve_analysis_project_scope(project_id=project_id, project_key=project_key)
+        resolve_analysis_project_scope(
+            project_id=project_id,
+            project_key=project_key,
+            workspace_id=workspace_id,
+            workspace_key=workspace_key,
+        )
     except ValueError as exc:
         raise _project_api_error(exc) from exc
 
@@ -207,6 +249,8 @@ async def create_analysis(
             raw_files,
             project_id=project_id,
             project_key=project_key,
+            workspace_id=workspace_id,
+            workspace_key=workspace_key,
             audit_context={
                 "source_interface": "api",
                 "trigger_type": trigger_type or "api_request",
@@ -248,14 +292,28 @@ def get_analysis(
     report_id: int,
     project_id: int | None = Query(default=None),
     project_key: str | None = Query(default=None),
+    workspace_id: int | None = Query(default=None),
+    workspace_key: str | None = Query(default=None),
 ) -> AnalysisDetailResponse:
     try:
-        if project_id is None and project_key is None:
+        _reject_unscoped_workspace_id(
+            project_id=project_id,
+            project_key=project_key,
+            workspace_id=workspace_id,
+        )
+        if (
+            project_id is None
+            and project_key is None
+            and workspace_id is None
+            and workspace_key is None
+        ):
             project_id = ensure_default_project().id
         report = fetch_analysis_report(
             report_id,
             project_id=project_id,
             project_key=project_key,
+            workspace_id=workspace_id,
+            workspace_key=workspace_key,
         )
     except ValueError as exc:
         raise _project_api_error(exc) from exc

--- a/api/schemas.py
+++ b/api/schemas.py
@@ -208,6 +208,9 @@ class ProjectData(BaseModel):
 class PersistedReportData(BaseModel):
     id: int
     project: ProjectData = Field(..., description="Owning project/workspace")
+    workspace: "WorkspaceData | None" = Field(
+        default=None, description="Optional project-local workspace/environment scope"
+    )
     risk_score: int
     severity: str
     recommendation: str

--- a/cli/analyze.py
+++ b/cli/analyze.py
@@ -269,6 +269,8 @@ def _run_analyze(
     *,
     project_id: int | None = None,
     project_key: str | None = None,
+    workspace_id: int | None = None,
+    workspace_key: str | None = None,
 ) -> int:
     if not paths:
         _emit_json(
@@ -281,7 +283,12 @@ def _run_analyze(
         return 2
 
     try:
-        resolve_analysis_project_scope(project_id=project_id, project_key=project_key)
+        resolve_analysis_project_scope(
+            project_id=project_id,
+            project_key=project_key,
+            workspace_id=workspace_id,
+            workspace_key=workspace_key,
+        )
     except ValueError as exc:
         _emit_json(
             build_error(
@@ -320,6 +327,8 @@ def _run_analyze(
                 raw_files,
                 project_id=project_id,
                 project_key=project_key,
+                workspace_id=workspace_id,
+                workspace_key=workspace_key,
                 audit_context={
                     "source_interface": "cli",
                     "trigger_type": os.getenv(
@@ -601,13 +610,24 @@ def build_parser() -> argparse.ArgumentParser:
     analyze_parser.add_argument(
         "--project",
         dest="project_key",
-        help="Project/workspace key for the analysis. Required unless --project-id is provided.",
+        help="Project key for the analysis. Required unless --project-id is provided.",
     )
     analyze_parser.add_argument(
         "--project-id",
         dest="project_id",
         type=int,
-        help="Numeric project/workspace id for the analysis. Required unless --project is provided.",
+        help="Numeric project id for the analysis. Required unless --project is provided.",
+    )
+    analyze_parser.add_argument(
+        "--workspace",
+        dest="workspace_key",
+        help="Optional project-local workspace/environment key for the analysis.",
+    )
+    analyze_parser.add_argument(
+        "--workspace-id",
+        dest="workspace_id",
+        type=int,
+        help="Optional numeric workspace/environment id for the analysis.",
     )
     analyze_parser.add_argument(
         "paths", nargs="*", help="Artifact file paths to analyze."
@@ -828,6 +848,8 @@ def main() -> None:
                 args.paths,
                 project_id=getattr(args, "project_id", None),
                 project_key=getattr(args, "project_key", None),
+                workspace_id=getattr(args, "workspace_id", None),
+                workspace_key=getattr(args, "workspace_key", None),
             )
         )
     if args.command == "project" and args.project_command == "create":

--- a/docs/project-workspaces.md
+++ b/docs/project-workspaces.md
@@ -7,7 +7,7 @@ DeployWhisper now scopes analyses and topology context to lightweight project/wo
 - Projects have a stable `project_key`, display name, optional description, repository URL, and default branch.
 - Workspaces have a stable project-local `workspace_key`, display name, optional description, optional environment label, and timestamps.
 - New analyses must attach to a project through the UI, API, CLI, or GitHub integration path.
-- Persisted reports now carry project metadata and history filters can scope by project.
+- Persisted reports now carry project metadata plus optional workspace metadata, and history/report filters can scope by project and workspace.
 - Topology uploads are stored per project, with legacy file-based topology continuing to resolve through the default `unassigned` project.
 - Topology drift checks now run on a persisted cadence (daily by default), reuse the imported source reference when available, and surface per-project added/removed/modified resource reports in settings.
 - Deployment outcome and reviewer feedback tables now exist with project foreign keys so later Epic 5 stories can extend the same isolation boundary without schema churn.
@@ -20,6 +20,9 @@ DeployWhisper now scopes analyses and topology context to lightweight project/wo
   - `GET /api/v1/projects/<project_key>/workspaces` lists workspace/environment records for a project
   - `POST /api/v1/projects/<project_key>/workspaces` creates a workspace/environment record
   - `POST /api/v1/analyses` requires multipart `project_key` or `project_id`
+  - `POST /api/v1/analyses` also accepts optional `workspace_key` or `workspace_id` to attach a run to a project-local workspace/environment
+  - `GET /api/v1/analyses?project_key=<key>&workspace_key=<workspace>` lists reports for one workspace
+  - `GET /api/v1/analyses/<id>?project_key=<key>&workspace_key=<workspace>` returns a report only when the requested scope matches
   - `GET /api/v1/context/topology?project_key=<key>` reads project-scoped topology status
   - `POST /api/v1/context/topology` stores project-scoped topology JSON with `project_key` or `project_id`
 - CLI:
@@ -27,7 +30,7 @@ DeployWhisper now scopes analyses and topology context to lightweight project/wo
   - `deploywhisper project list`
   - `deploywhisper project workspace create <project-key> <workspace-key> <display-name>`
   - `deploywhisper project workspace list <project-key>`
-  - `deploywhisper analyze --project <key> <artifact...>` or `deploywhisper analyze --project-id <id> <artifact...>`
+  - `deploywhisper analyze --project <key> [--workspace <workspace>] <artifact...>` or `deploywhisper analyze --project-id <id> [--workspace-id <id>] <artifact...>`
   - `deploywhisper topology import --from custom --source <topology.json> --project <key>`
   - `deploywhisper topology import --from terraform --source <state-or-uri> --project <key>`
   - The topology import command now routes through a shared source registry and returns a normalized import result with accepted, skipped, partially parsed, and unsupported resources.
@@ -37,6 +40,8 @@ DeployWhisper now scopes analyses and topology context to lightweight project/wo
 
 - Shared workspace chrome now keeps project switching in a dedicated global card below the header, with searchable filtering, keyboard navigation, and current/default project context shown consistently across pages.
 - Explicit `project_key` / `project_id` references now fail fast when they are unknown instead of silently falling back to `unassigned`.
+- Explicit `workspace_key` / `workspace_id` references fail fast when unknown or when they do not belong to the supplied project.
+- Report detail and history retrieval return the standard not-found envelope when the requested project/workspace scope does not match the report.
 - New API and CLI analysis submissions without a project reference fail fast with `missing_project_scope` instead of silently falling back to `unassigned`.
 - Conflicting `project_key` and `project_id` inputs are rejected.
 - In the current local/admin phase, unauthorized analysis scope means an unknown, conflicting, or otherwise invalid project reference. Full membership and role enforcement is intentionally deferred to the lightweight RBAC story.

--- a/migrations/versions/015_add_report_workspace_scope.py
+++ b/migrations/versions/015_add_report_workspace_scope.py
@@ -1,0 +1,47 @@
+"""Add optional workspace scope to analysis reports.
+
+Revision ID: 015_add_report_workspace_scope
+Revises: 014_add_project_workspace_records
+Create Date: 2026-05-06
+"""
+
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "015_add_report_workspace_scope"
+down_revision = "014_add_project_workspace_records"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "analysis_reports",
+        sa.Column("workspace_id", sa.Integer(), nullable=True),
+    )
+    with op.batch_alter_table("analysis_reports") as batch_op:
+        batch_op.create_foreign_key(
+            "fk_analysis_reports_workspace_id_project_workspaces",
+            "project_workspaces",
+            ["workspace_id"],
+            ["id"],
+            ondelete="SET NULL",
+        )
+        batch_op.create_index(
+            "ix_analysis_reports_workspace_id",
+            ["workspace_id"],
+            unique=False,
+        )
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("analysis_reports") as batch_op:
+        batch_op.drop_index("ix_analysis_reports_workspace_id")
+        batch_op.drop_constraint(
+            "fk_analysis_reports_workspace_id_project_workspaces",
+            type_="foreignkey",
+        )
+        batch_op.drop_column("workspace_id")

--- a/models/database.py
+++ b/models/database.py
@@ -43,6 +43,7 @@ _KNOWN_ALEMBIC_REVISIONS = {
     "012_add_feedback_event_fields",
     "013_add_incident_analysis_reference",
     "014_add_project_workspace_records",
+    "015_add_report_workspace_scope",
 }
 _BASELINE_TABLES = {"analysis_reports", "app_settings"}
 _EVIDENCE_TABLES = {
@@ -244,6 +245,36 @@ def _project_workspace_schema_complete(connection) -> bool:
     )
 
 
+def _analysis_report_workspace_scope_complete(connection) -> bool:
+    inspector = inspect(connection)
+    column_map = {
+        column["name"]: column
+        for column in inspect(connection).get_columns("analysis_reports")
+    }
+    workspace_column = column_map.get("workspace_id")
+    has_workspace_column = (
+        workspace_column is not None
+        and workspace_column["type"]._type_affinity is Integer
+        and workspace_column.get("nullable") is True
+    )
+    has_workspace_fk = any(
+        foreign_key.get("referred_table") == "project_workspaces"
+        and "workspace_id" in (foreign_key.get("constrained_columns") or [])
+        and "id" in (foreign_key.get("referred_columns") or [])
+        and (foreign_key.get("options") or {}).get("ondelete") == "SET NULL"
+        for foreign_key in inspector.get_foreign_keys("analysis_reports")
+    )
+    indexed_columns = {
+        tuple(index.get("column_names") or [])
+        for index in inspector.get_indexes("analysis_reports")
+    }
+    return (
+        has_workspace_column
+        and has_workspace_fk
+        and ("workspace_id",) in indexed_columns
+    )
+
+
 def _bootstrap_brownfield_revision() -> None:
     with engine.begin() as connection:
         tables = set(inspect(connection).get_table_names())
@@ -303,6 +334,25 @@ def _bootstrap_brownfield_revision() -> None:
         has_complete_incident_link = {"analysis_id"}.issubset(
             incident_record_columns
         ) and _incident_record_has_analysis_link(connection)
+        has_report_workspace_scope = "workspace_id" in report_columns
+        has_complete_report_workspace_scope = (
+            has_report_workspace_scope
+            and _analysis_report_workspace_scope_complete(connection)
+        )
+        if has_report_workspace_scope and not has_complete_report_workspace_scope:
+            raise RuntimeError(
+                "Detected a partial analysis report workspace scope schema without "
+                "a complete migration history. Manual recovery is required."
+            )
+        if (
+            has_complete_workspace_records
+            and "projects" in tables
+            and "topology_versions" in tables
+            and "project_id" in report_columns
+            and has_complete_report_workspace_scope
+        ):
+            _write_alembic_revision(connection, "015_add_report_workspace_scope")
+            return
         if (
             has_complete_workspace_records
             and "projects" in tables

--- a/models/repositories/analysis_reports.py
+++ b/models/repositories/analysis_reports.py
@@ -21,6 +21,7 @@ def _report_load_options(*, include_evidence: bool) -> list:
     options = [
         selectinload(AnalysisReport.risk_assessment),
         selectinload(AnalysisReport.project),
+        selectinload(AnalysisReport.workspace),
     ]
     findings_loader = selectinload(AnalysisReport.findings)
     if include_evidence:
@@ -33,6 +34,7 @@ def create_analysis_report(
     session: Session,
     *,
     project_id: int,
+    workspace_id: int | None = None,
     risk_score: int,
     severity: str,
     recommendation: str,
@@ -63,6 +65,7 @@ def create_analysis_report(
 ) -> AnalysisReport:
     report = AnalysisReport(
         project_id=project_id,
+        workspace_id=workspace_id,
         risk_score=risk_score,
         severity=severity,
         recommendation=recommendation,
@@ -174,13 +177,22 @@ def create_analysis_report(
 
 
 def get_analysis_report(
-    session: Session, report_id: int, *, include_evidence: bool = True
+    session: Session,
+    report_id: int,
+    *,
+    project_id: int | None = None,
+    workspace_id: int | None = None,
+    include_evidence: bool = True,
 ) -> AnalysisReport | None:
     stmt = (
         select(AnalysisReport)
         .options(*_report_load_options(include_evidence=include_evidence))
         .where(AnalysisReport.id == report_id)
     )
+    if project_id is not None:
+        stmt = stmt.where(AnalysisReport.project_id == project_id)
+    if workspace_id is not None:
+        stmt = stmt.where(AnalysisReport.workspace_id == workspace_id)
     return session.execute(stmt).scalar_one_or_none()
 
 
@@ -216,6 +228,7 @@ def list_analysis_reports(
     session: Session,
     *,
     project_id: int | None = None,
+    workspace_id: int | None = None,
     severity: str | None = None,
     recommendation: str | None = None,
     search: str | None = None,
@@ -230,6 +243,8 @@ def list_analysis_reports(
     )
     if project_id is not None:
         stmt = stmt.where(AnalysisReport.project_id == project_id)
+    if workspace_id is not None:
+        stmt = stmt.where(AnalysisReport.workspace_id == workspace_id)
     if severity:
         stmt = stmt.where(AnalysisReport.severity == severity)
     if recommendation:
@@ -253,6 +268,7 @@ def count_analysis_reports(
     session: Session,
     *,
     project_id: int | None = None,
+    workspace_id: int | None = None,
     severity: str | None = None,
     recommendation: str | None = None,
     search: str | None = None,
@@ -260,6 +276,8 @@ def count_analysis_reports(
     stmt = select(func.count()).select_from(AnalysisReport)
     if project_id is not None:
         stmt = stmt.where(AnalysisReport.project_id == project_id)
+    if workspace_id is not None:
+        stmt = stmt.where(AnalysisReport.workspace_id == workspace_id)
     if severity:
         stmt = stmt.where(AnalysisReport.severity == severity)
     if recommendation:
@@ -279,11 +297,14 @@ def count_analysis_reports_by_field(
     field_name: str,
     *,
     project_id: int | None = None,
+    workspace_id: int | None = None,
 ) -> dict[str, int]:
     column = getattr(AnalysisReport, field_name)
     stmt = select(column, func.count()).group_by(column)
     if project_id is not None:
         stmt = stmt.where(AnalysisReport.project_id == project_id)
+    if workspace_id is not None:
+        stmt = stmt.where(AnalysisReport.workspace_id == workspace_id)
     rows = session.execute(stmt).all()
     return {str(value): int(count) for value, count in rows if value is not None}
 
@@ -293,11 +314,13 @@ def latest_active_dashboard_report(
     *,
     now: datetime | None = None,
     project_id: int | None = None,
+    workspace_id: int | None = None,
 ) -> AnalysisReport | None:
     current_time = now or datetime.now(UTC)
     reports = list_analysis_reports(
         session,
         project_id=project_id,
+        workspace_id=workspace_id,
         include_evidence=False,
     )
     for report in reports:

--- a/models/repositories/projects.py
+++ b/models/repositories/projects.py
@@ -77,6 +77,10 @@ def create_workspace(
     return record
 
 
+def get_workspace(session: Session, workspace_id: int) -> ProjectWorkspace | None:
+    return session.get(ProjectWorkspace, workspace_id)
+
+
 def list_workspaces(
     session: Session,
     *,

--- a/models/tables.py
+++ b/models/tables.py
@@ -118,6 +118,9 @@ if "ProjectWorkspace" not in globals():
             onupdate=lambda: datetime.now(UTC),
         )
         project: Mapped["Project"] = relationship(back_populates="workspaces")
+        reports: Mapped[list["AnalysisReport"]] = relationship(
+            back_populates="workspace"
+        )
 
 
 if "AnalysisReport" not in globals():
@@ -130,6 +133,11 @@ if "AnalysisReport" not in globals():
         id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
         project_id: Mapped[int] = mapped_column(
             ForeignKey("projects.id", ondelete="RESTRICT"),
+            index=True,
+        )
+        workspace_id: Mapped[int | None] = mapped_column(
+            ForeignKey("project_workspaces.id", ondelete="SET NULL"),
+            nullable=True,
             index=True,
         )
         risk_score: Mapped[int] = mapped_column(Integer)
@@ -182,6 +190,9 @@ if "AnalysisReport" not in globals():
             back_populates="report"
         )
         project: Mapped["Project"] = relationship(back_populates="reports")
+        workspace: Mapped["ProjectWorkspace | None"] = relationship(
+            back_populates="reports"
+        )
         created_at: Mapped[datetime] = mapped_column(
             DateTime(timezone=True), default=lambda: datetime.now(UTC)
         )

--- a/services/analysis_service.py
+++ b/services/analysis_service.py
@@ -22,7 +22,11 @@ from llm.narrator import NarrativeResult, generate_narrative
 from llm.providers import generate_completion_with_settings
 from parsers.base import ParseBatchResult, UnifiedChange
 from services.intake_service import build_parse_batch
-from services.project_service import ProjectResolutionError, resolve_project_reference
+from services.project_service import (
+    ProjectResolutionError,
+    resolve_project_reference,
+    resolve_workspace_reference,
+)
 from services.report_service import build_share_report_link, persist_analysis_report
 from services.settings_service import resolve_provider_runtime
 from services.topology_service import (
@@ -683,6 +687,8 @@ def resolve_analysis_project_scope(
     *,
     project_id: int | None = None,
     project_key: str | None = None,
+    workspace_id: int | None = None,
+    workspace_key: str | None = None,
 ):
     """Resolve the required analysis project before artifact parsing."""
     raw_project_key = str(project_key) if project_key is not None else None
@@ -703,10 +709,16 @@ def resolve_analysis_project_scope(
                 "or use a workflow integration that derives one."
             ),
         )
-    return resolve_project_reference(
+    resolved_project = resolve_project_reference(
         project_id=project_id,
         project_key=cleaned_project_key or None,
     )
+    resolve_workspace_reference(
+        project_id=resolved_project.id,
+        workspace_id=workspace_id,
+        workspace_key=workspace_key,
+    )
+    return resolved_project
 
 
 def analyze_uploaded_files(
@@ -714,12 +726,16 @@ def analyze_uploaded_files(
     completion_client=None,
     project_id: int | None = None,
     project_key: str | None = None,
+    workspace_id: int | None = None,
+    workspace_key: str | None = None,
     audit_context: dict | None = None,
 ) -> AnalysisRunResult:
     """Run the shared parse -> assess -> persist pipeline."""
     resolved_project = resolve_analysis_project_scope(
         project_id=project_id,
         project_key=project_key,
+        workspace_id=workspace_id,
+        workspace_key=workspace_key,
     )
     artifacts = build_analysis_artifacts(
         files,
@@ -736,6 +752,8 @@ def analyze_uploaded_files(
         evidence_items=artifacts.evidence_items,
         artifact_snapshots={name: raw_content for name, raw_content in files},
         project_id=resolved_project.id,
+        workspace_id=workspace_id,
+        workspace_key=workspace_key,
         audit_context=audit_context,
     )
     return AnalysisRunResult(

--- a/services/project_service.py
+++ b/services/project_service.py
@@ -17,6 +17,7 @@ from models.repositories.projects import (
     get_default_project,
     get_project,
     get_project_by_key,
+    get_workspace,
     get_workspace_by_key,
     list_projects as list_project_records,
     list_workspaces as list_workspace_records,
@@ -524,6 +525,99 @@ def resolve_project_reference(
                 raise RuntimeError("Default project could not be resolved.")
             record = default_record
         return _serialize(record)
+
+
+def resolve_workspace_reference(
+    *,
+    project_id: int | None = None,
+    project_key: str | None = None,
+    workspace_id: int | None = None,
+    workspace_key: str | None = None,
+) -> WorkspaceRecord | None:
+    raw_workspace_key = str(workspace_key) if workspace_key is not None else None
+    cleaned_workspace_key = (
+        raw_workspace_key.strip() if raw_workspace_key is not None else None
+    )
+    if (
+        workspace_id is None
+        and raw_workspace_key is not None
+        and not cleaned_workspace_key
+    ):
+        raise ProjectResolutionError(
+            "invalid_workspace_reference",
+            "Workspace key must contain at least one letter or number.",
+        )
+    if workspace_id is None and not cleaned_workspace_key:
+        return None
+    if cleaned_workspace_key and project_id is None and project_key is None:
+        raise ProjectResolutionError(
+            "missing_project_scope",
+            "Project scope is required when resolving workspace_key.",
+        )
+
+    resolved_project = (
+        resolve_project_reference(project_id=project_id, project_key=project_key)
+        if project_id is not None or project_key is not None or cleaned_workspace_key
+        else None
+    )
+    normalized_workspace_key = (
+        normalize_workspace_key(cleaned_workspace_key)
+        if cleaned_workspace_key
+        else None
+    )
+    with SessionLocal() as session:
+        record_by_id = (
+            get_workspace(session, workspace_id) if workspace_id is not None else None
+        )
+        record_by_key = (
+            get_workspace_by_key(
+                session,
+                project_id=resolved_project.id,
+                workspace_key=normalized_workspace_key,
+            )
+            if resolved_project is not None and normalized_workspace_key is not None
+            else None
+        )
+        if workspace_id is not None and record_by_id is None:
+            raise ProjectResolutionError(
+                "workspace_not_found",
+                f"Unknown workspace reference: workspace_id={workspace_id}.",
+            )
+        if (
+            normalized_workspace_key is not None
+            and resolved_project is not None
+            and record_by_key is None
+        ):
+            raise ProjectResolutionError(
+                "workspace_not_found",
+                (
+                    "Unknown workspace reference: "
+                    f"project_key={resolved_project.project_key}, "
+                    f"workspace_key={normalized_workspace_key}."
+                ),
+            )
+        if (
+            record_by_id is not None
+            and resolved_project is not None
+            and record_by_id.project_id != resolved_project.id
+        ):
+            raise ProjectResolutionError(
+                "conflicting_workspace_reference",
+                "The supplied workspace_id does not belong to the supplied project.",
+            )
+        if (
+            record_by_id is not None
+            and record_by_key is not None
+            and record_by_id.id != record_by_key.id
+        ):
+            raise ProjectResolutionError(
+                "conflicting_workspace_reference",
+                "The supplied workspace_id and workspace_key refer to different workspaces.",
+            )
+        record = record_by_id or record_by_key
+        if record is None:
+            return None
+        return _serialize_workspace(record)
 
 
 def set_active_project(project_id: int) -> ProjectRecord:

--- a/services/report_service.py
+++ b/services/report_service.py
@@ -36,7 +36,9 @@ from services.artifact_snapshot_service import (
 )
 from services.project_service import (
     build_project_payload,
+    build_workspace_payload,
     resolve_project_reference,
+    resolve_workspace_reference,
 )
 from services.settings_service import get_dashboard_result_display_duration_seconds
 from services.settings_service import resolve_provider_runtime
@@ -60,6 +62,27 @@ def _resolve_project_id(
         project_id=project_id,
         project_key=project_key,
     ).id
+
+
+def _resolve_report_scope(
+    *,
+    project_id: int | None = None,
+    project_key: str | None = None,
+    workspace_id: int | None = None,
+    workspace_key: str | None = None,
+) -> tuple[int | None, int | None]:
+    workspace = resolve_workspace_reference(
+        project_id=project_id,
+        project_key=project_key,
+        workspace_id=workspace_id,
+        workspace_key=workspace_key,
+    )
+    if workspace is not None:
+        return workspace.project_id, workspace.id
+    return (
+        _resolve_project_id(project_id=project_id, project_key=project_key),
+        None,
+    )
 
 
 def build_share_report_link(report_id: int | None) -> str | None:
@@ -243,14 +266,17 @@ def _artifact_signature(files_analyzed: list[str]) -> tuple[str, ...]:
     return tuple(sorted(str(name) for name in files_analyzed if str(name).strip()))
 
 
-def _history_signature(report: dict[str, Any]) -> tuple[int, tuple[str, ...]] | None:
+def _history_signature(
+    report: dict[str, Any],
+) -> tuple[int, int, tuple[str, ...]] | None:
     artifact_signature = _artifact_signature(
         report.get("audit", {}).get("files_analyzed") or []
     )
     if not artifact_signature:
         return None
     project_id = int(report.get("project", {}).get("id") or 0)
-    return (project_id, artifact_signature)
+    workspace_id = int((report.get("workspace") or {}).get("id") or 0)
+    return (project_id, workspace_id, artifact_signature)
 
 
 def _normalize_free_text(value: Any) -> str:
@@ -562,12 +588,15 @@ def _find_previous_comparable_report(
         return None
     current_id = int(current_report["id"])
     current_project_id = int(current_report.get("project", {}).get("id") or 0)
+    current_workspace_id = int((current_report.get("workspace") or {}).get("id") or 0)
     previous_candidates = sorted(
         (
             report
             for report in candidate_reports
             if int(report["id"]) < current_id
             and int(report.get("project", {}).get("id") or 0) == current_project_id
+            and int((report.get("workspace") or {}).get("id") or 0)
+            == current_workspace_id
             and _artifact_signature(report.get("audit", {}).get("files_analyzed") or [])
             == current_signature
         ),
@@ -594,12 +623,16 @@ def fetch_previous_comparable_report(
     *,
     project_id: int | None = None,
     project_key: str | None = None,
+    workspace_id: int | None = None,
+    workspace_key: str | None = None,
     previous_report_id: int | None = None,
 ) -> dict | None:
     current_report = fetch_analysis_report(
         report_id,
         project_id=project_id,
         project_key=project_key,
+        workspace_id=workspace_id,
+        workspace_key=workspace_key,
     )
     if current_report is None:
         return None
@@ -608,6 +641,8 @@ def fetch_previous_comparable_report(
             previous_report_id,
             project_id=project_id,
             project_key=project_key,
+            workspace_id=workspace_id,
+            workspace_key=workspace_key,
         )
     serialized_reports = _list_serialized_reports(include_evidence=False)
     return _find_previous_comparable_report(current_report, serialized_reports)
@@ -927,6 +962,23 @@ def _serialize_report(report, *, include_evidence: bool = True) -> dict:
                 "updated_at": report.project.updated_at.isoformat(),
             }
         ),
+        "workspace": (
+            build_workspace_payload(
+                {
+                    "id": report.workspace.id,
+                    "project_id": report.workspace.project_id,
+                    "project_key": report.project.project_key,
+                    "workspace_key": report.workspace.workspace_key,
+                    "display_name": report.workspace.display_name,
+                    "description": report.workspace.description,
+                    "environment": report.workspace.environment,
+                    "created_at": report.workspace.created_at.isoformat(),
+                    "updated_at": report.workspace.updated_at.isoformat(),
+                }
+            )
+            if report.workspace is not None
+            else None
+        ),
         "risk_score": report.risk_score,
         "severity": report.severity,
         "recommendation": report.recommendation,
@@ -1006,6 +1058,8 @@ def persist_analysis_report(
     artifact_snapshots: dict[str, bytes | None] | None = None,
     project_id: int | None = None,
     project_key: str | None = None,
+    workspace_id: int | None = None,
+    workspace_key: str | None = None,
     audit_context: dict[str, Any] | None = None,
 ) -> dict:
     """Persist the completed analysis before the UI treats it as final."""
@@ -1016,9 +1070,14 @@ def persist_analysis_report(
     )
     audit = _build_audit_metadata(parse_batch, audit_context=audit_context)
     combined_warnings = list(dict.fromkeys([*assessment.warnings, *narrative.warnings]))
-    resolved_project = resolve_project_reference(
+    resolved_project_id, resolved_workspace_id = _resolve_report_scope(
         project_id=project_id,
         project_key=project_key,
+        workspace_id=workspace_id,
+        workspace_key=workspace_key,
+    )
+    resolved_project = resolve_project_reference(
+        project_id=resolved_project_id,
     )
     dashboard_display_duration_seconds = None
     if (
@@ -1034,6 +1093,7 @@ def persist_analysis_report(
             report = create_analysis_report(
                 session,
                 project_id=resolved_project.id,
+                workspace_id=resolved_workspace_id,
                 risk_score=assessment.score,
                 severity=assessment.severity,
                 recommendation=assessment.recommendation,
@@ -1093,17 +1153,26 @@ def fetch_analysis_report(
     *,
     project_id: int | None = None,
     project_key: str | None = None,
+    workspace_id: int | None = None,
+    workspace_key: str | None = None,
 ) -> dict | None:
-    scoped_project_id = _resolve_project_id(
-        project_id=project_id, project_key=project_key
+    scoped_project_id, scoped_workspace_id = _resolve_report_scope(
+        project_id=project_id,
+        project_key=project_key,
+        workspace_id=workspace_id,
+        workspace_key=workspace_key,
     )
 
     def operation():
         with SessionLocal() as session:
-            report = get_analysis_report(session, report_id, include_evidence=True)
+            report = get_analysis_report(
+                session,
+                report_id,
+                project_id=scoped_project_id,
+                workspace_id=scoped_workspace_id,
+                include_evidence=True,
+            )
             if report is None:
-                return None
-            if scoped_project_id is not None and report.project_id != scoped_project_id:
                 return None
             return _serialize_report(report, include_evidence=True)
 
@@ -1115,12 +1184,16 @@ def fetch_report_comparison(
     *,
     project_id: int | None = None,
     project_key: str | None = None,
+    workspace_id: int | None = None,
+    workspace_key: str | None = None,
     previous_report_id: int | None = None,
 ) -> dict | None:
     current_report = fetch_analysis_report(
         report_id,
         project_id=project_id,
         project_key=project_key,
+        workspace_id=workspace_id,
+        workspace_key=workspace_key,
     )
     if current_report is None:
         return None
@@ -1128,6 +1201,8 @@ def fetch_report_comparison(
         report_id,
         project_id=project_id,
         project_key=project_key,
+        workspace_id=workspace_id,
+        workspace_key=workspace_key,
         previous_report_id=previous_report_id,
     )
     if previous_report is None:
@@ -1137,6 +1212,8 @@ def fetch_report_comparison(
             int(previous_report["id"]),
             project_id=project_id,
             project_key=project_key,
+            workspace_id=workspace_id,
+            workspace_key=workspace_key,
         )
         if previous_report is None:
             return None
@@ -1253,6 +1330,8 @@ def fetch_filtered_analysis_history(
     *,
     project_id: int | None = None,
     project_key: str | None = None,
+    workspace_id: int | None = None,
+    workspace_key: str | None = None,
     severity: str | None = None,
     recommendation: str | None = None,
     search: str | None = None,
@@ -1260,6 +1339,8 @@ def fetch_filtered_analysis_history(
     page = fetch_filtered_analysis_history_page(
         project_id=project_id,
         project_key=project_key,
+        workspace_id=workspace_id,
+        workspace_key=workspace_key,
         severity=severity,
         recommendation=recommendation,
         search=search,
@@ -1271,6 +1352,8 @@ def fetch_filtered_analysis_history_page(
     *,
     project_id: int | None = None,
     project_key: str | None = None,
+    workspace_id: int | None = None,
+    workspace_key: str | None = None,
     severity: str | None = None,
     recommendation: str | None = None,
     search: str | None = None,
@@ -1280,9 +1363,11 @@ def fetch_filtered_analysis_history_page(
     page = max(page, 1)
     page_size = max(1, min(page_size, 100))
     offset = (page - 1) * page_size
-    resolved_project_id = _resolve_project_id(
+    resolved_project_id, resolved_workspace_id = _resolve_report_scope(
         project_id=project_id,
         project_key=project_key,
+        workspace_id=workspace_id,
+        workspace_key=workspace_key,
     )
 
     def operation():
@@ -1290,6 +1375,7 @@ def fetch_filtered_analysis_history_page(
             reports = list_analysis_reports(
                 session,
                 project_id=resolved_project_id,
+                workspace_id=resolved_workspace_id,
                 severity=severity,
                 recommendation=recommendation,
                 search=search,
@@ -1300,11 +1386,13 @@ def fetch_filtered_analysis_history_page(
             all_reports = list_analysis_reports(
                 session,
                 project_id=resolved_project_id,
+                workspace_id=resolved_workspace_id,
                 include_evidence=False,
             )
             total_count = count_analysis_reports(
                 session,
                 project_id=resolved_project_id,
+                workspace_id=resolved_workspace_id,
                 severity=severity,
                 recommendation=recommendation,
                 search=search,
@@ -1334,12 +1422,16 @@ def fetch_risk_trends(
     *,
     project_id: int | None = None,
     project_key: str | None = None,
+    workspace_id: int | None = None,
+    workspace_key: str | None = None,
 ) -> dict:
     """Return high-signal trend summaries over stored reports."""
     trend_sample_size = 100
-    resolved_project_id = _resolve_project_id(
+    resolved_project_id, resolved_workspace_id = _resolve_report_scope(
         project_id=project_id,
         project_key=project_key,
+        workspace_id=workspace_id,
+        workspace_key=workspace_key,
     )
 
     def operation():
@@ -1347,6 +1439,7 @@ def fetch_risk_trends(
             reports = list_analysis_reports(
                 session,
                 project_id=resolved_project_id,
+                workspace_id=resolved_workspace_id,
                 limit=trend_sample_size,
                 include_evidence=False,
             )
@@ -1355,16 +1448,19 @@ def fetch_risk_trends(
                 "total_reports": count_analysis_reports(
                     session,
                     project_id=resolved_project_id,
+                    workspace_id=resolved_workspace_id,
                 ),
                 "severity_counts": count_analysis_reports_by_field(
                     session,
                     "severity",
                     project_id=resolved_project_id,
+                    workspace_id=resolved_workspace_id,
                 ),
                 "recommendation_counts": count_analysis_reports_by_field(
                     session,
                     "recommendation",
                     project_id=resolved_project_id,
+                    workspace_id=resolved_workspace_id,
                 ),
             }
 
@@ -1410,11 +1506,15 @@ def fetch_dashboard_stats(
     *,
     project_id: int | None = None,
     project_key: str | None = None,
+    workspace_id: int | None = None,
+    workspace_key: str | None = None,
 ) -> dict:
     """Return dashboard-friendly aggregate metrics for the latest persisted analyses."""
-    resolved_project_id = _resolve_project_id(
+    resolved_project_id, resolved_workspace_id = _resolve_report_scope(
         project_id=project_id,
         project_key=project_key,
+        workspace_id=workspace_id,
+        workspace_key=workspace_key,
     )
 
     def operation():
@@ -1422,6 +1522,7 @@ def fetch_dashboard_stats(
             return list_analysis_reports(
                 session,
                 project_id=resolved_project_id,
+                workspace_id=resolved_workspace_id,
                 include_evidence=False,
             )
 
@@ -1448,11 +1549,15 @@ def fetch_dashboard_briefing(
     *,
     project_id: int | None = None,
     project_key: str | None = None,
+    workspace_id: int | None = None,
+    workspace_key: str | None = None,
 ) -> dict[str, Any]:
     """Return dashboard hero metrics and latest-scan context from persisted reports."""
-    resolved_project_id = _resolve_project_id(
+    resolved_project_id, resolved_workspace_id = _resolve_report_scope(
         project_id=project_id,
         project_key=project_key,
+        workspace_id=workspace_id,
+        workspace_key=workspace_key,
     )
 
     def operation():
@@ -1462,12 +1567,16 @@ def fetch_dashboard_briefing(
                 for report in list_analysis_reports(
                     session,
                     project_id=resolved_project_id,
+                    workspace_id=resolved_workspace_id,
                     include_evidence=False,
                 )
             ]
 
     serialized_reports = _run_with_schema_retry(operation)
-    stats = fetch_dashboard_stats(project_id=resolved_project_id)
+    stats = fetch_dashboard_stats(
+        project_id=resolved_project_id,
+        workspace_id=resolved_workspace_id,
+    )
     severity_counts = stats["severity_counts"]
     saved_briefings = len(serialized_reports)
     high_focus = severity_counts["high"] + severity_counts["critical"]
@@ -1520,12 +1629,16 @@ def fetch_active_dashboard_report(
     now: datetime | None = None,
     project_id: int | None = None,
     project_key: str | None = None,
+    workspace_id: int | None = None,
+    workspace_key: str | None = None,
 ) -> dict | None:
     """Return the most recent dashboard result still within its configured visibility window."""
     current_time = now or datetime.now(UTC)
-    resolved_project_id = _resolve_project_id(
+    resolved_project_id, resolved_workspace_id = _resolve_report_scope(
         project_id=project_id,
         project_key=project_key,
+        workspace_id=workspace_id,
+        workspace_key=workspace_key,
     )
 
     def operation():
@@ -1534,11 +1647,16 @@ def fetch_active_dashboard_report(
                 session,
                 now=current_time,
                 project_id=resolved_project_id,
+                workspace_id=resolved_workspace_id,
             )
             if report is None:
                 return None
             detailed_report = get_analysis_report(
-                session, report.id, include_evidence=True
+                session,
+                report.id,
+                project_id=resolved_project_id,
+                workspace_id=resolved_workspace_id,
+                include_evidence=True,
             )
             if detailed_report is None:
                 return None

--- a/tests/test_api/test_analyses.py
+++ b/tests/test_api/test_analyses.py
@@ -240,6 +240,104 @@ class AnalysesApiTests(unittest.TestCase):
         self.assertEqual(response.status_code, 404)
         self.assertEqual(response.json()["error"]["code"], "analysis_not_found")
 
+    def test_workspace_query_prevents_cross_workspace_report_lookup(self) -> None:
+        project = project_service_module.create_project(
+            project_key="payments",
+            display_name="Payments",
+        )
+        prod = project_service_module.create_workspace(
+            project_key=project.project_key,
+            workspace_key="prod",
+            display_name="Production",
+            environment="prod",
+        )
+        staging = project_service_module.create_workspace(
+            project_key=project.project_key,
+            workspace_key="staging",
+            display_name="Staging",
+            environment="staging",
+        )
+        scoped = report_service_module.persist_analysis_report(
+            ParseBatchResult(
+                files=[
+                    ParsedFileResult(
+                        file_name="payments-prod.json",
+                        tool="terraform",
+                        status="parsed",
+                        changes=[],
+                    )
+                ]
+            ),
+            RiskAssessment(
+                score=72,
+                severity="high",
+                recommendation="no-go",
+                top_risk="Production payment ingress widened.",
+                contributors=[],
+                interaction_risks=[],
+                partial_context=False,
+                warnings=[],
+            ),
+            NarrativeResult(
+                opening_sentence="NO-GO: production payment ingress widened.",
+                explanation="Workspace-scoped report.",
+                guidance=[],
+                degraded=False,
+                warnings=[],
+            ),
+            project_id=project.id,
+            workspace_id=prod.id,
+            audit_context={"source_interface": "api"},
+        )
+
+        wrong_workspace_response = self.client.get(
+            f"/api/v1/analyses/{scoped['id']}",
+            params={
+                "project_key": project.project_key,
+                "workspace_key": staging.workspace_key,
+            },
+        )
+        unscoped_workspace_id_response = self.client.get(
+            f"/api/v1/analyses/{scoped['id']}",
+            params={"workspace_id": prod.id},
+        )
+        unscoped_workspace_id_list_response = self.client.get(
+            "/api/v1/analyses",
+            params={"workspace_id": prod.id},
+        )
+        scoped_id_response = self.client.get(
+            f"/api/v1/analyses/{scoped['id']}",
+            params={"project_id": project.id, "workspace_id": prod.id},
+        )
+        scoped_list_response = self.client.get(
+            "/api/v1/analyses",
+            params={
+                "project_key": project.project_key,
+                "workspace_key": prod.workspace_key,
+            },
+        )
+
+        self.assertEqual(wrong_workspace_response.status_code, 404)
+        self.assertEqual(
+            wrong_workspace_response.json()["error"]["code"], "analysis_not_found"
+        )
+        self.assertEqual(unscoped_workspace_id_response.status_code, 400)
+        self.assertEqual(
+            unscoped_workspace_id_response.json()["error"]["code"],
+            "missing_project_scope",
+        )
+        self.assertEqual(unscoped_workspace_id_list_response.status_code, 400)
+        self.assertEqual(
+            unscoped_workspace_id_list_response.json()["error"]["code"],
+            "missing_project_scope",
+        )
+        self.assertEqual(scoped_id_response.status_code, 200)
+        self.assertEqual(scoped_id_response.json()["data"]["id"], scoped["id"])
+        self.assertEqual(scoped_list_response.status_code, 200)
+        payload = scoped_list_response.json()
+        self.assertEqual(payload["meta"]["total_count"], 1)
+        self.assertEqual(payload["data"][0]["workspace"]["workspace_key"], "prod")
+
     def test_configure_share_is_disabled_without_management_token(self) -> None:
         response = self.client.post(
             f"/api/v1/analyses/{self.persisted['id']}/share",

--- a/tests/test_cli/test_analyze.py
+++ b/tests/test_cli/test_analyze.py
@@ -718,6 +718,8 @@ class AnalyzeCliTests(unittest.TestCase):
             audit_context=None,
             project_id=None,
             project_key=None,
+            workspace_id=None,
+            workspace_key=None,
         ):
             return analysis_service_module.analyze_uploaded_files(
                 files,
@@ -725,6 +727,8 @@ class AnalyzeCliTests(unittest.TestCase):
                 audit_context=audit_context,
                 project_id=project_id,
                 project_key=project_key,
+                workspace_id=workspace_id,
+                workspace_key=workspace_key,
             )
 
         with (
@@ -771,6 +775,8 @@ class AnalyzeCliTests(unittest.TestCase):
             audit_context=None,
             project_id=None,
             project_key=None,
+            workspace_id=None,
+            workspace_key=None,
         ):
             return analysis_service_module.analyze_uploaded_files(
                 files,
@@ -778,6 +784,8 @@ class AnalyzeCliTests(unittest.TestCase):
                 audit_context=audit_context,
                 project_id=project_id,
                 project_key=project_key,
+                workspace_id=workspace_id,
+                workspace_key=workspace_key,
             )
 
         with (
@@ -824,6 +832,8 @@ class AnalyzeCliTests(unittest.TestCase):
             audit_context=None,
             project_id=None,
             project_key=None,
+            workspace_id=None,
+            workspace_key=None,
         ):
             return analysis_service_module.analyze_uploaded_files(
                 files,
@@ -831,6 +841,8 @@ class AnalyzeCliTests(unittest.TestCase):
                 audit_context=audit_context,
                 project_id=project_id,
                 project_key=project_key,
+                workspace_id=workspace_id,
+                workspace_key=workspace_key,
             )
 
         with (
@@ -1695,6 +1707,8 @@ class AnalyzeCliTests(unittest.TestCase):
             audit_context=None,
             project_id=None,
             project_key=None,
+            workspace_id=None,
+            workspace_key=None,
         ):
             print("unexpected provider noise")
             print("unexpected provider noise", file=sys.stderr)
@@ -1704,6 +1718,8 @@ class AnalyzeCliTests(unittest.TestCase):
                 audit_context=audit_context,
                 project_id=project_id,
                 project_key=project_key,
+                workspace_id=workspace_id,
+                workspace_key=workspace_key,
             )
 
         with (

--- a/tests/test_infra/test_container_contract.py
+++ b/tests/test_infra/test_container_contract.py
@@ -28,6 +28,7 @@ class ContainerContractTests(unittest.TestCase):
                 "012_add_feedback_event_fields.py",
                 "013_add_incident_analysis_reference.py",
                 "014_add_project_workspace_records.py",
+                "015_add_report_workspace_scope.py",
             ],
         )
         baseline_content = migrations[0].read_text(encoding="utf-8")
@@ -41,6 +42,7 @@ class ContainerContractTests(unittest.TestCase):
         feedback_content = migrations[8].read_text(encoding="utf-8")
         incident_link_content = migrations[9].read_text(encoding="utf-8")
         workspace_content = migrations[10].read_text(encoding="utf-8")
+        report_workspace_content = migrations[11].read_text(encoding="utf-8")
         self.assertIn("down_revision = None", baseline_content)
         self.assertIn('"app_settings"', baseline_content)
         self.assertIn(
@@ -87,6 +89,11 @@ class ContainerContractTests(unittest.TestCase):
         )
         self.assertIn('"project_workspaces"', workspace_content)
         self.assertIn('"workspace_key"', workspace_content)
+        self.assertIn(
+            'down_revision = "014_add_project_workspace_records"',
+            report_workspace_content,
+        )
+        self.assertIn('"workspace_id"', report_workspace_content)
 
     def test_dockerfile_exists(self) -> None:
         self.assertTrue(Path("Dockerfile").exists())

--- a/tests/test_infra/test_migrations.py
+++ b/tests/test_infra/test_migrations.py
@@ -53,6 +53,21 @@ class MigrationTests(unittest.TestCase):
         finally:
             sqlite_conn.close()
 
+    def _foreign_keys(self, table_name: str) -> list[dict]:
+        sqlite_conn = sqlite3.connect(self.db_path)
+        try:
+            return [
+                {
+                    "constrained_columns": [row[3]],
+                    "referred_table": row[2],
+                    "referred_columns": [row[4]],
+                    "ondelete": row[6],
+                }
+                for row in sqlite_conn.execute(f"PRAGMA foreign_key_list({table_name})")
+            ]
+        finally:
+            sqlite_conn.close()
+
     def _create_project_workspace_table(
         self,
         *,
@@ -98,6 +113,7 @@ class MigrationTests(unittest.TestCase):
         self.assertIn("analysis_id", self._table_columns("risk_assessments"))
         self.assertIn("analysis_id", self._table_columns("context_snapshots"))
         self.assertIn("project_id", self._table_columns("analysis_reports"))
+        self.assertIn("workspace_id", self._table_columns("analysis_reports"))
         self.assertIn("project_key", self._table_columns("projects"))
         self.assertIn("workspace_key", self._table_columns("project_workspaces"))
         self.assertIn("environment", self._table_columns("project_workspaces"))
@@ -115,6 +131,14 @@ class MigrationTests(unittest.TestCase):
         self.assertIn("share_password_hash", self._table_columns("analysis_reports"))
         self.assertIn("share_password_salt", self._table_columns("analysis_reports"))
         self.assertIn("share_redact_filenames", self._table_columns("analysis_reports"))
+        report_fks = self._foreign_keys("analysis_reports")
+        self.assertTrue(
+            any(
+                foreign_key["referred_table"] == "project_workspaces"
+                and foreign_key["constrained_columns"] == ["workspace_id"]
+                for foreign_key in report_fks
+            )
+        )
         report_schema_row = next(
             row
             for row in self._table_info("analysis_reports")
@@ -351,7 +375,7 @@ class MigrationTests(unittest.TestCase):
         self.assertIn("evidence_items", tables)
         self.assertIn("projects", tables)
         self.assertIn("topology_versions", tables)
-        self.assertEqual(revision, "014_add_project_workspace_records")
+        self.assertEqual(revision, "015_add_report_workspace_scope")
 
     def test_init_db_repairs_partial_evidence_schema_without_alembic_version(
         self,
@@ -400,7 +424,7 @@ class MigrationTests(unittest.TestCase):
         self.assertIn("findings", tables)
         self.assertIn("evidence_items", tables)
         self.assertIn("projects", tables)
-        self.assertEqual(revision, "014_add_project_workspace_records")
+        self.assertEqual(revision, "015_add_report_workspace_scope")
 
     def test_init_db_repairs_current_schema_without_alembic_version(self) -> None:
         command.upgrade(self._config(), "head")
@@ -426,10 +450,30 @@ class MigrationTests(unittest.TestCase):
         finally:
             sqlite_conn.close()
 
-        self.assertEqual(revision, "014_add_project_workspace_records")
+        self.assertEqual(revision, "015_add_report_workspace_scope")
         self.assertIn("report_schema_version", columns)
         self.assertIn("blast_radius_json", columns)
         self.assertIn("project_id", columns)
+        self.assertIn("workspace_id", columns)
+
+    def test_init_db_rejects_partial_report_workspace_scope_schema(self) -> None:
+        command.upgrade(self._config(), "014_add_project_workspace_records")
+        sqlite_conn = sqlite3.connect(self.db_path)
+        sqlite_conn.execute(
+            "ALTER TABLE analysis_reports ADD COLUMN workspace_id INTEGER"
+        )
+        sqlite_conn.execute("DROP TABLE alembic_version")
+        sqlite_conn.commit()
+        sqlite_conn.close()
+
+        reload(config_module)
+        reload(tables_module)
+        reload(database_module)
+
+        with self.assertRaisesRegex(
+            RuntimeError, "partial analysis report workspace scope schema"
+        ):
+            database_module.init_db()
 
     def test_init_db_rejects_partial_incident_analysis_link_schema(self) -> None:
         command.upgrade(self._config(), "011_add_deployment_outcome_fields")
@@ -583,7 +627,7 @@ class MigrationTests(unittest.TestCase):
         finally:
             sqlite_conn.close()
 
-        self.assertEqual(revision, "014_add_project_workspace_records")
+        self.assertEqual(revision, "015_add_report_workspace_scope")
 
 
 if __name__ == "__main__":

--- a/tests/test_services/test_report_service.py
+++ b/tests/test_services/test_report_service.py
@@ -1648,6 +1648,104 @@ class ReportServiceTests(unittest.TestCase):
             )
         )
 
+    def test_persist_analysis_report_stores_and_filters_workspace_scope(self) -> None:
+        project = project_service_module.create_project(
+            project_key="payments",
+            display_name="Payments",
+        )
+        prod = project_service_module.create_workspace(
+            project_key=project.project_key,
+            workspace_key="prod",
+            display_name="Production",
+            environment="prod",
+        )
+        staging = project_service_module.create_workspace(
+            project_key=project.project_key,
+            workspace_key="staging",
+            display_name="Staging",
+            environment="staging",
+        )
+
+        prod_report = report_service_module.persist_analysis_report(
+            ParseBatchResult(
+                files=[
+                    ParsedFileResult(
+                        file_name="payments-prod.json",
+                        tool="terraform",
+                        status="parsed",
+                        changes=[],
+                    )
+                ]
+            ),
+            RiskAssessment(
+                score=72,
+                severity="high",
+                recommendation="no-go",
+                top_risk="Production payment ingress widened.",
+                contributors=[],
+                interaction_risks=[],
+                partial_context=False,
+                warnings=[],
+            ),
+            NarrativeResult(
+                opening_sentence="NO-GO: production payment ingress widened.",
+                explanation="Workspace-scoped report.",
+                guidance=[],
+                degraded=False,
+                warnings=[],
+            ),
+            project_id=project.id,
+            workspace_id=prod.id,
+            audit_context={"source_interface": "api"},
+        )
+        report_service_module.persist_analysis_report(
+            ParseBatchResult(
+                files=[
+                    ParsedFileResult(
+                        file_name="payments-staging.json",
+                        tool="terraform",
+                        status="parsed",
+                        changes=[],
+                    )
+                ]
+            ),
+            RiskAssessment(
+                score=15,
+                severity="low",
+                recommendation="go",
+                top_risk="Staging payment ingress changed.",
+                contributors=[],
+                interaction_risks=[],
+                partial_context=False,
+                warnings=[],
+            ),
+            NarrativeResult(
+                opening_sentence="GO: staging payment ingress changed.",
+                explanation="Workspace-scoped report.",
+                guidance=[],
+                degraded=False,
+                warnings=[],
+            ),
+            project_id=project.id,
+            workspace_id=staging.id,
+            audit_context={"source_interface": "api"},
+        )
+
+        scoped_page = report_service_module.fetch_filtered_analysis_history_page(
+            project_key=project.project_key,
+            workspace_key=prod.workspace_key,
+        )
+        wrong_workspace = report_service_module.fetch_analysis_report(
+            prod_report["id"],
+            project_key=project.project_key,
+            workspace_key=staging.workspace_key,
+        )
+
+        self.assertEqual(scoped_page["total_count"], 1)
+        self.assertEqual(scoped_page["items"][0]["id"], prod_report["id"])
+        self.assertEqual(scoped_page["items"][0]["workspace"]["workspace_key"], "prod")
+        self.assertIsNone(wrong_workspace)
+
     def test_previous_scan_diffs_do_not_cross_project_boundaries(self) -> None:
         payments = project_service_module.create_project(
             project_key="payments",


### PR DESCRIPTION
Story 1.3 requires saved analyses and report history to respect project and optional workspace scope across API, CLI, service, and persistence paths. The implementation adds nullable report workspace scope, validates workspace references through the shared project service, and keeps retrieval/filtering paths constrained to the resolved project/workspace context. Brownfield schema detection now treats incomplete report workspace scope as partial instead of stamping the latest revision.

Constraint: Story 1.3 acceptance criteria require cross-project report lookups to return only an authorized error envelope.\nConstraint: Existing SQLite/Alembic bootstrap must keep brownfield installs recoverable without silently accepting partial schemas.\nRejected: Allow workspace_id to imply project scope in API retrieval | it bypasses the active project boundary for callers that only know a workspace id.\nRejected: Stamp revision 015 when workspace_id column exists | misses the migration's foreign key and index contract.\nConfidence: high\nScope-risk: moderate\nDirective: Do not relax report retrieval scope checks without adding an explicit caller authorization model.\nTested: ./.venv/bin/python -m unittest tests.test_services.test_report_service tests.test_api.test_analyses tests.test_infra.test_migrations tests.test_infra.test_container_contract -q\nTested: ./.venv/bin/ruff check .\nTested: ./.venv/bin/ruff format --check .\nTested: ./.venv/bin/python -m unittest discover -q\nTested: bash scripts/ci-local.sh\nNot-tested: Bandit local security scan; tool is not installed and ci-local skipped it

## What does this PR do?

<!-- Brief description of changes -->

## Type of change
- [ ] Feature (new functionality)
- [ ] Bugfix (non-breaking fix)
- [ ] Release preparation
- [ ] Hotfix (critical production fix)
- [ ] Docs / refactor / chore

## Checklist
- [ ] I have followed the branch naming convention
- [ ] Tests pass locally (`pytest tests/ -v`)
- [ ] Linting passes (`ruff check .`)
- [ ] Docker build succeeds
- [ ] I have updated docs if needed
- [ ] No secrets or .env values committed

## Related issue
Closes #