### PR TITLE
Clarify project scoping guidance for self-hosted operators

### DIFF
--- a/README.md
+++ b/README.md
@@ -504,6 +504,8 @@ Project documentation currently lives in a few places:
 - [UX Specification](./_bmad-output/planning-artifacts/ux-design-specification.md)
 - [Epics and Stories](./_bmad-output/planning-artifacts/epics.md)
 - [Implementation Readiness Report](./_bmad-output/planning-artifacts/implementation-readiness-report-2026-04-20.md)
+- [Project Model Guide](./docs/concepts/project-model.md)
+- [Project Workspaces](./docs/project-workspaces.md)
 - [Evidence Model Foundation](./docs/evidence-model.md)
 - [CI Guide](./docs/ci.md)
 - [CI Secrets Checklist](./docs/ci-secrets-checklist.md)

--- a/_bmad-output/implementation-artifacts/1-6-project-model-documentation.md
+++ b/_bmad-output/implementation-artifacts/1-6-project-model-documentation.md
@@ -1,0 +1,152 @@
+# Story 1.6: Project Model Documentation
+
+Status: done
+
+<!-- Generated from updated PRD/architecture/epics plus implementation-readiness-report-2026-05-01.md. -->
+
+## Story
+
+As a user deploying DeployWhisper,
+I want project modeling guidance,
+So that I can map monorepos, multi-repos, Terraform workspaces, Kubernetes clusters, and platform teams correctly.
+
+## Acceptance Criteria
+
+1. Given users read project model docs, When they compare deployment patterns, Then the docs explain recommended project/workspace mappings for common infrastructure setups. And examples remain self-hosted and do not assume a SaaS control plane.
+
+### Requirement Traceability
+
+- Primary PRD requirements: Epic 1 coverage: PRJ-01..10, HIS-08, NFR-SEC-07, DOC-22.
+- Supporting PRD / NFR / differentiation requirements: See `_bmad-output/planning-artifacts/prd.md`, `_bmad-output/planning-artifacts/architecture.md`, and `_bmad-output/planning-artifacts/implementation-readiness-report-2026-05-01.md`.
+- Coverage intent: Baseline + Delta.
+- Story alignment note: This story was created from the updated Epic 1 plan after the 2026-05-01 readiness rerun. The readiness report verified 187/187 PRD functional requirement IDs in the epics artifact, 38 NFR IDs present, and no critical or major readiness defects.
+
+## Tasks / Subtasks
+
+- [x] Implement and verify acceptance criterion 1. (AC: 1)
+- [x] Reuse existing services, repositories, schemas, and UI/CLI/API helpers before adding new abstractions. (AC: all)
+- [x] Add or update deterministic regression coverage for the changed behavior. (AC: all)
+- [x] Update relevant docs or examples if the story changes user-visible, operator, API, CLI, integration, or contribution behavior. (AC: all)
+- [x] Run required validation and record commands/results in the Dev Agent Record. (AC: all)
+
+### Review Findings
+
+- [x] [Review][Patch] Use the canonical DOC-22 project model path from planning artifacts [`docs/concepts/project-model.md:1`]
+- [x] [Review][Patch] Ensure docs regression tests are discovered by `python -m unittest discover -q` [`tests/test_docs/__init__.py:1`]
+- [x] [Review][Patch] Resolve cwd-sensitive docs test pathing [`tests/test_docs/test_project_model_documentation.py:9`]
+- [x] [Review][Patch] Strengthen regression coverage for actual mapping guidance and self-hosted/no-SaaS posture [`tests/test_docs/test_project_model_documentation.py:16`]
+- [x] [Review][Patch] Cover the new README and workspace documentation links [`tests/test_docs/test_project_model_documentation.py:62`]
+- [x] [Review][Patch] Document the GitHub project-key override needed for shared multi-repo project mapping [`docs/concepts/project-model.md:30`]
+- [x] [Review][Patch] Document that invalid `DEPLOYWHISPER_GITHUB_PROJECT_KEY` values fail instead of falling back to repo-derived keys [`docs/concepts/project-model.md:58`]
+- [x] [Review][Patch] Validate recommended-mappings table structure and columns in docs regression tests [`tests/test_docs/test_project_model_documentation.py:73`]
+- [x] [Review][Patch] Make link regression tests assert the intended README/workspace entry points, not only repeated href presence [`tests/test_docs/test_project_model_documentation.py:59`]
+- [x] [Review][Patch] Cover the README Project Workspaces link added by this story [`README.md:508`]
+- [x] [Review][Patch] Make invalid GitHub override docs assertion meaning-sensitive instead of newline-sensitive [`tests/test_docs/test_project_model_documentation.py:58`]
+- [x] [Review][Patch] Make recommended-mappings table parsing tolerant of harmless Markdown separator/header formatting [`tests/test_docs/test_project_model_documentation.py:91`]
+
+## Dev Notes
+
+### Epic Context
+
+- Epic: 1. Project, Workspace, and RBAC Foundation
+- Epic goal: Make DeployWhisper project-aware before reports, incidents, topology, scanner imports, and feedback become harder to migrate.
+- Epic coverage: PRJ-01..10, HIS-08, NFR-SEC-07, DOC-22
+
+### Architecture and Product Guardrails
+
+- Preserve DeployWhisper's local-first raw artifact boundary: raw IaC, scanner artifacts, incident exports, and sensitive context stay in the user's infrastructure by default.
+- Preserve the advisory-first core. Optional adapters may interpret report outputs, but canonical report semantics remain advisory unless explicit story scope says otherwise.
+- Reuse the shared analysis core and service layer before adapting UI, API, CLI, GitHub, or future workflow surfaces.
+- Keep Evidence Law behavior intact: no high or critical finding without deterministic evidence.
+- Keep project/workspace scope explicit for reports, incidents, topology, outcomes, feedback, scanner imports, and connector-related data.
+- Do not introduce new dependencies unless the active story explicitly requires and justifies them.
+
+### Source Tree Guidance
+
+- API routes belong under `api/routes/` and should use existing `ApiRoute` / `ApiError` envelope patterns.
+- Shared orchestration belongs in `services/`; parsers normalize input, analysis modules score/derive risk, and surfaces adapt outputs.
+- UI work belongs under `ui/routes/` and `ui/components/`, following the existing NiceGUI composition style.
+- CLI behavior belongs under `cli/` and must call the same service-layer paths as UI/API flows.
+- Persistence work belongs under `models/` with Alembic migrations when schema changes are required.
+- Documentation required by a story should be updated in the same workstream.
+
+### Testing Requirements
+
+- Use standard-library `unittest` in the existing `tests/test_*` layout.
+- Add focused regression tests for the layer changed by the story before broad refactors.
+- For Python changes, run `./.venv/bin/ruff check .`, `./.venv/bin/ruff format --check .`, and `./.venv/bin/python -m unittest discover -q` before closing implementation.
+- Use `bash scripts/ci-local.sh` for broader or cross-layer changes.
+
+### Project Structure Notes
+
+- Follow the current repository shape documented in `_bmad-output/project-context.md` and `AGENTS.md`.
+- If implementation reveals a conflict between this story and the current code baseline, keep the smallest compatible change and update the story notes rather than silently drifting from the PRD.
+
+### References
+
+- `_bmad-output/planning-artifacts/epics.md` - source Epic 1 / Story 1.6 definition.
+- `_bmad-output/planning-artifacts/prd.md` - functional and non-functional requirements.
+- `_bmad-output/planning-artifacts/architecture.md` - target architecture, boundaries, and guardrails.
+- `_bmad-output/planning-artifacts/ux-design-specification.md` - UX expectations for user-facing stories.
+- `_bmad-output/planning-artifacts/implementation-readiness-report-2026-05-01.md` - readiness verdict and residual story-format concern.
+- `_bmad-output/project-context.md` - repository-specific implementation rules.
+
+## Dev Agent Record
+
+### Agent Model Used
+
+GPT-5 Codex
+
+### Debug Log References
+
+- 2026-05-07: Started implementation on `feature/1-6-project-model-documentation`; sprint status moved to in-progress.
+- 2026-05-07: Red phase confirmed `./.venv/bin/python -m unittest tests.test_docs.test_project_model_documentation -q` failed because the project model guide was missing.
+- 2026-05-07: Green phase passed `./.venv/bin/python -m unittest tests.test_docs.test_project_model_documentation -q`.
+- 2026-05-07: Validation passed `./.venv/bin/ruff check .`.
+- 2026-05-07: Validation passed `./.venv/bin/ruff format --check .`.
+- 2026-05-07: Validation passed `./.venv/bin/python -m unittest discover -q` with 289 tests run and 1 skipped.
+- 2026-05-07: Fixed all Story 1.6 review findings: moved guide to canonical DOC-22 path, added GitHub multi-repo override guidance, and strengthened docs tests.
+- 2026-05-07: Review-fix validation passed `./.venv/bin/python -m unittest tests.test_docs.test_project_model_documentation -q` with 2 tests run.
+- 2026-05-07: Review-fix validation passed `./.venv/bin/ruff check .`.
+- 2026-05-07: Review-fix validation passed `./.venv/bin/ruff format --check .`.
+- 2026-05-07: Review-fix validation passed `./.venv/bin/python -m unittest discover -q` with 291 tests run and 1 skipped.
+- 2026-05-07: Fixed re-review findings: documented invalid GitHub override failure behavior, parsed recommended-mapping table structure in tests, and asserted exact documentation entry-point links.
+- 2026-05-07: Re-review fix validation passed `./.venv/bin/python -m unittest tests.test_docs.test_project_model_documentation -q` with 2 tests run.
+- 2026-05-07: Re-review fix validation passed `./.venv/bin/ruff check .`.
+- 2026-05-07: Re-review fix validation passed `./.venv/bin/ruff format --check .`.
+- 2026-05-07: Re-review fix validation passed `./.venv/bin/python -m unittest discover -q` with 291 tests run and 1 skipped.
+- 2026-05-07: Fixed latest re-review findings: README Project Workspaces link coverage, whitespace-normalized invalid GitHub override assertion, and tolerant recommended-mapping table parsing.
+- 2026-05-07: Latest re-review fix validation passed `./.venv/bin/python -m unittest tests.test_docs.test_project_model_documentation -q` with 2 tests run.
+- 2026-05-07: Latest re-review fix validation passed `./.venv/bin/ruff check .`.
+- 2026-05-07: Latest re-review fix validation passed `./.venv/bin/ruff format --check .`.
+- 2026-05-07: Latest re-review fix validation passed `./.venv/bin/python -m unittest discover -q` with 291 tests run and 1 skipped.
+- 2026-05-07: Final Story 1.6 closeout review found no accepted findings; story status moved to done.
+
+### Completion Notes List
+
+- Added a project modeling guide covering common self-hosted setup patterns and recommended project/workspace mappings.
+- Linked the guide from project workspace documentation and the README documentation index.
+- Added deterministic docs regression coverage for the required guide sections and self-hosted pattern language.
+- Resolved review findings by using the canonical DOC-22 docs path, documenting GitHub multi-repo override behavior, and ensuring docs regression tests run under standard discovery.
+- Resolved re-review findings by documenting invalid GitHub override behavior and tightening docs tests for table structure plus intended entry-point links.
+- Resolved latest re-review findings by asserting the README workspace entry point, making invalid override coverage meaning-based, and allowing harmless Markdown table formatting changes.
+- Completed closeout after final review triage left no accepted findings.
+
+### File List
+
+- `README.md`
+- `docs/concepts/project-model.md`
+- `docs/project-workspaces.md`
+- `tests/test_docs/__init__.py`
+- `tests/test_docs/test_project_model_documentation.py`
+- `_bmad-output/implementation-artifacts/sprint-status.yaml`
+- `_bmad-output/implementation-artifacts/1-6-project-model-documentation.md`
+
+## Change Log
+
+- 2026-05-01: Story created/aligned from updated PRD, architecture, epics, sprint status, and readiness report.
+- 2026-05-07: Implemented project modeling documentation and verification coverage; story moved to review.
+- 2026-05-07: Fixed Story 1.6 code-review findings and revalidated.
+- 2026-05-07: Fixed Story 1.6 re-review findings and revalidated.
+- 2026-05-07: Fixed latest Story 1.6 re-review findings and revalidated focused docs checks, lint, formatting, and full unittest discovery.
+- 2026-05-07: Closed Story 1.6 after final review triage accepted no findings.

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -55,7 +55,7 @@ development_status:
   1-3-project-scoped-report-persistence: done
   1-4-project-scoped-learning-and-context-records: done
   1-5-lightweight-rbac-role-model: done
-  1-6-project-model-documentation: ready-for-dev
+  1-6-project-model-documentation: done
   epic-1-retrospective: optional
 
   epic-2: in-progress

--- a/docs/concepts/project-model.md
+++ b/docs/concepts/project-model.md
@@ -1,0 +1,122 @@
+## Project Model Guide
+
+DeployWhisper uses projects and workspaces to keep reports, topology, outcomes,
+feedback, and future connector data scoped to the right operational boundary.
+This guide helps self-hosted operators choose those boundaries before shared
+usage hardens.
+
+DeployWhisper does not require a SaaS control plane. The examples below assume a
+self-hosted install where your own UI, API, CLI, GitHub integration, or trusted
+internal automation supplies project and workspace keys.
+
+### Modeling Rules
+
+- Use a project for the durable ownership and context boundary: product, service
+  group, repository group, platform area, or deployment domain.
+- Use a workspace for deployable variants inside that boundary: environment,
+  Terraform workspace, Kubernetes cluster, namespace, cloud account, region, or
+  GitOps application.
+- Keep one project when the same owners, incidents, topology, retention, and
+  review expectations apply.
+- Split projects when teams should not see each other's reports, incidents,
+  topology, deployment outcomes, or future connector credentials.
+- Prefer stable lowercase keys such as `payments-api`, `platform-networking`,
+  `prod-us-east`, or `cluster-blue`. Renaming a project later is more expensive
+  once reports and outcomes depend on it.
+
+### Recommended Mappings
+
+| Infrastructure setup | Recommended project mapping | Recommended workspace mapping | Example keys |
+| --- | --- | --- | --- |
+| Monorepo with several services owned by one platform or product group | Use one project for the repository or product area when incidents, topology, and review ownership are shared. Split into multiple projects only when service groups require separate access boundaries. | Use workspaces for environments, deploy targets, or service slices that need separate history filters. | Project `commerce-platform`; workspaces `checkout-prod`, `catalog-prod`, `shared-staging` |
+| Multi-repo product with one deployment domain | Use one project for the product or service group, even when source lives in multiple repositories. This keeps cross-repo reports, topology, and outcomes together. For GitHub App automation across several repositories, set `DEPLOYWHISPER_GITHUB_PROJECT_KEY` to the shared project key instead of relying on the repo-derived default. | Use workspaces for environment, account, region, or deployment lane. | Project `payments`; workspaces `dev`, `staging`, `prod-us-east` |
+| Independent multi-repo services with different owners | Use one project per service or bounded context so reports and feedback do not leak across teams. Repo-derived GitHub project keys are a reasonable default for this pattern. | Use each service's environment, account, namespace, or region as the workspace. | Projects `billing-api`, `ledger-worker`; workspaces `prod`, `staging` |
+| Terraform workspace based delivery | Use a project for the Terraform stack or platform domain. Avoid making every Terraform workspace a project unless ownership or visibility differs. | Map each Terraform workspace to a DeployWhisper workspace. | Project `platform-networking`; workspaces `tf-dev`, `tf-staging`, `tf-prod` |
+| Kubernetes cluster based delivery | Use a project for the application group, cluster ownership area, or platform capability. Split projects when cluster teams and app teams need separate report boundaries. | Map clusters, namespaces, or GitOps applications to workspaces depending on how deployments are reviewed. | Project `customer-portal`; workspaces `cluster-blue`, `cluster-green`, `prod-namespace` |
+| Platform team shared infrastructure | Use one project per platform capability when context and credentials should stay separate, such as networking, identity, observability, or CI/CD. | Use workspaces for cloud accounts, clusters, regions, or maturity stages. | Projects `platform-identity`, `platform-observability`; workspaces `prod-account`, `sandbox-account` |
+
+### Pattern Guidance
+
+#### Monorepo
+
+For a monorepo, start with the smallest number of projects that preserves review
+ownership. A single project works well when the repository has shared platform
+ownership and a common topology graph. Add workspaces for deployable service
+slices or environments when users need filtered history without separate
+authorization boundaries.
+
+Use separate projects inside a monorepo when service teams should not see each
+other's reports or when incidents, scanner imports, topology, and deployment
+outcomes are managed independently.
+
+#### Multi-Repo
+
+For a multi-repo product, choose the project boundary by operational domain, not
+by Git repository count. Several repositories can share one project when they
+ship one product or depend on the same incident memory and topology context.
+
+When using the GitHub App integration for a shared multi-repo project, set
+`DEPLOYWHISPER_GITHUB_PROJECT_KEY` in that automation path. Without the
+override, the integration derives an owner-safe project key from each repository
+slug, which is better suited to independent service projects.
+Treat the override as required configuration when present: an unknown, malformed,
+or blank project key stops GitHub artifact loading and analysis instead of
+falling back to the repo-derived default.
+
+Use separate projects for independent services, regulated domains, or platform
+areas with different maintainers. This keeps future RBAC, retention, connector
+credentials, and report search boundaries clear.
+
+#### Terraform Workspaces
+
+Treat a Terraform workspace as a DeployWhisper workspace when it represents an
+environment, account, region, or tenant under one stack. This keeps plan history
+and outcomes grouped under the owning project while still allowing `dev`,
+`staging`, and `prod` filtering.
+
+Create separate DeployWhisper projects only when Terraform workspaces represent
+separate ownership boundaries rather than deployment variants.
+
+#### Kubernetes Clusters
+
+For Kubernetes, decide whether reviewers reason about risk by application,
+cluster, namespace, or GitOps application. Use that decision to pick workspace
+keys. For example, an application team might use one project with `dev-cluster`
+and `prod-cluster` workspaces, while a platform team might use one project per
+cluster capability.
+
+Keep topology imports aligned with the same project/workspace choice so blast
+radius and context freshness remain understandable.
+
+#### Platform Teams
+
+Platform teams often own shared infrastructure where cross-service context is the
+point. Model each platform capability as its own project when credentials,
+topology, or incident history must remain distinct. Use workspaces for accounts,
+regions, clusters, or rollout stages.
+
+When a platform team supports many application teams, avoid a single global
+catch-all project unless all participants should share the same reports and
+outcomes. Separate projects make future RBAC and connector scoping safer.
+
+### Self-Hosted Authorization Notes
+
+In local self-hosted mode, omitted lightweight actor headers and CLI actor
+environment variables preserve admin behavior. Before exposing project-scoped
+APIs in a shared self-hosted install, put DeployWhisper behind a trusted identity
+layer, proxy, or middleware that strips caller-supplied actor headers and injects
+verified role and project scope.
+
+This keeps DeployWhisper local-first while making the future path to shared-team
+RBAC explicit.
+
+### Quick Checklist
+
+- Can every report, topology import, deployment outcome, and feedback event name
+  exactly one project?
+- Are workspaces deployment variants inside the same ownership boundary?
+- Would two teams be surprised to see each other's reports? If yes, use separate
+  projects.
+- Would two environments share incident memory and topology? If yes, use
+  workspaces under one project.
+- Are project and workspace keys stable enough for API, CLI, and automation use?

--- a/docs/project-workspaces.md
+++ b/docs/project-workspaces.md
@@ -2,6 +2,8 @@
 
 DeployWhisper now scopes analyses and topology context to lightweight project/workspace records instead of treating all history as one global pile.
 
+For setup-specific modeling guidance, see the [Project Model Guide](./concepts/project-model.md).
+
 ### What Changed
 
 - Projects have a stable `project_key`, display name, optional description, repository URL, and default branch.

--- a/tests/test_docs/__init__.py
+++ b/tests/test_docs/__init__.py
@@ -1,0 +1,1 @@
+"""Documentation regression tests."""

--- a/tests/test_docs/test_project_model_documentation.py
+++ b/tests/test_docs/test_project_model_documentation.py
@@ -1,0 +1,156 @@
+"""Tests for project model documentation coverage."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import re
+
+import unittest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+PROJECT_MODEL_GUIDE = REPO_ROOT / "docs" / "concepts" / "project-model.md"
+
+
+class ProjectModelDocumentationTests(unittest.TestCase):
+    def test_project_modeling_guide_covers_common_self_hosted_mappings(self) -> None:
+        self.assertTrue(PROJECT_MODEL_GUIDE.exists(), "Project model guide is missing.")
+        content = PROJECT_MODEL_GUIDE.read_text(encoding="utf-8").lower()
+
+        self.assertIn("does not require a saas control plane", content)
+        self.assertIn("self-hosted install", content)
+
+        expected_mappings = {
+            "monorepo with several services owned by one platform or product group": [
+                "use one project for the repository or product area",
+                "use workspaces for environments, deploy targets, or service slices",
+            ],
+            "multi-repo product with one deployment domain": [
+                "use one project for the product or service group",
+                "deploywhisper_github_project_key",
+                "use workspaces for environment, account, region, or deployment lane",
+            ],
+            "independent multi-repo services with different owners": [
+                "use one project per service or bounded context",
+                "repo-derived github project keys are a reasonable default",
+            ],
+            "terraform workspace based delivery": [
+                "use a project for the terraform stack or platform domain",
+                "map each terraform workspace to a deploywhisper workspace",
+            ],
+            "kubernetes cluster based delivery": [
+                "use a project for the application group",
+                "map clusters, namespaces, or gitops applications to workspaces",
+            ],
+            "platform team shared infrastructure": [
+                "use one project per platform capability",
+                "use workspaces for cloud accounts, clusters, regions, or maturity stages",
+            ],
+        }
+        for setup, expected_phrases in expected_mappings.items():
+            with self.subTest(setup=setup):
+                row = self._recommended_mapping_rows(content)[setup]
+                for phrase in expected_phrases:
+                    self.assertIn(phrase, " ".join(row.values()))
+
+        self.assertIn("| infrastructure setup |", content)
+        self.assertIn("| recommended project mapping |", content)
+        self.assertIn("| recommended workspace mapping |", content)
+        self.assertIn(
+            "unknown, malformed, or blank project key stops github artifact loading",
+            self._squash_whitespace(content),
+        )
+
+    def test_documentation_links_point_to_project_model_guide(self) -> None:
+        link_expectations = {
+            REPO_ROOT / "README.md": (
+                {
+                    "Project Model Guide": "./docs/concepts/project-model.md",
+                    "Project Workspaces": "./docs/project-workspaces.md",
+                },
+            ),
+            REPO_ROOT / "docs" / "project-workspaces.md": (
+                {"Project Model Guide": "./concepts/project-model.md"},
+            ),
+        }
+
+        for source, (expected_links,) in link_expectations.items():
+            with self.subTest(source=source.name):
+                content = source.read_text(encoding="utf-8")
+                actual_links = dict(self._markdown_links(content))
+                for label, expected_href in expected_links.items():
+                    with self.subTest(label=label):
+                        self.assertEqual(expected_href, actual_links.get(label))
+                        target = (source.parent / expected_href).resolve()
+                        self.assertTrue(target.exists())
+
+                model_target = (
+                    source.parent / expected_links["Project Model Guide"]
+                ).resolve()
+                self.assertEqual(PROJECT_MODEL_GUIDE, model_target)
+
+    @staticmethod
+    def _markdown_links(content: str) -> list[tuple[str, str]]:
+        return re.findall(r"\[([^\]]+)\]\(([^)]+)\)", content)
+
+    @staticmethod
+    def _recommended_mapping_rows(content: str) -> dict[str, dict[str, str]]:
+        lines = content.splitlines()
+        expected_headers = [
+            "infrastructure setup",
+            "recommended project mapping",
+            "recommended workspace mapping",
+            "example keys",
+        ]
+        header_index = next(
+            (
+                index
+                for index, line in enumerate(lines)
+                if ProjectModelDocumentationTests._table_cells(line) == expected_headers
+            ),
+            None,
+        )
+        if header_index is None:
+            raise AssertionError("Recommended mappings table header is missing.")
+
+        headers = ProjectModelDocumentationTests._table_cells(lines[header_index])
+        separator = ProjectModelDocumentationTests._table_cells(lines[header_index + 1])
+        if headers != expected_headers or not all(
+            ProjectModelDocumentationTests._is_separator_cell(cell)
+            for cell in separator
+        ):
+            raise AssertionError("Recommended mappings table header is malformed.")
+
+        rows: dict[str, dict[str, str]] = {}
+        for line in lines[header_index + 2 :]:
+            if not line.startswith("| "):
+                break
+            cells = ProjectModelDocumentationTests._table_cells(line)
+            if len(cells) != len(expected_headers):
+                raise AssertionError(f"Malformed recommended mapping row: {line!r}")
+            row = dict(zip(expected_headers, cells, strict=True))
+            rows[row["infrastructure setup"]] = row
+
+        if len(rows) != 6:
+            raise AssertionError("Recommended mappings table must contain six rows.")
+        return rows
+
+    @staticmethod
+    def _table_cells(line: str) -> list[str]:
+        if not line.lstrip().startswith("|"):
+            return []
+        return [
+            re.sub(r"\s+", " ", cell.strip()).lower()
+            for cell in re.split(r"(?<!\\)\|", line.strip().strip("|"))
+        ]
+
+    @staticmethod
+    def _is_separator_cell(cell: str) -> bool:
+        return bool(re.fullmatch(r":?-{3,}:?", cell))
+
+    @staticmethod
+    def _squash_whitespace(content: str) -> str:
+        return re.sub(r"\s+", " ", content).strip()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Story 1.6 needed a durable project model guide so operators can map monorepos, multi-repo products, Terraform workspaces, Kubernetes clusters, and platform teams without assuming a SaaS control plane. The implementation keeps the change documentation-only, links the guide from the existing docs entry points, and adds regression coverage for the required guidance and links.

Constraint: DOC-22 requires docs/concepts/project-model.md as the canonical guide path
Rejected: Add a new runtime modeling abstraction | story scope is documentation guidance only
Confidence: high
Scope-risk: narrow
Directive: Keep project modeling examples self-hosted and aligned with local-first project/workspace behavior
Tested: ./.venv/bin/python -m unittest tests.test_docs.test_project_model_documentation -q
Tested: ./.venv/bin/ruff check .
Tested: ./.venv/bin/ruff format --check .
Tested: ./.venv/bin/python -m unittest discover -q (291 tests, 1 skipped)
Not-tested: bash scripts/ci-local.sh

## What does this PR do?

<!-- Brief description of changes -->

## Type of change
- [ ] Feature (new functionality)
- [ ] Bugfix (non-breaking fix)
- [ ] Release preparation
- [ ] Hotfix (critical production fix)
- [ ] Docs / refactor / chore

## Checklist
- [ ] I have followed the branch naming convention
- [ ] Tests pass locally (`pytest tests/ -v`)
- [ ] Linting passes (`ruff check .`)
- [ ] Docker build succeeds
- [ ] I have updated docs if needed
- [ ] No secrets or .env values committed

## Related issue
Closes #