### PR TITLE
Preserve project boundaries for learning context

### DIFF
--- a/_bmad-output/implementation-artifacts/1-4-project-scoped-learning-and-context-records.md
+++ b/_bmad-output/implementation-artifacts/1-4-project-scoped-learning-and-context-records.md
@@ -1,0 +1,148 @@
+# Story 1.4: Project-Scoped Learning and Context Records
+
+Status: done
+
+<!-- Generated from updated PRD/architecture/epics plus implementation-readiness-report-2026-05-01.md. -->
+
+## Story
+
+As a platform admin,
+I want incidents, outcomes, feedback, topology, and scanner imports scoped consistently,
+So that future learning and context never cross project boundaries.
+
+## Acceptance Criteria
+
+1. Given incidents, deployment outcomes, feedback, topology, or scanner imports are created or queried, When they are created or queried, Then they are scoped to project and optional workspace where applicable. And repository queries and API responses prevent accidental cross-project leakage.
+2. Given a context or learning record has no project scope, When validation runs before persistence, Then persistence fails with an actionable error unless the object type is explicitly global by architecture.
+
+### Requirement Traceability
+
+- Primary PRD requirements: Epic 1 coverage: PRJ-01..10, HIS-08, NFR-SEC-07, DOC-22.
+- Supporting PRD / NFR / differentiation requirements: See `_bmad-output/planning-artifacts/prd.md`, `_bmad-output/planning-artifacts/architecture.md`, and `_bmad-output/planning-artifacts/implementation-readiness-report-2026-05-01.md`.
+- Coverage intent: Baseline + Delta.
+- Story alignment note: This story was created from the updated Epic 1 plan after the 2026-05-01 readiness rerun. The readiness report verified 187/187 PRD functional requirement IDs in the epics artifact, 38 NFR IDs present, and no critical or major readiness defects.
+
+## Tasks / Subtasks
+
+- [x] Implement and verify acceptance criterion 1. (AC: 1)
+- [x] Implement and verify acceptance criterion 2. (AC: 2)
+- [x] Reuse existing services, repositories, schemas, and UI/CLI/API helpers before adding new abstractions. (AC: all)
+- [x] Add or update deterministic regression coverage for the changed behavior. (AC: all)
+- [x] Update relevant docs or examples if the story changes user-visible, operator, API, CLI, integration, or contribution behavior. (AC: all)
+- [x] Run required validation and record commands/results in the Dev Agent Record. (AC: all)
+
+### Review Findings
+
+- [x] [Review][Patch] Enforce database-level project/workspace consistency for scoped learning/context rows [migrations/versions/016_scope_learning_context_records.py:112]
+- [x] [Review][Patch] Do not mirror workspace-scoped default-project topology into the legacy global topology file [services/topology_service.py:967]
+
+## Dev Notes
+
+### Epic Context
+
+- Epic: 1. Project, Workspace, and RBAC Foundation
+- Epic goal: Make DeployWhisper project-aware before reports, incidents, topology, scanner imports, and feedback become harder to migrate.
+- Epic coverage: PRJ-01..10, HIS-08, NFR-SEC-07, DOC-22
+
+### Architecture and Product Guardrails
+
+- Preserve DeployWhisper's local-first raw artifact boundary: raw IaC, scanner artifacts, incident exports, and sensitive context stay in the user's infrastructure by default.
+- Preserve the advisory-first core. Optional adapters may interpret report outputs, but canonical report semantics remain advisory unless explicit story scope says otherwise.
+- Reuse the shared analysis core and service layer before adapting UI, API, CLI, GitHub, or future workflow surfaces.
+- Keep Evidence Law behavior intact: no high or critical finding without deterministic evidence.
+- Keep project/workspace scope explicit for reports, incidents, topology, outcomes, feedback, scanner imports, and connector-related data.
+- Do not introduce new dependencies unless the active story explicitly requires and justifies them.
+
+### Source Tree Guidance
+
+- API routes belong under `api/routes/` and should use existing `ApiRoute` / `ApiError` envelope patterns.
+- Shared orchestration belongs in `services/`; parsers normalize input, analysis modules score/derive risk, and surfaces adapt outputs.
+- UI work belongs under `ui/routes/` and `ui/components/`, following the existing NiceGUI composition style.
+- CLI behavior belongs under `cli/` and must call the same service-layer paths as UI/API flows.
+- Persistence work belongs under `models/` with Alembic migrations when schema changes are required.
+- Documentation required by a story should be updated in the same workstream.
+
+### Testing Requirements
+
+- Use standard-library `unittest` in the existing `tests/test_*` layout.
+- Add focused regression tests for the layer changed by the story before broad refactors.
+- For Python changes, run `./.venv/bin/ruff check .`, `./.venv/bin/ruff format --check .`, and `./.venv/bin/python -m unittest discover -q` before closing implementation.
+- Use `bash scripts/ci-local.sh` for broader or cross-layer changes.
+
+### Project Structure Notes
+
+- Follow the current repository shape documented in `_bmad-output/project-context.md` and `AGENTS.md`.
+- If implementation reveals a conflict between this story and the current code baseline, keep the smallest compatible change and update the story notes rather than silently drifting from the PRD.
+
+### References
+
+- `_bmad-output/planning-artifacts/epics.md` - source Epic 1 / Story 1.4 definition.
+- `_bmad-output/planning-artifacts/prd.md` - functional and non-functional requirements.
+- `_bmad-output/planning-artifacts/architecture.md` - target architecture, boundaries, and guardrails.
+- `_bmad-output/planning-artifacts/ux-design-specification.md` - UX expectations for user-facing stories.
+- `_bmad-output/planning-artifacts/implementation-readiness-report-2026-05-01.md` - readiness verdict and residual story-format concern.
+- `_bmad-output/project-context.md` - repository-specific implementation rules.
+
+## Dev Agent Record
+
+### Agent Model Used
+
+GPT-5 Codex
+
+### Debug Log References
+
+- `./.venv/bin/python -m pytest tests/test_services/test_incident_service.py tests/test_services/test_deployment_outcome_service.py tests/test_services/test_feedback_service.py tests/test_services/test_topology_service.py -q` - passed, 35 tests.
+- `./.venv/bin/python -m pytest tests/test_analysis/test_incident_matcher.py tests/test_services/test_backtesting_service.py tests/test_services/test_analysis_service.py -q` - passed, 28 tests.
+- `./.venv/bin/python -m pytest tests/test_api/test_deployments.py tests/test_api/test_context.py tests/test_cli/test_analyze.py -q` - passed, 51 tests.
+- `./.venv/bin/python -m pytest tests/test_infra/test_migrations.py tests/test_infra/test_container_contract.py -q` - passed, 22 tests.
+- `./.venv/bin/python -m pytest tests/test_analysis/test_incident_matcher.py tests/test_services/test_incident_service.py tests/test_services/test_deployment_outcome_service.py tests/test_services/test_feedback_service.py tests/test_services/test_topology_service.py tests/test_services/test_backtesting_service.py tests/test_services/test_analysis_service.py tests/test_api/test_deployments.py tests/test_api/test_context.py tests/test_cli/test_analyze.py tests/test_infra/test_migrations.py tests/test_infra/test_container_contract.py -q` - passed, 136 tests.
+- `./.venv/bin/python -m unittest tests.test_ui.test_history_page.HistoryPageRenderingTests.test_history_page_renders_calibration_snapshot_from_backtest_feed -q -b` - passed, 1 test.
+- `./.venv/bin/ruff check .` - passed.
+- `./.venv/bin/ruff format --check .` - passed, 256 files already formatted.
+- `./.venv/bin/python -m unittest discover -q -b` - passed, 249 tests, 1 skipped.
+- `bash scripts/ci-local.sh` - passed; Bandit security scan skipped because Bandit is not installed.
+- `./.venv/bin/python -m pytest tests/test_infra/test_migrations.py::MigrationTests::test_upgrade_head_creates_evidence_schema_on_clean_database tests/test_infra/test_migrations.py::MigrationTests::test_learning_context_scope_rejects_cross_project_workspace_rows tests/test_services/test_topology_service.py::TopologyServiceTests::test_default_project_workspace_topology_does_not_update_legacy_file -q` - passed, 3 tests.
+- `./.venv/bin/python -m pytest tests/test_infra/test_migrations.py tests/test_infra/test_container_contract.py tests/test_services/test_topology_service.py tests/test_services/test_incident_service.py tests/test_services/test_deployment_outcome_service.py tests/test_services/test_feedback_service.py -q` - passed, 59 tests.
+
+### Completion Notes List
+
+- Added database and Alembic support for project/workspace-scoped learning and context records across incidents, outcomes, feedback, and topology records.
+- Enforced explicit project scope for incident persistence and propagated project/workspace scope through incident matching, deployment outcomes, feedback summaries, topology import/query paths, API schemas, and CLI commands.
+- Added cross-project and cross-workspace regression coverage for repository/service behavior, migration shape, API/CLI integration paths, and topology isolation.
+- Made the history calibration snapshot test deterministic within the rolling 7-day backtesting window.
+- Addressed code-review findings by adding database-level project/workspace consistency constraints for scoped learning/context rows and preventing workspace-scoped default-project topology from updating the legacy project-level topology file.
+
+### File List
+
+- `_bmad-output/implementation-artifacts/1-4-project-scoped-learning-and-context-records.md`
+- `_bmad-output/implementation-artifacts/sprint-status.yaml`
+- `analysis/incident_matcher.py`
+- `api/routes/deployments.py`
+- `api/routes/settings.py`
+- `api/schemas.py`
+- `cli/analyze.py`
+- `docs/deployment-history.md`
+- `migrations/versions/016_scope_learning_context_records.py`
+- `models/database.py`
+- `models/repositories/deployment_outcomes.py`
+- `models/repositories/feedback_events.py`
+- `models/repositories/incident_records.py`
+- `models/tables.py`
+- `services/analysis_service.py`
+- `services/deployment_outcome_service.py`
+- `services/feedback_service.py`
+- `services/incident_service.py`
+- `services/topology_service.py`
+- `tests/test_analysis/test_incident_matcher.py`
+- `tests/test_infra/test_container_contract.py`
+- `tests/test_infra/test_migrations.py`
+- `tests/test_services/test_deployment_outcome_service.py`
+- `tests/test_services/test_feedback_service.py`
+- `tests/test_services/test_incident_service.py`
+- `tests/test_services/test_topology_service.py`
+- `tests/test_ui/test_history_page.py`
+
+## Change Log
+
+- 2026-05-01: Story created/aligned from updated PRD, architecture, epics, sprint status, and readiness report.
+- 2026-05-06: Implemented project/workspace-scoped learning and context record persistence, query filtering, API/CLI propagation, regression coverage, and validation.

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -53,7 +53,7 @@ development_status:
   1-1-project-and-workspace-records: done
   1-2-project-aware-analysis-submission: review
   1-3-project-scoped-report-persistence: done
-  1-4-project-scoped-learning-and-context-records: ready-for-dev
+  1-4-project-scoped-learning-and-context-records: done
   1-5-lightweight-rbac-role-model: ready-for-dev
   1-6-project-model-documentation: ready-for-dev
   epic-1-retrospective: optional

--- a/analysis/incident_matcher.py
+++ b/analysis/incident_matcher.py
@@ -23,9 +23,20 @@ class IncidentMatch(BaseModel):
     summary: str = Field(..., description="Short operational explanation")
 
 
-def load_incident_candidates() -> list[dict]:
+def load_incident_candidates(
+    *,
+    project_id: int | None = None,
+    project_key: str | None = None,
+    workspace_id: int | None = None,
+    workspace_key: str | None = None,
+) -> list[dict]:
     """Return stored incident records for future similarity matching."""
-    return get_incident_records()
+    return get_incident_records(
+        project_id=project_id,
+        project_key=project_key,
+        workspace_id=workspace_id,
+        workspace_key=workspace_key,
+    )
 
 
 TOKEN_PATTERN = re.compile(r"[a-z0-9_./-]+", re.IGNORECASE)
@@ -88,10 +99,21 @@ def _recency_bonus(incident_date: str | None) -> float:
 
 
 def find_incident_matches(
-    changes: list[UnifiedChange], min_similarity: float = 0.2
+    changes: list[UnifiedChange],
+    min_similarity: float = 0.2,
+    *,
+    project_id: int | None = None,
+    project_key: str | None = None,
+    workspace_id: int | None = None,
+    workspace_key: str | None = None,
 ) -> list[IncidentMatch]:
     """Return incident matches ranked by simple token overlap."""
-    candidates = load_incident_candidates()
+    candidates = load_incident_candidates(
+        project_id=project_id,
+        project_key=project_key,
+        workspace_id=workspace_id,
+        workspace_key=workspace_key,
+    )
     if not candidates:
         return []
 

--- a/api/routes/deployments.py
+++ b/api/routes/deployments.py
@@ -96,6 +96,8 @@ def create_deployment_outcome_route(
             summary=payload.summary,
             project_id=payload.project_id,
             project_key=payload.project_key,
+            workspace_id=payload.workspace_id,
+            workspace_key=payload.workspace_key,
             source_interface="api",
         )
     except ValueError as exc:
@@ -121,6 +123,8 @@ def get_deployment_outcomes(
     outcome: str | None = Query(default=None),
     project_id: int | None = Query(default=None),
     project_key: str | None = Query(default=None),
+    workspace_id: int | None = Query(default=None),
+    workspace_key: str | None = Query(default=None),
     limit: int = Query(default=100, ge=1, le=200),
 ) -> DeploymentOutcomeListResponse:
     try:
@@ -129,6 +133,8 @@ def get_deployment_outcomes(
             outcome=outcome,
             project_id=project_id,
             project_key=project_key,
+            workspace_id=workspace_id,
+            workspace_key=workspace_key,
             limit=limit,
         )
     except ValueError as exc:

--- a/api/routes/settings.py
+++ b/api/routes/settings.py
@@ -35,6 +35,8 @@ def _build_topology_context_response(
     *,
     project_id: int | None = None,
     project_key: str | None = None,
+    workspace_id: int | None = None,
+    workspace_key: str | None = None,
 ) -> TopologyContextResponse:
     try:
         project = resolve_project_reference(
@@ -42,7 +44,11 @@ def _build_topology_context_response(
         )
     except ValueError as exc:
         raise _project_api_error(exc) from exc
-    status = get_topology_status(project_id=project.id)
+    status = get_topology_status(
+        project_id=project.id,
+        workspace_id=workspace_id,
+        workspace_key=workspace_key,
+    )
     return TopologyContextResponse(
         data=TopologyContextData(
             project=ProjectData(**project.model_dump()),
@@ -56,10 +62,14 @@ def _build_topology_context_response(
 def get_project_topology(
     project_id: int | None = Query(default=None),
     project_key: str | None = Query(default=None),
+    workspace_id: int | None = Query(default=None),
+    workspace_key: str | None = Query(default=None),
 ) -> TopologyContextResponse:
     return _build_topology_context_response(
         project_id=project_id,
         project_key=project_key,
+        workspace_id=workspace_id,
+        workspace_key=workspace_key,
     )
 
 
@@ -77,6 +87,8 @@ def save_project_topology(payload: TopologyContextRequest) -> TopologyContextRes
         save_topology_definition(
             json.dumps(payload.topology),
             project_id=project.id,
+            workspace_id=payload.workspace_id,
+            workspace_key=payload.workspace_key,
         )
     except ValueError as exc:
         raise ApiError(
@@ -85,4 +97,8 @@ def save_project_topology(payload: TopologyContextRequest) -> TopologyContextRes
             message=str(exc),
         ) from exc
 
-    return _build_topology_context_response(project_id=project.id)
+    return _build_topology_context_response(
+        project_id=project.id,
+        workspace_id=payload.workspace_id,
+        workspace_key=payload.workspace_key,
+    )

--- a/api/schemas.py
+++ b/api/schemas.py
@@ -333,18 +333,25 @@ class DeploymentOutcomeCreateRequest(BaseModel):
         description="Optional operator summary for the deployment outcome.",
     )
     project_id: int | None = Field(
-        default=None,
-        description="Optional numeric project/workspace identifier.",
+        default=None, description="Optional numeric project identifier."
     )
     project_key: str | None = Field(
-        default=None,
-        description="Optional stable project/workspace key.",
+        default=None, description="Optional stable project key."
+    )
+    workspace_id: int | None = Field(
+        default=None, description="Optional numeric workspace identifier."
+    )
+    workspace_key: str | None = Field(
+        default=None, description="Optional stable workspace key."
     )
 
 
 class DeploymentOutcomeData(BaseModel):
     id: int = Field(..., description="Stable deployment outcome identifier.")
     project: ProjectData = Field(..., description="Owning project/workspace.")
+    workspace: WorkspaceData | None = Field(
+        default=None, description="Optional workspace/environment scope."
+    )
     analysis_id: int | None = Field(
         default=None,
         description="Analysis report identifier tied to this deployment.",
@@ -440,6 +447,12 @@ class TopologyContextRequest(BaseModel):
     )
     project_key: str | None = Field(
         default=None, description="Optional stable project key"
+    )
+    workspace_id: int | None = Field(
+        default=None, description="Optional numeric workspace identifier"
+    )
+    workspace_key: str | None = Field(
+        default=None, description="Optional stable workspace key"
     )
 
 

--- a/cli/analyze.py
+++ b/cli/analyze.py
@@ -451,6 +451,8 @@ def _run_outcome_record(args: argparse.Namespace) -> int:
             summary=args.summary,
             project_id=args.project_id,
             project_key=args.project_key,
+            workspace_id=args.workspace_id,
+            workspace_key=args.workspace_key,
             source_interface="cli",
         )
     except ValueError as exc:
@@ -483,8 +485,14 @@ def _run_topology_import(args: argparse.Namespace) -> int:
             args.source_type,
             args.source,
             project_id=project.id,
+            workspace_id=args.workspace_id,
+            workspace_key=args.workspace_key,
         )
-        status = get_topology_status(project_id=project.id)
+        status = get_topology_status(
+            project_id=project.id,
+            workspace_id=args.workspace_id,
+            workspace_key=args.workspace_key,
+        )
     except ValueError as exc:
         _emit_json(
             build_error(
@@ -732,7 +740,18 @@ def build_parser() -> argparse.ArgumentParser:
         "--project-id",
         dest="project_id",
         type=int,
-        help="Optional numeric project/workspace id for validation.",
+        help="Optional numeric project id for validation.",
+    )
+    outcome_record_parser.add_argument(
+        "--workspace",
+        dest="workspace_key",
+        help="Optional workspace/environment key for validation.",
+    )
+    outcome_record_parser.add_argument(
+        "--workspace-id",
+        dest="workspace_id",
+        type=int,
+        help="Optional numeric workspace/environment id for validation.",
     )
 
     topology_parser = subparsers.add_parser(
@@ -758,13 +777,24 @@ def build_parser() -> argparse.ArgumentParser:
     topology_import_parser.add_argument(
         "--project",
         dest="project_key",
-        help="Project/workspace key for the topology import.",
+        help="Project key for the topology import.",
     )
     topology_import_parser.add_argument(
         "--project-id",
         dest="project_id",
         type=int,
-        help="Numeric project/workspace id for the topology import.",
+        help="Numeric project id for the topology import.",
+    )
+    topology_import_parser.add_argument(
+        "--workspace",
+        dest="workspace_key",
+        help="Optional workspace/environment key for the topology import.",
+    )
+    topology_import_parser.add_argument(
+        "--workspace-id",
+        dest="workspace_id",
+        type=int,
+        help="Optional numeric workspace/environment id for the topology import.",
     )
     github_parser = subparsers.add_parser(
         "github", help="GitHub workflow setup helpers."

--- a/docs/deployment-history.md
+++ b/docs/deployment-history.md
@@ -24,6 +24,12 @@ Query stored outcome history:
 curl "http://localhost:8080/api/v1/deployments/outcomes?analysis_id=42"
 ```
 
+Project and workspace filters are also supported for scoped history views:
+
+```bash
+curl "http://localhost:8080/api/v1/deployments/outcomes?project_key=payments&workspace_key=prod"
+```
+
 Supported outcome values are `success`, `failure`, and `rolled_back`.
 Set `DEPLOYWHISPER_OUTCOME_TOKEN` (or `APP_DEPLOYMENT_OUTCOME_TOKEN`) on the server before using the ingestion endpoint.
 
@@ -36,6 +42,8 @@ deploywhisper outcome record \
   --analysis-id 42 \
   --outcome success \
   --deployed-at 2026-04-30T08:15:00Z \
+  --project payments \
+  --workspace prod \
   --environment prod
 ```
 
@@ -45,6 +53,7 @@ deploywhisper outcome record \
 
 - Migration `011_add_deployment_outcome_fields` adds `deployed_at` and `linked_incident_id` to the existing `deployment_outcomes` table.
 - Migration `011_add_deployment_outcome_fields` also backfills the previously metadata-only `incident_records` table into the Alembic chain so `alembic upgrade head` produces a complete schema.
-- Outcome capture stays project-scoped by deriving the owning workspace from the referenced `analysis_id`.
-- Incident linkage is optional and validates against the existing `incident_records` table when provided.
+- Migration `016_scope_learning_context_records` adds project/workspace scope to incidents, topology snapshots, feedback, and deployment outcomes.
+- Outcome capture stays project/workspace-scoped by deriving the owning scope from the referenced `analysis_id`.
+- Incident linkage is optional and validates that the incident belongs to the same project and compatible workspace when provided.
 - The webhook-style ingestion path now requires `X-DeployWhisper-Outcome-Token`, aligned with the repo's existing explicit token-based mutation pattern.

--- a/migrations/versions/016_scope_learning_context_records.py
+++ b/migrations/versions/016_scope_learning_context_records.py
@@ -1,0 +1,201 @@
+"""Scope learning and context records by project/workspace.
+
+Revision ID: 016_scope_learning_context_records
+Revises: 015_add_report_workspace_scope
+Create Date: 2026-05-06
+"""
+
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "016_scope_learning_context_records"
+down_revision = "015_add_report_workspace_scope"
+branch_labels = None
+depends_on = None
+
+
+def _default_project_id(connection) -> int:
+    project_id = connection.execute(
+        sa.text(
+            """
+            SELECT id
+            FROM projects
+            WHERE is_default = 1 OR project_key = 'unassigned'
+            ORDER BY is_default DESC, id ASC
+            LIMIT 1
+            """
+        )
+    ).scalar()
+    if project_id is None:
+        project_id = connection.execute(
+            sa.text("SELECT id FROM projects LIMIT 1")
+        ).scalar()
+    if project_id is None:
+        raise RuntimeError("Cannot scope existing learning records without a project.")
+    return int(project_id)
+
+
+def upgrade() -> None:
+    connection = op.get_bind()
+    default_project_id = _default_project_id(connection)
+
+    op.add_column(
+        "incident_records", sa.Column("project_id", sa.Integer(), nullable=True)
+    )
+    op.add_column(
+        "incident_records", sa.Column("workspace_id", sa.Integer(), nullable=True)
+    )
+    op.add_column(
+        "deployment_outcomes", sa.Column("workspace_id", sa.Integer(), nullable=True)
+    )
+    op.add_column(
+        "feedback_events", sa.Column("workspace_id", sa.Integer(), nullable=True)
+    )
+    op.add_column(
+        "topology_versions", sa.Column("workspace_id", sa.Integer(), nullable=True)
+    )
+
+    connection.execute(
+        sa.text(
+            """
+            UPDATE incident_records
+            SET project_id = (
+                    SELECT analysis_reports.project_id
+                    FROM analysis_reports
+                    WHERE analysis_reports.id = incident_records.analysis_id
+                ),
+                workspace_id = (
+                    SELECT analysis_reports.workspace_id
+                    FROM analysis_reports
+                    WHERE analysis_reports.id = incident_records.analysis_id
+                )
+            WHERE analysis_id IS NOT NULL
+            """
+        )
+    )
+    connection.execute(
+        sa.text(
+            "UPDATE incident_records SET project_id = :project_id WHERE project_id IS NULL"
+        ),
+        {"project_id": default_project_id},
+    )
+    connection.execute(
+        sa.text(
+            """
+            UPDATE deployment_outcomes
+            SET workspace_id = (
+                SELECT analysis_reports.workspace_id
+                FROM analysis_reports
+                WHERE analysis_reports.id = deployment_outcomes.analysis_id
+            )
+            WHERE analysis_id IS NOT NULL
+            """
+        )
+    )
+    connection.execute(
+        sa.text(
+            """
+            UPDATE feedback_events
+            SET workspace_id = (
+                SELECT analysis_reports.workspace_id
+                FROM analysis_reports
+                WHERE analysis_reports.id = feedback_events.analysis_id
+            )
+            WHERE analysis_id IS NOT NULL
+            """
+        )
+    )
+
+    with op.batch_alter_table("project_workspaces") as batch_op:
+        batch_op.create_unique_constraint(
+            "uq_project_workspaces_project_id_id",
+            ["project_id", "id"],
+        )
+
+    with op.batch_alter_table("incident_records") as batch_op:
+        batch_op.alter_column(
+            "project_id",
+            existing_type=sa.Integer(),
+            nullable=False,
+        )
+        batch_op.create_foreign_key(
+            "fk_incident_records_project_id_projects",
+            "projects",
+            ["project_id"],
+            ["id"],
+            ondelete="CASCADE",
+        )
+        batch_op.create_foreign_key(
+            "fk_incident_records_workspace_id_project_workspaces",
+            "project_workspaces",
+            ["workspace_id"],
+            ["id"],
+            ondelete="SET NULL",
+        )
+        batch_op.create_foreign_key(
+            "fk_incident_records_project_workspace_scope",
+            "project_workspaces",
+            ["project_id", "workspace_id"],
+            ["project_id", "id"],
+        )
+        batch_op.create_index("ix_incident_records_project_id", ["project_id"])
+        batch_op.create_index("ix_incident_records_workspace_id", ["workspace_id"])
+
+    for table_name in ("deployment_outcomes", "feedback_events", "topology_versions"):
+        with op.batch_alter_table(table_name) as batch_op:
+            batch_op.create_foreign_key(
+                f"fk_{table_name}_workspace_id_project_workspaces",
+                "project_workspaces",
+                ["workspace_id"],
+                ["id"],
+                ondelete="SET NULL",
+            )
+            batch_op.create_foreign_key(
+                f"fk_{table_name}_project_workspace_scope",
+                "project_workspaces",
+                ["project_id", "workspace_id"],
+                ["project_id", "id"],
+            )
+            batch_op.create_index(f"ix_{table_name}_workspace_id", ["workspace_id"])
+
+
+def downgrade() -> None:
+    for table_name in ("topology_versions", "feedback_events", "deployment_outcomes"):
+        with op.batch_alter_table(table_name) as batch_op:
+            batch_op.drop_index(f"ix_{table_name}_workspace_id")
+            batch_op.drop_constraint(
+                f"fk_{table_name}_project_workspace_scope",
+                type_="foreignkey",
+            )
+            batch_op.drop_constraint(
+                f"fk_{table_name}_workspace_id_project_workspaces",
+                type_="foreignkey",
+            )
+            batch_op.drop_column("workspace_id")
+
+    with op.batch_alter_table("incident_records") as batch_op:
+        batch_op.drop_index("ix_incident_records_workspace_id")
+        batch_op.drop_index("ix_incident_records_project_id")
+        batch_op.drop_constraint(
+            "fk_incident_records_project_workspace_scope",
+            type_="foreignkey",
+        )
+        batch_op.drop_constraint(
+            "fk_incident_records_workspace_id_project_workspaces",
+            type_="foreignkey",
+        )
+        batch_op.drop_constraint(
+            "fk_incident_records_project_id_projects",
+            type_="foreignkey",
+        )
+        batch_op.drop_column("workspace_id")
+        batch_op.drop_column("project_id")
+
+    with op.batch_alter_table("project_workspaces") as batch_op:
+        batch_op.drop_constraint(
+            "uq_project_workspaces_project_id_id",
+            type_="unique",
+        )

--- a/models/database.py
+++ b/models/database.py
@@ -44,6 +44,7 @@ _KNOWN_ALEMBIC_REVISIONS = {
     "013_add_incident_analysis_reference",
     "014_add_project_workspace_records",
     "015_add_report_workspace_scope",
+    "016_scope_learning_context_records",
 }
 _BASELINE_TABLES = {"analysis_reports", "app_settings"}
 _EVIDENCE_TABLES = {
@@ -275,6 +276,84 @@ def _analysis_report_workspace_scope_complete(connection) -> bool:
     )
 
 
+def _learning_context_scope_complete(connection) -> bool:
+    inspector = inspect(connection)
+    workspace_unique_columns = {
+        tuple(unique.get("column_names") or [])
+        for unique in inspector.get_unique_constraints("project_workspaces")
+    }
+    has_workspace_project_id_unique = (
+        "project_id",
+        "id",
+    ) in workspace_unique_columns
+
+    def has_workspace_scope(table_name: str) -> bool:
+        columns = {
+            column["name"]: column for column in inspector.get_columns(table_name)
+        }
+        workspace_column = columns.get("workspace_id")
+        has_workspace_column = (
+            workspace_column is not None
+            and workspace_column["type"]._type_affinity is Integer
+            and workspace_column.get("nullable") is True
+        )
+        has_workspace_fk = any(
+            foreign_key.get("referred_table") == "project_workspaces"
+            and "workspace_id" in (foreign_key.get("constrained_columns") or [])
+            and "id" in (foreign_key.get("referred_columns") or [])
+            and (foreign_key.get("options") or {}).get("ondelete") == "SET NULL"
+            for foreign_key in inspector.get_foreign_keys(table_name)
+        )
+        has_project_workspace_scope_fk = any(
+            foreign_key.get("referred_table") == "project_workspaces"
+            and (foreign_key.get("constrained_columns") or [])
+            == ["project_id", "workspace_id"]
+            and (foreign_key.get("referred_columns") or []) == ["project_id", "id"]
+            for foreign_key in inspector.get_foreign_keys(table_name)
+        )
+        indexed_columns = {
+            tuple(index.get("column_names") or [])
+            for index in inspector.get_indexes(table_name)
+        }
+        return (
+            has_workspace_column
+            and has_workspace_fk
+            and has_project_workspace_scope_fk
+            and ("workspace_id",) in indexed_columns
+        )
+
+    incident_columns = {
+        column["name"]: column for column in inspector.get_columns("incident_records")
+    }
+    incident_project_column = incident_columns.get("project_id")
+    has_incident_project_column = (
+        incident_project_column is not None
+        and incident_project_column["type"]._type_affinity is Integer
+        and incident_project_column.get("nullable") is False
+    )
+    has_incident_project_fk = any(
+        foreign_key.get("referred_table") == "projects"
+        and "project_id" in (foreign_key.get("constrained_columns") or [])
+        and "id" in (foreign_key.get("referred_columns") or [])
+        and (foreign_key.get("options") or {}).get("ondelete") == "CASCADE"
+        for foreign_key in inspector.get_foreign_keys("incident_records")
+    )
+    incident_indexed_columns = {
+        tuple(index.get("column_names") or [])
+        for index in inspector.get_indexes("incident_records")
+    }
+    return (
+        has_workspace_project_id_unique
+        and has_incident_project_column
+        and has_incident_project_fk
+        and ("project_id",) in incident_indexed_columns
+        and has_workspace_scope("incident_records")
+        and has_workspace_scope("deployment_outcomes")
+        and has_workspace_scope("feedback_events")
+        and has_workspace_scope("topology_versions")
+    )
+
+
 def _bootstrap_brownfield_revision() -> None:
     with engine.begin() as connection:
         tables = set(inspect(connection).get_table_names())
@@ -339,6 +418,36 @@ def _bootstrap_brownfield_revision() -> None:
             has_report_workspace_scope
             and _analysis_report_workspace_scope_complete(connection)
         )
+        scoped_learning_columns_present = (
+            "project_id" in incident_record_columns
+            or "workspace_id" in incident_record_columns
+            or "workspace_id" in deployment_outcome_columns
+            or "workspace_id" in feedback_event_columns
+            or (
+                "topology_versions" in tables
+                and "workspace_id"
+                in {
+                    column["name"]
+                    for column in inspect(connection).get_columns("topology_versions")
+                }
+            )
+        )
+        has_complete_learning_context_scope = (
+            "incident_records" in tables
+            and "deployment_outcomes" in tables
+            and "feedback_events" in tables
+            and "topology_versions" in tables
+            and scoped_learning_columns_present
+            and _learning_context_scope_complete(connection)
+        )
+        if scoped_learning_columns_present and not has_complete_learning_context_scope:
+            raise RuntimeError(
+                "Detected a partial learning/context scope schema without a complete "
+                "migration history. Manual recovery is required."
+            )
+        if has_complete_learning_context_scope:
+            _write_alembic_revision(connection, "016_scope_learning_context_records")
+            return
         if has_report_workspace_scope and not has_complete_report_workspace_scope:
             raise RuntimeError(
                 "Detected a partial analysis report workspace scope schema without "

--- a/models/repositories/deployment_outcomes.py
+++ b/models/repositories/deployment_outcomes.py
@@ -13,6 +13,7 @@ from models.tables import DeploymentOutcome
 def _deployment_outcome_load_options() -> list:
     return [
         selectinload(DeploymentOutcome.project),
+        selectinload(DeploymentOutcome.workspace),
     ]
 
 
@@ -20,6 +21,7 @@ def create_deployment_outcome(
     session: Session,
     *,
     project_id: int,
+    workspace_id: int | None = None,
     analysis_id: int,
     outcome_label: str,
     deployed_at: datetime,
@@ -29,6 +31,7 @@ def create_deployment_outcome(
 ) -> DeploymentOutcome:
     outcome = DeploymentOutcome(
         project_id=project_id,
+        workspace_id=workspace_id,
         analysis_id=analysis_id,
         outcome_label=outcome_label,
         deployed_at=deployed_at,
@@ -50,6 +53,7 @@ def list_deployment_outcomes(
     session: Session,
     *,
     project_id: int | None = None,
+    workspace_id: int | None = None,
     analysis_id: int | None = None,
     outcome_label: str | None = None,
     limit: int = 100,
@@ -62,6 +66,8 @@ def list_deployment_outcomes(
     )
     if project_id is not None:
         stmt = stmt.where(DeploymentOutcome.project_id == project_id)
+    if workspace_id is not None:
+        stmt = stmt.where(DeploymentOutcome.workspace_id == workspace_id)
     if analysis_id is not None:
         stmt = stmt.where(DeploymentOutcome.analysis_id == analysis_id)
     if outcome_label:

--- a/models/repositories/feedback_events.py
+++ b/models/repositories/feedback_events.py
@@ -12,6 +12,7 @@ def create_feedback_event(
     session: Session,
     *,
     project_id: int,
+    workspace_id: int | None = None,
     analysis_id: int,
     finding_id: str | None = None,
     reviewer_role: str | None = None,
@@ -24,6 +25,7 @@ def create_feedback_event(
 ) -> FeedbackEvent:
     event = FeedbackEvent(
         project_id=project_id,
+        workspace_id=workspace_id,
         analysis_id=analysis_id,
         finding_id=finding_id,
         reviewer_role=reviewer_role,
@@ -44,6 +46,7 @@ def list_feedback_events(
     session: Session,
     *,
     project_id: int | None = None,
+    workspace_id: int | None = None,
     analysis_id: int | None = None,
     limit: int | None = None,
 ) -> list[FeedbackEvent]:
@@ -52,6 +55,8 @@ def list_feedback_events(
     )
     if project_id is not None:
         stmt = stmt.where(FeedbackEvent.project_id == project_id)
+    if workspace_id is not None:
+        stmt = stmt.where(FeedbackEvent.workspace_id == workspace_id)
     if analysis_id is not None:
         stmt = stmt.where(FeedbackEvent.analysis_id == analysis_id)
     if limit is not None:

--- a/models/repositories/incident_records.py
+++ b/models/repositories/incident_records.py
@@ -11,6 +11,8 @@ from models.tables import IncidentRecord
 def create_incident_record(
     session: Session,
     *,
+    project_id: int,
+    workspace_id: int | None = None,
     title: str,
     severity: str,
     source_file: str,
@@ -19,6 +21,8 @@ def create_incident_record(
     content: str,
 ) -> IncidentRecord:
     record = IncidentRecord(
+        project_id=project_id,
+        workspace_id=workspace_id,
         title=title,
         severity=severity,
         source_file=source_file,
@@ -32,8 +36,18 @@ def create_incident_record(
     return record
 
 
-def list_incident_records(session: Session) -> list[IncidentRecord]:
-    result = session.execute(select(IncidentRecord).order_by(IncidentRecord.id.asc()))
+def list_incident_records(
+    session: Session,
+    *,
+    project_id: int | None = None,
+    workspace_id: int | None = None,
+) -> list[IncidentRecord]:
+    stmt = select(IncidentRecord).order_by(IncidentRecord.id.asc())
+    if project_id is not None:
+        stmt = stmt.where(IncidentRecord.project_id == project_id)
+    if workspace_id is not None:
+        stmt = stmt.where(IncidentRecord.workspace_id == workspace_id)
+    result = session.execute(stmt)
     return list(result.scalars().all())
 
 

--- a/models/tables.py
+++ b/models/tables.py
@@ -26,8 +26,24 @@ if "IncidentRecord" not in globals():
         """Stored incident context for later similarity matching."""
 
         __tablename__ = "incident_records"
+        __table_args__ = (
+            ForeignKeyConstraint(
+                ["project_id", "workspace_id"],
+                ["project_workspaces.project_id", "project_workspaces.id"],
+                name="fk_incident_records_project_workspace_scope",
+            ),
+        )
 
         id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+        project_id: Mapped[int] = mapped_column(
+            ForeignKey("projects.id", ondelete="CASCADE"),
+            index=True,
+        )
+        workspace_id: Mapped[int | None] = mapped_column(
+            ForeignKey("project_workspaces.id", ondelete="SET NULL"),
+            nullable=True,
+            index=True,
+        )
         title: Mapped[str] = mapped_column(String(255))
         severity: Mapped[str] = mapped_column(String(20), default="unknown")
         source_file: Mapped[str] = mapped_column(String(255))
@@ -43,6 +59,11 @@ if "IncidentRecord" not in globals():
         )
         deployment_outcomes: Mapped[list["DeploymentOutcome"]] = relationship(
             back_populates="incident"
+        )
+        project: Mapped["Project"] = relationship(back_populates="incident_records")
+        workspace: Mapped["ProjectWorkspace | None"] = relationship(
+            back_populates="incident_records",
+            foreign_keys=[workspace_id],
         )
 
 
@@ -80,6 +101,10 @@ if "Project" not in globals():
             back_populates="project",
             cascade="all, delete-orphan",
         )
+        incident_records: Mapped[list["IncidentRecord"]] = relationship(
+            back_populates="project",
+            cascade="all, delete-orphan",
+        )
         topology_versions: Mapped[list["TopologyVersion"]] = relationship(
             back_populates="project",
             cascade="all, delete-orphan",
@@ -97,6 +122,11 @@ if "ProjectWorkspace" not in globals():
                 "project_id",
                 "workspace_key",
                 name="uq_project_workspaces_project_key",
+            ),
+            UniqueConstraint(
+                "project_id",
+                "id",
+                name="uq_project_workspaces_project_id_id",
             ),
         )
 
@@ -120,6 +150,22 @@ if "ProjectWorkspace" not in globals():
         project: Mapped["Project"] = relationship(back_populates="workspaces")
         reports: Mapped[list["AnalysisReport"]] = relationship(
             back_populates="workspace"
+        )
+        deployment_outcomes: Mapped[list["DeploymentOutcome"]] = relationship(
+            back_populates="workspace",
+            foreign_keys="DeploymentOutcome.workspace_id",
+        )
+        incident_records: Mapped[list["IncidentRecord"]] = relationship(
+            back_populates="workspace",
+            foreign_keys="IncidentRecord.workspace_id",
+        )
+        topology_versions: Mapped[list["TopologyVersion"]] = relationship(
+            back_populates="workspace",
+            foreign_keys="TopologyVersion.workspace_id",
+        )
+        feedback_events: Mapped[list["FeedbackEvent"]] = relationship(
+            back_populates="workspace",
+            foreign_keys="FeedbackEvent.workspace_id",
         )
 
 
@@ -361,10 +407,22 @@ if "TopologyVersion" not in globals():
         """Persisted topology snapshot scoped to one project."""
 
         __tablename__ = "topology_versions"
+        __table_args__ = (
+            ForeignKeyConstraint(
+                ["project_id", "workspace_id"],
+                ["project_workspaces.project_id", "project_workspaces.id"],
+                name="fk_topology_versions_project_workspace_scope",
+            ),
+        )
 
         id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
         project_id: Mapped[int] = mapped_column(
             ForeignKey("projects.id", ondelete="CASCADE"),
+            index=True,
+        )
+        workspace_id: Mapped[int | None] = mapped_column(
+            ForeignKey("project_workspaces.id", ondelete="SET NULL"),
+            nullable=True,
             index=True,
         )
         source_type: Mapped[str] = mapped_column(String(30), default="manual")
@@ -373,6 +431,10 @@ if "TopologyVersion" not in globals():
             DateTime(timezone=True), default=lambda: datetime.now(UTC)
         )
         project: Mapped["Project"] = relationship(back_populates="topology_versions")
+        workspace: Mapped["ProjectWorkspace | None"] = relationship(
+            back_populates="topology_versions",
+            foreign_keys=[workspace_id],
+        )
 
 
 if "DeploymentOutcome" not in globals():
@@ -381,10 +443,22 @@ if "DeploymentOutcome" not in globals():
         """Persisted deployment outcome scoped to one project."""
 
         __tablename__ = "deployment_outcomes"
+        __table_args__ = (
+            ForeignKeyConstraint(
+                ["project_id", "workspace_id"],
+                ["project_workspaces.project_id", "project_workspaces.id"],
+                name="fk_deployment_outcomes_project_workspace_scope",
+            ),
+        )
 
         id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
         project_id: Mapped[int] = mapped_column(
             ForeignKey("projects.id", ondelete="CASCADE"),
+            index=True,
+        )
+        workspace_id: Mapped[int | None] = mapped_column(
+            ForeignKey("project_workspaces.id", ondelete="SET NULL"),
+            nullable=True,
             index=True,
         )
         analysis_id: Mapped[int | None] = mapped_column(
@@ -405,6 +479,10 @@ if "DeploymentOutcome" not in globals():
             DateTime(timezone=True), default=lambda: datetime.now(UTC)
         )
         project: Mapped["Project"] = relationship(back_populates="deployment_outcomes")
+        workspace: Mapped["ProjectWorkspace | None"] = relationship(
+            back_populates="deployment_outcomes",
+            foreign_keys=[workspace_id],
+        )
         report: Mapped["AnalysisReport | None"] = relationship(
             back_populates="deployment_outcomes"
         )
@@ -419,10 +497,22 @@ if "FeedbackEvent" not in globals():
         """Persisted reviewer feedback event scoped to one project."""
 
         __tablename__ = "feedback_events"
+        __table_args__ = (
+            ForeignKeyConstraint(
+                ["project_id", "workspace_id"],
+                ["project_workspaces.project_id", "project_workspaces.id"],
+                name="fk_feedback_events_project_workspace_scope",
+            ),
+        )
 
         id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
         project_id: Mapped[int] = mapped_column(
             ForeignKey("projects.id", ondelete="CASCADE"),
+            index=True,
+        )
+        workspace_id: Mapped[int | None] = mapped_column(
+            ForeignKey("project_workspaces.id", ondelete="SET NULL"),
+            nullable=True,
             index=True,
         )
         analysis_id: Mapped[int | None] = mapped_column(
@@ -439,4 +529,8 @@ if "FeedbackEvent" not in globals():
         outcome_label: Mapped[str | None] = mapped_column(String(80), nullable=True)
         created_at: Mapped[datetime] = mapped_column(
             DateTime(timezone=True), default=lambda: datetime.now(UTC)
+        )
+        workspace: Mapped["ProjectWorkspace | None"] = relationship(
+            back_populates="feedback_events",
+            foreign_keys=[workspace_id],
         )

--- a/services/analysis_service.py
+++ b/services/analysis_service.py
@@ -231,13 +231,27 @@ def _build_context_completeness(
     *,
     project_id: int | None = None,
     project_key: str | None = None,
+    workspace_id: int | None = None,
+    workspace_key: str | None = None,
 ) -> ContextCompleteness:
     topology_status = get_topology_status(
         project_id=project_id,
         project_key=project_key,
+        workspace_id=workspace_id,
+        workspace_key=workspace_key,
     )
     topology_freshness_days = _topology_freshness_days(topology_status.updated_at)
-    incident_index_size = len(load_incident_candidates())
+    if project_id is None and project_key is None:
+        incident_index_size = 0
+    else:
+        incident_index_size = len(
+            load_incident_candidates(
+                project_id=project_id,
+                project_key=project_key,
+                workspace_id=workspace_id,
+                workspace_key=workspace_key,
+            )
+        )
     parser_success_rate = round(
         parse_batch.parsed_count / max(len(parse_batch.files), 1),
         2,
@@ -631,6 +645,8 @@ def build_analysis_artifacts(
     *,
     project_id: int | None = None,
     project_key: str | None = None,
+    workspace_id: int | None = None,
+    workspace_key: str | None = None,
     completion_client=None,
 ) -> AnalysisArtifacts:
     """Build all analysis artifacts up to, but not including, persistence."""
@@ -640,6 +656,8 @@ def build_analysis_artifacts(
     topology, topology_warning = load_topology(
         project_id=project_id,
         project_key=project_key,
+        workspace_id=workspace_id,
+        workspace_key=workspace_key,
     )
     assessment = evaluate_parse_batch(
         parse_batch,
@@ -652,6 +670,8 @@ def build_analysis_artifacts(
         parse_batch,
         project_id=project_id,
         project_key=project_key,
+        workspace_id=workspace_id,
+        workspace_key=workspace_key,
     )
     findings = build_findings(
         assessment=assessment,
@@ -664,7 +684,17 @@ def build_analysis_artifacts(
     rollback_plan = generate_rollback_plan(
         changes, partial_context=parse_batch.has_partial_context
     )
-    incident_matches = find_incident_matches(changes)
+    incident_matches = (
+        []
+        if project_id is None and project_key is None
+        else find_incident_matches(
+            changes,
+            project_id=project_id,
+            project_key=project_key,
+            workspace_id=workspace_id,
+            workspace_key=workspace_key,
+        )
+    )
     narrative = generate_narrative(
         assessment.model_copy(deep=True),
         [finding.model_copy(deep=True) for finding in findings],
@@ -740,6 +770,8 @@ def analyze_uploaded_files(
     artifacts = build_analysis_artifacts(
         files,
         project_id=resolved_project.id,
+        workspace_id=workspace_id,
+        workspace_key=workspace_key,
         completion_client=completion_client,
     )
     persisted_report = persist_analysis_report(

--- a/services/deployment_outcome_service.py
+++ b/services/deployment_outcome_service.py
@@ -17,6 +17,7 @@ from models.repositories.incident_records import get_incident_record
 from models.repositories.projects import get_project, get_project_by_key
 from services.backtesting_service import invalidate_backtesting_snapshot
 from services.project_service import ensure_default_project, normalize_project_key
+from services.project_service import resolve_workspace_reference
 
 ALLOWED_DEPLOYMENT_OUTCOMES = {"success", "failure", "rolled_back"}
 
@@ -80,11 +81,31 @@ def _serialize_project(project) -> dict[str, Any]:
     }
 
 
+def _serialize_workspace(workspace) -> dict[str, Any]:
+    created_at = workspace.created_at
+    updated_at = workspace.updated_at
+    project_key = workspace.project.project_key if workspace.project is not None else ""
+    return {
+        "id": workspace.id,
+        "project_id": workspace.project_id,
+        "project_key": project_key,
+        "workspace_key": workspace.workspace_key,
+        "display_name": workspace.display_name,
+        "description": workspace.description,
+        "environment": workspace.environment,
+        "created_at": _isoformat_utc(created_at),
+        "updated_at": _isoformat_utc(updated_at),
+    }
+
+
 def _serialize_deployment_outcome(outcome) -> dict[str, Any]:
     deployed_at = outcome.deployed_at or outcome.created_at
     return {
         "id": outcome.id,
         "project": _serialize_project(outcome.project),
+        "workspace": _serialize_workspace(outcome.workspace)
+        if outcome.workspace is not None
+        else None,
         "analysis_id": outcome.analysis_id,
         "outcome": outcome.outcome_label,
         "deployed_at": _isoformat_utc(deployed_at),
@@ -164,6 +185,8 @@ def record_deployment_outcome(
     summary: str | None = None,
     project_id: int | None = None,
     project_key: str | None = None,
+    workspace_id: int | None = None,
+    workspace_key: str | None = None,
     source_interface: str | None = None,
 ) -> dict[str, Any]:
     del source_interface
@@ -188,18 +211,45 @@ def record_deployment_outcome(
                 "conflicting_project_reference",
                 "The supplied project reference does not match the analysis report project.",
             )
-        linked_project_id = report.project_id
+        requested_workspace = resolve_workspace_reference(
+            project_id=report.project_id,
+            workspace_id=workspace_id,
+            workspace_key=workspace_key,
+        )
         if (
-            linked_incident_id is not None
-            and get_incident_record(session, linked_incident_id) is None
+            requested_workspace is not None
+            and requested_workspace.id != report.workspace_id
         ):
             raise DeploymentOutcomeError(
-                "incident_not_found",
-                f"Incident record not found: {linked_incident_id}.",
+                "conflicting_workspace_reference",
+                "The supplied workspace reference does not match the analysis report workspace.",
             )
+        linked_project_id = report.project_id
+        if linked_incident_id is not None:
+            incident = get_incident_record(session, linked_incident_id)
+            if incident is None:
+                raise DeploymentOutcomeError(
+                    "incident_not_found",
+                    f"Incident record not found: {linked_incident_id}.",
+                )
+            if incident.project_id != report.project_id:
+                raise DeploymentOutcomeError(
+                    "conflicting_incident_scope",
+                    "The linked incident belongs to a different project.",
+                )
+            if (
+                incident.workspace_id is not None
+                and report.workspace_id is not None
+                and incident.workspace_id != report.workspace_id
+            ):
+                raise DeploymentOutcomeError(
+                    "conflicting_incident_scope",
+                    "The linked incident belongs to a different workspace.",
+                )
         recorded = create_deployment_outcome_record(
             session,
             project_id=report.project_id,
+            workspace_id=report.workspace_id,
             analysis_id=analysis_id,
             outcome_label=normalized_outcome,
             deployed_at=normalized_timestamp,
@@ -219,6 +269,8 @@ def list_deployment_outcomes(
     outcome: str | None = None,
     project_id: int | None = None,
     project_key: str | None = None,
+    workspace_id: int | None = None,
+    workspace_key: str | None = None,
     limit: int = 100,
 ) -> list[dict[str, Any]]:
     normalized_outcome = _normalize_outcome(outcome) if outcome is not None else None
@@ -231,6 +283,7 @@ def list_deployment_outcomes(
         resolved_project_id = (
             requested_project.id if requested_project is not None else None
         )
+        resolved_workspace_id = None
         if analysis_id is not None:
             report = get_analysis_report(session, analysis_id, include_evidence=False)
             if report is None:
@@ -247,11 +300,28 @@ def list_deployment_outcomes(
                     "The supplied project reference does not match the analysis report project.",
                 )
             resolved_project_id = report.project_id
+            resolved_workspace_id = report.workspace_id
         if resolved_project_id is None:
             resolved_project_id = ensure_default_project().id
+        requested_workspace = resolve_workspace_reference(
+            project_id=resolved_project_id,
+            workspace_id=workspace_id,
+            workspace_key=workspace_key,
+        )
+        if requested_workspace is not None:
+            if (
+                resolved_workspace_id is not None
+                and requested_workspace.id != resolved_workspace_id
+            ):
+                raise DeploymentOutcomeError(
+                    "conflicting_workspace_reference",
+                    "The supplied workspace reference does not match the analysis report workspace.",
+                )
+            resolved_workspace_id = requested_workspace.id
         outcomes = list_deployment_outcome_records(
             session,
             project_id=resolved_project_id,
+            workspace_id=resolved_workspace_id,
             analysis_id=analysis_id,
             outcome_label=normalized_outcome,
             limit=limit,

--- a/services/feedback_service.py
+++ b/services/feedback_service.py
@@ -15,6 +15,7 @@ from services.project_service import (
     build_project_payload,
     ensure_default_project,
     resolve_project_reference,
+    resolve_workspace_reference,
 )
 
 
@@ -44,6 +45,7 @@ def _serialize_event(event) -> dict[str, Any]:
     return {
         "id": event.id,
         "project_id": event.project_id,
+        "workspace_id": event.workspace_id,
         "analysis_id": event.analysis_id,
         "finding_id": event.finding_id,
         "reviewer_role": event.reviewer_role,
@@ -65,6 +67,27 @@ def _project_payload(
     return build_project_payload(
         resolve_project_reference(project_id=project_id, project_key=project_key)
     )
+
+
+def _resolve_summary_scope(
+    *,
+    project_id: int | None,
+    project_key: str | None,
+    workspace_id: int | None,
+    workspace_key: str | None,
+):
+    if project_id is None and project_key is None:
+        project = ensure_default_project()
+    else:
+        project = resolve_project_reference(
+            project_id=project_id, project_key=project_key
+        )
+    workspace = resolve_workspace_reference(
+        project_id=project.id,
+        workspace_id=workspace_id,
+        workspace_key=workspace_key,
+    )
+    return project, workspace
 
 
 def record_finding_feedback(
@@ -108,6 +131,7 @@ def record_finding_feedback(
         event = create_feedback_event(
             session,
             project_id=report.project_id,
+            workspace_id=report.workspace_id,
             analysis_id=analysis_id,
             finding_id=normalized_finding_id,
             reviewer_role=reviewer_role,
@@ -142,6 +166,7 @@ def record_false_negative_feedback(
         event = create_feedback_event(
             session,
             project_id=report.project_id,
+            workspace_id=report.workspace_id,
             analysis_id=analysis_id,
             reviewer_role=reviewer_role,
             false_negative_note=normalized_note,
@@ -177,15 +202,21 @@ def fetch_feedback_summary(
     *,
     project_id: int | None = None,
     project_key: str | None = None,
+    workspace_id: int | None = None,
+    workspace_key: str | None = None,
 ) -> dict[str, Any]:
-    if project_id is None and project_key is None:
-        project = ensure_default_project()
-    else:
-        project = resolve_project_reference(
-            project_id=project_id, project_key=project_key
-        )
+    project, workspace = _resolve_summary_scope(
+        project_id=project_id,
+        project_key=project_key,
+        workspace_id=workspace_id,
+        workspace_key=workspace_key,
+    )
     with SessionLocal() as session:
-        events = list_feedback_events(session, project_id=project.id)
+        events = list_feedback_events(
+            session,
+            project_id=project.id,
+            workspace_id=workspace.id if workspace is not None else None,
+        )
 
     latest_finding_feedback: dict[tuple[int | None, str], Any] = {}
     latest_false_negative_by_report: dict[int | None, Any] = {}

--- a/services/incident_service.py
+++ b/services/incident_service.py
@@ -11,6 +11,10 @@ from models.repositories.incident_records import (
     list_incident_records,
 )
 from services.backtesting_service import invalidate_backtesting_snapshot
+from services.project_service import (
+    resolve_project_reference,
+    resolve_workspace_reference,
+)
 
 SEVERITY_PATTERN = re.compile(r"\b(P0|P1|P2|critical|high|medium|low)\b", re.IGNORECASE)
 DATE_PATTERN = re.compile(
@@ -56,6 +60,10 @@ def ingest_incident_document(
     content: str,
     *,
     analysis_id: int | None = None,
+    project_id: int | None = None,
+    project_key: str | None = None,
+    workspace_id: int | None = None,
+    workspace_key: str | None = None,
 ) -> dict:
     """Normalize and persist an incident document from markdown/plain text input."""
     normalized_content = content.strip()
@@ -63,16 +71,60 @@ def ingest_incident_document(
     severity = _extract_severity(normalized_content)
     incident_date = _extract_incident_date(normalized_content)
     report = None
-    linked_project_id: int | None = None
+    resolved_project_id: int | None = None
+    resolved_workspace_id: int | None = None
     with SessionLocal() as session:
         if analysis_id is not None:
             report = get_analysis_report(session, analysis_id, include_evidence=False)
         if analysis_id is not None and report is None:
             raise ValueError(f"Analysis report not found: {analysis_id}.")
         if report is not None:
-            linked_project_id = report.project_id
+            resolved_project_id = report.project_id
+            resolved_workspace_id = report.workspace_id
+            requested_project = (
+                resolve_project_reference(
+                    project_id=project_id, project_key=project_key
+                )
+                if project_id is not None or project_key is not None
+                else None
+            )
+            if (
+                requested_project is not None
+                and requested_project.id != resolved_project_id
+            ):
+                raise ValueError(
+                    "The supplied project reference does not match the analysis report project."
+                )
+            requested_workspace = resolve_workspace_reference(
+                project_id=resolved_project_id,
+                workspace_id=workspace_id,
+                workspace_key=workspace_key,
+            )
+            if (
+                requested_workspace is not None
+                and requested_workspace.id != resolved_workspace_id
+            ):
+                raise ValueError(
+                    "The supplied workspace reference does not match the analysis report workspace."
+                )
+        else:
+            if project_id is None and project_key is None:
+                raise ValueError("Project scope is required for incident records.")
+            project = resolve_project_reference(
+                project_id=project_id,
+                project_key=project_key,
+            )
+            workspace = resolve_workspace_reference(
+                project_id=project.id,
+                workspace_id=workspace_id,
+                workspace_key=workspace_key,
+            )
+            resolved_project_id = project.id
+            resolved_workspace_id = workspace.id if workspace is not None else None
         record = create_incident_record(
             session,
+            project_id=resolved_project_id,
+            workspace_id=resolved_workspace_id,
             title=title,
             severity=severity,
             source_file=source_file,
@@ -80,10 +132,12 @@ def ingest_incident_document(
             analysis_id=analysis_id,
             content=normalized_content,
         )
-    if linked_project_id is not None:
-        invalidate_backtesting_snapshot(project_id=linked_project_id)
+    if resolved_project_id is not None:
+        invalidate_backtesting_snapshot(project_id=resolved_project_id)
     return {
         "id": record.id,
+        "project_id": record.project_id,
+        "workspace_id": record.workspace_id,
         "title": record.title,
         "severity": record.severity,
         "source_file": record.source_file,
@@ -92,13 +146,33 @@ def ingest_incident_document(
     }
 
 
-def get_incident_records() -> list[dict]:
+def get_incident_records(
+    *,
+    project_id: int | None = None,
+    project_key: str | None = None,
+    workspace_id: int | None = None,
+    workspace_key: str | None = None,
+) -> list[dict]:
     """Return stored incidents for later matching workflows."""
+    if project_id is None and project_key is None:
+        raise ValueError("Project scope is required for incident records.")
+    project = resolve_project_reference(project_id=project_id, project_key=project_key)
+    workspace = resolve_workspace_reference(
+        project_id=project.id,
+        workspace_id=workspace_id,
+        workspace_key=workspace_key,
+    )
     with SessionLocal() as session:
-        records = list_incident_records(session)
+        records = list_incident_records(
+            session,
+            project_id=project.id,
+            workspace_id=workspace.id if workspace is not None else None,
+        )
     return [
         {
             "id": record.id,
+            "project_id": record.project_id,
+            "workspace_id": record.workspace_id,
             "title": record.title,
             "severity": record.severity,
             "source_file": record.source_file,

--- a/services/topology_service.py
+++ b/services/topology_service.py
@@ -16,8 +16,10 @@ from models.repositories.settings import get_setting, upsert_setting
 from models.tables import TopologyVersion
 from services.project_service import (
     build_project_payload,
+    build_workspace_payload,
     list_projects,
     resolve_project_reference,
+    resolve_workspace_reference,
 )
 from services.settings_service import get_topology_drift_check_interval_hours
 
@@ -215,8 +217,12 @@ def _topology_path() -> Path:
     return Path(settings.topology_path)
 
 
-def _topology_scope_path(project: dict) -> Path:
-    return Path(f"project://{project['project_key']}/topology/latest")
+def _topology_scope_path(project: dict, workspace: dict | None = None) -> Path:
+    if workspace is None:
+        return Path(f"project://{project['project_key']}/topology/latest")
+    return Path(
+        f"project://{project['project_key']}/{workspace['workspace_key']}/topology/latest"
+    )
 
 
 def _invalid_stored_topology_status(path: Path, message: str) -> TopologyStatus:
@@ -292,8 +298,12 @@ def _resource_snapshot(payload: dict[str, Any] | None) -> dict[str, dict[str, An
     return snapshot
 
 
-def _drift_setting_key(project: dict[str, Any]) -> str:
-    return f"topology_drift_status::{project['id']}"
+def _drift_setting_key(
+    project: dict[str, Any], workspace: dict[str, Any] | None = None
+) -> str:
+    if workspace is None:
+        return f"topology_drift_status::{project['id']}"
+    return f"topology_drift_status::{project['id']}::{workspace['id']}"
 
 
 def _parse_iso_datetime(value: str | None) -> datetime | None:
@@ -317,9 +327,11 @@ def _build_next_check_at(checked_at: str | None, interval_hours: int) -> str | N
     )
 
 
-def _load_cached_topology_drift(project: dict[str, Any]) -> TopologyDriftStatus | None:
+def _load_cached_topology_drift(
+    project: dict[str, Any], workspace: dict[str, Any] | None = None
+) -> TopologyDriftStatus | None:
     with SessionLocal() as session:
-        record = get_setting(session, _drift_setting_key(project))
+        record = get_setting(session, _drift_setting_key(project, workspace))
     if record is None:
         return None
     try:
@@ -332,12 +344,14 @@ def _load_cached_topology_drift(project: dict[str, Any]) -> TopologyDriftStatus 
 
 
 def _save_topology_drift(
-    project: dict[str, Any], drift_status: TopologyDriftStatus
+    project: dict[str, Any],
+    drift_status: TopologyDriftStatus,
+    workspace: dict[str, Any] | None = None,
 ) -> TopologyDriftStatus:
     with SessionLocal() as session:
         upsert_setting(
             session,
-            key=_drift_setting_key(project),
+            key=_drift_setting_key(project, workspace),
             value=json.dumps(drift_status.model_dump()),
         )
     return drift_status
@@ -408,15 +422,18 @@ def run_due_topology_drift_checks() -> list[TopologyDriftStatus]:
 
 def _load_latest_topology_payload(
     project: dict,
+    workspace: dict | None = None,
 ) -> tuple[dict | None, Path, TopologyStatus | None]:
-    topology_path = _topology_scope_path(project)
+    topology_path = _topology_scope_path(project, workspace)
     with SessionLocal() as session:
-        record = (
-            session.query(TopologyVersion)
-            .filter(TopologyVersion.project_id == int(project["id"]))
-            .order_by(TopologyVersion.id.desc())
-            .first()
+        stmt = session.query(TopologyVersion).filter(
+            TopologyVersion.project_id == int(project["id"])
         )
+        if workspace is None:
+            stmt = stmt.filter(TopologyVersion.workspace_id.is_(None))
+        else:
+            stmt = stmt.filter(TopologyVersion.workspace_id == int(workspace["id"]))
+        record = stmt.order_by(TopologyVersion.id.desc()).first()
         if record is None:
             if bool(project.get("is_default")):
                 legacy_status = _read_legacy_topology_status()
@@ -934,9 +951,10 @@ def _persist_topology_payload(
     payload: dict[str, Any],
     *,
     project: dict[str, Any],
+    workspace: dict[str, Any] | None,
     source_type: str,
 ) -> TopologyStatus:
-    topology_path = _topology_scope_path(project)
+    topology_path = _topology_scope_path(project, workspace)
     candidate_status = _build_topology_status(payload, path=topology_path, exists=False)
     if candidate_status.blocking_errors:
         raise TopologyImportError(
@@ -946,7 +964,7 @@ def _persist_topology_payload(
         )
 
     with SessionLocal() as session:
-        if bool(project.get("is_default")):
+        if bool(project.get("is_default")) and workspace is None:
             legacy_path = _topology_path()
             try:
                 legacy_path.parent.mkdir(parents=True, exist_ok=True)
@@ -963,12 +981,16 @@ def _persist_topology_payload(
         session.add(
             TopologyVersion(
                 project_id=int(project["id"]),
+                workspace_id=int(workspace["id"]) if workspace is not None else None,
                 source_type=source_type,
                 payload_json=json.dumps(payload),
             )
         )
         session.commit()
-    return get_topology_status(project_id=int(project["id"]))
+    return get_topology_status(
+        project_id=int(project["id"]),
+        workspace_id=int(workspace["id"]) if workspace is not None else None,
+    )
 
 
 def _canonical_service(service: dict[str, Any]) -> dict[str, Any]:
@@ -1051,6 +1073,8 @@ def check_topology_drift(
     *,
     project_id: int | None = None,
     project_key: str | None = None,
+    workspace_id: int | None = None,
+    workspace_key: str | None = None,
     force: bool = False,
 ) -> TopologyDriftStatus:
     """Run or reuse a scheduled topology drift check for one project."""
@@ -1058,11 +1082,21 @@ def check_topology_drift(
     project = build_project_payload(
         resolve_project_reference(project_id=project_id, project_key=project_key)
     )
-    payload, _, status_override = _load_latest_topology_payload(project)
+    workspace_record = resolve_workspace_reference(
+        project_id=int(project["id"]),
+        workspace_id=workspace_id,
+        workspace_key=workspace_key,
+    )
+    workspace = (
+        build_workspace_payload(workspace_record)
+        if workspace_record is not None
+        else None
+    )
+    payload, _, status_override = _load_latest_topology_payload(project, workspace)
     import_metadata = _import_metadata(payload or {})
     source_type = str(import_metadata.get("source_type") or "").strip() or None
     source_ref = str(import_metadata.get("source_ref") or "").strip() or None
-    cached_status = _load_cached_topology_drift(project)
+    cached_status = _load_cached_topology_drift(project, workspace)
 
     if not force and not _is_drift_check_due(cached_status, interval_hours):
         return cached_status or _build_drift_status(
@@ -1085,6 +1119,7 @@ def check_topology_drift(
                     "Topology drift is unavailable because no valid topology import is active."
                 ],
             ),
+            workspace,
         )
 
     if not source_type or not source_ref:
@@ -1099,6 +1134,7 @@ def check_topology_drift(
                     "Topology drift is unavailable because the active topology does not include an import source reference."
                 ],
             ),
+            workspace,
         )
 
     if source_type == "manual":
@@ -1113,6 +1149,7 @@ def check_topology_drift(
                     "Topology drift is unavailable for manual topology uploads because there is no source connector to re-evaluate."
                 ],
             ),
+            workspace,
         )
 
     try:
@@ -1127,6 +1164,7 @@ def check_topology_drift(
                 source_ref=source_ref,
                 warnings=[str(exc)],
             ),
+            workspace,
         )
 
     if change_set.operation != "replace":
@@ -1142,6 +1180,7 @@ def check_topology_drift(
                     "Topology drift is not supported for the active source connector yet."
                 ],
             ),
+            workspace,
         )
 
     current_resources = _resource_snapshot(payload)
@@ -1177,19 +1216,33 @@ def check_topology_drift(
         modified_resources=modified_resources,
         warnings=change_set.warnings,
     )
-    return _save_topology_drift(project, drift_status)
+    return _save_topology_drift(project, drift_status, workspace)
 
 
 def get_topology_status(
     *,
     project_id: int | None = None,
     project_key: str | None = None,
+    workspace_id: int | None = None,
+    workspace_key: str | None = None,
 ) -> TopologyStatus:
     """Return the active topology context with validation details for admin workflows."""
     project = build_project_payload(
         resolve_project_reference(project_id=project_id, project_key=project_key)
     )
-    payload, topology_path, status_override = _load_latest_topology_payload(project)
+    workspace_record = resolve_workspace_reference(
+        project_id=int(project["id"]),
+        workspace_id=workspace_id,
+        workspace_key=workspace_key,
+    )
+    workspace = (
+        build_workspace_payload(workspace_record)
+        if workspace_record is not None
+        else None
+    )
+    payload, topology_path, status_override = _load_latest_topology_payload(
+        project, workspace
+    )
     if status_override is not None and payload is None:
         return status_override
     if payload is None:
@@ -1205,7 +1258,10 @@ def get_topology_status(
             ],
         )
     status = _build_topology_status(payload, path=topology_path, exists=True)
-    status.drift = check_topology_drift(project_id=int(project["id"]))
+    status.drift = check_topology_drift(
+        project_id=int(project["id"]),
+        workspace_id=int(workspace["id"]) if workspace is not None else None,
+    )
     return status
 
 
@@ -1215,6 +1271,8 @@ def import_topology_source(
     *,
     project_id: int | None = None,
     project_key: str | None = None,
+    workspace_id: int | None = None,
+    workspace_key: str | None = None,
 ) -> TopologyImportResult:
     """Import topology through the shared source registry."""
     normalized_source_type = str(source_type or "").strip().lower()
@@ -1227,7 +1285,17 @@ def import_topology_source(
     project = build_project_payload(
         resolve_project_reference(project_id=project_id, project_key=project_key)
     )
-    previous_payload, _, _ = _load_latest_topology_payload(project)
+    workspace_record = resolve_workspace_reference(
+        project_id=int(project["id"]),
+        workspace_id=workspace_id,
+        workspace_key=workspace_key,
+    )
+    workspace = (
+        build_workspace_payload(workspace_record)
+        if workspace_record is not None
+        else None
+    )
+    previous_payload, _, _ = _load_latest_topology_payload(project, workspace)
     change_set = _lookup_source_handler(normalized_source_type)(source_ref)
     warnings = list(change_set.warnings)
 
@@ -1250,6 +1318,7 @@ def import_topology_source(
     status = _persist_topology_payload(
         payload,
         project=project,
+        workspace=workspace,
         source_type=normalized_source_type,
     )
     warnings.extend(status.warnings)
@@ -1269,12 +1338,16 @@ def save_topology_definition(
     *,
     project_id: int | None = None,
     project_key: str | None = None,
+    workspace_id: int | None = None,
+    workspace_key: str | None = None,
 ) -> TopologyStatus:
     """Persist topology input as the active blast-radius context and return validation feedback."""
     validation_status = validate_topology_definition(
         raw_text,
         project_id=project_id,
         project_key=project_key,
+        workspace_id=workspace_id,
+        workspace_key=workspace_key,
     )
     if validation_status.blocking_errors:
         raise ValueError(" ".join(validation_status.blocking_errors))
@@ -1282,6 +1355,16 @@ def save_topology_definition(
     payload = dict(validation_status.payload or {})
     project = build_project_payload(
         resolve_project_reference(project_id=project_id, project_key=project_key)
+    )
+    workspace_record = resolve_workspace_reference(
+        project_id=int(project["id"]),
+        workspace_id=workspace_id,
+        workspace_key=workspace_key,
+    )
+    workspace = (
+        build_workspace_payload(workspace_record)
+        if workspace_record is not None
+        else None
     )
     change_set = _build_custom_change_set(payload)
 
@@ -1293,6 +1376,7 @@ def save_topology_definition(
                 source_ref="inline://manual-topology",
             ),
             project=project,
+            workspace=workspace,
             source_type="manual",
         )
     except TopologyImportError as exc:
@@ -1304,6 +1388,8 @@ def validate_topology_definition(
     *,
     project_id: int | None = None,
     project_key: str | None = None,
+    workspace_id: int | None = None,
+    workspace_key: str | None = None,
 ) -> TopologyStatus:
     """Validate topology input without persisting it."""
     try:
@@ -1317,11 +1403,21 @@ def validate_topology_definition(
     project = build_project_payload(
         resolve_project_reference(project_id=project_id, project_key=project_key)
     )
+    workspace_record = resolve_workspace_reference(
+        project_id=int(project["id"]),
+        workspace_id=workspace_id,
+        workspace_key=workspace_key,
+    )
+    workspace = (
+        build_workspace_payload(workspace_record)
+        if workspace_record is not None
+        else None
+    )
     validation_payload = dict(payload)
     validation_payload["updated_at"] = _current_timestamp()
     validation_status = _build_topology_status(
         validation_payload,
-        path=_topology_scope_path(project),
+        path=_topology_scope_path(project, workspace),
         exists=False,
     )
 
@@ -1341,8 +1437,15 @@ def load_topology(
     *,
     project_id: int | None = None,
     project_key: str | None = None,
+    workspace_id: int | None = None,
+    workspace_key: str | None = None,
 ) -> tuple[dict | None, str | None]:
     """Load topology context and return an optional warning."""
-    status = get_topology_status(project_id=project_id, project_key=project_key)
+    status = get_topology_status(
+        project_id=project_id,
+        project_key=project_key,
+        workspace_id=workspace_id,
+        workspace_key=workspace_key,
+    )
     messages = status.blocking_errors + status.warnings
     return status.payload, _join_warnings(messages)

--- a/tests/test_analysis/test_incident_matcher.py
+++ b/tests/test_analysis/test_incident_matcher.py
@@ -12,6 +12,7 @@ import config as config_module
 import models.database as database_module
 import models.tables as tables_module
 import services.incident_service as incident_service_module
+import services.project_service as project_service_module
 import analysis.incident_matcher as incident_matcher_module
 from parsers.base import UnifiedChange
 
@@ -24,9 +25,14 @@ class IncidentMatcherTests(unittest.TestCase):
         reload(config_module)
         reload(tables_module)
         reload(database_module)
+        reload(project_service_module)
         reload(incident_service_module)
         reload(incident_matcher_module)
         database_module.init_db()
+        self.project = project_service_module.create_project(
+            project_key="payments",
+            display_name="Payments",
+        )
 
     def tearDown(self) -> None:
         database_module.engine.dispose()
@@ -37,6 +43,7 @@ class IncidentMatcherTests(unittest.TestCase):
         incident_service_module.ingest_incident_document(
             "incident.md",
             "# Database exposure\nDate: 2026-04-16\nSeverity: P1\nTerraform security group database exposure during deployment restart.",
+            project_id=self.project.id,
         )
         changes = [
             UnifiedChange(
@@ -47,7 +54,10 @@ class IncidentMatcherTests(unittest.TestCase):
                 summary="Terraform security group database exposure during deployment restart.",
             )
         ]
-        matches = incident_matcher_module.find_incident_matches(changes)
+        matches = incident_matcher_module.find_incident_matches(
+            changes,
+            project_id=self.project.id,
+        )
         self.assertEqual(len(matches), 1)
         self.assertEqual(matches[0].title, "Database exposure")
         self.assertGreater(matches[0].similarity, 0.2)
@@ -63,13 +73,17 @@ class IncidentMatcherTests(unittest.TestCase):
                 summary="Terraform security group database exposure during deployment restart.",
             )
         ]
-        matches = incident_matcher_module.find_incident_matches(changes)
+        matches = incident_matcher_module.find_incident_matches(
+            changes,
+            project_id=self.project.id,
+        )
         self.assertEqual(matches, [])
 
     def test_find_incident_matches_avoids_generic_token_false_positive(self) -> None:
         incident_service_module.ingest_incident_document(
             "generic.md",
             "# Generic deployment note\nSeverity: low\nA deployment changed a resource and included a service update.",
+            project_id=self.project.id,
         )
         changes = [
             UnifiedChange(
@@ -81,7 +95,7 @@ class IncidentMatcherTests(unittest.TestCase):
             )
         ]
         matches = incident_matcher_module.find_incident_matches(
-            changes, min_similarity=0.15
+            changes, min_similarity=0.15, project_id=self.project.id
         )
         self.assertEqual(matches, [])
 
@@ -89,10 +103,12 @@ class IncidentMatcherTests(unittest.TestCase):
         incident_service_module.ingest_incident_document(
             "generic.md",
             "# Generic deployment note\nSeverity: low\nSecurity group update.",
+            project_id=self.project.id,
         )
         incident_service_module.ingest_incident_document(
             "specific.md",
             "# Database exposure\nSeverity: P1\nTerraform security group database exposure during deployment restart.",
+            project_id=self.project.id,
         )
         changes = [
             UnifiedChange(
@@ -104,7 +120,7 @@ class IncidentMatcherTests(unittest.TestCase):
             )
         ]
         matches = incident_matcher_module.find_incident_matches(
-            changes, min_similarity=0.1
+            changes, min_similarity=0.1, project_id=self.project.id
         )
         self.assertGreaterEqual(len(matches), 1)
         self.assertEqual(matches[0].title, "Database exposure")
@@ -115,10 +131,12 @@ class IncidentMatcherTests(unittest.TestCase):
         incident_service_module.ingest_incident_document(
             "older.md",
             "# Similar deploy\nDate: 2024-01-01\nSeverity: low\nDatabase exposure during deploy restart.",
+            project_id=self.project.id,
         )
         incident_service_module.ingest_incident_document(
             "recent.md",
             "# Similar deploy\nDate: 2026-04-16\nSeverity: P1\nDatabase exposure during deploy restart.",
+            project_id=self.project.id,
         )
         changes = [
             UnifiedChange(
@@ -130,7 +148,7 @@ class IncidentMatcherTests(unittest.TestCase):
             )
         ]
         matches = incident_matcher_module.find_incident_matches(
-            changes, min_similarity=0.1
+            changes, min_similarity=0.1, project_id=self.project.id
         )
         self.assertGreaterEqual(len(matches), 2)
         self.assertEqual(matches[0].source_file, "recent.md")

--- a/tests/test_infra/test_container_contract.py
+++ b/tests/test_infra/test_container_contract.py
@@ -29,6 +29,7 @@ class ContainerContractTests(unittest.TestCase):
                 "013_add_incident_analysis_reference.py",
                 "014_add_project_workspace_records.py",
                 "015_add_report_workspace_scope.py",
+                "016_scope_learning_context_records.py",
             ],
         )
         baseline_content = migrations[0].read_text(encoding="utf-8")
@@ -43,6 +44,7 @@ class ContainerContractTests(unittest.TestCase):
         incident_link_content = migrations[9].read_text(encoding="utf-8")
         workspace_content = migrations[10].read_text(encoding="utf-8")
         report_workspace_content = migrations[11].read_text(encoding="utf-8")
+        learning_context_scope_content = migrations[12].read_text(encoding="utf-8")
         self.assertIn("down_revision = None", baseline_content)
         self.assertIn('"app_settings"', baseline_content)
         self.assertIn(
@@ -94,6 +96,13 @@ class ContainerContractTests(unittest.TestCase):
             report_workspace_content,
         )
         self.assertIn('"workspace_id"', report_workspace_content)
+        self.assertIn(
+            'down_revision = "015_add_report_workspace_scope"',
+            learning_context_scope_content,
+        )
+        self.assertIn('"incident_records"', learning_context_scope_content)
+        self.assertIn('"project_id"', learning_context_scope_content)
+        self.assertIn('"workspace_id"', learning_context_scope_content)
 
     def test_dockerfile_exists(self) -> None:
         self.assertTrue(Path("Dockerfile").exists())

--- a/tests/test_infra/test_migrations.py
+++ b/tests/test_infra/test_migrations.py
@@ -68,6 +68,46 @@ class MigrationTests(unittest.TestCase):
         finally:
             sqlite_conn.close()
 
+    def _foreign_key_groups(self, table_name: str) -> list[dict]:
+        sqlite_conn = sqlite3.connect(self.db_path)
+        try:
+            grouped: dict[int, dict] = {}
+            rows = sqlite_conn.execute(f"PRAGMA foreign_key_list({table_name})")
+            for row in rows:
+                group = grouped.setdefault(
+                    row[0],
+                    {
+                        "constrained_columns": [],
+                        "referred_table": row[2],
+                        "referred_columns": [],
+                        "ondelete": row[6],
+                    },
+                )
+                group["constrained_columns"].append(row[3])
+                group["referred_columns"].append(row[4])
+            return list(grouped.values())
+        finally:
+            sqlite_conn.close()
+
+    def _unique_constraint_columns(self, table_name: str) -> set[tuple[str, ...]]:
+        sqlite_conn = sqlite3.connect(self.db_path)
+        try:
+            unique_columns: set[tuple[str, ...]] = set()
+            for index_row in sqlite_conn.execute(f"PRAGMA index_list({table_name})"):
+                is_unique = bool(index_row[2])
+                if not is_unique:
+                    continue
+                columns = tuple(
+                    column_row[2]
+                    for column_row in sqlite_conn.execute(
+                        f"PRAGMA index_info({index_row[1]})"
+                    )
+                )
+                unique_columns.add(columns)
+            return unique_columns
+        finally:
+            sqlite_conn.close()
+
     def _create_project_workspace_table(
         self,
         *,
@@ -131,6 +171,10 @@ class MigrationTests(unittest.TestCase):
         self.assertIn("share_password_hash", self._table_columns("analysis_reports"))
         self.assertIn("share_password_salt", self._table_columns("analysis_reports"))
         self.assertIn("share_redact_filenames", self._table_columns("analysis_reports"))
+        self.assertIn(
+            ("project_id", "id"),
+            self._unique_constraint_columns("project_workspaces"),
+        )
         report_fks = self._foreign_keys("analysis_reports")
         self.assertTrue(
             any(
@@ -139,6 +183,23 @@ class MigrationTests(unittest.TestCase):
                 for foreign_key in report_fks
             )
         )
+        for table_name in (
+            "incident_records",
+            "deployment_outcomes",
+            "feedback_events",
+            "topology_versions",
+        ):
+            grouped_fks = self._foreign_key_groups(table_name)
+            self.assertTrue(
+                any(
+                    foreign_key["referred_table"] == "project_workspaces"
+                    and foreign_key["constrained_columns"]
+                    == ["project_id", "workspace_id"]
+                    and foreign_key["referred_columns"] == ["project_id", "id"]
+                    for foreign_key in grouped_fks
+                ),
+                f"{table_name} should enforce workspace/project consistency",
+            )
         report_schema_row = next(
             row
             for row in self._table_info("analysis_reports")
@@ -151,6 +212,85 @@ class MigrationTests(unittest.TestCase):
             if row[1] == "share_redact_filenames"
         )
         self.assertIsNone(share_redact_row[4])
+
+    def test_learning_context_scope_rejects_cross_project_workspace_rows(
+        self,
+    ) -> None:
+        command.upgrade(self._config(), "head")
+
+        sqlite_conn = sqlite3.connect(self.db_path)
+        sqlite_conn.execute("PRAGMA foreign_keys = ON")
+        try:
+            first_project_id = sqlite_conn.execute(
+                "SELECT id FROM projects WHERE project_key = ? LIMIT 1",
+                ("unassigned",),
+            ).fetchone()[0]
+            sqlite_conn.execute(
+                """
+                INSERT INTO projects (
+                    project_key,
+                    display_name,
+                    is_default,
+                    created_at,
+                    updated_at
+                ) VALUES (?, ?, ?, ?, ?)
+                """,
+                (
+                    "platform",
+                    "Platform",
+                    0,
+                    "2026-05-06T00:00:00+00:00",
+                    "2026-05-06T00:00:00+00:00",
+                ),
+            )
+            other_project_id = sqlite_conn.execute(
+                "SELECT id FROM projects WHERE project_key = ? LIMIT 1",
+                ("platform",),
+            ).fetchone()[0]
+            sqlite_conn.execute(
+                """
+                INSERT INTO project_workspaces (
+                    project_id,
+                    workspace_key,
+                    display_name,
+                    created_at,
+                    updated_at
+                ) VALUES (?, ?, ?, ?, ?)
+                """,
+                (
+                    other_project_id,
+                    "prod",
+                    "Production",
+                    "2026-05-06T00:00:00+00:00",
+                    "2026-05-06T00:00:00+00:00",
+                ),
+            )
+            workspace_id = sqlite_conn.execute(
+                "SELECT id FROM project_workspaces WHERE workspace_key = ? LIMIT 1",
+                ("prod",),
+            ).fetchone()[0]
+
+            with self.assertRaises(sqlite3.IntegrityError):
+                sqlite_conn.execute(
+                    """
+                    INSERT INTO topology_versions (
+                        project_id,
+                        workspace_id,
+                        source_type,
+                        payload_json,
+                        created_at
+                    ) VALUES (?, ?, ?, ?, ?)
+                    """,
+                    (
+                        first_project_id,
+                        workspace_id,
+                        "manual",
+                        "{}",
+                        "2026-05-06T00:00:00+00:00",
+                    ),
+                )
+        finally:
+            sqlite_conn.close()
 
     def test_upgrade_head_preserves_existing_analysis_reports(self) -> None:
         command.upgrade(self._config(), "0001_create_analysis_reports")
@@ -375,7 +515,7 @@ class MigrationTests(unittest.TestCase):
         self.assertIn("evidence_items", tables)
         self.assertIn("projects", tables)
         self.assertIn("topology_versions", tables)
-        self.assertEqual(revision, "015_add_report_workspace_scope")
+        self.assertEqual(revision, "016_scope_learning_context_records")
 
     def test_init_db_repairs_partial_evidence_schema_without_alembic_version(
         self,
@@ -424,7 +564,7 @@ class MigrationTests(unittest.TestCase):
         self.assertIn("findings", tables)
         self.assertIn("evidence_items", tables)
         self.assertIn("projects", tables)
-        self.assertEqual(revision, "015_add_report_workspace_scope")
+        self.assertEqual(revision, "016_scope_learning_context_records")
 
     def test_init_db_repairs_current_schema_without_alembic_version(self) -> None:
         command.upgrade(self._config(), "head")
@@ -450,7 +590,7 @@ class MigrationTests(unittest.TestCase):
         finally:
             sqlite_conn.close()
 
-        self.assertEqual(revision, "015_add_report_workspace_scope")
+        self.assertEqual(revision, "016_scope_learning_context_records")
         self.assertIn("report_schema_version", columns)
         self.assertIn("blast_radius_json", columns)
         self.assertIn("project_id", columns)
@@ -627,7 +767,7 @@ class MigrationTests(unittest.TestCase):
         finally:
             sqlite_conn.close()
 
-        self.assertEqual(revision, "015_add_report_workspace_scope")
+        self.assertEqual(revision, "016_scope_learning_context_records")
 
 
 if __name__ == "__main__":

--- a/tests/test_services/test_backtesting_service.py
+++ b/tests/test_services/test_backtesting_service.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import os
 import tempfile
 import unittest
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from importlib import reload
 from pathlib import Path
 from unittest import mock
@@ -88,6 +88,9 @@ class BacktestingServiceTests(unittest.TestCase):
             project_id=self.project.id,
             audit_context={"source_interface": "api"},
         )
+
+    def _recent_deployed_at(self, *, hours_ago: int = 24) -> str:
+        return (datetime.now(UTC) - timedelta(hours=hours_ago)).isoformat()
 
     def test_run_weekly_backtest_computes_failed_deploy_warning_rows(self) -> None:
         warned_report = self._persist_report(
@@ -296,7 +299,7 @@ class BacktestingServiceTests(unittest.TestCase):
         deployment_outcome_service_module.record_deployment_outcome(
             analysis_id=warned_report["id"],
             outcome="failure",
-            deployed_at="2026-04-29T09:00:00Z",
+            deployed_at=self._recent_deployed_at(hours_ago=24),
         )
 
         summary = backtesting_service_module.fetch_calibration_dashboard_seed(
@@ -322,7 +325,7 @@ class BacktestingServiceTests(unittest.TestCase):
         deployment_outcome_service_module.record_deployment_outcome(
             analysis_id=warned_report["id"],
             outcome="failure",
-            deployed_at="2026-04-29T09:00:00Z",
+            deployed_at=self._recent_deployed_at(hours_ago=24),
         )
         first = backtesting_service_module.fetch_calibration_dashboard_seed(
             project_id=self.project.id
@@ -337,7 +340,7 @@ class BacktestingServiceTests(unittest.TestCase):
         deployment_outcome_service_module.record_deployment_outcome(
             analysis_id=quiet_report["id"],
             outcome="failure",
-            deployed_at="2026-04-29T10:00:00Z",
+            deployed_at=self._recent_deployed_at(hours_ago=23),
         )
 
         refreshed = backtesting_service_module.fetch_calibration_dashboard_seed(

--- a/tests/test_services/test_deployment_outcome_service.py
+++ b/tests/test_services/test_deployment_outcome_service.py
@@ -40,6 +40,11 @@ class DeploymentOutcomeServiceTests(unittest.TestCase):
             project_key="payments",
             display_name="Payments",
         )
+        self.workspace = project_service_module.create_workspace(
+            project_key="payments",
+            workspace_key="prod",
+            display_name="Production",
+        )
         self.persisted_report = report_service_module.persist_analysis_report(
             ParseBatchResult(
                 files=[
@@ -69,6 +74,7 @@ class DeploymentOutcomeServiceTests(unittest.TestCase):
                 warnings=[],
             ),
             project_id=self.project.id,
+            workspace_id=self.workspace.id,
             audit_context={"source_interface": "api"},
         )
 
@@ -87,6 +93,8 @@ class DeploymentOutcomeServiceTests(unittest.TestCase):
                 severity="high",
                 source_file="incident.md",
                 incident_date="2026-04-30",
+                project_id=self.project.id,
+                workspace_id=self.workspace.id,
                 content="Rollback needed after checkout deployment.",
             )
 
@@ -102,6 +110,7 @@ class DeploymentOutcomeServiceTests(unittest.TestCase):
 
         self.assertEqual(recorded["analysis_id"], self.persisted_report["id"])
         self.assertEqual(recorded["project"]["project_key"], "payments")
+        self.assertEqual(recorded["workspace"]["workspace_key"], "prod")
         self.assertEqual(recorded["outcome"], "rolled_back")
         self.assertEqual(recorded["linked_incident_id"], incident.id)
         self.assertEqual(recorded["environment"], "prod")
@@ -128,6 +137,35 @@ class DeploymentOutcomeServiceTests(unittest.TestCase):
             )
 
         self.assertEqual(ctx.exception.code, "conflicting_project_reference")
+
+    def test_record_deployment_outcome_rejects_cross_project_incident_link(
+        self,
+    ) -> None:
+        other_project = project_service_module.create_project(
+            project_key="platform",
+            display_name="Platform",
+        )
+        with SessionLocal() as session:
+            incident = create_incident_record(
+                session,
+                title="Platform degraded",
+                severity="high",
+                source_file="platform-incident.md",
+                incident_date="2026-04-30",
+                project_id=other_project.id,
+                content="Platform rollback needed.",
+            )
+
+        with self.assertRaises(
+            deployment_outcome_service_module.DeploymentOutcomeError
+        ) as ctx:
+            deployment_outcome_service_module.record_deployment_outcome(
+                analysis_id=self.persisted_report["id"],
+                outcome="rolled_back",
+                linked_incident_id=incident.id,
+            )
+
+        self.assertEqual(ctx.exception.code, "conflicting_incident_scope")
 
     def test_list_deployment_outcomes_filters_by_analysis_id(self) -> None:
         deployment_outcome_service_module.record_deployment_outcome(
@@ -186,3 +224,64 @@ class DeploymentOutcomeServiceTests(unittest.TestCase):
         self.assertEqual(len(results), 1)
         self.assertEqual(results[0]["analysis_id"], self.persisted_report["id"])
         self.assertEqual(results[0]["project"]["project_key"], "payments")
+        self.assertEqual(results[0]["workspace"]["workspace_key"], "prod")
+
+    def test_list_deployment_outcomes_filters_by_workspace_id(self) -> None:
+        staging_workspace = project_service_module.create_workspace(
+            project_key="payments",
+            workspace_key="staging",
+            display_name="Staging",
+        )
+        deployment_outcome_service_module.record_deployment_outcome(
+            analysis_id=self.persisted_report["id"],
+            outcome="success",
+            deployed_at="2026-04-30T08:15:00Z",
+            source_interface="api",
+        )
+        staging_report = report_service_module.persist_analysis_report(
+            ParseBatchResult(
+                files=[
+                    ParsedFileResult(
+                        file_name="payments-staging.tf",
+                        tool="terraform",
+                        status="parsed",
+                        changes=[],
+                    )
+                ]
+            ),
+            RiskAssessment(
+                score=20,
+                severity="low",
+                recommendation="go",
+                top_risk="Staging report.",
+                contributors=[],
+                interaction_risks=[],
+                partial_context=False,
+                warnings=[],
+            ),
+            NarrativeResult(
+                opening_sentence="GO: staging report.",
+                explanation="Staging report.",
+                guidance=[],
+                degraded=False,
+                warnings=[],
+            ),
+            project_id=self.project.id,
+            workspace_id=staging_workspace.id,
+            audit_context={"source_interface": "api"},
+        )
+        deployment_outcome_service_module.record_deployment_outcome(
+            analysis_id=staging_report["id"],
+            outcome="failure",
+            deployed_at="2026-04-30T09:30:00Z",
+            source_interface="api",
+        )
+
+        results = deployment_outcome_service_module.list_deployment_outcomes(
+            project_id=self.project.id,
+            workspace_id=self.workspace.id,
+        )
+
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0]["analysis_id"], self.persisted_report["id"])
+        self.assertEqual(results[0]["workspace"]["workspace_key"], "prod")

--- a/tests/test_services/test_feedback_service.py
+++ b/tests/test_services/test_feedback_service.py
@@ -39,6 +39,11 @@ class FeedbackServiceTests(unittest.TestCase):
             project_key="payments",
             display_name="Payments",
         )
+        self.workspace = project_service_module.create_workspace(
+            project_key="payments",
+            workspace_key="prod",
+            display_name="Production",
+        )
         self.report = report_service_module.persist_analysis_report(
             ParseBatchResult(
                 files=[
@@ -83,6 +88,7 @@ class FeedbackServiceTests(unittest.TestCase):
                 )
             ],
             project_id=self.project.id,
+            workspace_id=self.workspace.id,
             audit_context={"source_interface": "ui"},
         )
         self.finding_id = self.report["findings"][0]["finding_id"]
@@ -104,6 +110,8 @@ class FeedbackServiceTests(unittest.TestCase):
         )
 
         self.assertEqual(event["analysis_id"], self.report["id"])
+        self.assertEqual(event["project_id"], self.project.id)
+        self.assertEqual(event["workspace_id"], self.workspace.id)
         self.assertEqual(event["finding_id"], self.finding_id)
         self.assertFalse(event["useful"])
         self.assertTrue(event["false_positive_flag"])
@@ -119,6 +127,8 @@ class FeedbackServiceTests(unittest.TestCase):
         )
 
         self.assertEqual(event["analysis_id"], self.report["id"])
+        self.assertEqual(event["project_id"], self.project.id)
+        self.assertEqual(event["workspace_id"], self.workspace.id)
         self.assertIsNone(event["finding_id"])
         self.assertEqual(
             event["false_negative_note"],
@@ -145,7 +155,8 @@ class FeedbackServiceTests(unittest.TestCase):
         )
 
         summary = feedback_service_module.fetch_feedback_summary(
-            project_id=self.project.id
+            project_id=self.project.id,
+            workspace_id=self.workspace.id,
         )
 
         self.assertEqual(summary["project"]["project_key"], "payments")
@@ -157,6 +168,79 @@ class FeedbackServiceTests(unittest.TestCase):
         self.assertIn(
             "payments failover prerequisite", summary["recent_notes"][0]["text"]
         )
+
+    def test_feedback_summary_filters_by_workspace(self) -> None:
+        staging_workspace = project_service_module.create_workspace(
+            project_key="payments",
+            workspace_key="staging",
+            display_name="Staging",
+        )
+        staging_report = report_service_module.persist_analysis_report(
+            ParseBatchResult(
+                files=[
+                    ParsedFileResult(
+                        file_name="payments-staging.tf",
+                        tool="terraform",
+                        status="parsed",
+                        changes=[],
+                    )
+                ]
+            ),
+            RiskAssessment(
+                score=44,
+                severity="medium",
+                recommendation="caution",
+                top_risk="Staging report for feedback tests.",
+                contributors=[],
+                interaction_risks=[],
+                partial_context=False,
+                warnings=[],
+            ),
+            NarrativeResult(
+                opening_sentence="CAUTION: staging feedback test report.",
+                explanation="Staging feedback test report.",
+                guidance=[],
+                degraded=False,
+                warnings=[],
+            ),
+            findings=[
+                Finding(
+                    finding_id="finding-staging",
+                    analysis_id=0,
+                    title="MEDIUM: staging security group",
+                    description="Security group needs review.",
+                    severity="medium",
+                    category="networking/ingress",
+                    deterministic=True,
+                    confidence=1.0,
+                    uncertainty_note=None,
+                    evidence_refs=[],
+                    skill_id=None,
+                )
+            ],
+            project_id=self.project.id,
+            workspace_id=staging_workspace.id,
+            audit_context={"source_interface": "ui"},
+        )
+        feedback_service_module.record_finding_feedback(
+            analysis_id=self.report["id"],
+            finding_id=self.finding_id,
+            useful=True,
+        )
+        feedback_service_module.record_finding_feedback(
+            analysis_id=staging_report["id"],
+            finding_id=staging_report["findings"][0]["finding_id"],
+            useful=False,
+        )
+
+        summary = feedback_service_module.fetch_feedback_summary(
+            project_id=self.project.id,
+            workspace_id=self.workspace.id,
+        )
+
+        self.assertEqual(summary["totals"]["events_recorded"], 1)
+        self.assertEqual(summary["current_state"]["useful_count"], 1)
+        self.assertEqual(summary["current_state"]["not_useful_count"], 0)
 
     def test_record_finding_feedback_rejects_unknown_finding(self) -> None:
         with self.assertRaises(feedback_service_module.FeedbackError) as ctx:

--- a/tests/test_services/test_incident_service.py
+++ b/tests/test_services/test_incident_service.py
@@ -28,9 +28,15 @@ class IncidentServiceTests(unittest.TestCase):
         reload(config_module)
         reload(tables_module)
         reload(database_module)
+        reload(project_service_module)
+        reload(report_service_module)
         reload(incident_service_module)
         reload(incident_matcher_module)
         database_module.init_db()
+        self.project = project_service_module.create_project(
+            project_key="payments",
+            display_name="Payments",
+        )
 
     def tearDown(self) -> None:
         database_module.engine.dispose()
@@ -41,28 +47,94 @@ class IncidentServiceTests(unittest.TestCase):
         result = incident_service_module.ingest_incident_document(
             "incident.md",
             "# Database exposure\nDate: 2026-04-16\nSeverity: P1\nThe security group was opened too broadly.",
+            project_id=self.project.id,
         )
         self.assertEqual(result["title"], "Database exposure")
         self.assertEqual(result["severity"], "critical")
         self.assertEqual(result["incident_date"], "2026-04-16")
 
-        records = incident_service_module.get_incident_records()
+        records = incident_service_module.get_incident_records(
+            project_id=self.project.id
+        )
         self.assertEqual(len(records), 1)
         self.assertEqual(records[0]["source_file"], "incident.md")
+        self.assertEqual(records[0]["project_id"], self.project.id)
+
+    def test_ingest_incident_document_requires_project_scope(self) -> None:
+        with self.assertRaises(ValueError) as ctx:
+            incident_service_module.ingest_incident_document(
+                "incident.md",
+                "# Database exposure\nSeverity: high\nRollback required.",
+            )
+
+        self.assertIn("Project scope is required", str(ctx.exception))
 
     def test_incident_matcher_can_load_stored_candidates(self) -> None:
         incident_service_module.ingest_incident_document(
             "incident.md",
             "# Database exposure\nSeverity: high\nThe security group was opened too broadly.",
+            project_id=self.project.id,
         )
-        candidates = incident_matcher_module.load_incident_candidates()
+        candidates = incident_matcher_module.load_incident_candidates(
+            project_id=self.project.id
+        )
         self.assertEqual(len(candidates), 1)
         self.assertEqual(candidates[0]["title"], "Database exposure")
+
+    def test_incident_candidates_do_not_cross_project_or_workspace(self) -> None:
+        other_project = project_service_module.create_project(
+            project_key="platform",
+            display_name="Platform",
+        )
+        prod_workspace = project_service_module.create_workspace(
+            project_key="payments",
+            workspace_key="prod",
+            display_name="Production",
+        )
+        staging_workspace = project_service_module.create_workspace(
+            project_key="payments",
+            workspace_key="staging",
+            display_name="Staging",
+        )
+        incident_service_module.ingest_incident_document(
+            "payments-prod.md",
+            "# Payments prod exposure\nSeverity: high\nPayment API ingress opened.",
+            project_id=self.project.id,
+            workspace_id=prod_workspace.id,
+        )
+        incident_service_module.ingest_incident_document(
+            "payments-staging.md",
+            "# Payments staging exposure\nSeverity: high\nPayment API ingress opened.",
+            project_id=self.project.id,
+            workspace_id=staging_workspace.id,
+        )
+        incident_service_module.ingest_incident_document(
+            "platform.md",
+            "# Platform exposure\nSeverity: high\nPlatform ingress opened.",
+            project_id=other_project.id,
+        )
+
+        prod_candidates = incident_matcher_module.load_incident_candidates(
+            project_id=self.project.id,
+            workspace_id=prod_workspace.id,
+        )
+        project_candidates = incident_matcher_module.load_incident_candidates(
+            project_id=self.project.id,
+        )
+
+        self.assertEqual(
+            [item["source_file"] for item in prod_candidates], ["payments-prod.md"]
+        )
+        self.assertEqual(
+            [item["source_file"] for item in project_candidates],
+            ["payments-prod.md", "payments-staging.md"],
+        )
 
     def test_ingest_plain_text_without_heading_or_severity_uses_fallbacks(self) -> None:
         result = incident_service_module.ingest_incident_document(
             "plain.txt",
             "Database access widened during deployment and required emergency rollback.",
+            project_id=self.project.id,
         )
         self.assertEqual(
             result["title"],
@@ -72,7 +144,7 @@ class IncidentServiceTests(unittest.TestCase):
         self.assertIsNone(result["incident_date"])
 
     def test_ingest_incident_document_can_reference_analysis_id(self) -> None:
-        project = project_service_module.ensure_default_project()
+        project = self.project
         report = report_service_module.persist_analysis_report(
             ParseBatchResult(
                 files=[
@@ -112,8 +184,9 @@ class IncidentServiceTests(unittest.TestCase):
         )
 
         self.assertEqual(result["analysis_id"], report["id"])
-        records = incident_service_module.get_incident_records()
+        records = incident_service_module.get_incident_records(project_id=project.id)
         self.assertEqual(records[0]["analysis_id"], report["id"])
+        self.assertEqual(records[0]["project_id"], project.id)
 
 
 if __name__ == "__main__":

--- a/tests/test_services/test_topology_service.py
+++ b/tests/test_services/test_topology_service.py
@@ -86,6 +86,136 @@ class TopologyServiceTests(unittest.TestCase):
         self.assertIsNone(default_topology)
         self.assertIn("not configured", default_warning)
 
+    def test_topology_imports_are_isolated_by_workspace(self) -> None:
+        project_service_module.create_project(
+            project_key="payments",
+            display_name="Payments",
+        )
+        prod_workspace = project_service_module.create_workspace(
+            project_key="payments",
+            workspace_key="prod",
+            display_name="Production",
+        )
+        staging_workspace = project_service_module.create_workspace(
+            project_key="payments",
+            workspace_key="staging",
+            display_name="Staging",
+        )
+        prod_path = Path(self.tempdir.name) / "prod-topology.json"
+        staging_path = Path(self.tempdir.name) / "staging-topology.json"
+        prod_path.write_text(
+            json.dumps(
+                {
+                    "services": [
+                        {
+                            "id": "prod-api",
+                            "label": "Prod API",
+                            "resource_keys": ["Deployment/prod-api"],
+                            "downstream": [],
+                        }
+                    ]
+                }
+            ),
+            encoding="utf-8",
+        )
+        staging_path.write_text(
+            json.dumps(
+                {
+                    "services": [
+                        {
+                            "id": "staging-api",
+                            "label": "Staging API",
+                            "resource_keys": ["Deployment/staging-api"],
+                            "downstream": [],
+                        }
+                    ]
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        import_topology_source(
+            "custom",
+            str(prod_path),
+            project_key="payments",
+            workspace_id=prod_workspace.id,
+        )
+        import_topology_source(
+            "custom",
+            str(staging_path),
+            project_key="payments",
+            workspace_id=staging_workspace.id,
+        )
+
+        prod_topology, _ = load_topology(
+            project_key="payments",
+            workspace_id=prod_workspace.id,
+        )
+        staging_topology, _ = load_topology(
+            project_key="payments",
+            workspace_id=staging_workspace.id,
+        )
+
+        assert prod_topology is not None
+        assert staging_topology is not None
+        self.assertEqual(prod_topology["services"][0]["id"], "prod-api")
+        self.assertEqual(staging_topology["services"][0]["id"], "staging-api")
+
+    def test_default_project_workspace_topology_does_not_update_legacy_file(
+        self,
+    ) -> None:
+        default_project = project_service_module.ensure_default_project()
+        workspace = project_service_module.create_workspace(
+            project_key=default_project.project_key,
+            workspace_key="prod",
+            display_name="Production",
+        )
+        topology_path = Path(self.tempdir.name) / "legacy-topology.json"
+        topology_path.write_text(
+            json.dumps(
+                {
+                    "services": [
+                        {
+                            "id": "legacy-api",
+                            "label": "Legacy API",
+                            "resource_keys": ["Deployment/legacy-api"],
+                            "downstream": [],
+                        }
+                    ]
+                }
+            ),
+            encoding="utf-8",
+        )
+        fake_settings = SimpleNamespace(topology_path=str(topology_path))
+
+        with patch("services.topology_service.settings", fake_settings):
+            save_topology_definition(
+                json.dumps(
+                    {
+                        "services": [
+                            {
+                                "id": "prod-api",
+                                "label": "Prod API",
+                                "resource_keys": ["Deployment/prod-api"],
+                                "downstream": [],
+                            }
+                        ]
+                    }
+                ),
+                project_id=default_project.id,
+                workspace_id=workspace.id,
+            )
+            project_topology, _ = load_topology(project_id=default_project.id)
+            workspace_topology, _ = load_topology(
+                project_id=default_project.id,
+                workspace_id=workspace.id,
+            )
+
+        assert project_topology is not None
+        assert workspace_topology is not None
+        self.assertEqual(project_topology["services"][0]["id"], "legacy-api")
+        self.assertEqual(workspace_topology["services"][0]["id"], "prod-api")
+
     def test_import_topology_source_reports_diff_and_discards_raw_source_fields(
         self,
     ) -> None:

--- a/tests/test_ui/test_history_page.py
+++ b/tests/test_ui/test_history_page.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import os
 import tempfile
 import unittest
+from datetime import UTC, datetime, timedelta
 from importlib import reload
 
 import app as app_module
@@ -409,7 +410,7 @@ class HistoryPageRenderingTests(unittest.TestCase):
         deployment_outcome_service_module.record_deployment_outcome(
             analysis_id=report["id"],
             outcome="failure",
-            deployed_at="2026-04-29T08:00:00Z",
+            deployed_at=(datetime.now(UTC) - timedelta(days=1)).isoformat(),
         )
 
         response = self.client.get("/history")


### PR DESCRIPTION
Story 1.4 scopes incidents, outcomes, feedback, topology, and matching inputs so learning/context records cannot bleed across projects or workspaces. The implementation keeps existing API, CLI, and service paths over shared persistence rules, and adds migration-time plus ORM-level constraints for workspace/project consistency.

Constraint: Story 1.4 requires project scope before persistence and optional workspace isolation where applicable
Rejected: Service-only workspace validation | database-level invariants are needed to defend repository/direct-write paths
Confidence: high
Scope-risk: moderate
Directive: Do not add learning/context persistence paths without validating scope in services and preserving DB project/workspace consistency
Tested: ./.venv/bin/ruff check .; ./.venv/bin/ruff format --check .; ./.venv/bin/python -m unittest discover -q -b; bash scripts/ci-local.sh
Not-tested: Bandit security scan; local CI skipped because Bandit is not installed

## What does this PR do?

<!-- Brief description of changes -->

## Type of change
- [ ] Feature (new functionality)
- [ ] Bugfix (non-breaking fix)
- [ ] Release preparation
- [ ] Hotfix (critical production fix)
- [ ] Docs / refactor / chore

## Checklist
- [ ] I have followed the branch naming convention
- [ ] Tests pass locally (`pytest tests/ -v`)
- [ ] Linting passes (`ruff check .`)
- [ ] Docker build succeeds
- [ ] I have updated docs if needed
- [ ] No secrets or .env values committed

## Related issue
Closes #