### PR TITLE
Accept Terraform plans as defensible evidence

### DIFF
--- a/.agents/skills/bmad-create-story/checklist.md
+++ b/.agents/skills/bmad-create-story/checklist.md
@@ -156,6 +156,7 @@ You will systematically re-do the entire story creation process, but with a crit
 - **Breaking changes:** Missing requirements that could break existing functionality
 - **Test failures:** Missing test requirements that could allow bugs to reach production
 - **UX violations:** Missing user experience requirements that could ruin the product
+- **UI validation omissions:** Missing Playwright/browser validation task for stories that change UI routes, NiceGUI components, rendered report/history/dashboard surfaces, browser interactions, keyboard behavior, or accessibility semantics
 - **Learning failures:** Missing previous story context that could repeat same mistakes
 
 #### **3.5 Implementation DISASTERS**

--- a/.agents/skills/bmad-create-story/template.md
+++ b/.agents/skills/bmad-create-story/template.md
@@ -27,12 +27,15 @@ so that {{benefit}}.
   - [ ] Subtask 1.1
 - [ ] Task 2 (AC: #)
   - [ ] Subtask 2.1
+- [ ] UI validation gate (AC: UI-facing ACs, if applicable)
+  - [ ] If this story changes any UI route, NiceGUI component, rendered report/history/dashboard surface, browser interaction, keyboard behavior, or accessibility semantics, add or update Playwright coverage and run the relevant browser validation before review. Use `npm run test:ui-review` for review/report flows, `RUN_UI_A11Y=1 bash scripts/ci-local.sh` when the full local UI lane is needed, and `npm run test:ui-review:voiceover` on macOS for screen-reader or keyboard/a11y semantics. If no UI surface is touched, record "UI validation not applicable" in the Dev Agent Record.
 
 ## Dev Notes
 
 - Relevant architecture patterns and constraints
 - Source tree components to touch
 - Testing standards summary
+- UI validation requirement: UI-facing stories must be validated in a real browser with Playwright before moving to review; do not close UI work with only Python/unit tests.
 
 ### Project Structure Notes
 

--- a/.agents/skills/bmad-dev-story/checklist.md
+++ b/.agents/skills/bmad-dev-story/checklist.md
@@ -16,6 +16,7 @@ validation-rules:
   - 'All implementation requirements from story Dev Notes must be satisfied'
   - 'Definition of Done checklist must pass completely'
   - 'Enhanced story context must contain sufficient technical guidance'
+  - 'UI-facing stories must include recorded Playwright browser validation, or an explicit UI-not-applicable note'
 ---
 
 # 🎯 Enhanced Definition of Done Checklist
@@ -42,6 +43,7 @@ validation-rules:
 - [ ] **Unit Tests:** Unit tests added/updated for ALL core functionality introduced/changed by this story
 - [ ] **Integration Tests:** Integration tests added/updated for component interactions when story requirements demand them
 - [ ] **End-to-End Tests:** End-to-end tests created for critical user flows when story requirements specify them
+- [ ] **UI Browser Validation:** If the story changes any UI route, NiceGUI component, rendered report/history/dashboard surface, browser interaction, keyboard behavior, or accessibility semantics, Playwright browser validation was run and recorded in the Dev Agent Record. If no UI was touched, the Dev Agent Record explicitly says "UI validation not applicable."
 - [ ] **Test Coverage:** Tests cover acceptance criteria and edge cases from story Dev Notes
 - [ ] **Regression Prevention:** ALL existing tests pass (no regressions introduced)
 - [ ] **Code Quality:** Linting and static checks pass when configured in project

--- a/.agents/skills/bmad-dev-story/workflow.md
+++ b/.agents/skills/bmad-dev-story/workflow.md
@@ -298,6 +298,7 @@ Load config from `{project-root}/_bmad/bmm/config.yaml` and resolve:
     <action>Create unit tests for business logic and core functionality introduced/changed by the task</action>
     <action>Add integration tests for component interactions specified in story requirements</action>
     <action>Include end-to-end tests for critical user flows when story requirements demand them</action>
+    <action>If the story changes any UI route, NiceGUI component, rendered report/history/dashboard surface, browser interaction, keyboard behavior, or accessibility semantics, add or update Playwright browser validation for that flow. Use API/database/test fixtures for setup; use the browser only to validate the user-visible behavior.</action>
     <action>Cover edge cases and error handling scenarios identified in story Dev Notes</action>
   </step>
 
@@ -307,9 +308,11 @@ Load config from `{project-root}/_bmad/bmm/config.yaml` and resolve:
     <action>Run the new tests to verify implementation correctness</action>
     <action>Run linting and code quality checks if configured in project</action>
     <action>Run repo-configured security checks for touched code when available (for Python, include Bandit if configured)</action>
+    <action>If UI-facing files or browser-visible behavior changed, run Playwright browser validation before review. For this repo, use `npm run test:ui-review` for review/report flows, `RUN_UI_A11Y=1 bash scripts/ci-local.sh` when the full local UI lane is needed, and `npm run test:ui-review:voiceover` on macOS when keyboard or screen-reader semantics changed. If a UI story has no applicable browser check, record the reason explicitly in the Dev Agent Record instead of silently skipping it.</action>
     <action>Validate implementation meets ALL story acceptance criteria; enforce quantitative thresholds explicitly</action>
     <action if="regression tests fail">STOP and fix before continuing - identify breaking changes immediately</action>
     <action if="new tests fail">STOP and fix before continuing - ensure implementation correctness</action>
+    <action if="required UI Playwright validation fails or is skipped without a documented non-applicability reason">STOP and fix before continuing</action>
   </step>
 
   <step n="8" goal="Validate and mark task complete ONLY when fully done">
@@ -377,6 +380,7 @@ Load config from `{project-root}/_bmad/bmm/config.yaml` and resolve:
       - Unit tests for core functionality added/updated
       - Integration tests for component interactions added when required
       - End-to-end tests for critical flows added when story demands them
+      - UI-facing changes validated in a browser with Playwright, with command/result recorded; or Dev Agent Record explicitly states UI validation was not applicable
       - All tests pass (no regressions, new tests successful)
       - Code quality checks pass (linting, static analysis if configured)
       - Security checks pass for touched code when configured (for Python, Bandit where available)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -109,6 +109,11 @@ Minimum expectations:
   - `bash scripts/ci-local.sh`
 - If the app behavior changed, run the app locally when possible:
   - `python app.py`
+- If a story changes any UI route, NiceGUI component, rendered report/history/dashboard surface, browser interaction, keyboard behavior, or accessibility semantics, run browser-side Playwright validation and record the command/result in the story Dev Agent Record before moving the story to review:
+  - `npm run test:ui-review` for review/report flows
+  - `RUN_UI_A11Y=1 bash scripts/ci-local.sh` when the full local UI lane is needed
+  - `npm run test:ui-review:voiceover` on macOS for screen-reader or keyboard/a11y semantics
+  - If no UI surface is touched, record `UI validation not applicable` instead of silently skipping UI validation.
 - If dependencies are not installed, bootstrap locally:
   - `python3 -m venv .venv`
   - `source .venv/bin/activate`

--- a/_bmad-output/implementation-artifacts/2-2-terraform-plan-json-intake.md
+++ b/_bmad-output/implementation-artifacts/2-2-terraform-plan-json-intake.md
@@ -1,0 +1,284 @@
+# Story 2.2: Terraform Plan JSON Intake
+
+Status: review
+
+<!-- Generated from updated PRD/architecture/epics plus implementation-readiness-report-2026-05-01.md. -->
+
+## Story
+
+As a platform engineer,
+I want Terraform plan JSON accepted as a first-class input,
+So that deployment review can use concrete planned changes instead of only source files.
+
+## Acceptance Criteria
+
+1. Given a Terraform plan JSON file is submitted, When intake and parsing run, Then plan actions, resources, modules, and relevant metadata are normalized into the shared change model. And unsupported or redacted plan fields are reported explicitly.
+
+### Requirement Traceability
+
+- Primary PRD requirements: Epic 2 coverage: ING-01..09, EVD-01..12, RSK-01..10, HIS-01..02, NFR-SEC-01..06, NFR-REL-01..04.
+- Supporting PRD / NFR / differentiation requirements: See `_bmad-output/planning-artifacts/prd.md`, `_bmad-output/planning-artifacts/architecture.md`, and `_bmad-output/planning-artifacts/implementation-readiness-report-2026-05-01.md`.
+- Coverage intent: Baseline + Delta.
+- Story alignment note: This story was created from the updated Epic 2 plan after the 2026-05-01 readiness rerun. The readiness report verified 187/187 PRD functional requirement IDs in the epics artifact, 38 NFR IDs present, and no critical or major readiness defects.
+
+## Tasks / Subtasks
+
+- [x] Implement and verify acceptance criterion 1. (AC: 1)
+- [x] Reuse existing services, repositories, schemas, and UI/CLI/API helpers before adding new abstractions. (AC: all)
+- [x] Add or update deterministic regression coverage for the changed behavior. (AC: all)
+- [x] Update relevant docs or examples if the story changes user-visible, operator, API, CLI, integration, or contribution behavior. (AC: all)
+- [x] Run required validation and record commands/results in the Dev Agent Record. (AC: all)
+
+### Review Findings
+
+- [x] [Review][Patch] Valid all-`no-op` Terraform plans fail parsing [parsers/terraform_parser.py:158] — fixed by preserving `no-op` resource changes as normalized plan entries and scoring them as no planned change.
+- [x] [Review][Patch] Module-scoped resources lose resource-specific summaries [parsers/terraform_parser.py:39] — fixed by classifying Terraform plan summaries from the resource `type`, even when the address is module-scoped.
+- [x] [Review][Patch] CLI output metadata contract lacks direct regression coverage [tests/test_cli/test_analyze.py:566] — fixed with direct CLI parse-batch metadata assertions.
+- [x] [Review][Patch] Top-level Terraform plan metadata and unsupported sections are silently dropped [parsers/terraform_parser.py:191] — fixed by carrying plan format/Terraform versions and reporting unsupported top-level sections as `plan.<field>`.
+- [x] [Review][Patch] Terraform replacement actions normalize as pure destroys in downstream risk/evidence layers [analysis/risk_scorer.py:121] — fixed by normalizing delete/create replacement actions as `replace` in risk scoring and evidence hints.
+- [x] [Review][Patch] Terraform data-source read actions score as infrastructure modifications [analysis/risk_scorer.py:121] — fixed by treating `read` as a non-mutating low-risk action in risk scoring and evidence hints.
+- [x] [Review][Patch] Terraform `no-op` blast-radius text can imply downstream impact when topology matches [analysis/risk_scorer.py:371] — fixed by returning no-planned-change blast-radius text before topology-specific messaging.
+- [x] [Review][Patch] Terraform replacement and mixed destructive actions are still not canonical at the shared change-model boundary [parsers/terraform_parser.py:220] — fixed by canonicalizing Terraform actions into the shared change model while preserving raw action lists in metadata.
+- [x] [Review][Patch] Terraform metadata details are duplicated into persisted and LLM-visible summary text [parsers/terraform_parser.py:192] — fixed by keeping plan metadata structured in `UnifiedChange.metadata` and removing metadata expansion from summaries.
+- [x] [Review][Patch] Module-scoped non-allowlisted resources are still summarized as module-level changes [parsers/terraform_parser.py:79] — fixed by treating module-scoped addresses with a resource `type` as resources, not module-level changes.
+- [x] [Review][Patch] Root-scope Terraform unknown/sensitive markers are silently dropped [parsers/terraform_parser.py:88] — fixed by reporting root-level markers as `<root>`.
+- [x] [Review][Patch] Non-mutating `no-op`/`read` reasoning can still imply downstream impact when topology matches [analysis/risk_scorer.py:400] — fixed by using non-mutating blast-radius reasoning before topology downstream-impact text.
+- [x] [Review][Patch] Composite action downgrades can hide destructive changes [analysis/risk_scorer.py:124] — fixed by centralizing shared action normalization and only treating `no-op`/`read` as non-mutating when they are the sole action.
+- [x] [Review][Patch] Non-mutating Terraform plan entries still produce blast-radius impact [analysis/blast_radius.py:64] — fixed by filtering non-mutating changes out of blast-radius traversal and unmatched-resource warnings.
+- [x] [Review][Patch] Rollback guidance does not understand the new Terraform action vocabulary [analysis/rollback_planner.py:46] — fixed by skipping non-mutating changes and treating `replace` as destructive for rollback priority, criticality, estimates, and complexity.
+- [x] [Review][Patch] Interaction-risk scoring can be fabricated from non-mutating Terraform entries [analysis/interaction_risk.py:68] — fixed by excluding non-mutating changes from cross-tool interaction grouping.
+- [x] [Review][Patch] Missing or unknown Terraform action lists are coerced into mutating `modify` changes [parsers/base.py:54] — fixed by requiring non-empty known Terraform plan actions before creating normalized changes, with explicit parser failures for missing or unsupported action lists.
+- [x] [Review][Patch] Terraform plan entries without an address are normalized as fake `unknown` resources [parsers/terraform_parser.py:198] — fixed by validating resource-change addresses and rejecting missing or blank addresses instead of manufacturing an `unknown` resource.
+- [x] [Review][Patch] Malformed supported metadata shapes are silently dropped instead of reported explicitly [parsers/terraform_parser.py:105] — fixed by reporting invalid supported metadata shapes as `change.<field>.invalid` unsupported-field markers while preserving safe normalized metadata values.
+- [x] [Review][Patch] Zero-diff Terraform plan JSON files are rejected instead of accepted as first-class plan input [parsers/registry.py:136] — fixed by emitting a plan-level `no-op` normalized entry for valid Terraform plan JSON files with empty `resource_changes`.
+- [x] [Review][Patch] LLM-assisted scoring reintroduces risk points for non-mutating `no-op` and `read` entries [analysis/risk_scorer.py:628] — fixed by centralizing contribution calculation and forcing non-mutating contributors to remain low severity with zero contribution after LLM scoring.
+- [x] [Review][Patch] Read-only typed Terraform resources can still get mutating summaries [parsers/terraform_parser.py:47] — fixed by short-circuiting `read` summaries before resource-type-specific mutating summary text.
+- [x] [Review][Patch] Terraform replacement actions still classify as medium-risk `go` findings despite destructive replacement semantics [analysis/risk_scorer.py:45] — fixed by classifying replacement actions as high-risk in risk/evidence scoring and applying destructive-critical/production semantics.
+- [x] [Review][Patch] Non-mutating Terraform `no-op` and `read` entries can still force a `no-go` recommendation through raw-file security flags [analysis/risk_scorer.py:459] — fixed by bypassing raw-file security flags for `no-op` and `read` contributors.
+- [x] [Review][Patch] LLM-assisted scoring can still replace deterministic non-mutating reasoning with high-risk wording [analysis/risk_scorer.py:621] — fixed by preserving deterministic non-mutating reasoning while still recording LLM scoring source metadata.
+- [x] [Review][Patch] UI upload results do not explicitly display Terraform plan metadata [ui/components/upload_panel.py:588] — fixed by passing parse batches into upload results and rendering Terraform module, replacement, unknown, redacted, and unsupported metadata.
+- [x] [Review][Patch] Persisted report and history surfaces drop Terraform plan metadata after intake [services/report_service.py:1475] — fixed by carrying parser metadata into risk contributors, API schemas, persisted report payloads, and history/report detail surfaces.
+- [x] [Review][Patch] Terraform plan JSON without `resource_changes` is accepted as a synthetic no-op plan [parsers/terraform_parser.py:263] — fixed by requiring `resource_changes` to be present and only synthesizing no-op for an explicit empty list.
+- [x] [Review][Patch] Non-native or contradictory Terraform action sets can be accepted and silently normalized [parsers/terraform_parser.py:20] — fixed by validating native Terraform plan action vocabulary and supported action combinations before normalization.
+- [x] [Review][Patch] Parser metadata is threaded through API/persistence/UI without JSON-safety validation [parsers/base.py:32] — fixed by sanitizing parser metadata to JSON-safe primitives and containers at the shared change-model boundary.
+- [x] [Review][Patch] All-non-mutating Terraform plans still invoke LLM scoring and can emit irrelevant provider-failure warnings [analysis/risk_scorer.py:716] — fixed by short-circuiting LLM scoring when every contributor is `no-op` or `read`.
+- [x] [Review][Patch] UI/report metadata rendering truncates explicit redacted and unsupported Terraform field lists [ui/components/change_table.py:10] — fixed by rendering full redacted and unsupported field lists while keeping less critical metadata compact.
+- [x] [Review][Patch] Upload feedback rerender drops the parse-batch metadata table [ui/components/upload_panel.py:451] — fixed by preserving and passing the current parse batch on feedback-triggered result rerenders.
+- [x] [Review][Patch] Review-facing UI validation was not recorded for the metadata rendering changes [_bmad-output/project-context.md:73] — fixed by running and recording `npm run test:ui-review` for the changed review surfaces.
+- [x] [Review][Patch] Terraform resource addresses are validated with trim semantics but returned untrimmed [parsers/terraform_parser.py:168] — fixed by returning canonical stripped resource addresses and adding padded-address parser coverage.
+- [x] [Review][Patch] Duplicate Terraform action entries are accepted because validation collapses actions through a set [parsers/terraform_parser.py:150] — fixed by rejecting duplicate action entries before supported-action-set normalization.
+- [x] [Review][Patch] Plan-scoped unsupported fields are duplicated onto every per-resource metadata record [parsers/terraform_parser.py:198] — fixed by separating plan-level unsupported fields into `plan_unsupported_fields` and attaching them once per parsed plan.
+- [x] [Review][Patch] Upload-panel metadata rerender coverage inspects source text instead of runtime behavior [tests/test_ui/test_upload_panel.py:208] — fixed by extracting and behavior-testing the feedback rerender callback that preserves parse-batch metadata.
+- [x] [Review][Patch] Non-mutating Terraform plan entries still emit evidence items for no-change inputs [evidence/extractor.py:96] — fixed by suppressing Terraform `no-op` and `read` entries at evidence extraction while preserving them in parse-batch metadata.
+- [x] [Review][Patch] Upload change table can flood review results with non-mutating Terraform `no-op` and `read` entries [ui/components/change_table.py:91] — fixed by filtering Terraform non-mutating entries from the default normalized-change review table.
+- [x] [Review][Patch] API/CLI coverage does not assert `plan_unsupported_fields` serialization or duplicate-action parse failures [tests/test_api/test_analyses.py:720] — fixed with API and CLI assertions for plan-level unsupported fields and duplicate Terraform action parse failures.
+- [x] [Review][Patch] Upload metadata rerender test does not verify rendered metadata survives feedback rerender [tests/test_ui/test_upload_panel.py:209] — fixed by rendering the preserved parse batch through the change table in the rerender callback regression.
+- [x] [Review][Patch] Empty Terraform plan `plan_unsupported_fields` persistence/history path lacks real-parser coverage [tests/test_services/test_report_service.py:209] — fixed with real Terraform parser coverage for empty-plan `plan_unsupported_fields` through report fetch and history metadata.
+- [x] [Review][Patch] Real analysis pipeline drops Terraform parser metadata before persisted report/history rendering [analysis/risk_engine.py:34] — fixed by passing parser metadata into evidence-backed risk scoring and covering the real parser-to-persisted-report/history path.
+- [x] [Review][Patch] Filtering Terraform non-mutating rows can hide plan-level unsupported fields from upload review results [ui/components/change_table.py:71] — fixed by surfacing hidden Terraform plan-scope metadata before the mutating change table.
+- [x] [Review][Patch] Persisted report/history still lose Terraform metadata for all-non-mutating plans [services/analysis_service.py:693] — fixed by scoring all-non-mutating Terraform batches as deterministic low-risk contributors when evidence extraction intentionally returns no evidence, preserving parser metadata through persisted report/history payloads.
+- [x] [Review][Patch] Upload review hides non-plan metadata on filtered Terraform no-op/read rows [ui/components/change_table.py:66] — fixed by rendering complete hidden Terraform metadata lines for filtered `no-op`/`read` rows.
+- [x] [Review][Patch] Hidden Terraform plan metadata is merged across files without file attribution [ui/components/change_table.py:66] — fixed by prefixing hidden Terraform metadata with the originating parsed file name instead of aggregating metadata across files.
+- [x] [Review][Patch] Browser-level regression coverage is missing for Terraform metadata rendering and feedback rerender [tests/e2e/report_review.keyboard.spec.js:68] — fixed by seeding Terraform metadata in the browser review harness and asserting metadata survives dashboard feedback rerender and history-detail navigation.
+- [x] [Review][Patch] Explicit empty evidence can suppress mutating batch scoring [services/analysis_service.py:89] — fixed by re-extracting evidence for mutating batches when callers pass an explicit empty evidence list while preserving deterministic all-non-mutating Terraform scoring.
+- [x] [Review][Patch] Non-object Terraform plan JSON roots fail with an unclean parser error [parsers/terraform_parser.py:280] — fixed by rejecting non-object Terraform plan JSON roots with a clean parser `ValueError`.
+- [x] [Review][Patch] Mixed Terraform plans lose non-mutating metadata after persistence [evidence/extractor.py:117] — fixed by carrying Terraform `no-op`/`read` changes as zero-score supplemental contributors in evidence-backed mixed assessments, with persisted report/history coverage.
+- [x] [Review][Patch] `change.generated_config` is silently dropped instead of surfaced [parsers/terraform_parser.py:218] — fixed by reporting `change.generated_config` in unsupported Terraform metadata instead of accepting and discarding it.
+- [x] [Review][Patch] Required security validation was recorded as skipped rather than completed [scripts/ci-local.sh:18] — fixed by installing Bandit in the local venv and rerunning local CI with the Bandit high/high gate active, plus `pip_audit`.
+- [x] [Review][Patch] Story completion artifact does not reconcile to the full diff [_bmad-output/implementation-artifacts/2-2-terraform-plan-json-intake.md:208] — fixed by reconciling this story's file list with the current full diff.
+
+## Dev Notes
+
+### Epic Context
+
+- Epic: 2. Trusted Evidence Core and Evidence Law
+- Epic goal: Make the core analysis defensible, stable, and evidence-backed.
+- Epic coverage: ING-01..09, EVD-01..12, RSK-01..10, HIS-01..02, NFR-SEC-01..06, NFR-REL-01..04
+
+### Architecture and Product Guardrails
+
+- Preserve DeployWhisper's local-first raw artifact boundary: raw IaC, scanner artifacts, incident exports, and sensitive context stay in the user's infrastructure by default.
+- Preserve the advisory-first core. Optional adapters may interpret report outputs, but canonical report semantics remain advisory unless explicit story scope says otherwise.
+- Reuse the shared analysis core and service layer before adapting UI, API, CLI, GitHub, or future workflow surfaces.
+- Keep Evidence Law behavior intact: no high or critical finding without deterministic evidence.
+- Keep project/workspace scope explicit for reports, incidents, topology, outcomes, feedback, scanner imports, and connector-related data.
+- Do not introduce new dependencies unless the active story explicitly requires and justifies them.
+
+### Source Tree Guidance
+
+- API routes belong under `api/routes/` and should use existing `ApiRoute` / `ApiError` envelope patterns.
+- Shared orchestration belongs in `services/`; parsers normalize input, analysis modules score/derive risk, and surfaces adapt outputs.
+- UI work belongs under `ui/routes/` and `ui/components/`, following the existing NiceGUI composition style.
+- CLI behavior belongs under `cli/` and must call the same service-layer paths as UI/API flows.
+- Persistence work belongs under `models/` with Alembic migrations when schema changes are required.
+- Documentation required by a story should be updated in the same workstream.
+
+### Testing Requirements
+
+- Use standard-library `unittest` in the existing `tests/test_*` layout.
+- Add focused regression tests for the layer changed by the story before broad refactors.
+- For Python changes, run `./.venv/bin/ruff check .`, `./.venv/bin/ruff format --check .`, and `./.venv/bin/python -m unittest discover -q` before closing implementation.
+- Use `bash scripts/ci-local.sh` for broader or cross-layer changes.
+
+### Project Structure Notes
+
+- Follow the current repository shape documented in `_bmad-output/project-context.md` and `AGENTS.md`.
+- If implementation reveals a conflict between this story and the current code baseline, keep the smallest compatible change and update the story notes rather than silently drifting from the PRD.
+
+### References
+
+- `_bmad-output/planning-artifacts/epics.md` - source Epic 2 / Story 2.2 definition.
+- `_bmad-output/planning-artifacts/prd.md` - functional and non-functional requirements.
+- `_bmad-output/planning-artifacts/architecture.md` - target architecture, boundaries, and guardrails.
+- `_bmad-output/planning-artifacts/ux-design-specification.md` - UX expectations for user-facing stories.
+- `_bmad-output/planning-artifacts/implementation-readiness-report-2026-05-01.md` - readiness verdict and residual story-format concern.
+- `_bmad-output/project-context.md` - repository-specific implementation rules.
+
+## Dev Agent Record
+
+### Agent Model Used
+
+GPT-5 Codex
+
+### Debug Log References
+
+- 2026-05-08: Started implementation on `feature/2-2-terraform-plan-json-intake`.
+- 2026-05-08: Implementation plan: add metadata support to shared parser/API change payloads, extend Terraform plan JSON parsing for modules/actions and redaction/unknown-field notes, update report schema docs, and lock behavior with parser/API/service regressions.
+- 2026-05-08: Focused parser/API regression run passed: `./.venv/bin/python -m unittest tests.test_parsers.test_terraform_parser tests.test_api.test_analyses.AnalysesApiTests.test_create_analysis_persists_submission_manifest_with_partial_coverage -q` (6 tests OK).
+- 2026-05-08: Ruff validation passed: `./.venv/bin/ruff check .` and `./.venv/bin/ruff format --check .`.
+- 2026-05-08: Full unittest validation passed: `./.venv/bin/python -m unittest discover -q` (300 tests OK, 1 skipped).
+- 2026-05-08: Local CI passed: `bash scripts/ci-local.sh` (Bandit not installed; security scan skipped by script).
+- 2026-05-08: Code review findings fixed for all-`no-op` plan parsing, module-scoped resource summaries, and CLI metadata coverage.
+- 2026-05-08: Focused review-fix validation passed: parser, registry, CLI metadata, risk scorer, and evidence extractor regressions (24 tests OK), plus focused Ruff check and format check.
+- 2026-05-08: Full review-fix validation passed: `./.venv/bin/ruff check .`, `./.venv/bin/ruff format --check .`, `./.venv/bin/python -m unittest discover -q` (300 tests OK, 1 skipped), `bash scripts/ci-local.sh` (Bandit not installed; security scan skipped by script), and `git diff --check`.
+- 2026-05-08: Re-review findings fixed for top-level Terraform plan metadata reporting, replacement/read action normalization, and topology-aware `no-op` blast-radius text.
+- 2026-05-08: Re-review fix validation passed: focused parser/registry/risk/evidence/API/CLI tests (28 tests OK), `./.venv/bin/ruff check .`, `./.venv/bin/ruff format --check .`, and `./.venv/bin/python -m unittest discover -q` (300 tests OK, 1 skipped).
+- 2026-05-08: Local CI passed after re-review fixes: `bash scripts/ci-local.sh` (Bandit not installed; security scan skipped by script).
+- 2026-05-08: Follow-up review findings fixed for canonical Terraform shared actions, metadata-only plan details, generic module-scoped resource summaries, root unknown/sensitive markers, and non-mutating topology reasoning.
+- 2026-05-08: Follow-up review fix validation passed: focused parser/registry/risk/evidence/API/CLI tests (31 tests OK), `./.venv/bin/ruff check .`, `./.venv/bin/ruff format --check .`, `./.venv/bin/python -m unittest discover -q` (300 tests OK, 1 skipped), and `bash scripts/ci-local.sh` (Bandit not installed; security scan skipped by script).
+- 2026-05-08: Re-ran BMad code review. Blind Hunter and Edge Case Hunter completed; Acceptance Auditor timed out and was recorded as a failed layer. Review produced four actionable patch findings and one dismissed speculative metadata-contract hardening item.
+- 2026-05-08: Fixed review findings for shared action precedence, non-mutating blast-radius impact, rollback planning action vocabulary, and non-mutating interaction-risk false positives.
+- 2026-05-08: Review-fix validation passed: focused parser/risk/blast-radius/rollback/interaction/evidence tests (36 tests OK), `./.venv/bin/ruff check .`, `./.venv/bin/ruff format --check .`, `./.venv/bin/python -m unittest discover -q` (300 tests OK, 1 skipped), and `bash scripts/ci-local.sh` (Bandit not installed; security scan skipped by script).
+- 2026-05-08: Re-ran BMad code review. Blind Hunter, Edge Case Hunter, and Acceptance Auditor completed. Review produced six actionable patch findings and dismissed two non-blocking policy/payload-shape concerns.
+- 2026-05-08: Fixed latest review findings for Terraform plan action/address validation, invalid metadata shape reporting, zero-diff plan intake, LLM non-mutating score preservation, and read-only typed summaries.
+- 2026-05-08: Latest review-fix validation passed: focused parser/registry/risk tests (35 tests OK), `./.venv/bin/ruff check .`, `./.venv/bin/ruff format --check .`, `./.venv/bin/python -m unittest discover -q` (300 tests OK, 1 skipped), `bash scripts/ci-local.sh` (Bandit not installed; security scan skipped by script), and `git diff --check`.
+- 2026-05-08: Re-ran BMad code review. Blind Hunter, Edge Case Hunter, and Acceptance Auditor completed. Review produced five actionable patch findings and dismissed two non-blocking parser-policy concerns.
+- 2026-05-08: Fixed latest review findings for replacement risk severity, non-mutating security/LLM verdict preservation, and Terraform metadata reporting across upload and persisted report surfaces.
+- 2026-05-08: Latest review-fix validation passed: focused risk/evidence/report/UI tests (85 tests OK), ruff check/format, full unittest discovery (301 tests OK, 1 skipped), local CI (Bandit skipped by script because not installed), and git diff --check.
+- 2026-05-08: Re-ran BMad code review. Blind Hunter, Edge Case Hunter, and Acceptance Auditor completed. Review produced seven actionable patch findings after triage and dismissed two findings as already handled or not required for non-mutating blast-radius output.
+- 2026-05-08: Fixed latest review findings for Terraform plan JSON shape/action validation, parser metadata JSON-safety, deterministic non-mutating scoring, full redacted/unsupported metadata rendering, upload feedback rerender metadata preservation, and review UI harness validation.
+- 2026-05-08: Latest review-fix validation passed: focused parser/risk/UI tests (73 tests OK), API/CLI/service regression tests (173 tests OK), post-format combined focused suite (246 tests OK), Ruff check/format, full unittest discovery (303 tests OK, 1 skipped), local CI (303 tests OK, 1 skipped; Bandit skipped by script because not installed), `APP_PORT=18080 npm run test:ui-review` (1 WebKit test passed), and `git diff --check`.
+- 2026-05-08: Fixed follow-up review findings for trimmed Terraform plan addresses, duplicate action validation, plan-level unsupported-field deduplication, and runtime upload feedback rerender coverage.
+- 2026-05-08: Follow-up review-fix validation passed: focused parser/UI/API/report/history tests (131 tests OK), `./.venv/bin/ruff check .`, `./.venv/bin/ruff format --check .`, `./.venv/bin/python -m unittest discover -q` (303 tests OK, 1 skipped), `bash scripts/ci-local.sh` (303 tests OK, 1 skipped; Bandit skipped by script because not installed), `APP_PORT=18080 npm run test:ui-review` (1 WebKit test passed), and `git diff --check`.
+- 2026-05-08: Re-ran BMad code review. Blind Hunter, Edge Case Hunter, and Acceptance Auditor completed. Review produced five actionable patch findings around non-mutating evidence/UI behavior and additional API/CLI/UI/persistence coverage.
+- 2026-05-08: Fixed latest review findings for non-mutating Terraform evidence suppression, upload change-table filtering, API/CLI duplicate-action and `plan_unsupported_fields` serialization coverage, rendered upload rerender metadata coverage, and empty-plan real-parser persistence/history metadata coverage.
+- 2026-05-08: Latest review-fix validation passed: focused evidence/API/CLI/UI/report regressions (11 tests OK), `./.venv/bin/ruff check .`, `./.venv/bin/ruff format --check .`, `./.venv/bin/python -m unittest discover -q` (304 tests OK, 1 skipped), `bash scripts/ci-local.sh` (304 tests OK, 1 skipped; Bandit skipped by script because not installed), `APP_PORT=18080 npm run test:ui-review` (1 WebKit test passed), and `git diff --check`.
+- 2026-05-08: Re-ran BMad code review. Local Blind Hunter, Edge Case Hunter, and Acceptance Auditor passes completed. Review produced two actionable patch findings around real-pipeline Terraform metadata propagation and non-mutating row filtering hiding plan-level unsupported metadata.
+- 2026-05-08: Fixed latest review findings for real-pipeline Terraform metadata propagation and upload plan-level metadata visibility.
+- 2026-05-08: Latest review-fix validation passed: focused service/API/UI regressions (4 tests OK), `./.venv/bin/ruff check .`, `./.venv/bin/ruff format --check .`, `./.venv/bin/python -m unittest discover -q` (306 tests OK, 1 skipped), `bash scripts/ci-local.sh` (306 tests OK, 1 skipped; Bandit skipped by script because not installed), `APP_PORT=18080 npm run test:ui-review` (1 WebKit test passed), and `git diff --check`.
+- 2026-05-08: Re-ran BMad code review. Blind Hunter, Edge Case Hunter, and Acceptance Auditor completed. Review produced four actionable patch findings around non-mutating Terraform metadata persistence, hidden upload metadata attribution, and browser-level metadata/rerender coverage; one Blind Hunter finding about empty change IDs was dismissed because `UnifiedChange` populates change IDs after validation.
+- 2026-05-08: Fixed latest review findings for all-non-mutating Terraform metadata persistence, hidden non-mutating upload metadata attribution, first-mutating resource plan metadata placement, and browser-level metadata/feedback-rerender coverage.
+- 2026-05-08: Latest review-fix validation passed: targeted regressions (5 tests OK), affected parser/service/API/UI suite (97 tests OK), `./.venv/bin/ruff check .`, `./.venv/bin/ruff format --check .`, `./.venv/bin/python -m unittest discover -q` (308 tests OK, 1 skipped), `bash scripts/ci-local.sh` (308 tests OK, 1 skipped; Bandit skipped by script because not installed), `APP_PORT=18080 npm run test:ui-review` (1 WebKit test passed), and `git diff --check`.
+- 2026-05-08: Re-ran BMad code review. Blind Hunter, Edge Case Hunter, and Acceptance Auditor completed. Acceptance Auditor was clean; Blind/Edge produced two actionable patch findings for explicit empty evidence on mutating batches and non-object Terraform plan JSON parser errors. Two blind-layer findings were dismissed as noise because `app.run()` already honors `APP_PORT`/`APP_HOST`, and legacy `modify`/`destroy` plan actions are intentionally rejected as non-native Terraform plan JSON.
+- 2026-05-08: Fixed latest review findings for explicit-empty-evidence mutating batch scoring and non-object Terraform plan JSON parser errors.
+- 2026-05-08: Latest review-fix validation passed: focused parser/service regressions (3 tests OK), affected parser/service suites (41 tests OK), `./.venv/bin/ruff check .`, `./.venv/bin/ruff format --check .`, `./.venv/bin/python -m unittest discover -q` (308 tests OK, 1 skipped), `bash scripts/ci-local.sh` (308 tests OK, 1 skipped; Bandit skipped by script because not installed), `APP_PORT=18080 npm run test:ui-review` (1 WebKit test passed), and `git diff --check`.
+- 2026-05-08: Re-ran BMad code review. Blind Hunter, Edge Case Hunter, and Acceptance Auditor completed. Review produced four actionable patch findings for mixed-plan non-mutating metadata persistence, `generated_config` reporting, security validation evidence, and story file-list reconciliation; one planned-values unsupported-field concern was dismissed as intentional explicit partial-coverage reporting.
+- 2026-05-08: Fixed latest review findings for mixed-plan non-mutating metadata persistence, `generated_config` unsupported-field reporting, completed security validation evidence, and story file-list reconciliation.
+- 2026-05-08: Latest review-fix validation passed: focused parser/service/API regressions (3 tests OK), affected parser/service/API suites (88 tests OK), `./.venv/bin/ruff check .`, `./.venv/bin/ruff format --check .`, `./.venv/bin/python -m unittest discover -q` (308 tests OK, 1 skipped), `./.venv/bin/python -m pip_audit -r requirements.txt` (no known vulnerabilities), `bash scripts/ci-local.sh` (Bandit active; high/high gate passed; 308 tests OK, 1 skipped), `APP_PORT=18080 npm run test:ui-review` (1 WebKit test passed), and `git diff --check`.
+
+### Completion Notes List
+
+- Added parser-normalized change metadata to the shared `UnifiedChange` model and API `ChangeData` payload.
+- Extended Terraform plan JSON intake to preserve module address, provider/resource metadata, action lists, replacement paths, unknown-after-apply paths, redacted sensitive paths, and unsupported plan fields.
+- Preserved Terraform plan JSON `no-op` resources as low-risk normalized entries so valid no-change plans remain accepted.
+- Documented the parse batch change metadata contract in the report v2 schema notes.
+- Resolved code review findings by preserving Terraform `no-op` plan resources without scoring them as modifications, restoring resource-specific summaries for module-scoped resources, and adding CLI metadata output coverage.
+- Resolved re-review findings by reporting top-level Terraform plan metadata/unsupported sections, treating replacement/read actions correctly downstream, and keeping `no-op` blast-radius text consistent when topology is available.
+- Resolved follow-up review findings by canonicalizing Terraform parser actions at the shared model boundary, keeping Terraform metadata out of summaries, preserving root marker paths, and avoiding downstream-impact reasoning for non-mutating actions.
+- Resolved latest review findings by centralizing action normalization and applying non-mutating/replacement semantics consistently across risk scoring, blast radius, rollback planning, interaction risk, parser output, and evidence hints.
+- Re-ran BMad code review and moved the story back to in-progress for unresolved Terraform parser and non-mutating LLM-scoring patch findings.
+- Resolved latest review findings by rejecting malformed Terraform action/address records, preserving invalid metadata shape markers, accepting zero-diff plans as plan-level no-op entries, preserving non-mutating zero scores after LLM scoring, and using read-only summaries for typed read entries.
+- Re-ran BMad code review and moved the story back to in-progress for unresolved replacement-risk, non-mutating verdict, and Terraform metadata reporting patch findings.
+- Resolved latest review findings by treating replacements as high/destructive risk, preserving deterministic no-op/read verdicts, carrying Terraform metadata into persisted contributors, and rendering metadata in upload/history report surfaces.
+- Re-ran BMad code review and moved the story back to in-progress for unresolved Terraform action validation, metadata JSON-safety, non-mutating LLM, metadata rendering, upload rerender, and UI-review validation findings.
+- Resolved latest review findings by tightening Terraform plan JSON validation, sanitizing parser metadata, keeping all-non-mutating plans deterministic, preserving upload metadata rerenders, fully enumerating redacted/unsupported Terraform metadata in UI/report surfaces, and restoring the seeded UI-review harness for project-scoped review flows.
+- Resolved follow-up review findings by canonicalizing whitespace-padded Terraform plan addresses, rejecting duplicate native actions, reporting plan-level unsupported fields once per parsed plan, and replacing source-inspection rerender coverage with behavior coverage.
+- Re-ran BMad code review and moved the story back to in-progress for unresolved non-mutating evidence/UI behavior and coverage patch findings.
+- Resolved latest review findings by keeping Terraform no-op/read entries parse-visible but out of evidence and default upload review rows, and by adding API/CLI/UI/report regressions for the remaining metadata and duplicate-action coverage gaps.
+- Re-ran BMad code review and moved the story back to in-progress for unresolved real-pipeline metadata propagation and upload plan-level metadata visibility patch findings.
+- Resolved latest review findings by preserving parser metadata through evidence-backed scoring into persisted report/history contributors, and by rendering hidden non-mutating Terraform plan metadata in upload review results.
+- Re-ran BMad code review and moved the story back to in-progress for unresolved non-mutating metadata persistence, hidden upload metadata attribution, and browser-level metadata/rerender coverage patch findings.
+- Resolved latest review findings by preserving all-non-mutating Terraform metadata through deterministic low-risk contributors, rendering complete hidden metadata with file attribution, attaching plan-level metadata to the first mutating resource when present, and adding browser coverage for metadata rendering across feedback rerender and history detail.
+- Re-ran BMad code review and moved the story back to in-progress for unresolved explicit-empty-evidence mutating scoring and non-object Terraform plan JSON parser hardening patch findings.
+- Resolved latest review findings by restoring mutating evidence extraction fallback for explicit empty evidence lists while preserving all-non-mutating Terraform metadata scoring, and by rejecting non-object Terraform plan roots with a clean parser error.
+- Re-ran BMad code review and moved the story back to in-progress for unresolved mixed-plan metadata persistence, generated-config reporting, security validation evidence, and story file-list reconciliation patch findings.
+- Resolved latest review findings by preserving non-mutating Terraform metadata in mixed persisted assessments, surfacing generated Terraform config as unsupported metadata, completing security validation with Bandit active, and reconciling the completion file list.
+
+### File List
+
+- `_bmad-output/implementation-artifacts/2-2-terraform-plan-json-intake.md`
+- `_bmad-output/implementation-artifacts/sprint-status.yaml`
+- `.agents/skills/bmad-create-story/checklist.md`
+- `.agents/skills/bmad-create-story/template.md`
+- `.agents/skills/bmad-dev-story/checklist.md`
+- `.agents/skills/bmad-dev-story/workflow.md`
+- `AGENTS.md`
+- `_bmad-output/project-context.md`
+- `analysis/blast_radius.py`
+- `analysis/interaction_risk.py`
+- `analysis/risk_engine.py`
+- `analysis/rollback_planner.py`
+- `analysis/risk_scorer.py`
+- `api/schemas.py`
+- `docs/ci.md`
+- `docs/schemas/report-v2.md`
+- `evidence/extractor.py`
+- `parsers/base.py`
+- `parsers/terraform_parser.py`
+- `playwright.config.cjs`
+- `services/analysis_service.py`
+- `tests/e2e/seeded_server.py`
+- `tests/e2e/report_review.keyboard.spec.js`
+- `tests/test_api/test_analyses.py`
+- `tests/test_analysis/test_risk_scorer.py`
+- `tests/test_analysis/test_blast_radius.py`
+- `tests/test_analysis/test_interaction_risk.py`
+- `tests/test_analysis/test_rollback_planner.py`
+- `tests/test_cli/test_analyze.py`
+- `tests/test_parsers/test_terraform_parser.py`
+- `tests/test_parsers/test_registry.py`
+- `tests/test_services/test_analysis_service.py`
+- `tests/test_services/test_evidence_extractor.py`
+- `tests/test_services/test_github_app_service.py`
+- `tests/test_services/test_report_service.py`
+- `tests/test_ui/test_history_page.py`
+- `tests/test_ui/test_upload_panel.py`
+- `ui/components/change_table.py`
+- `ui/components/report_detail_page.py`
+- `ui/components/upload_panel.py`
+
+## Change Log
+
+- 2026-05-01: Story created/aligned from updated PRD, architecture, epics, sprint status, and readiness report.
+- 2026-05-08: Implemented Terraform plan JSON metadata normalization and moved story to review.
+- 2026-05-08: Fixed code review findings for all-`no-op` Terraform plan intake, module-scoped resource summaries, and CLI metadata regression coverage.
+- 2026-05-08: Fixed re-review findings for top-level Terraform plan metadata reporting and downstream non-mutating/replacement action handling.
+- 2026-05-08: Fixed follow-up re-review findings for canonical shared Terraform actions, summary/metadata separation, root marker reporting, and topology-aware non-mutating reasoning.
+- 2026-05-08: Re-ran code review and moved story back to in-progress for unresolved patch findings.
+- 2026-05-08: Fixed latest review findings across shared action normalization, blast-radius filtering, rollback planning, and interaction-risk detection; moved story back to review.
+- 2026-05-08: Re-ran code review and moved story back to in-progress for unresolved Terraform parser and non-mutating LLM-scoring patch findings.
+- 2026-05-08: Fixed latest Terraform parser and risk-scoring review findings; moved story back to review.
+- 2026-05-08: Re-ran code review and moved story back to in-progress for unresolved replacement-risk, non-mutating verdict, and Terraform metadata reporting patch findings.
+- 2026-05-08: Fixed latest replacement-risk, non-mutating verdict, and Terraform metadata reporting review findings; moved story back to review.
+- 2026-05-08: Re-ran code review and moved story back to in-progress for unresolved Terraform action validation, metadata JSON-safety, non-mutating LLM, metadata rendering, upload rerender, and UI-review validation patch findings.
+- 2026-05-08: Fixed latest Terraform validation, metadata safety/rendering, non-mutating scoring, upload rerender, and UI-review validation findings; moved story back to review.
+- 2026-05-08: Fixed follow-up review findings for Terraform address/action validation, plan-level unsupported-field reporting, and upload rerender behavior coverage; moved story back to review.
+- 2026-05-08: Re-ran code review and moved story back to in-progress for unresolved non-mutating evidence/UI behavior and coverage patch findings.
+- 2026-05-08: Fixed latest non-mutating evidence/UI and metadata coverage review findings; moved story back to review.
+- 2026-05-08: Re-ran code review and moved story back to in-progress for unresolved real-pipeline metadata propagation and non-mutating upload metadata visibility findings.
+- 2026-05-08: Fixed latest real-pipeline metadata propagation and upload metadata visibility findings; moved story back to review.
+- 2026-05-08: Re-ran code review and moved story back to in-progress for unresolved non-mutating metadata persistence, upload metadata attribution, and browser-level metadata/rerender coverage findings.
+- 2026-05-08: Fixed latest non-mutating metadata persistence, upload metadata attribution, first-mutating plan metadata placement, and browser metadata/rerender coverage findings; moved story back to review.
+- 2026-05-08: Re-ran code review and moved story back to in-progress for unresolved explicit empty-evidence scoring and malformed Terraform plan JSON root parser-error findings.
+- 2026-05-08: Fixed latest explicit empty-evidence scoring and malformed Terraform plan root parser-error review findings; moved story back to review.
+- 2026-05-08: Re-ran code review and moved story back to in-progress for unresolved mixed-plan metadata persistence, generated-config reporting, security validation evidence, and story file-list reconciliation findings.

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -60,7 +60,7 @@ development_status:
 
   epic-2: in-progress
   2-1-submission-manifest-and-provenance: done
-  2-2-terraform-plan-json-intake: ready-for-dev
+  2-2-terraform-plan-json-intake: review
   2-3-evidence-item-model-and-extraction: ready-for-dev
   2-4-finding-model-and-evidence-links: ready-for-dev
   2-5-evidence-law-runtime-gate: ready-for-dev

--- a/_bmad-output/project-context.md
+++ b/_bmad-output/project-context.md
@@ -1,11 +1,11 @@
 ---
 project_name: 'deploywhisper'
 user_name: 'psaho01'
-date: '2026-04-25'
+date: '2026-05-08'
 sections_completed:
   ['technology_stack', 'language_rules', 'framework_rules', 'testing_rules', 'quality_rules', 'workflow_rules', 'anti_patterns']
 status: 'complete'
-rule_count: 34
+rule_count: 35
 optimized_for_llm: true
 ---
 
@@ -71,6 +71,7 @@ _This file contains critical rules and patterns that AI agents must follow when 
 - When instructions conflict, prefer the implemented codebase plus `README.md`, `docs/ci.md`, and current scripts over stale contributor prose.
 - Validate changes with the repo’s real commands after edits. For Python changes, run `./.venv/bin/ruff check .` and `./.venv/bin/ruff format --check .` (or the equivalent through `bash scripts/ci-local.sh`) before concluding work. At minimum, keep relevant `unittest` coverage green; use `bash scripts/ci-local.sh` when the touched area is broad enough.
 - For review-flow or accessibility-sensitive UI changes, also run `npm run test:ui-review`; when working on macOS and the change affects keyboard or screen-reader semantics, run `npm run setup:ui-review` once per machine and `npm run test:ui-review:voiceover` before closing the task.
+- For any UI-facing story, include an explicit story task for browser validation. If the story changes a UI route, NiceGUI component, rendered report/history/dashboard surface, browser interaction, keyboard behavior, or accessibility semantics, the dev agent must run Playwright validation in a browser and record the command/result in the Dev Agent Record. Use `npm run test:ui-review` for review/report flows, `RUN_UI_A11Y=1 bash scripts/ci-local.sh` for the full local UI lane, and `npm run test:ui-review:voiceover` on macOS for screen-reader or keyboard/a11y semantics. If no UI surface is touched, record `UI validation not applicable`; do not silently skip UI validation.
 - Treat security checks as part of normal completion criteria when they apply. Keep Bandit-compatible implementations in touched code, prefer modern hashes such as `sha256`/`blake2` over `sha1`/`md5`, and do not waive security findings when a safe fix is straightforward.
 - For AI-agent story execution, follow `CONTRIBUTING.md` Git Flow: start from `develop`, create one short-lived `feature/<identifier>-<short-description>` branch per story (or `bugfix/...` for defect work), commit incrementally on that branch, and target `develop` with a PR. Do not commit directly to `main` or `develop`.
 - For AI-agent story closure, the final reviewer must ensure the story ends on a Git Flow-compliant short-lived branch. If review happens on `develop`, the reviewer must create the proper `feature/*` or `bugfix/*` branch from that state, commit the story changes there, push it to remote, and optionally open the PR to `develop` before declaring the story lifecycle complete. A story is not properly closed if it remains only on `main`, `develop`, or detached HEAD.
@@ -103,4 +104,4 @@ _This file contains critical rules and patterns that AI agents must follow when 
 - Update it when tooling, validation commands, or architecture boundaries materially change.
 - Remove rules that become obsolete or are contradicted by the current codebase.
 
-Last Updated: 2026-04-25
+Last Updated: 2026-05-08

--- a/analysis/blast_radius.py
+++ b/analysis/blast_radius.py
@@ -6,7 +6,7 @@ from collections import deque
 
 from pydantic import BaseModel, Field
 
-from parsers.base import UnifiedChange
+from parsers.base import UnifiedChange, is_non_mutating_action
 
 
 class ImpactNode(BaseModel):
@@ -34,6 +34,17 @@ class BlastRadiusResult(BaseModel):
 def compute_blast_radius(
     changes: list[UnifiedChange], topology: dict | None, warning: str | None = None
 ) -> BlastRadiusResult:
+    mutating_changes = [
+        change for change in changes if not is_non_mutating_action(change.action)
+    ]
+    if not mutating_changes:
+        return BlastRadiusResult(
+            affected=[],
+            direct_count=0,
+            transitive_count=0,
+            warning=warning,
+        )
+
     if not topology:
         return BlastRadiusResult(
             affected=[],
@@ -61,7 +72,7 @@ def compute_blast_radius(
     seen: set[str] = set()
     unmatched_resources: list[str] = []
 
-    for change in changes:
+    for change in mutating_changes:
         matched_service_ids = resource_to_service_ids.get(change.resource_id, [])
         if not matched_service_ids:
             unmatched_resources.append(change.resource_id)

--- a/analysis/interaction_risk.py
+++ b/analysis/interaction_risk.py
@@ -7,7 +7,7 @@ import re
 
 from pydantic import BaseModel, Field
 
-from parsers.base import UnifiedChange
+from parsers.base import UnifiedChange, is_non_mutating_action
 
 
 class InteractionRisk(BaseModel):
@@ -68,6 +68,8 @@ STOP_WORDS = {
 def _collect_groups(changes: list[UnifiedChange]) -> dict[str, list[UnifiedChange]]:
     grouped: dict[str, list[UnifiedChange]] = defaultdict(list)
     for change in changes:
+        if is_non_mutating_action(change.action):
+            continue
         grouped[change.tool].append(change)
     return grouped
 

--- a/analysis/risk_engine.py
+++ b/analysis/risk_engine.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from typing import Any
 from urllib.parse import parse_qs, unquote, urlparse
 
 from analysis.interaction_risk import detect_interaction_risks
@@ -31,15 +32,24 @@ def _parse_source_ref(source_ref: str) -> tuple[str, str, str, str]:
     return parsed.scheme or "unknown", source_file, resource_id, action
 
 
-def _evidence_to_change(item: EvidenceItem) -> UnifiedChange:
+def _evidence_to_change(
+    item: EvidenceItem,
+    *,
+    change_metadata_by_id: dict[str, dict[str, Any]] | None = None,
+) -> UnifiedChange:
     tool, source_file, resource_id, action = _parse_source_ref(item.source_ref)
+    change_id = item.related_change_ids[0] if item.related_change_ids else ""
+    metadata = (
+        dict(change_metadata_by_id.get(change_id, {})) if change_metadata_by_id else {}
+    )
     return UnifiedChange(
-        change_id=item.related_change_ids[0] if item.related_change_ids else "",
+        change_id=change_id,
         source_file=source_file,
         tool=tool,
         resource_id=resource_id,
         action=action,
         summary=item.summary,
+        metadata=metadata,
     )
 
 
@@ -109,9 +119,15 @@ def score_evidence(
     *,
     topology: dict | None = None,
     raw_files: dict[str, bytes | None] | None = None,
+    change_metadata_by_id: dict[str, dict[str, Any]] | None = None,
+    supplemental_changes: list[UnifiedChange] | None = None,
     completion_client=None,
 ) -> RiskAssessment:
-    changes = [_evidence_to_change(item) for item in evidence_items]
+    changes = [
+        _evidence_to_change(item, change_metadata_by_id=change_metadata_by_id)
+        for item in evidence_items
+    ]
+    changes.extend(supplemental_changes or [])
     contributors = [
         _apply_evidence_fields(
             _build_contributor(change, topology=topology, raw_files=raw_files),
@@ -119,15 +135,24 @@ def score_evidence(
         )
         for item, change in zip(evidence_items, changes, strict=False)
     ]
+    contributors.extend(
+        _build_contributor(change, topology=topology, raw_files=raw_files)
+        for change in changes[len(evidence_items) :]
+    )
     contributors, llm_warning, llm_used = _apply_llm_scores(
         contributors,
         partial_context=partial_context,
         completion_client=completion_client,
     )
+    evidence_contributor_count = len(evidence_items)
     contributors = [
         _apply_evidence_fields(contributor, item)
-        for contributor, item in zip(contributors, evidence_items, strict=False)
-    ]
+        for contributor, item in zip(
+            contributors[:evidence_contributor_count],
+            evidence_items,
+            strict=False,
+        )
+    ] + contributors[evidence_contributor_count:]
     contributors.sort(key=_contributor_sort_key, reverse=True)
     interaction_risks = detect_interaction_risks(changes)
     warnings: list[str] = []

--- a/analysis/risk_scorer.py
+++ b/analysis/risk_scorer.py
@@ -6,14 +6,19 @@ import json
 import logging
 import re
 from collections import deque
-from typing import Literal
+from typing import Any, Literal
 
 from pydantic import BaseModel, Field
 
 from analysis.interaction_risk import InteractionRisk, detect_interaction_risks
 from evidence.models import ContextCompleteness
 from llm.providers import generate_completion_with_settings
-from parsers.base import ParseBatchResult, UnifiedChange
+from parsers.base import (
+    NON_MUTATING_ACTIONS,
+    ParseBatchResult,
+    UnifiedChange,
+    normalize_change_action,
+)
 from services.settings_service import resolve_provider_runtime
 
 RiskSeverity = Literal["low", "medium", "high", "critical"]
@@ -32,9 +37,12 @@ SEVERITY_SCORE: dict[RiskSeverity, int] = {
     "critical": 92,
 }
 ACTION_BASE_SEVERITY = {
+    "no-op": "low",
     "apply": "low",
     "create": "low",
     "modify": "medium",
+    "read": "low",
+    "replace": "high",
     "destroy": "high",
 }
 CATEGORY_BASE_SEVERITY = {
@@ -86,6 +94,10 @@ class RiskContributor(BaseModel):
     reasoning: str = Field(
         default="", description="Explicit explanation for this change score"
     )
+    metadata: dict[str, Any] = Field(
+        default_factory=dict,
+        description="Parser-specific normalized metadata for this contributor",
+    )
 
 
 class RiskAssessment(BaseModel):
@@ -118,16 +130,7 @@ class RiskAssessment(BaseModel):
 
 
 def _normalize_action(action: str) -> str:
-    parts = action.split("+")
-    if "apply" in parts:
-        return "apply"
-    if "destroy" in parts or "delete" in parts:
-        return "destroy"
-    if "modify" in parts or "update" in parts or "replace" in parts:
-        return "modify"
-    if "create" in parts:
-        return "create"
-    return "modify"
+    return normalize_change_action(action)
 
 
 def _severity_max(left: RiskSeverity, right: RiskSeverity) -> RiskSeverity:
@@ -368,6 +371,10 @@ def _security_flags(
 def _blast_radius_text(
     category: str, downstream_scope: int | None, normalized_action: str
 ) -> str:
+    if normalized_action == "no-op":
+        return "no planned change"
+    if normalized_action == "read":
+        return "read-only lookup; no infrastructure mutation planned"
     if downstream_scope is None:
         if normalized_action == "apply":
             return "unknown downstream impact — standalone manifest without cluster context"
@@ -387,7 +394,9 @@ def _heuristic_reasoning(change: UnifiedChange, contributor: RiskContributor) ->
         f"in the {contributor.resource_category} category",
         f"targeting {contributor.environment}.",
     ]
-    if contributor.downstream_scope is not None:
+    if contributor.normalized_action in NON_MUTATING_ACTIONS:
+        parts.append(contributor.blast_radius + ".")
+    elif contributor.downstream_scope is not None:
         parts.append(
             f"It may affect {contributor.downstream_scope} downstream service(s) or resource groups."
         )
@@ -401,6 +410,8 @@ def _heuristic_reasoning(change: UnifiedChange, contributor: RiskContributor) ->
 def _heuristic_severity(
     change: UnifiedChange, contributor: RiskContributor
 ) -> RiskSeverity:
+    if contributor.normalized_action in NON_MUTATING_ACTIONS:
+        return "low"
     if contributor.normalized_action == "apply":
         if contributor.security_flags:
             return "high" if len(contributor.security_flags) == 1 else "critical"
@@ -419,15 +430,19 @@ def _heuristic_severity(
     severity = _severity_max(
         severity, CATEGORY_BASE_SEVERITY[contributor.resource_category]
     )
-    if contributor.normalized_action == "destroy" and contributor.resource_category in {
-        "networking/ingress",
-        "namespace",
-        "iam/rbac",
-        "data/service",
-    }:
+    if contributor.normalized_action in {"destroy", "replace"} and (
+        contributor.resource_category
+        in {
+            "networking/ingress",
+            "namespace",
+            "iam/rbac",
+            "data/service",
+        }
+    ):
         severity = "critical"
     if contributor.environment == "production" and contributor.normalized_action in {
         "modify",
+        "replace",
         "destroy",
     }:
         severity = _raise_severity(severity)
@@ -449,7 +464,11 @@ def _build_contributor(
     normalized_action = _normalize_action(change.action)
     resource_category = _resource_category(change)
     downstream_scope = _downstream_scope(change, topology)
-    security_flags = _security_flags(change, raw_files)
+    security_flags = (
+        []
+        if normalized_action in NON_MUTATING_ACTIONS
+        else _security_flags(change, raw_files)
+    )
     environment = _environment(change, raw_files=raw_files)
     draft = RiskContributor(
         source_file=change.source_file,
@@ -466,25 +485,33 @@ def _build_contributor(
         downstream_scope=downstream_scope,
         security_flags=security_flags,
         environment=environment,
+        metadata=dict(change.metadata),
     )
     draft.severity = _heuristic_severity(change, draft)
     draft.reasoning = _heuristic_reasoning(change, draft)
-    draft.contribution = min(
+    draft.contribution = _contribution_score(draft)
+    return draft
+
+
+def _contribution_score(contributor: RiskContributor) -> int:
+    if contributor.normalized_action in NON_MUTATING_ACTIONS:
+        return 0
+    return min(
         100,
-        SEVERITY_SCORE[draft.severity]
+        SEVERITY_SCORE[contributor.severity]
         + (
-            min(draft.downstream_scope * 3, 12)
-            if draft.downstream_scope is not None
+            min(contributor.downstream_scope * 3, 12)
+            if contributor.downstream_scope is not None
             else 0
         )
         + (
             8
-            if draft.environment == "production" and draft.normalized_action != "create"
+            if contributor.environment == "production"
+            and contributor.normalized_action != "create"
             else 0
         )
-        + min(len(draft.security_flags) * 10, 20),
+        + min(len(contributor.security_flags) * 10, 20),
     )
-    return draft
 
 
 def _sanitize_scope_claims(text: str, contributors: list[RiskContributor]) -> str:
@@ -604,20 +631,16 @@ def _apply_llm_scores(
         if severity not in SEVERITY_ORDER:
             updated.append(contributor)
             continue
+        if contributor.normalized_action in NON_MUTATING_ACTIONS:
+            contributor.severity = "low"
+            contributor.contribution = 0
+            updated.append(contributor)
+            continue
         contributor.severity = severity  # type: ignore[assignment]
         contributor.reasoning = _sanitize_scope_claims(
             str(llm_item.get("reasoning", contributor.reasoning)), [contributor]
         )
-        contributor.contribution = min(
-            100,
-            SEVERITY_SCORE[contributor.severity]
-            + (
-                min(contributor.downstream_scope * 3, 12)
-                if contributor.downstream_scope is not None
-                else 0
-            )
-            + min(len(contributor.security_flags) * 10, 20),
-        )
+        contributor.contribution = _contribution_score(contributor)
         updated.append(contributor)
     return updated, None, True
 
@@ -690,11 +713,18 @@ def score_changes(
         _build_contributor(change, topology=topology, raw_files=raw_files)
         for change in changes
     ]
-    contributors, llm_warning, llm_used = _apply_llm_scores(
-        contributors,
-        partial_context=partial_context,
-        completion_client=completion_client,
-    )
+    if contributors and all(
+        contributor.normalized_action in NON_MUTATING_ACTIONS
+        for contributor in contributors
+    ):
+        llm_warning = None
+        llm_used = False
+    else:
+        contributors, llm_warning, llm_used = _apply_llm_scores(
+            contributors,
+            partial_context=partial_context,
+            completion_client=completion_client,
+        )
     contributors.sort(
         key=lambda contributor: (
             SEVERITY_ORDER[contributor.severity],

--- a/analysis/rollback_planner.py
+++ b/analysis/rollback_planner.py
@@ -7,7 +7,7 @@ from typing import Literal
 
 from pydantic import BaseModel, Field
 
-from parsers.base import UnifiedChange
+from parsers.base import UnifiedChange, is_non_mutating_action, normalize_change_action
 
 RollbackComplexity = Literal["low", "medium", "high"]
 
@@ -44,7 +44,8 @@ class RollbackPlan(BaseModel):
 
 
 def _rollback_priority(change: UnifiedChange) -> tuple[int, str]:
-    if change.action in {"destroy", "delete", "destroy+modify"}:
+    normalized_action = normalize_change_action(change.action)
+    if normalized_action in {"destroy", "replace"}:
         priority = 0
     elif change.tool in {"terraform", "cloudformation"}:
         priority = 1
@@ -74,9 +75,10 @@ def _estimate_step_minutes(change: UnifiedChange) -> int:
         "ansible": 7,
         "jenkins": 6,
     }.get(change.tool, 5)
-    if change.action in {"destroy", "delete", "destroy+modify"}:
+    normalized_action = normalize_change_action(change.action)
+    if normalized_action in {"destroy", "replace"}:
         base_minutes += 5
-    elif change.action in {"modify", "update", "patch"}:
+    elif normalized_action == "modify" or change.action == "patch":
         base_minutes += 2
     return base_minutes
 
@@ -85,12 +87,15 @@ def _complexity_details(
     changes: list[UnifiedChange], *, partial_context: bool
 ) -> tuple[int, str]:
     if not changes:
-        return (1, "No parsed changes were available, so rollback effort is minimal.")
+        return (
+            1,
+            "No mutating parsed changes were available, so rollback effort is minimal.",
+        )
 
     destructive_count = sum(
         1
         for change in changes
-        if change.action in {"destroy", "delete", "destroy+modify"}
+        if normalize_change_action(change.action) in {"destroy", "replace"}
     )
     tool_count = len({change.tool for change in changes})
 
@@ -143,7 +148,10 @@ def build_rollback_copy_text(plan: RollbackPlan) -> str:
 def generate_rollback_plan(
     changes: list[UnifiedChange], partial_context: bool = False
 ) -> RollbackPlan:
-    ordered_changes = sorted(changes, key=_rollback_priority)
+    mutating_changes = [
+        change for change in changes if not is_non_mutating_action(change.action)
+    ]
+    ordered_changes = sorted(mutating_changes, key=_rollback_priority)
     steps: list[RollbackStep] = []
     for index, change in enumerate(ordered_changes, start=1):
         steps.append(
@@ -151,12 +159,12 @@ def generate_rollback_plan(
                 order=index,
                 title=f"Revert {change.resource_id}",
                 detail=(
-                    f"Rollback the {change.tool} change for {change.resource_id} from {change.source_file} "
+                    f"Rollback the {change.tool} {normalize_change_action(change.action)} change for {change.resource_id} from {change.source_file} "
                     f"and verify the prior stable state is restored."
                 ),
                 estimated_minutes=_estimate_step_minutes(change),
                 critical=index == 1
-                or change.action in {"destroy", "delete", "destroy+modify"},
+                or normalize_change_action(change.action) in {"destroy", "replace"},
             )
         )
 
@@ -165,7 +173,7 @@ def generate_rollback_plan(
             RollbackStep(
                 order=1,
                 title="No rollback steps generated",
-                detail="No parsed changes were available to build rollback guidance.",
+                detail="No mutating parsed changes were available to build rollback guidance.",
                 estimated_minutes=0,
                 critical=False,
             )
@@ -177,12 +185,14 @@ def generate_rollback_plan(
             "Rollback plan may be incomplete because one or more files failed to parse."
         )
     complexity_score, complexity_explanation = _complexity_details(
-        changes, partial_context=partial_context
+        mutating_changes, partial_context=partial_context
     )
 
     return RollbackPlan(
         steps=steps,
-        complexity=_complexity_for_changes(changes, partial_context=partial_context),
+        complexity=_complexity_for_changes(
+            mutating_changes, partial_context=partial_context
+        ),
         complexity_score=complexity_score,
         complexity_explanation=complexity_explanation,
         warning=warning,

--- a/api/schemas.py
+++ b/api/schemas.py
@@ -567,6 +567,10 @@ class ChangeData(BaseModel):
     resource_id: str = Field(..., description="Resource identifier")
     action: str = Field(..., description="Change action")
     summary: str = Field(..., description="Human-readable summary")
+    metadata: dict[str, Any] = Field(
+        default_factory=dict,
+        description="Optional parser-specific normalized metadata",
+    )
 
 
 class ParseIssueData(BaseModel):
@@ -633,6 +637,10 @@ class RiskContributorData(BaseModel):
     )
     severity: RiskSeverity = Field(..., description="Per-resource severity")
     reasoning: str = Field(default="", description="Per-resource scoring explanation")
+    metadata: dict[str, Any] = Field(
+        default_factory=dict,
+        description="Parser-specific normalized metadata carried into reports",
+    )
 
 
 class FindingData(BaseModel):

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -75,7 +75,7 @@ These logs are retained for 14 days.
 - Source tree must compile with `python -m compileall`
 - Every shard must pass its assigned `unittest` targets
 - Pull requests get a changed-test fast-feedback run
-- Accessibility-sensitive UI work should include the opt-in Playwright keyboard smoke locally, plus the VoiceOver lane on macOS when the change affects review semantics, tab order, or screen-reader announcements
+- UI-facing stories must record browser-side Playwright validation before moving to review. Use `npm run test:ui-review` for review/report flows, `RUN_UI_A11Y=1 bash scripts/ci-local.sh` for the full local UI lane, and the VoiceOver lane on macOS when the change affects review semantics, tab order, keyboard behavior, or screen-reader announcements. If no UI surface is touched, record `UI validation not applicable` in the story Dev Agent Record.
 
 ## Notes
 

--- a/docs/schemas/report-v2.md
+++ b/docs/schemas/report-v2.md
@@ -32,6 +32,40 @@ This schema version applies to:
 }
 ```
 
+### Analysis parse batch change shape
+
+API and CLI analysis responses include the parser-normalized `parse_batch` payload
+before persistence. Persisted report contributors also carry the same parser
+metadata so history, shared report, and dashboard result surfaces can show module
+context, replacement paths, and fields Terraform marked unknown or sensitive
+without storing raw plan internals in a separate contract.
+
+```json
+{
+  "source_file": "tfplan.json",
+  "tool": "terraform",
+  "resource_id": "module.network.aws_security_group.web",
+  "action": "modify",
+  "summary": "Security group module.network.aws_security_group.web changes network access rules and should be reviewed for exposure before deploy.",
+  "metadata": {
+    "source_format": "terraform_plan_json",
+    "plan_format_version": "1.2",
+    "terraform_version": "1.8.5",
+    "module_address": "module.network",
+    "mode": "managed",
+    "resource_type": "aws_security_group",
+    "resource_name": "web",
+    "provider_name": "registry.terraform.io/hashicorp/aws",
+    "actions": ["update"],
+    "replace_paths": ["ingress.0.cidr_blocks"],
+    "unknown_after_apply": ["arn"],
+    "redacted_fields": ["ingress.0.description"],
+    "unsupported_fields": ["change.importing"],
+    "plan_unsupported_fields": ["plan.resource_drift"]
+  }
+}
+```
+
 ### Persisted report shape
 
 ```json
@@ -145,7 +179,23 @@ This schema version applies to:
   ],
   "findings": [],
   "evidence_items": [],
-  "contributors": [],
+  "contributors": [
+    {
+      "source_file": "plan.json",
+      "tool": "terraform",
+      "resource_id": "module.network.aws_security_group.web",
+      "action": "modify",
+      "normalized_action": "modify",
+      "severity": "high",
+      "metadata": {
+        "module_address": "module.network",
+        "replace_paths": ["ingress.0.cidr_blocks"],
+        "unknown_after_apply": ["arn"],
+        "redacted_fields": ["ingress.0.description"],
+        "plan_unsupported_fields": ["plan.resource_drift"]
+      }
+    }
+  ],
   "audit": {
     "files_analyzed": ["plan.json"]
   }
@@ -167,3 +217,4 @@ This schema version applies to:
 - degraded narrative visibility fields
 - submission manifest payloads that record accepted, excluded, failed, partial, sensitive, provenance, and redaction status
 - durable submission manifest fallback identity/status metadata for malformed-manifest recovery
+- parser-normalized change metadata for Terraform plan JSON format and Terraform versions, module paths, replacement paths, unknown-after-apply fields, redacted fields, and unsupported resource/change/plan fields

--- a/evidence/extractor.py
+++ b/evidence/extractor.py
@@ -6,7 +6,12 @@ import hashlib
 from urllib.parse import quote
 
 from evidence.models import EvidenceItem, RiskSeverity
-from parsers.base import NormalizedChange, ParseBatchResult
+from parsers.base import (
+    NormalizedChange,
+    ParseBatchResult,
+    is_non_mutating_action,
+    normalize_change_action,
+)
 
 SEVERITY_ORDER: dict[RiskSeverity, int] = {
     "low": 1,
@@ -15,10 +20,12 @@ SEVERITY_ORDER: dict[RiskSeverity, int] = {
     "critical": 4,
 }
 ACTION_BASE_SEVERITY: dict[str, RiskSeverity] = {
+    "no-op": "low",
     "apply": "low",
     "create": "low",
     "modify": "medium",
-    "replace": "medium",
+    "read": "low",
+    "replace": "high",
     "update": "medium",
     "destroy": "high",
     "delete": "high",
@@ -66,19 +73,7 @@ MEDIUM_RISK_TOKENS = {
 
 
 def _normalize_action(action: str) -> str:
-    parts = action.split("+")
-    for candidate in (
-        "apply",
-        "destroy",
-        "delete",
-        "modify",
-        "update",
-        "replace",
-        "create",
-    ):
-        if candidate in parts:
-            return candidate
-    return "modify"
+    return normalize_change_action(action)
 
 
 def _max_severity(left: RiskSeverity, right: RiskSeverity) -> RiskSeverity:
@@ -98,7 +93,10 @@ def _build_source_ref(change: NormalizedChange) -> str:
 
 
 def _severity_hint(change: NormalizedChange) -> RiskSeverity:
-    severity = ACTION_BASE_SEVERITY.get(_normalize_action(change.action), "medium")
+    normalized_action = _normalize_action(change.action)
+    if is_non_mutating_action(normalized_action):
+        return "low"
+    severity = ACTION_BASE_SEVERITY.get(normalized_action, "medium")
     resource_id = change.resource_id.lower()
     if resource_id.startswith("service/"):
         return _max_severity(severity, "high")
@@ -117,6 +115,8 @@ class EvidenceExtractor:
     """Translate normalized parser changes into evidence-domain items."""
 
     def extract(self, change: NormalizedChange) -> list[EvidenceItem]:
+        if change.tool == "terraform" and is_non_mutating_action(change.action):
+            return []
         handler = getattr(self, f"extract_{change.tool}", None)
         if handler is None:
             return [self._build_item(change)]

--- a/parsers/base.py
+++ b/parsers/base.py
@@ -3,9 +3,10 @@
 from __future__ import annotations
 
 import hashlib
-from typing import Literal
+import math
+from typing import Any, Literal
 
-from pydantic import BaseModel, Field, model_validator
+from pydantic import BaseModel, Field, field_validator, model_validator
 
 
 def _build_change_id(
@@ -19,6 +20,18 @@ def _build_change_id(
     return f"chg-{hashlib.sha256(seed.encode('utf-8')).hexdigest()[:12]}"
 
 
+def _json_safe_value(value: Any) -> Any:
+    if value is None or isinstance(value, bool | str | int):
+        return value
+    if isinstance(value, float):
+        return value if math.isfinite(value) else str(value)
+    if isinstance(value, dict):
+        return {str(key): _json_safe_value(nested) for key, nested in value.items()}
+    if isinstance(value, list | tuple | set):
+        return [_json_safe_value(nested) for nested in value]
+    return str(value)
+
+
 class UnifiedChange(BaseModel):
     change_id: str = Field(
         default="",
@@ -29,6 +42,18 @@ class UnifiedChange(BaseModel):
     resource_id: str = Field(..., description="Resource identifier")
     action: str = Field(..., description="Change action")
     summary: str = Field(..., description="Human-readable summary")
+    metadata: dict[str, Any] = Field(
+        default_factory=dict,
+        description="Optional parser-specific normalized metadata",
+    )
+
+    @field_validator("metadata", mode="before")
+    @classmethod
+    def _sanitize_metadata(cls, value: Any) -> dict[str, Any]:
+        if not isinstance(value, dict):
+            return {}
+        safe = _json_safe_value(value)
+        return safe if isinstance(safe, dict) else {}
 
     @model_validator(mode="after")
     def _populate_change_id(self) -> UnifiedChange:
@@ -44,6 +69,34 @@ class UnifiedChange(BaseModel):
 
 NormalizedChange = UnifiedChange
 build_change_id = _build_change_id
+NON_MUTATING_ACTIONS = {"no-op", "read"}
+
+
+def normalize_change_action(action: str | list[str]) -> str:
+    """Collapse parser action vocabulary into shared lifecycle actions."""
+    if isinstance(action, str):
+        parts = {part.strip() for part in action.split("+") if part.strip()}
+    else:
+        parts = {str(part).strip() for part in action if str(part).strip()}
+    if parts == {"no-op"}:
+        return "no-op"
+    if parts == {"read"}:
+        return "read"
+    if "replace" in parts or ("create" in parts and {"delete", "destroy"} & parts):
+        return "replace"
+    if {"delete", "destroy"} & parts:
+        return "destroy"
+    if {"modify", "update"} & parts:
+        return "modify"
+    if "create" in parts:
+        return "create"
+    if "apply" in parts:
+        return "apply"
+    return "modify"
+
+
+def is_non_mutating_action(action: str) -> bool:
+    return normalize_change_action(action) in NON_MUTATING_ACTIONS
 
 
 ParseStatus = Literal["parsed", "failed", "skipped"]

--- a/parsers/terraform_parser.py
+++ b/parsers/terraform_parser.py
@@ -5,10 +5,38 @@ from __future__ import annotations
 import json
 from io import StringIO
 from pathlib import Path
+from typing import Any
 
 import hcl2
 
-from parsers.base import UnifiedChange, build_change_id
+from parsers.base import (
+    UnifiedChange,
+    build_change_id,
+    is_non_mutating_action,
+    normalize_change_action,
+)
+
+SUPPORTED_PLAN_FIELDS = {
+    "format_version",
+    "resource_changes",
+    "terraform_version",
+}
+PLAN_LEVEL_RESOURCE_ID = "terraform-plan"
+SUPPORTED_PLAN_ACTIONS = {
+    "create",
+    "delete",
+    "no-op",
+    "read",
+    "update",
+}
+SUPPORTED_PLAN_ACTION_SETS = {
+    frozenset({"no-op"}),
+    frozenset({"read"}),
+    frozenset({"create"}),
+    frozenset({"update"}),
+    frozenset({"delete"}),
+    frozenset({"create", "delete"}),
+}
 
 
 def _normalize_hcl_label(label: object) -> str:
@@ -19,35 +47,300 @@ def _normalize_hcl_label(label: object) -> str:
     return normalized
 
 
-def _terraform_summary(address: str, action: str) -> str:
+def _address_matches_type(
+    address: str, *, actual_type: str | None, expected_type: str
+) -> bool:
     normalized = address.lower()
-    if normalized.startswith("aws_security_group."):
+    expected_type = expected_type.lower()
+    return (
+        (actual_type or "").lower() == expected_type
+        or normalized.startswith(f"{expected_type}.")
+        or f".{expected_type}." in normalized
+    )
+
+
+def _terraform_summary(
+    address: str, action: str, *, resource_type: str | None = None
+) -> str:
+    normalized = address.lower()
+    if action == "no-op":
+        return f"Terraform resource {address} has no planned changes."
+    if action == "read":
+        return f"Terraform resource {address} is read-only; no infrastructure mutation planned."
+    if _address_matches_type(
+        normalized, actual_type=resource_type, expected_type="aws_security_group"
+    ):
         return f"Security group {address} changes network access rules and should be reviewed for exposure before deploy."
-    if normalized.startswith("aws_vpc."):
+    if _address_matches_type(
+        normalized, actual_type=resource_type, expected_type="aws_vpc"
+    ):
         return f"VPC {address} changes network boundaries and may affect connected routing or segmentation."
     if (
-        normalized.startswith("aws_iam_role.")
-        or normalized.startswith("aws_iam_policy.")
-        or normalized.startswith("aws_iam_role_policy_attachment.")
+        _address_matches_type(
+            normalized, actual_type=resource_type, expected_type="aws_iam_role"
+        )
+        or _address_matches_type(
+            normalized, actual_type=resource_type, expected_type="aws_iam_policy"
+        )
+        or _address_matches_type(
+            normalized,
+            actual_type=resource_type,
+            expected_type="aws_iam_role_policy_attachment",
+        )
     ):
         return f"IAM resource {address} changes access permissions and should be reviewed for privilege impact."
-    if normalized.startswith("aws_eks_cluster.") or normalized.startswith(
-        "aws_eks_node_group."
+    if _address_matches_type(
+        normalized,
+        actual_type=resource_type,
+        expected_type="aws_eks_cluster",
+    ) or _address_matches_type(
+        normalized,
+        actual_type=resource_type,
+        expected_type="aws_eks_node_group",
     ):
         return f"EKS resource {address} changes cluster or node-group behavior and may affect workload availability."
-    if normalized.startswith("module."):
+    if normalized.startswith("module.") and resource_type is None:
         return f"Terraform module {address} updated in configuration and may affect multiple downstream resources."
     return f"Terraform resource {address} marked for {action}."
 
 
+def _path_to_string(path: list[Any]) -> str:
+    return ".".join(str(part) for part in path)
+
+
+def _valid_marker_tree(value: Any) -> bool:
+    if isinstance(value, bool):
+        return True
+    if isinstance(value, dict):
+        return all(_valid_marker_tree(nested) for nested in value.values())
+    if isinstance(value, list):
+        return all(_valid_marker_tree(nested) for nested in value)
+    return False
+
+
+def _true_value_paths(value: Any, prefix: list[Any] | None = None) -> list[str]:
+    path = prefix or []
+    if value is True:
+        return [_path_to_string(path)] if path else ["<root>"]
+    if isinstance(value, dict):
+        paths: list[str] = []
+        for key, nested in value.items():
+            paths.extend(_true_value_paths(nested, [*path, key]))
+        return paths
+    if isinstance(value, list):
+        paths: list[str] = []
+        for index, nested in enumerate(value):
+            paths.extend(_true_value_paths(nested, [*path, index]))
+        return paths
+    return []
+
+
+def _replace_paths(change: dict[str, Any]) -> list[str]:
+    paths = change.get("replace_paths")
+    if not isinstance(paths, list):
+        return []
+    normalized: list[str] = []
+    for path in paths:
+        if isinstance(path, list):
+            normalized.append(_path_to_string(path))
+    return normalized
+
+
+def _action_list(change: dict[str, Any], *, address: str) -> list[str]:
+    actions = change.get("actions")
+    if not isinstance(actions, list) or not actions:
+        raise ValueError(
+            f"Terraform plan resource {address} is missing required change.actions."
+        )
+    normalized = [str(action).strip() for action in actions]
+    if len(set(normalized)) != len(normalized):
+        raise ValueError(
+            f"Duplicate Terraform action(s) for {address}: {', '.join(normalized)}."
+        )
+    invalid_actions = [
+        action
+        for action in normalized
+        if not action or action not in SUPPORTED_PLAN_ACTIONS
+    ]
+    if invalid_actions:
+        raise ValueError(
+            f"Unsupported Terraform action(s) for {address}: {', '.join(invalid_actions)}."
+        )
+    if frozenset(normalized) not in SUPPORTED_PLAN_ACTION_SETS:
+        raise ValueError(
+            f"Unsupported Terraform action combination for {address}: {', '.join(normalized)}."
+        )
+    return normalized
+
+
+def _resource_address(resource: dict[str, Any], *, index: int) -> str:
+    address = resource.get("address")
+    if not isinstance(address, str) or not address.strip():
+        raise ValueError(
+            f"Terraform plan resource change at index {index} is missing required address."
+        )
+    return address.strip()
+
+
+def _invalid_metadata_fields(change: dict[str, Any]) -> list[str]:
+    invalid: list[str] = []
+    if "replace_paths" in change:
+        paths = change.get("replace_paths")
+        if not isinstance(paths, list) or any(
+            not isinstance(path, list) for path in paths
+        ):
+            invalid.append("change.replace_paths.invalid")
+    for field in ("after_unknown", "after_sensitive", "before_sensitive"):
+        if field in change and not _valid_marker_tree(change.get(field)):
+            invalid.append(f"change.{field}.invalid")
+    return invalid
+
+
+def _unsupported_plan_fields(payload: dict[str, Any]) -> list[str]:
+    return [
+        f"plan.{field}"
+        for field in sorted(payload)
+        if field not in SUPPORTED_PLAN_FIELDS
+    ]
+
+
+def _unsupported_fields(resource: dict[str, Any], change: dict[str, Any]) -> list[str]:
+    supported_resource_fields = {
+        "address",
+        "change",
+        "index",
+        "mode",
+        "module_address",
+        "name",
+        "provider_name",
+        "type",
+    }
+    supported_change_fields = {
+        "actions",
+        "after",
+        "after_sensitive",
+        "after_unknown",
+        "before",
+        "before_sensitive",
+        "replace_paths",
+    }
+    resource_fields = [
+        f"resource_change.{field}"
+        for field in sorted(resource)
+        if field not in supported_resource_fields
+    ]
+    change_fields = [
+        f"change.{field}"
+        for field in sorted(change)
+        if field not in supported_change_fields
+    ]
+    return [
+        *change_fields,
+        *_invalid_metadata_fields(change),
+        *resource_fields,
+    ]
+
+
+def _plan_metadata(
+    resource: dict[str, Any],
+    change: dict[str, Any],
+    payload: dict[str, Any],
+    *,
+    actions: list[str],
+    include_plan_unsupported_fields: bool = False,
+) -> dict[str, Any]:
+    metadata = {
+        "source_format": "terraform_plan_json",
+        "plan_format_version": payload.get("format_version"),
+        "terraform_version": payload.get("terraform_version"),
+        "resource_change_count": len(payload.get("resource_changes", []) or []),
+        "module_address": resource.get("module_address"),
+        "mode": resource.get("mode"),
+        "resource_type": resource.get("type"),
+        "resource_name": resource.get("name"),
+        "provider_name": resource.get("provider_name"),
+        "actions": actions,
+        "replace_paths": _replace_paths(change),
+        "unknown_after_apply": _true_value_paths(change.get("after_unknown") or {}),
+        "redacted_fields": sorted(
+            {
+                *_true_value_paths(change.get("before_sensitive") or {}),
+                *_true_value_paths(change.get("after_sensitive") or {}),
+            }
+        ),
+        "unsupported_fields": _unsupported_fields(resource, change),
+    }
+    if include_plan_unsupported_fields:
+        metadata["plan_unsupported_fields"] = _unsupported_plan_fields(payload)
+    return metadata
+
+
 def _parse_terraform_plan_json(name: str, raw_content: bytes) -> list[UnifiedChange]:
     payload = json.loads(raw_content.decode("utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError("Terraform plan JSON must be an object.")
+    if "resource_changes" not in payload:
+        raise ValueError("Terraform plan JSON is missing required resource_changes.")
     resource_changes = payload.get("resource_changes", [])
-    changes: list[UnifiedChange] = []
+    if not isinstance(resource_changes, list):
+        raise ValueError("Terraform plan resource_changes must be a list.")
+    if not resource_changes:
+        actions = ["no-op"]
+        metadata = _plan_metadata(
+            {},
+            {"actions": actions},
+            payload,
+            actions=actions,
+            include_plan_unsupported_fields=True,
+        )
+        return [
+            UnifiedChange(
+                change_id=build_change_id(
+                    name, "terraform", PLAN_LEVEL_RESOURCE_ID, "no-op", 0
+                ),
+                source_file=name,
+                tool="terraform",
+                resource_id=PLAN_LEVEL_RESOURCE_ID,
+                action="no-op",
+                summary=f"Terraform plan {name} has no planned resource changes.",
+                metadata=metadata,
+            )
+        ]
+    parsed_resources: list[
+        tuple[int, dict[str, Any], dict[str, Any], str, list[str], str]
+    ] = []
     for index, resource in enumerate(resource_changes):
-        address = resource.get("address", "unknown")
-        actions = resource.get("change", {}).get("actions", [])
-        action = "+".join(actions) if actions else "modify"
+        if not isinstance(resource, dict):
+            raise ValueError(
+                f"Terraform plan resource change at index {index} must be an object."
+            )
+        change = resource.get("change", {})
+        if not isinstance(change, dict):
+            raise ValueError(
+                f"Terraform plan resource change at index {index} has invalid change payload."
+            )
+        address = _resource_address(resource, index=index)
+        actions = _action_list(change, address=address)
+        action = normalize_change_action(actions)
+        parsed_resources.append((index, resource, change, address, actions, action))
+
+    plan_metadata_index = next(
+        (
+            index
+            for index, *_rest, action in parsed_resources
+            if not is_non_mutating_action(action)
+        ),
+        parsed_resources[0][0],
+    )
+    changes: list[UnifiedChange] = []
+    for index, resource, change, address, actions, action in parsed_resources:
+        metadata = _plan_metadata(
+            resource,
+            change,
+            payload,
+            actions=actions,
+            include_plan_unsupported_fields=index == plan_metadata_index,
+        )
         changes.append(
             UnifiedChange(
                 change_id=build_change_id(name, "terraform", address, action, index),
@@ -55,7 +348,12 @@ def _parse_terraform_plan_json(name: str, raw_content: bytes) -> list[UnifiedCha
                 tool="terraform",
                 resource_id=address,
                 action=action,
-                summary=_terraform_summary(address, action),
+                summary=_terraform_summary(
+                    address,
+                    action,
+                    resource_type=metadata["resource_type"],
+                ),
+                metadata=metadata,
             )
         )
     return changes

--- a/playwright.config.cjs
+++ b/playwright.config.cjs
@@ -1,6 +1,9 @@
 const { devices } = require("@playwright/test");
 const { screenReaderConfig } = require("@guidepup/playwright");
 
+const serverPort = process.env.APP_PORT || "8080";
+const serverUrl = `http://127.0.0.1:${serverPort}`;
+
 module.exports = {
   ...screenReaderConfig,
   testDir: "./tests/e2e",
@@ -13,13 +16,13 @@ module.exports = {
   retries: process.env.CI ? 1 : 0,
   reporter: process.env.CI ? "github" : "list",
   use: {
-    baseURL: "http://127.0.0.1:8080",
+    baseURL: serverUrl,
     headless: false,
     trace: "retain-on-failure",
   },
   webServer: {
     command: "./.venv/bin/python tests/e2e/seeded_server.py",
-    url: "http://127.0.0.1:8080/",
+    url: `${serverUrl}/`,
     reuseExistingServer: false,
     timeout: 120_000,
   },

--- a/services/analysis_service.py
+++ b/services/analysis_service.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 from datetime import UTC, datetime
+from typing import Any
 from pydantic import BaseModel, Field
 
 from analysis.blast_radius import BlastRadiusResult, compute_blast_radius
@@ -13,14 +14,14 @@ from analysis.incident_matcher import (
     load_incident_candidates,
 )
 from analysis.risk_engine import score_evidence
-from analysis.risk_scorer import RiskAssessment
+from analysis.risk_scorer import RiskAssessment, score_changes
 from analysis.rollback_planner import RollbackPlan, generate_rollback_plan
 from evidence.extractor import extract_batch_evidence
 from evidence.mappers import build_findings
 from evidence.models import ContextCompleteness, EvidenceItem, Finding
 from llm.narrator import NarrativeResult, generate_narrative
 from llm.providers import generate_completion_with_settings
-from parsers.base import ParseBatchResult, UnifiedChange
+from parsers.base import ParseBatchResult, UnifiedChange, is_non_mutating_action
 from services.intake_service import build_parse_batch
 from services.project_service import (
     ProjectResolutionError,
@@ -43,6 +44,8 @@ def evaluate_evidence(
     partial_context: bool = False,
     topology: dict | None = None,
     raw_files: dict[str, bytes | None] | None = None,
+    change_metadata_by_id: dict[str, dict[str, Any]] | None = None,
+    supplemental_changes: list[UnifiedChange] | None = None,
     completion_client=None,
 ) -> RiskAssessment:
     """Return a reusable unified risk assessment from evidence inputs."""
@@ -51,8 +54,46 @@ def evaluate_evidence(
         partial_context=partial_context,
         topology=topology,
         raw_files=raw_files,
+        change_metadata_by_id=change_metadata_by_id,
+        supplemental_changes=supplemental_changes,
         completion_client=completion_client,
     )
+
+
+def _change_metadata_by_id(batch: ParseBatchResult) -> dict[str, dict[str, Any]]:
+    metadata_by_id: dict[str, dict[str, Any]] = {}
+    for file_result in batch.files:
+        if file_result.status != "parsed":
+            continue
+        for change in file_result.changes:
+            if change.metadata:
+                metadata_by_id[change.change_id] = dict(change.metadata)
+    return metadata_by_id
+
+
+def _all_changes_are_non_mutating_terraform(changes: list[UnifiedChange]) -> bool:
+    return bool(changes) and all(
+        change.tool == "terraform" and is_non_mutating_action(change.action)
+        for change in changes
+    )
+
+
+def _supplemental_non_mutating_terraform_changes(
+    changes: list[UnifiedChange], evidence_items: list[EvidenceItem]
+) -> list[UnifiedChange]:
+    evidence_change_ids = {
+        change_id
+        for item in evidence_items
+        for change_id in item.related_change_ids
+        if change_id
+    }
+    return [
+        change
+        for change in changes
+        if change.tool == "terraform"
+        and is_non_mutating_action(change.action)
+        and change.change_id not in evidence_change_ids
+    ]
 
 
 def evaluate_parse_batch(
@@ -65,13 +106,34 @@ def evaluate_parse_batch(
     completion_client=None,
 ) -> RiskAssessment:
     """Compatibility wrapper that scores extracted evidence for a parse batch."""
+    scored_evidence_items = (
+        list(evidence_items)
+        if evidence_items is not None
+        else extract_batch_evidence(batch)
+    )
+    changes = _collect_changes(batch)
+    partial_context_value = (
+        batch.has_partial_context if partial_context is None else partial_context
+    )
+    if not scored_evidence_items and _all_changes_are_non_mutating_terraform(changes):
+        return score_changes(
+            changes,
+            partial_context=partial_context_value,
+            topology=topology,
+            raw_files=raw_files,
+            completion_client=completion_client,
+        )
+    if not scored_evidence_items:
+        scored_evidence_items = extract_batch_evidence(batch)
     return evaluate_evidence(
-        evidence_items or extract_batch_evidence(batch),
-        partial_context=batch.has_partial_context
-        if partial_context is None
-        else partial_context,
+        scored_evidence_items,
+        partial_context=partial_context_value,
         topology=topology,
         raw_files=raw_files,
+        change_metadata_by_id=_change_metadata_by_id(batch),
+        supplemental_changes=_supplemental_non_mutating_terraform_changes(
+            changes, scored_evidence_items
+        ),
         completion_client=completion_client,
     )
 

--- a/tests/e2e/report_review.keyboard.spec.js
+++ b/tests/e2e/report_review.keyboard.spec.js
@@ -71,6 +71,20 @@ test.describe("review keyboard flow", () => {
     await page.goto("/", { waitUntil: "networkidle" });
     await expect(page.getByText("5-second verdict")).toBeVisible();
     await page.waitForFunction(() => window.dwReviewAccessibilityInstalled === true);
+    await expect(page.getByText("Module: module.network").first()).toBeVisible();
+    await expect(
+      page
+        .getByText("Provider: registry.terraform.io/hashicorp/aws")
+        .first()
+    ).toBeVisible();
+    await expect(
+      page.getByText("Unsupported plan fields: plan.planned_values").first()
+    ).toBeVisible();
+    await page.getByRole("button", { name: "Thumbs up" }).first().click();
+    await expect(page.getByText("Module: module.network").first()).toBeVisible();
+    await expect(
+      page.getByText("Unsupported plan fields: plan.planned_values").first()
+    ).toBeVisible();
 
     const findingRows = page.locator('[data-dw-finding-row="1"]');
     await expect(findingRows).toHaveCount(2);
@@ -136,6 +150,10 @@ test.describe("review keyboard flow", () => {
     await page.waitForFunction(() => window.dwReviewAccessibilityInstalled === true);
     await expect(page.getByText("Analysis report detail")).toBeVisible();
     await expect(page.getByText("Back to History")).toBeVisible();
+    await expect(page.getByText("Module: module.network").first()).toBeVisible();
+    await expect(
+      page.getByText("Unsupported plan fields: plan.planned_values").first()
+    ).toBeVisible();
     await expect(page.locator('[data-dw-modal-root="1"]')).toHaveCount(0);
     await expect(page.locator('[data-dw-review-section="findings"]')).toBeVisible();
     await expect(page.locator('[data-dw-review-section="context"]')).toBeVisible();

--- a/tests/e2e/seeded_server.py
+++ b/tests/e2e/seeded_server.py
@@ -9,7 +9,6 @@ from importlib import import_module, reload
 from pathlib import Path
 
 import nicegui.run as nicegui_run
-import uvicorn
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 if str(REPO_ROOT) not in sys.path:
@@ -86,6 +85,13 @@ def _seed_review_report(report_service_module) -> None:
                         resource_id="aws_security_group.main",
                         action="modify",
                         summary="Security group exposure risk",
+                        metadata={
+                            "module_address": "module.network",
+                            "provider_name": "registry.terraform.io/hashicorp/aws",
+                            "redacted_fields": ["ingress.0.description"],
+                            "unsupported_fields": ["change.importing"],
+                            "plan_unsupported_fields": ["plan.planned_values"],
+                        },
                     ),
                     UnifiedChange(
                         source_file="plan.json",
@@ -114,6 +120,13 @@ def _seed_review_report(report_service_module) -> None:
                 contribution=20,
                 summary="Ingress widens production access.",
                 severity="critical",
+                metadata={
+                    "module_address": "module.network",
+                    "provider_name": "registry.terraform.io/hashicorp/aws",
+                    "redacted_fields": ["ingress.0.description"],
+                    "unsupported_fields": ["change.importing"],
+                    "plan_unsupported_fields": ["plan.planned_values"],
+                },
             ),
             RiskContributor(
                 evidence_id="ev-002",
@@ -253,13 +266,14 @@ def _seed_review_report(report_service_module) -> None:
             "source_interface": "ui",
             "trigger_type": "dashboard_upload",
         },
+        project_key="payments",
     )
 
 
 def _seed_projects() -> None:
-    from services.project_service import create_project
+    from services.project_service import create_project, set_active_project
 
-    create_project(
+    payments_project = create_project(
         project_key="payments",
         display_name="Payments",
         repository_url="https://github.com/acme/payments-api.git",
@@ -271,6 +285,7 @@ def _seed_projects() -> None:
         repository_url="https://github.com/acme/platform-hub.git",
         default_branch="main",
     )
+    set_active_project(payments_project.id)
 
 
 def main() -> None:
@@ -279,28 +294,7 @@ def main() -> None:
     _seed_projects()
     _seed_review_report(report_service_module)
     app_module = import_module("app")
-    app_module.fastapi_app.config.add_run_config(
-        reload=False,
-        title="DeployWhisper",
-        viewport="width=device-width, initial-scale=1",
-        favicon="/assets/favicon.ico",
-        dark=False,
-        language="en-US",
-        binding_refresh_interval=0.1,
-        reconnect_timeout=3.0,
-        message_history_length=1000,
-        tailwind=True,
-        unocss=None,
-        prod_js=True,
-        show_welcome_message=False,
-        markdown=False,
-    )
-    uvicorn.run(
-        app_module.create_app(),
-        host=os.environ["APP_HOST"],
-        port=int(os.environ["APP_PORT"]),
-        log_level="info",
-    )
+    app_module.run()
 
 
 if __name__ == "__main__":

--- a/tests/test_analysis/test_blast_radius.py
+++ b/tests/test_analysis/test_blast_radius.py
@@ -64,3 +64,48 @@ class BlastRadiusTests(unittest.TestCase):
         self.assertTrue(result.warning)
         self.assertIn("no topology mapping found", result.warning)
         self.assertEqual(result.unmatched_resources, ["aws_security_group.main"])
+
+    def test_compute_blast_radius_ignores_noop_and_read_changes(self) -> None:
+        topology = {
+            "services": [
+                {
+                    "id": "api",
+                    "label": "API Service",
+                    "resource_keys": [
+                        "aws_security_group.main",
+                        "data.aws_ami.latest",
+                    ],
+                    "downstream": ["worker"],
+                },
+                {
+                    "id": "worker",
+                    "label": "Worker",
+                    "resource_keys": [],
+                    "downstream": [],
+                },
+            ]
+        }
+        changes = [
+            UnifiedChange(
+                source_file="plan.json",
+                tool="terraform",
+                resource_id="aws_security_group.main",
+                action="no-op",
+                summary="Terraform resource aws_security_group.main has no planned changes.",
+            ),
+            UnifiedChange(
+                source_file="plan.json",
+                tool="terraform",
+                resource_id="data.aws_ami.latest",
+                action="read",
+                summary="Terraform resource data.aws_ami.latest marked for read.",
+            ),
+        ]
+
+        result = compute_blast_radius(changes, topology)
+
+        self.assertEqual(result.affected, [])
+        self.assertEqual(result.direct_count, 0)
+        self.assertEqual(result.transitive_count, 0)
+        self.assertEqual(result.unmatched_resources, [])
+        self.assertIsNone(result.warning)

--- a/tests/test_analysis/test_interaction_risk.py
+++ b/tests/test_analysis/test_interaction_risk.py
@@ -75,3 +75,55 @@ class InteractionRiskTests(unittest.TestCase):
         )
         self.assertTrue(assessment.interaction_risks)
         self.assertEqual(assessment.top_risk, assessment.interaction_risks[0].summary)
+
+    def test_detect_interaction_risk_ignores_non_mutating_changes(self) -> None:
+        changes = [
+            UnifiedChange(
+                source_file="plan.json",
+                tool="terraform",
+                resource_id="aws_security_group.payments",
+                action="no-op",
+                summary="Terraform payments security group has no planned changes.",
+            ),
+            UnifiedChange(
+                source_file="data.json",
+                tool="terraform",
+                resource_id="data.aws_ami.payments",
+                action="read",
+                summary="Terraform data source payments marked for read.",
+            ),
+            UnifiedChange(
+                source_file="deployment.yaml",
+                tool="kubernetes",
+                resource_id="Deployment/payments",
+                action="modify",
+                summary="Kubernetes deployment payments changed.",
+            ),
+        ]
+
+        findings = detect_interaction_risks(changes)
+
+        self.assertEqual(findings, [])
+
+    def test_score_changes_does_not_promote_non_mutating_interaction(self) -> None:
+        assessment = score_changes(
+            [
+                UnifiedChange(
+                    source_file="plan.json",
+                    tool="terraform",
+                    resource_id="aws_security_group.payments",
+                    action="no-op",
+                    summary="Terraform payments security group has no planned changes.",
+                ),
+                UnifiedChange(
+                    source_file="deployment.yaml",
+                    tool="kubernetes",
+                    resource_id="Deployment/payments",
+                    action="modify",
+                    summary="Kubernetes deployment payments changed.",
+                ),
+            ]
+        )
+
+        self.assertEqual(assessment.interaction_risks, [])
+        self.assertNotIn("Terraform and Kubernetes", assessment.top_risk)

--- a/tests/test_analysis/test_risk_scorer.py
+++ b/tests/test_analysis/test_risk_scorer.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import unittest
 
 from analysis.risk_scorer import score_changes, score_parse_batch
@@ -52,6 +53,223 @@ class RiskScorerTests(unittest.TestCase):
         self.assertLessEqual(assessment.score, 60)
         self.assertIn(assessment.severity, {"medium", "low"})
         self.assertEqual(assessment.recommendation, "go")
+
+    def test_noop_changes_do_not_score_as_modifications(self) -> None:
+        assessment = score_changes(
+            [
+                UnifiedChange(
+                    source_file="plan.json",
+                    tool="terraform",
+                    resource_id="aws_security_group.main",
+                    action="no-op",
+                    summary="Terraform resource aws_security_group.main has no planned changes.",
+                )
+            ]
+        )
+
+        self.assertEqual(assessment.score, 0)
+        self.assertEqual(assessment.severity, "low")
+        self.assertEqual(assessment.recommendation, "go")
+        self.assertEqual(assessment.contributors[0].normalized_action, "no-op")
+
+    def test_noop_changes_keep_no_planned_change_blast_radius_with_topology(
+        self,
+    ) -> None:
+        assessment = score_changes(
+            [
+                UnifiedChange(
+                    source_file="plan.json",
+                    tool="terraform",
+                    resource_id="aws_security_group.main",
+                    action="no-op",
+                    summary="Terraform resource aws_security_group.main has no planned changes.",
+                )
+            ],
+            topology={
+                "services": [
+                    {
+                        "id": "api",
+                        "resource_keys": ["aws_security_group.main"],
+                        "downstream": ["worker"],
+                    },
+                    {"id": "worker", "resource_keys": [], "downstream": []},
+                ]
+            },
+        )
+
+        contributor = assessment.contributors[0]
+        self.assertEqual(assessment.score, 0)
+        self.assertEqual(contributor.downstream_scope, 2)
+        self.assertEqual(contributor.blast_radius, "no planned change")
+        self.assertNotIn("may affect", contributor.reasoning)
+
+    def test_replacement_actions_are_not_normalized_as_destroy_only(self) -> None:
+        assessment = score_changes(
+            [
+                UnifiedChange(
+                    source_file="plan.json",
+                    tool="terraform",
+                    resource_id="aws_instance.web",
+                    action="delete+create",
+                    summary="Terraform resource aws_instance.web marked for delete+create.",
+                    metadata={"replace_paths": ["ami"]},
+                )
+            ]
+        )
+
+        contributor = assessment.contributors[0]
+        self.assertEqual(contributor.normalized_action, "replace")
+        self.assertEqual(contributor.severity, "high")
+        self.assertEqual(assessment.recommendation, "no-go")
+        self.assertEqual(contributor.metadata["replace_paths"], ["ami"])
+
+    def test_mixed_destructive_actions_normalize_as_destroy(self) -> None:
+        assessment = score_changes(
+            [
+                UnifiedChange(
+                    source_file="plan.json",
+                    tool="terraform",
+                    resource_id="aws_instance.web",
+                    action="modify+delete",
+                    summary="Terraform resource aws_instance.web marked for destroy.",
+                )
+            ]
+        )
+
+        self.assertEqual(assessment.contributors[0].normalized_action, "destroy")
+
+    def test_non_mutating_changes_ignore_raw_file_security_flags(self) -> None:
+        assessment = score_changes(
+            [
+                UnifiedChange(
+                    source_file="plan.json",
+                    tool="terraform",
+                    resource_id="aws_security_group.main",
+                    action="no-op",
+                    summary="Terraform resource aws_security_group.main has no planned changes.",
+                )
+            ],
+            raw_files={"plan.json": b'protocol -1 cidr_blocks = ["0.0.0.0/0"]'},
+        )
+
+        contributor = assessment.contributors[0]
+        self.assertEqual(assessment.score, 0)
+        self.assertEqual(assessment.severity, "low")
+        self.assertEqual(assessment.recommendation, "go")
+        self.assertEqual(contributor.security_flags, [])
+
+    def test_mixed_non_mutating_and_mutating_actions_do_not_downgrade(self) -> None:
+        assessment = score_changes(
+            [
+                UnifiedChange(
+                    source_file="plan.json",
+                    tool="terraform",
+                    resource_id="aws_instance.deleted",
+                    action="read+delete",
+                    summary="Terraform resource aws_instance.deleted marked for destroy.",
+                ),
+                UnifiedChange(
+                    source_file="plan.json",
+                    tool="terraform",
+                    resource_id="aws_instance.updated",
+                    action="no-op+update",
+                    summary="Terraform resource aws_instance.updated marked for modify.",
+                ),
+            ]
+        )
+
+        by_resource = {
+            contributor.resource_id: contributor.normalized_action
+            for contributor in assessment.contributors
+        }
+        self.assertEqual(by_resource["aws_instance.deleted"], "destroy")
+        self.assertEqual(by_resource["aws_instance.updated"], "modify")
+
+    def test_read_only_changes_do_not_score_as_modifications(self) -> None:
+        assessment = score_changes(
+            [
+                UnifiedChange(
+                    source_file="plan.json",
+                    tool="terraform",
+                    resource_id="data.aws_ami.latest",
+                    action="read",
+                    summary="Terraform resource data.aws_ami.latest marked for read.",
+                    metadata={"mode": "data"},
+                )
+            ]
+        )
+
+        contributor = assessment.contributors[0]
+        self.assertEqual(assessment.score, 0)
+        self.assertEqual(assessment.severity, "low")
+        self.assertEqual(contributor.normalized_action, "read")
+        self.assertEqual(
+            contributor.blast_radius,
+            "read-only lookup; no infrastructure mutation planned",
+        )
+
+    def test_llm_scoring_keeps_non_mutating_changes_at_zero(self) -> None:
+        def fake_completion(**_: object) -> str:
+            self.fail("Non-mutating changes should not invoke LLM scoring.")
+            return json.dumps(
+                {
+                    "overall_severity": "medium",
+                    "recommendation": "go",
+                    "top_risk": "LLM attempted to score the no-op change.",
+                    "overall_reasoning": "No-op entry should remain deterministic.",
+                    "change_scores": [
+                        {
+                            "source_file": "plan.json",
+                            "resource_id": "aws_security_group.main",
+                            "severity": "medium",
+                            "reasoning": "LLM marked this as medium risk.",
+                        }
+                    ],
+                }
+            )
+
+        assessment = score_changes(
+            [
+                UnifiedChange(
+                    source_file="plan.json",
+                    tool="terraform",
+                    resource_id="aws_security_group.main",
+                    action="no-op",
+                    summary="Terraform resource aws_security_group.main has no planned changes.",
+                )
+            ],
+            completion_client=fake_completion,
+        )
+
+        self.assertEqual(assessment.source, "heuristic-only")
+        self.assertEqual(assessment.score, 0)
+        self.assertEqual(assessment.severity, "low")
+        self.assertEqual(assessment.recommendation, "go")
+        self.assertEqual(assessment.contributors[0].contribution, 0)
+        self.assertEqual(assessment.contributors[0].severity, "low")
+        self.assertNotIn("medium risk", assessment.contributors[0].reasoning)
+        self.assertNotIn("medium risk", assessment.top_risk)
+
+    def test_non_mutating_llm_failure_does_not_emit_provider_warning(self) -> None:
+        def failing_completion(**_: object) -> str:
+            raise RuntimeError("provider unavailable")
+
+        assessment = score_changes(
+            [
+                UnifiedChange(
+                    source_file="plan.json",
+                    tool="terraform",
+                    resource_id="data.aws_ami.latest",
+                    action="read",
+                    summary="Terraform resource data.aws_ami.latest is read-only.",
+                )
+            ],
+            completion_client=failing_completion,
+        )
+
+        self.assertEqual(assessment.source, "heuristic-only")
+        self.assertEqual(assessment.score, 0)
+        self.assertEqual(assessment.warnings, [])
 
     def test_high_impact_changes_can_reach_critical_and_no_go(self) -> None:
         assessment = score_changes(

--- a/tests/test_analysis/test_rollback_planner.py
+++ b/tests/test_analysis/test_rollback_planner.py
@@ -62,3 +62,56 @@ class RollbackPlannerTests(unittest.TestCase):
         plan = generate_rollback_plan(changes)
         self.assertEqual(plan.complexity, "high")
         self.assertEqual(plan.complexity_score, 4)
+
+    def test_generate_rollback_plan_skips_noop_and_read_changes(self) -> None:
+        changes = [
+            UnifiedChange(
+                source_file="plan.json",
+                tool="terraform",
+                resource_id="aws_security_group.main",
+                action="no-op",
+                summary="Terraform resource aws_security_group.main has no planned changes.",
+            ),
+            UnifiedChange(
+                source_file="plan.json",
+                tool="terraform",
+                resource_id="data.aws_ami.latest",
+                action="read",
+                summary="Terraform resource data.aws_ami.latest marked for read.",
+            ),
+        ]
+
+        plan = generate_rollback_plan(changes)
+
+        self.assertEqual(len(plan.steps), 1)
+        self.assertEqual(plan.steps[0].title, "No rollback steps generated")
+        self.assertFalse(plan.steps[0].critical)
+        self.assertEqual(plan.steps[0].estimated_minutes, 0)
+        self.assertEqual(plan.complexity, "low")
+        self.assertEqual(plan.complexity_score, 1)
+
+    def test_generate_rollback_plan_treats_replace_as_destructive(self) -> None:
+        changes = [
+            UnifiedChange(
+                source_file="plan.json",
+                tool="terraform",
+                resource_id="aws_instance.web",
+                action="replace",
+                summary="Terraform resource aws_instance.web marked for replace.",
+            ),
+            UnifiedChange(
+                source_file="deployment.yaml",
+                tool="kubernetes",
+                resource_id="Deployment/api",
+                action="modify",
+                summary="Kubernetes deployment changed.",
+            ),
+        ]
+
+        plan = generate_rollback_plan(changes)
+
+        self.assertEqual(plan.steps[0].title, "Revert aws_instance.web")
+        self.assertTrue(plan.steps[0].critical)
+        self.assertGreater(plan.steps[0].estimated_minutes, 10)
+        self.assertEqual(plan.complexity_score, 3)
+        self.assertIn("destructive change", plan.complexity_explanation)

--- a/tests/test_api/test_analyses.py
+++ b/tests/test_api/test_analyses.py
@@ -526,7 +526,7 @@ class AnalysesApiTests(unittest.TestCase):
                 "files",
                 (
                     "plan.json",
-                    b'{"resource_changes": [{"address": "aws_security_group.main", "change": {"actions": ["modify"]}}]}',
+                    b'{"resource_changes": [{"address": "aws_security_group.main", "change": {"actions": ["update"]}}]}',
                     "application/json",
                 ),
             )
@@ -622,6 +622,194 @@ class AnalysesApiTests(unittest.TestCase):
         )
         self.assertEqual(payload["data"]["persisted_report"]["id"], 2)
 
+    def test_create_analysis_preserves_real_pipeline_metadata_in_persisted_contributors(
+        self,
+    ) -> None:
+        project_service_module.create_project(
+            project_key="payments",
+            display_name="Payments",
+        )
+        files = [
+            (
+                "files",
+                (
+                    "plan.json",
+                    (
+                        b'{"planned_values": {}, "resource_changes": ['
+                        b'{"address": "data.aws_ami.selected", "mode": "data", '
+                        b'"change": {"actions": ["read"], "after_unknown": {"id": true}}}, '
+                        b'{"address": '
+                        b'"module.network.aws_security_group.main", "module_address": '
+                        b'"module.network", "provider_name": '
+                        b'"registry.terraform.io/hashicorp/aws", "type": '
+                        b'"aws_security_group", "name": "main", "change": '
+                        b'{"actions": ["update"]}}]}'
+                    ),
+                    "application/json",
+                ),
+            )
+        ]
+        narrative = NarrativeResult(
+            opening_sentence="CAUTION: review the security group update.",
+            explanation="The deployment should be reviewed.",
+            guidance=[],
+            degraded=False,
+            warnings=[],
+        )
+
+        with (
+            patch(
+                "analysis.risk_scorer.generate_completion_with_settings",
+                return_value='{"change_scores": []}',
+            ),
+            patch(
+                "services.analysis_service.generate_narrative", return_value=narrative
+            ),
+            patch("services.analysis_service.find_incident_matches", return_value=[]),
+        ):
+            response = self.client.post(
+                "/api/v1/analyses",
+                files=files,
+                data={"project_key": "payments"},
+            )
+
+        self.assertEqual(response.status_code, 200)
+        payload = response.json()
+        contributors = {
+            contributor["resource_id"]: contributor
+            for contributor in payload["data"]["persisted_report"]["contributors"]
+        }
+        metadata = contributors["module.network.aws_security_group.main"]["metadata"]
+        self.assertEqual(metadata["module_address"], "module.network")
+        self.assertEqual(
+            metadata["provider_name"], "registry.terraform.io/hashicorp/aws"
+        )
+        self.assertEqual(metadata["plan_unsupported_fields"], ["plan.planned_values"])
+        self.assertEqual(
+            contributors["data.aws_ami.selected"]["metadata"]["unknown_after_apply"],
+            ["id"],
+        )
+        self.assertIsNone(contributors["data.aws_ami.selected"]["evidence_id"])
+        self.assertEqual(contributors["data.aws_ami.selected"]["contribution"], 0)
+
+        detail = self.client.get(
+            f"/api/v1/analyses/{payload['data']['persisted_report']['id']}",
+            params={"project_key": "payments"},
+        )
+        self.assertEqual(detail.status_code, 200)
+        detail_contributors = {
+            contributor["resource_id"]: contributor
+            for contributor in detail.json()["data"]["contributors"]
+        }
+        self.assertEqual(
+            detail_contributors["module.network.aws_security_group.main"]["metadata"][
+                "plan_unsupported_fields"
+            ],
+            ["plan.planned_values"],
+        )
+        self.assertEqual(
+            detail_contributors["data.aws_ami.selected"]["metadata"][
+                "unknown_after_apply"
+            ],
+            ["id"],
+        )
+
+        history = self.client.get(
+            "/api/v1/analyses",
+            params={"project_key": "payments"},
+        )
+        self.assertEqual(history.status_code, 200)
+        history_contributors = {
+            contributor["resource_id"]: contributor
+            for contributor in history.json()["data"][0]["contributors"]
+        }
+        self.assertEqual(
+            history_contributors["module.network.aws_security_group.main"]["metadata"][
+                "plan_unsupported_fields"
+            ],
+            ["plan.planned_values"],
+        )
+        self.assertEqual(
+            history_contributors["data.aws_ami.selected"]["metadata"][
+                "unknown_after_apply"
+            ],
+            ["id"],
+        )
+
+    def test_create_analysis_preserves_all_non_mutating_plan_metadata(
+        self,
+    ) -> None:
+        project_service_module.create_project(
+            project_key="payments",
+            display_name="Payments",
+        )
+        files = [
+            (
+                "files",
+                (
+                    "empty-plan.json",
+                    (
+                        b'{"format_version": "1.2", "terraform_version": "1.8.5", '
+                        b'"planned_values": {}, "resource_changes": []}'
+                    ),
+                    "application/json",
+                ),
+            )
+        ]
+        narrative = NarrativeResult(
+            opening_sentence="GO: no planned infrastructure changes.",
+            explanation="The submitted Terraform plan contains no resource changes.",
+            guidance=[],
+            degraded=False,
+            warnings=[],
+        )
+
+        with (
+            patch(
+                "services.analysis_service.generate_narrative", return_value=narrative
+            ),
+            patch("services.analysis_service.find_incident_matches", return_value=[]),
+        ):
+            response = self.client.post(
+                "/api/v1/analyses",
+                files=files,
+                data={"project_key": "payments"},
+            )
+
+        self.assertEqual(response.status_code, 200)
+        payload = response.json()
+        contributor = payload["data"]["persisted_report"]["contributors"][0]
+        self.assertEqual(contributor["resource_id"], "terraform-plan")
+        self.assertEqual(contributor["contribution"], 0)
+        self.assertEqual(
+            contributor["metadata"]["plan_unsupported_fields"],
+            ["plan.planned_values"],
+        )
+
+        detail = self.client.get(
+            f"/api/v1/analyses/{payload['data']['persisted_report']['id']}",
+            params={"project_key": "payments"},
+        )
+        self.assertEqual(detail.status_code, 200)
+        self.assertEqual(
+            detail.json()["data"]["contributors"][0]["metadata"][
+                "plan_unsupported_fields"
+            ],
+            ["plan.planned_values"],
+        )
+
+        history = self.client.get(
+            "/api/v1/analyses",
+            params={"project_key": "payments"},
+        )
+        self.assertEqual(history.status_code, 200)
+        self.assertEqual(
+            history.json()["data"][0]["contributors"][0]["metadata"][
+                "plan_unsupported_fields"
+            ],
+            ["plan.planned_values"],
+        )
+
     def test_create_analysis_persists_submission_manifest_with_partial_coverage(
         self,
     ) -> None:
@@ -634,7 +822,15 @@ class AnalysesApiTests(unittest.TestCase):
                 "files",
                 (
                     "plan.json",
-                    b'{"resource_changes": [{"address": "aws_security_group.main", "change": {"actions": ["update"]}}]}',
+                    (
+                        b'{"planned_values": {}, "resource_changes": [{"address": "module.network.aws_security_group.main", '
+                        b'"module_address": "module.network", "type": "aws_security_group", '
+                        b'"name": "main", "provider_name": "registry.terraform.io/hashicorp/aws", '
+                        b'"change": {"actions": ["update"], "after_unknown": {"arn": true}, '
+                        b'"after_sensitive": {"ingress": [{"description": true}]}, '
+                        b'"replace_paths": [["ingress", 0, "cidr_blocks"]], '
+                        b'"importing": {"id": "sg-123"}}, "deposed": "legacy"}]}'
+                    ),
                     "application/json",
                 ),
             ),
@@ -709,6 +905,23 @@ class AnalysesApiTests(unittest.TestCase):
         self.assertTrue(by_name["notes.txt"]["partial"])
         self.assertEqual(by_name["plan.json"]["provenance"]["source_interface"], "api")
         self.assertEqual(by_name["plan.json"]["provenance"]["trigger_id"], "build-77")
+        change = payload["data"]["parse_batch"]["files"][0]["changes"][0]
+        self.assertEqual(
+            change["resource_id"], "module.network.aws_security_group.main"
+        )
+        self.assertEqual(change["metadata"]["module_address"], "module.network")
+        self.assertEqual(change["metadata"]["unknown_after_apply"], ["arn"])
+        self.assertEqual(
+            change["metadata"]["redacted_fields"], ["ingress.0.description"]
+        )
+        self.assertEqual(
+            change["metadata"]["unsupported_fields"],
+            ["change.importing", "resource_change.deposed"],
+        )
+        self.assertEqual(
+            change["metadata"]["plan_unsupported_fields"],
+            ["plan.planned_values"],
+        )
         self.assertTrue(payload["data"]["assessment"]["partial_context"])
 
         detail = self.client.get(
@@ -720,6 +933,68 @@ class AnalysesApiTests(unittest.TestCase):
             detail.json()["data"]["submission_manifest"]["failed_artifact_count"],
             1,
         )
+
+    def test_create_analysis_surfaces_duplicate_terraform_action_parse_failure(
+        self,
+    ) -> None:
+        project_service_module.create_project(
+            project_key="payments",
+            display_name="Payments",
+        )
+        files = [
+            (
+                "files",
+                (
+                    "plan.json",
+                    b'{"resource_changes": [{"address": "aws_security_group.main", "change": {"actions": ["update"]}}]}',
+                    "application/json",
+                ),
+            ),
+            (
+                "files",
+                (
+                    "duplicate-plan.json",
+                    b'{"resource_changes": [{"address": "aws_instance.web", "change": {"actions": ["create", "create"]}}]}',
+                    "application/json",
+                ),
+            ),
+        ]
+        narrative = NarrativeResult(
+            opening_sentence="CAUTION: review partial analysis.",
+            explanation="One Terraform plan could not be parsed.",
+            guidance=[],
+            degraded=False,
+            warnings=[],
+        )
+
+        with (
+            patch(
+                "services.analysis_service.generate_narrative", return_value=narrative
+            ),
+            patch("services.analysis_service.find_incident_matches", return_value=[]),
+        ):
+            response = self.client.post(
+                "/api/v1/analyses",
+                files=files,
+                data={"project_key": "payments"},
+            )
+
+        self.assertEqual(response.status_code, 200)
+        payload = response.json()
+        by_name = {
+            file_result["file_name"]: file_result
+            for file_result in payload["data"]["parse_batch"]["files"]
+        }
+        self.assertEqual(by_name["plan.json"]["status"], "parsed")
+        self.assertEqual(by_name["duplicate-plan.json"]["status"], "failed")
+        self.assertIn(
+            "Duplicate Terraform action",
+            by_name["duplicate-plan.json"]["issue"]["message"],
+        )
+        manifest = payload["data"]["persisted_report"]["submission_manifest"]
+        self.assertEqual(manifest["accepted_artifact_count"], 2)
+        self.assertEqual(manifest["failed_artifact_count"], 1)
+        self.assertTrue(manifest["partial_analysis"])
 
     def test_create_analysis_denies_role_without_submit_capability(self) -> None:
         project_service_module.create_project(
@@ -947,7 +1222,7 @@ class AnalysesApiTests(unittest.TestCase):
                 "files",
                 (
                     "plan.json",
-                    b'{"resource_changes": [{"address": "aws_security_group.main", "change": {"actions": ["modify"]}}]}',
+                    b'{"resource_changes": [{"address": "aws_security_group.main", "change": {"actions": ["update"]}}]}',
                     "application/json",
                 ),
             )
@@ -992,7 +1267,7 @@ class AnalysesApiTests(unittest.TestCase):
                 "files",
                 (
                     "plan.json",
-                    b'{"resource_changes": [{"address": "aws_security_group.main", "change": {"actions": ["modify"]}}]}',
+                    b'{"resource_changes": [{"address": "aws_security_group.main", "change": {"actions": ["update"]}}]}',
                     "application/json",
                 ),
             )
@@ -1033,7 +1308,7 @@ class AnalysesApiTests(unittest.TestCase):
                 "files",
                 (
                     "plan.json",
-                    b'{"resource_changes": [{"address": "aws_security_group.main", "change": {"actions": ["modify"]}}]}',
+                    b'{"resource_changes": [{"address": "aws_security_group.main", "change": {"actions": ["update"]}}]}',
                     "application/json",
                 ),
             )
@@ -1054,7 +1329,7 @@ class AnalysesApiTests(unittest.TestCase):
                 "files",
                 (
                     "plan.json",
-                    b'{"resource_changes": [{"address": "aws_security_group.main", "change": {"actions": ["modify"]}}]}',
+                    b'{"resource_changes": [{"address": "aws_security_group.main", "change": {"actions": ["update"]}}]}',
                     "application/json",
                 ),
             )
@@ -1084,7 +1359,7 @@ class AnalysesApiTests(unittest.TestCase):
                 "files",
                 (
                     "plan.json",
-                    b'{"resource_changes": [{"address": "aws_security_group.main", "change": {"actions": ["modify"]}}]}',
+                    b'{"resource_changes": [{"address": "aws_security_group.main", "change": {"actions": ["update"]}}]}',
                     "application/json",
                 ),
             )
@@ -1108,7 +1383,7 @@ class AnalysesApiTests(unittest.TestCase):
                 "files",
                 (
                     "plan.json",
-                    b'{"resource_changes": [{"address": "aws_security_group.main", "change": {"actions": ["modify"]}}]}',
+                    b'{"resource_changes": [{"address": "aws_security_group.main", "change": {"actions": ["update"]}}]}',
                     "application/json",
                 ),
             )
@@ -1151,7 +1426,7 @@ class AnalysesApiTests(unittest.TestCase):
                 "files",
                 (
                     "plan.json",
-                    b'{"resource_changes": [{"address": "aws_security_group.main", "change": {"actions": ["modify"]}}]}',
+                    b'{"resource_changes": [{"address": "aws_security_group.main", "change": {"actions": ["update"]}}]}',
                     "application/json",
                 ),
             )
@@ -1186,7 +1461,7 @@ class AnalysesApiTests(unittest.TestCase):
                 "files",
                 (
                     "plan.json",
-                    b'{"resource_changes": [{"address": "aws_security_group.main", "change": {"actions": ["modify"]}}]}',
+                    b'{"resource_changes": [{"address": "aws_security_group.main", "change": {"actions": ["update"]}}]}',
                     "application/json",
                 ),
             )
@@ -1245,7 +1520,7 @@ class AnalysesApiTests(unittest.TestCase):
                 "files",
                 (
                     "plan.json",
-                    b'{"resource_changes": [{"address": "aws_security_group.first", "change": {"actions": ["modify"]}}]}',
+                    b'{"resource_changes": [{"address": "aws_security_group.first", "change": {"actions": ["update"]}}]}',
                     "application/json",
                 ),
             ),
@@ -1253,7 +1528,7 @@ class AnalysesApiTests(unittest.TestCase):
                 "files",
                 (
                     "plan.json",
-                    b'{"resource_changes": [{"address": "aws_security_group.second", "change": {"actions": ["modify"]}}]}',
+                    b'{"resource_changes": [{"address": "aws_security_group.second", "change": {"actions": ["update"]}}]}',
                     "application/json",
                 ),
             ),
@@ -1380,7 +1655,7 @@ class AnalysesApiTests(unittest.TestCase):
                 "files",
                 (
                     "plan.json",
-                    b'{"resource_changes": [{"address": "aws_security_group.main", "change": {"actions": ["modify"]}}]}',
+                    b'{"resource_changes": [{"address": "aws_security_group.main", "change": {"actions": ["update"]}}]}',
                     "application/json",
                 ),
             )

--- a/tests/test_cli/test_analyze.py
+++ b/tests/test_cli/test_analyze.py
@@ -572,7 +572,14 @@ class AnalyzeCliTests(unittest.TestCase):
         )
         artifact_path = Path(self.tempdir.name) / "plan.json"
         artifact_path.write_text(
-            '{"resource_changes": [{"address": "aws_security_group.main", "change": {"actions": ["modify"]}}]}',
+            (
+                '{"planned_values": {}, "resource_changes": [{"address": "module.network.aws_security_group.main", '
+                '"module_address": "module.network", "type": "aws_security_group", '
+                '"name": "main", "provider_name": "registry.terraform.io/hashicorp/aws", '
+                '"change": {"actions": ["update"], "after_unknown": {"arn": true}, '
+                '"after_sensitive": {"ingress": [{"description": true}]}, '
+                '"replace_paths": [["ingress", 0, "cidr_blocks"]]}}]}'
+            ),
             encoding="utf-8",
         )
         narrative = NarrativeResult(
@@ -634,6 +641,19 @@ class AnalyzeCliTests(unittest.TestCase):
         self.assertEqual(
             payload["data"]["persisted_report"]["report_schema_version"], "v2"
         )
+        change = payload["data"]["parse_batch"]["files"][0]["changes"][0]
+        self.assertEqual(
+            change["resource_id"], "module.network.aws_security_group.main"
+        )
+        self.assertEqual(change["metadata"]["module_address"], "module.network")
+        self.assertEqual(change["metadata"]["unknown_after_apply"], ["arn"])
+        self.assertEqual(
+            change["metadata"]["redacted_fields"], ["ingress.0.description"]
+        )
+        self.assertEqual(
+            change["metadata"]["plan_unsupported_fields"],
+            ["plan.planned_values"],
+        )
         self.assertEqual(
             payload["data"]["persisted_report"]["audit"]["source_interface"], "cli"
         )
@@ -641,6 +661,66 @@ class AnalyzeCliTests(unittest.TestCase):
             payload["data"]["persisted_report"]["audit"]["trigger_type"], "cli_command"
         )
         self.assertEqual(payload["data"]["persisted_report"]["id"], 1)
+
+    def test_analyze_command_serializes_duplicate_terraform_action_parse_failure(
+        self,
+    ) -> None:
+        project_service_module.create_project(
+            project_key="payments",
+            display_name="Payments",
+        )
+        valid_path = Path(self.tempdir.name) / "plan.json"
+        valid_path.write_text(
+            '{"resource_changes": [{"address": "aws_security_group.main", "change": {"actions": ["update"]}}]}',
+            encoding="utf-8",
+        )
+        duplicate_path = Path(self.tempdir.name) / "duplicate-plan.json"
+        duplicate_path.write_text(
+            '{"resource_changes": [{"address": "aws_instance.web", "change": {"actions": ["create", "create"]}}]}',
+            encoding="utf-8",
+        )
+        narrative = NarrativeResult(
+            opening_sentence="CAUTION: review partial analysis.",
+            explanation="One Terraform plan could not be parsed.",
+            guidance=[],
+            degraded=False,
+            warnings=[],
+        )
+        output = io.StringIO()
+
+        with (
+            patch(
+                "services.analysis_service.generate_narrative", return_value=narrative
+            ),
+            patch("services.analysis_service.find_incident_matches", return_value=[]),
+            patch(
+                "sys.argv",
+                [
+                    "deploywhisper",
+                    "analyze",
+                    "--project",
+                    "payments",
+                    str(valid_path),
+                    str(duplicate_path),
+                ],
+            ),
+            redirect_stdout(output),
+        ):
+            with self.assertRaises(SystemExit) as ctx:
+                main()
+
+        self.assertEqual(ctx.exception.code, 0)
+        payload = json.loads(output.getvalue())
+        by_name = {
+            file_result["file_name"]: file_result
+            for file_result in payload["data"]["parse_batch"]["files"]
+        }
+        self.assertEqual(by_name["plan.json"]["status"], "parsed")
+        self.assertEqual(by_name["duplicate-plan.json"]["status"], "failed")
+        self.assertIn(
+            "Duplicate Terraform action",
+            by_name["duplicate-plan.json"]["issue"]["message"],
+        )
 
     def test_analyze_command_captures_trigger_context_from_environment_when_available(
         self,
@@ -651,7 +731,7 @@ class AnalyzeCliTests(unittest.TestCase):
         )
         artifact_path = Path(self.tempdir.name) / "plan.json"
         artifact_path.write_text(
-            '{"resource_changes": [{"address": "aws_security_group.main", "change": {"actions": ["modify"]}}]}',
+            '{"resource_changes": [{"address": "aws_security_group.main", "change": {"actions": ["update"]}}]}',
             encoding="utf-8",
         )
         narrative = NarrativeResult(
@@ -707,7 +787,7 @@ class AnalyzeCliTests(unittest.TestCase):
         )
         artifact_path = Path(self.tempdir.name) / "plan.json"
         artifact_path.write_text(
-            '{"resource_changes": [{"address": "aws_security_group.main", "change": {"actions": ["modify"]}}]}',
+            '{"resource_changes": [{"address": "aws_security_group.main", "change": {"actions": ["update"]}}]}',
             encoding="utf-8",
         )
         output = io.StringIO()
@@ -764,7 +844,7 @@ class AnalyzeCliTests(unittest.TestCase):
         )
         artifact_path = Path(self.tempdir.name) / "plan.json"
         artifact_path.write_text(
-            '{"resource_changes": [{"address": "aws_security_group.main", "change": {"actions": ["modify"]}}]}',
+            '{"resource_changes": [{"address": "aws_security_group.main", "change": {"actions": ["update"]}}]}',
             encoding="utf-8",
         )
         output = io.StringIO()
@@ -821,7 +901,7 @@ class AnalyzeCliTests(unittest.TestCase):
         )
         artifact_path = Path(self.tempdir.name) / "plan.json"
         artifact_path.write_text(
-            '{"resource_changes": [{"address": "aws_security_group.main", "change": {"actions": ["modify"]}}]}',
+            '{"resource_changes": [{"address": "aws_security_group.main", "change": {"actions": ["update"]}}]}',
             encoding="utf-8",
         )
         output = io.StringIO()
@@ -1914,7 +1994,7 @@ class AnalyzeCliTests(unittest.TestCase):
         )
         artifact_path = Path(self.tempdir.name) / "plan.json"
         artifact_path.write_text(
-            '{"resource_changes": [{"address": "aws_security_group.main", "change": {"actions": ["modify"]}}]}',
+            '{"resource_changes": [{"address": "aws_security_group.main", "change": {"actions": ["update"]}}]}',
             encoding="utf-8",
         )
         stdout = io.StringIO()
@@ -1956,7 +2036,7 @@ class AnalyzeCliTests(unittest.TestCase):
     def test_analyze_command_rejects_unknown_project_before_parsing(self) -> None:
         artifact_path = Path(self.tempdir.name) / "plan.json"
         artifact_path.write_text(
-            '{"resource_changes": [{"address": "aws_security_group.main", "change": {"actions": ["modify"]}}]}',
+            '{"resource_changes": [{"address": "aws_security_group.main", "change": {"actions": ["update"]}}]}',
             encoding="utf-8",
         )
         stdout = io.StringIO()
@@ -1999,7 +2079,7 @@ class AnalyzeCliTests(unittest.TestCase):
     ) -> None:
         artifact_path = Path(self.tempdir.name) / "plan.json"
         artifact_path.write_text(
-            '{"resource_changes": [{"address": "aws_security_group.main", "change": {"actions": ["modify"]}}]}',
+            '{"resource_changes": [{"address": "aws_security_group.main", "change": {"actions": ["update"]}}]}',
             encoding="utf-8",
         )
         stdout = io.StringIO()
@@ -2033,7 +2113,7 @@ class AnalyzeCliTests(unittest.TestCase):
     ) -> None:
         artifact_path = Path(self.tempdir.name) / "plan.json"
         artifact_path.write_text(
-            '{"resource_changes": [{"address": "aws_security_group.main", "change": {"actions": ["modify"]}}]}',
+            '{"resource_changes": [{"address": "aws_security_group.main", "change": {"actions": ["update"]}}]}',
             encoding="utf-8",
         )
         stdout = io.StringIO()
@@ -2078,11 +2158,11 @@ class AnalyzeCliTests(unittest.TestCase):
         first_path = first_dir / "plan.json"
         second_path = second_dir / "plan.json"
         first_path.write_text(
-            '{"resource_changes": [{"address": "aws_security_group.first", "change": {"actions": ["modify"]}}]}',
+            '{"resource_changes": [{"address": "aws_security_group.first", "change": {"actions": ["update"]}}]}',
             encoding="utf-8",
         )
         second_path.write_text(
-            '{"resource_changes": [{"address": "aws_security_group.second", "change": {"actions": ["modify"]}}]}',
+            '{"resource_changes": [{"address": "aws_security_group.second", "change": {"actions": ["update"]}}]}',
             encoding="utf-8",
         )
         output = io.StringIO()
@@ -2139,7 +2219,7 @@ class AnalyzeCliTests(unittest.TestCase):
         )
         artifact_path = Path(self.tempdir.name) / "plan.json"
         artifact_path.write_text(
-            '{"resource_changes": [{"address": "aws_security_group.main", "change": {"actions": ["modify"]}}]}',
+            '{"resource_changes": [{"address": "aws_security_group.main", "change": {"actions": ["update"]}}]}',
             encoding="utf-8",
         )
         stdout = io.StringIO()
@@ -2309,7 +2389,7 @@ class AnalyzeCliTests(unittest.TestCase):
         )
         artifact_path = Path(self.tempdir.name) / "plan.json"
         artifact_path.write_text(
-            '{"resource_changes": [{"address": "aws_security_group.main", "change": {"actions": ["modify"]}}]}',
+            '{"resource_changes": [{"address": "aws_security_group.main", "change": {"actions": ["update"]}}]}',
             encoding="utf-8",
         )
         stdout = io.StringIO()

--- a/tests/test_parsers/test_registry.py
+++ b/tests/test_parsers/test_registry.py
@@ -13,7 +13,7 @@ class ParserRegistryTests(unittest.TestCase):
         files = [
             (
                 "plan.json",
-                b'{"resource_changes": [{"address": "aws_security_group.main", "change": {"actions": ["modify"]}}]}',
+                b'{"resource_changes": [{"address": "aws_security_group.main", "change": {"actions": ["update"]}}]}',
             ),
             (
                 "deployment.yaml",
@@ -31,9 +31,12 @@ class ParserRegistryTests(unittest.TestCase):
         files = [
             (
                 "plan.json",
-                b'{"resource_changes": [{"address": "aws_security_group.main", "change": {"actions": ["modify"]}}]}',
+                b'{"resource_changes": [{"address": "aws_security_group.main", "change": {"actions": ["update"]}}]}',
             ),
-            ("empty-plan.json", b'{"resource_changes": []}'),
+            (
+                "broken-plan.json",
+                b'{"resource_changes": [{"address": "aws_instance.web", "change": {}}]}',
+            ),
         ]
         batch = parse_uploaded_files(files)
         self.assertEqual(batch.parsed_count, 1)
@@ -77,7 +80,7 @@ module "network" {
             [
                 (
                     "eks-plan.json",
-                    b'{"resource_changes": [{"address": "aws_eks_cluster.platform", "change": {"actions": ["modify"]}}]}',
+                    b'{"resource_changes": [{"address": "aws_eks_cluster.platform", "change": {"actions": ["update"]}}]}',
                 )
             ]
         )
@@ -91,7 +94,7 @@ module "network" {
             [
                 (
                     "plan.json",
-                    b'{"resource_changes": [{"address": "aws_security_group.main", "change": {"actions": ["modify"]}}]}',
+                    b'{"resource_changes": [{"address": "aws_security_group.main", "change": {"actions": ["update"]}}]}',
                 ),
                 (
                     "deployment.yaml",
@@ -113,13 +116,30 @@ module "network" {
         self.assertFalse(batch.has_partial_context)
         self.assertEqual(batch.files[0].status, "skipped")
 
-    def test_parse_uploaded_files_marks_supported_but_empty_result_as_failure(
+    def test_parse_uploaded_files_accepts_zero_diff_terraform_plan(
         self,
     ) -> None:
         batch = parse_uploaded_files([("plan.json", b'{"resource_changes": []}')])
-        self.assertEqual(batch.parsed_count, 0)
-        self.assertEqual(batch.failed_count, 1)
-        self.assertIn("No normalized changes produced", batch.files[0].issue.message)
+        self.assertEqual(batch.parsed_count, 1)
+        self.assertEqual(batch.failed_count, 0)
+        self.assertEqual(batch.files[0].changes[0].action, "no-op")
+        self.assertIn("no planned resource changes", batch.files[0].changes[0].summary)
+
+    def test_parse_uploaded_files_accepts_terraform_plan_with_only_noop_changes(
+        self,
+    ) -> None:
+        batch = parse_uploaded_files(
+            [
+                (
+                    "plan.json",
+                    b'{"resource_changes": [{"address": "aws_security_group.main", "change": {"actions": ["no-op"]}}]}',
+                )
+            ]
+        )
+
+        self.assertEqual(batch.parsed_count, 1)
+        self.assertEqual(batch.failed_count, 0)
+        self.assertEqual(batch.files[0].changes[0].action, "no-op")
 
 
 if __name__ == "__main__":

--- a/tests/test_parsers/test_terraform_parser.py
+++ b/tests/test_parsers/test_terraform_parser.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import unittest
 
+from parsers.base import UnifiedChange
 from parsers.terraform_parser import parse_terraform
 
 
@@ -26,9 +27,416 @@ class TerraformParserTests(unittest.TestCase):
         changes = parse_terraform("plan.json", raw)
 
         self.assertEqual(len(changes), 1)
-        self.assertEqual(changes[0].action, "create+delete")
+        self.assertEqual(changes[0].action, "replace")
+        self.assertEqual(changes[0].metadata["actions"], ["create", "delete"])
         self.assertEqual(changes[0].resource_id, "aws_iam_policy.deploy")
         self.assertIn("changes access permissions", changes[0].summary)
+
+    def test_parse_terraform_plan_json_preserves_module_and_plan_metadata(
+        self,
+    ) -> None:
+        raw = b"""{
+  "format_version": "1.2",
+  "terraform_version": "1.8.5",
+  "checks": [],
+  "resource_drift": [],
+  "resource_changes": [
+    {
+      "address": "module.network.aws_security_group.web",
+      "module_address": "module.network",
+      "mode": "managed",
+      "type": "aws_security_group",
+      "name": "web",
+      "provider_name": "registry.terraform.io/hashicorp/aws",
+      "change": {
+        "actions": ["update"],
+        "after_unknown": {"arn": true, "tags": {"DeploymentId": true}},
+        "after_sensitive": {"ingress": [{"description": true}]},
+        "replace_paths": [["ingress", 0, "cidr_blocks"]],
+        "importing": {"id": "sg-123"}
+      },
+      "deposed": "unsupported-object-marker"
+    }
+  ]
+}"""
+
+        changes = parse_terraform("tfplan.json", raw)
+
+        self.assertEqual(len(changes), 1)
+        change = changes[0]
+        self.assertEqual(change.resource_id, "module.network.aws_security_group.web")
+        self.assertEqual(change.action, "modify")
+        self.assertEqual(change.metadata["source_format"], "terraform_plan_json")
+        self.assertEqual(change.metadata["plan_format_version"], "1.2")
+        self.assertEqual(change.metadata["terraform_version"], "1.8.5")
+        self.assertEqual(change.metadata["module_address"], "module.network")
+        self.assertEqual(change.metadata["resource_type"], "aws_security_group")
+        self.assertEqual(change.metadata["resource_name"], "web")
+        self.assertEqual(
+            change.metadata["provider_name"], "registry.terraform.io/hashicorp/aws"
+        )
+        self.assertEqual(change.metadata["replace_paths"], ["ingress.0.cidr_blocks"])
+        self.assertEqual(
+            change.metadata["unknown_after_apply"],
+            ["arn", "tags.DeploymentId"],
+        )
+        self.assertEqual(
+            change.metadata["redacted_fields"],
+            ["ingress.0.description"],
+        )
+        self.assertEqual(
+            change.metadata["unsupported_fields"],
+            [
+                "change.importing",
+                "resource_change.deposed",
+            ],
+        )
+        self.assertEqual(
+            change.metadata["plan_unsupported_fields"],
+            ["plan.checks", "plan.resource_drift"],
+        )
+        self.assertIn("changes network access rules", change.summary)
+        self.assertNotIn("Plan metadata:", change.summary)
+
+    def test_parse_terraform_plan_json_trims_resource_addresses(self) -> None:
+        raw = b"""{
+  "resource_changes": [
+    {
+      "address": " aws_instance.web ",
+      "change": {"actions": ["update"]}
+    }
+  ]
+}"""
+
+        changes = parse_terraform("tfplan.json", raw)
+
+        self.assertEqual(changes[0].resource_id, "aws_instance.web")
+        self.assertEqual(
+            changes[0].summary,
+            "Terraform resource aws_instance.web marked for modify.",
+        )
+
+    def test_parse_terraform_plan_json_reports_root_unknown_and_sensitive_flags(
+        self,
+    ) -> None:
+        raw = b"""{
+  "resource_changes": [
+    {
+      "address": "aws_instance.web",
+      "change": {
+        "actions": ["update"],
+        "after_unknown": true,
+        "after_sensitive": true
+      }
+    }
+  ]
+}"""
+
+        changes = parse_terraform("tfplan.json", raw)
+
+        self.assertEqual(changes[0].metadata["unknown_after_apply"], ["<root>"])
+        self.assertEqual(changes[0].metadata["redacted_fields"], ["<root>"])
+
+    def test_parse_terraform_plan_json_summarizes_module_scoped_generic_resource(
+        self,
+    ) -> None:
+        raw = b"""{
+  "resource_changes": [
+    {
+      "address": "module.compute.aws_instance.web",
+      "module_address": "module.compute",
+      "type": "aws_instance",
+      "change": {"actions": ["update"]}
+    }
+  ]
+}"""
+
+        changes = parse_terraform("tfplan.json", raw)
+
+        self.assertEqual(changes[0].action, "modify")
+        self.assertIn(
+            "Terraform resource module.compute.aws_instance.web marked for modify.",
+            changes[0].summary,
+        )
+        self.assertNotIn("Terraform module", changes[0].summary)
+
+    def test_parse_terraform_plan_json_preserves_noop_resources(self) -> None:
+        raw = b"""{
+  "resource_changes": [
+    {
+      "address": "aws_security_group.unchanged",
+      "change": {"actions": ["no-op"]}
+    },
+    {
+      "address": "aws_security_group.updated",
+      "change": {"actions": ["update"]}
+    }
+  ]
+}"""
+
+        changes = parse_terraform("tfplan.json", raw)
+
+        self.assertEqual(
+            [change.resource_id for change in changes],
+            ["aws_security_group.unchanged", "aws_security_group.updated"],
+        )
+        self.assertEqual(changes[0].action, "no-op")
+        self.assertEqual(changes[0].metadata["actions"], ["no-op"])
+        self.assertIn("no planned changes", changes[0].summary)
+
+    def test_parse_terraform_plan_json_attaches_plan_metadata_to_first_mutation(
+        self,
+    ) -> None:
+        raw = b"""{
+  "planned_values": {},
+  "resource_changes": [
+    {
+      "address": "data.aws_ami.selected",
+      "mode": "data",
+      "change": {"actions": ["read"]}
+    },
+    {
+      "address": "aws_security_group.updated",
+      "type": "aws_security_group",
+      "change": {"actions": ["update"]}
+    }
+  ]
+}"""
+
+        changes = parse_terraform("tfplan.json", raw)
+
+        self.assertEqual(changes[0].action, "read")
+        self.assertNotIn("plan_unsupported_fields", changes[0].metadata)
+        self.assertEqual(changes[1].action, "modify")
+        self.assertEqual(
+            changes[1].metadata["plan_unsupported_fields"], ["plan.planned_values"]
+        )
+
+    def test_parse_terraform_plan_json_accepts_empty_plan_as_noop_entry(self) -> None:
+        raw = b"""{
+  "format_version": "1.2",
+  "terraform_version": "1.8.5",
+  "planned_values": {},
+  "resource_changes": []
+}"""
+
+        changes = parse_terraform("tfplan.json", raw)
+
+        self.assertEqual(len(changes), 1)
+        self.assertEqual(changes[0].resource_id, "terraform-plan")
+        self.assertEqual(changes[0].action, "no-op")
+        self.assertIn("no planned resource changes", changes[0].summary)
+        self.assertEqual(changes[0].metadata["actions"], ["no-op"])
+        self.assertEqual(changes[0].metadata["resource_change_count"], 0)
+        self.assertEqual(
+            changes[0].metadata["plan_unsupported_fields"], ["plan.planned_values"]
+        )
+
+    def test_parse_terraform_plan_json_rejects_missing_resource_changes(
+        self,
+    ) -> None:
+        with self.assertRaisesRegex(ValueError, "missing required resource_changes"):
+            parse_terraform(
+                "tfplan.json",
+                b'{"format_version": "1.2", "terraform_version": "1.8.5"}',
+            )
+
+    def test_parse_terraform_plan_json_rejects_non_object_root(
+        self,
+    ) -> None:
+        for raw in (b"null", b"[]", b'"plan"'):
+            with self.subTest(raw=raw):
+                with self.assertRaisesRegex(
+                    ValueError, "Terraform plan JSON must be an object"
+                ):
+                    parse_terraform("tfplan.json", raw)
+
+    def test_parse_terraform_plan_json_rejects_non_native_plan_actions(
+        self,
+    ) -> None:
+        with self.assertRaisesRegex(ValueError, "Unsupported Terraform action"):
+            parse_terraform(
+                "tfplan.json",
+                b'{"resource_changes": [{"address": "aws_instance.web", "change": {"actions": ["modify"]}}]}',
+            )
+
+        with self.assertRaisesRegex(ValueError, "Unsupported Terraform action"):
+            parse_terraform(
+                "tfplan.json",
+                b'{"resource_changes": [{"address": "aws_instance.web", "change": {"actions": ["destroy"]}}]}',
+            )
+
+    def test_parse_terraform_plan_json_rejects_unsupported_action_combinations(
+        self,
+    ) -> None:
+        with self.assertRaisesRegex(
+            ValueError, "Unsupported Terraform action combination"
+        ):
+            parse_terraform(
+                "tfplan.json",
+                b'{"resource_changes": [{"address": "aws_instance.web", "change": {"actions": ["read", "delete"]}}]}',
+            )
+
+        with self.assertRaisesRegex(
+            ValueError, "Unsupported Terraform action combination"
+        ):
+            parse_terraform(
+                "tfplan.json",
+                b'{"resource_changes": [{"address": "aws_instance.web", "change": {"actions": ["no-op", "update"]}}]}',
+            )
+
+    def test_parse_terraform_plan_json_rejects_duplicate_actions(self) -> None:
+        with self.assertRaisesRegex(ValueError, "Duplicate Terraform action"):
+            parse_terraform(
+                "tfplan.json",
+                b'{"resource_changes": [{"address": "aws_instance.web", "change": {"actions": ["create", "create"]}}]}',
+            )
+
+        with self.assertRaisesRegex(ValueError, "Duplicate Terraform action"):
+            parse_terraform(
+                "tfplan.json",
+                b'{"resource_changes": [{"address": "aws_instance.web", "change": {"actions": ["delete", "create", "create"]}}]}',
+            )
+
+    def test_parse_terraform_plan_json_reports_plan_unsupported_fields_once(
+        self,
+    ) -> None:
+        raw = b"""{
+  "planned_values": {},
+  "resource_changes": [
+    {
+      "address": "aws_instance.web",
+      "change": {"actions": ["update"]}
+    },
+    {
+      "address": "aws_instance.worker",
+      "change": {"actions": ["update"]}
+    }
+  ]
+}"""
+
+        changes = parse_terraform("tfplan.json", raw)
+
+        self.assertEqual(
+            changes[0].metadata["plan_unsupported_fields"], ["plan.planned_values"]
+        )
+        self.assertNotIn("plan_unsupported_fields", changes[1].metadata)
+        self.assertEqual(changes[0].metadata["unsupported_fields"], [])
+        self.assertEqual(changes[1].metadata["unsupported_fields"], [])
+
+    def test_parse_terraform_plan_json_rejects_missing_or_unknown_actions(
+        self,
+    ) -> None:
+        with self.assertRaisesRegex(ValueError, "missing required change.actions"):
+            parse_terraform(
+                "tfplan.json",
+                b'{"resource_changes": [{"address": "aws_instance.web", "change": {}}]}',
+            )
+
+        with self.assertRaisesRegex(ValueError, "Unsupported Terraform action"):
+            parse_terraform(
+                "tfplan.json",
+                b'{"resource_changes": [{"address": "aws_instance.web", "change": {"actions": ["future-op"]}}]}',
+            )
+
+    def test_parse_terraform_plan_json_rejects_missing_resource_address(
+        self,
+    ) -> None:
+        with self.assertRaisesRegex(ValueError, "missing required address"):
+            parse_terraform(
+                "tfplan.json",
+                b'{"resource_changes": [{"change": {"actions": ["update"]}}]}',
+            )
+
+    def test_parse_terraform_plan_json_reports_invalid_metadata_shapes(
+        self,
+    ) -> None:
+        raw = b"""{
+  "resource_changes": [
+    {
+      "address": "aws_instance.web",
+      "change": {
+        "actions": ["update"],
+        "replace_paths": "ami",
+        "after_unknown": "arn",
+        "after_sensitive": "secret"
+      }
+    }
+  ]
+}"""
+
+        changes = parse_terraform("tfplan.json", raw)
+
+        unsupported = changes[0].metadata["unsupported_fields"]
+        self.assertIn("change.after_sensitive.invalid", unsupported)
+        self.assertIn("change.after_unknown.invalid", unsupported)
+        self.assertIn("change.replace_paths.invalid", unsupported)
+        self.assertEqual(changes[0].metadata["replace_paths"], [])
+        self.assertEqual(changes[0].metadata["unknown_after_apply"], [])
+        self.assertEqual(changes[0].metadata["redacted_fields"], [])
+
+    def test_parse_terraform_plan_json_reports_generated_config_as_unsupported(
+        self,
+    ) -> None:
+        raw = b"""{
+  "resource_changes": [
+    {
+      "address": "aws_instance.imported",
+      "change": {
+        "actions": ["update"],
+        "generated_config": "resource \\"aws_instance\\" \\"imported\\" {}"
+      }
+    }
+  ]
+}"""
+
+        changes = parse_terraform("tfplan.json", raw)
+
+        self.assertIn(
+            "change.generated_config",
+            changes[0].metadata["unsupported_fields"],
+        )
+        self.assertNotIn("generated_config", changes[0].metadata)
+
+    def test_unified_change_metadata_is_json_safe(self) -> None:
+        change = UnifiedChange(
+            source_file="tfplan.json",
+            tool="terraform",
+            resource_id="aws_instance.web",
+            action="modify",
+            summary="Terraform resource aws_instance.web marked for modify.",
+            metadata={
+                "tuple_value": ("a", "b"),
+                "set_value": {"x", "y"},
+                "object_value": object(),
+                10: "numeric key",
+            },
+        )
+
+        self.assertEqual(change.metadata["tuple_value"], ["a", "b"])
+        self.assertIsInstance(change.metadata["set_value"], list)
+        self.assertIsInstance(change.metadata["object_value"], str)
+        self.assertEqual(change.metadata["10"], "numeric key")
+
+    def test_parse_terraform_plan_json_summarizes_typed_read_as_read_only(
+        self,
+    ) -> None:
+        raw = b"""{
+  "resource_changes": [
+    {
+      "address": "data.aws_security_group.selected",
+      "mode": "data",
+      "type": "aws_security_group",
+      "change": {"actions": ["read"]}
+    }
+  ]
+}"""
+
+        changes = parse_terraform("tfplan.json", raw)
+
+        self.assertEqual(changes[0].action, "read")
+        self.assertIn("read-only", changes[0].summary)
+        self.assertNotIn("changes network access rules", changes[0].summary)
 
     def test_parse_terraform_hcl_extracts_resource_and_module_changes(self) -> None:
         raw = b"""

--- a/tests/test_services/test_analysis_service.py
+++ b/tests/test_services/test_analysis_service.py
@@ -11,6 +11,7 @@ from analysis.interaction_risk import InteractionRisk
 from analysis.risk_scorer import RiskAssessment, RiskContributor
 from analysis.blast_radius import BlastRadiusResult
 from analysis.rollback_planner import RollbackPlan
+from evidence.extractor import extract_batch_evidence
 from llm.narrator import NarrativeResult
 from parsers.base import ParseBatchResult, ParsedFileResult, UnifiedChange
 from services.analysis_service import (
@@ -18,6 +19,7 @@ from services.analysis_service import (
     build_advisory_summary,
     build_analysis_artifacts,
     build_share_summary,
+    evaluate_parse_batch,
     resolve_analysis_project_scope,
 )
 
@@ -101,7 +103,7 @@ class AnalysisServiceTests(unittest.TestCase):
                 [
                     (
                         "plan.json",
-                        b'{"resource_changes": [{"address": "aws_security_group.main"}]}',
+                        b'{"resource_changes": [{"address": "aws_security_group.main", "change": {"actions": ["update"]}}]}',
                     ),
                     ("broken.tf", b"SECRET_TOKEN=should-not-leave-intake\nresource {"),
                     (".env", b"SECRET=1"),
@@ -165,7 +167,7 @@ class AnalysisServiceTests(unittest.TestCase):
                 [
                     (
                         "plan.json",
-                        b'{"resource_changes": [{"address": "aws_security_group.main"}]}',
+                        b'{"resource_changes": [{"address": "aws_security_group.main", "change": {"actions": ["update"]}}]}',
                     ),
                     (".env", b"SECRET=1"),
                     ("notes.txt", b"hello"),
@@ -319,7 +321,7 @@ class AnalysisServiceTests(unittest.TestCase):
                 [
                     (
                         "plan.json",
-                        b'{"resource_changes": [{"address": "aws_security_group.main", "change": {"actions": ["modify"]}}]}',
+                        b'{"resource_changes": [{"address": "aws_security_group.main", "change": {"actions": ["update"]}}]}',
                     )
                 ]
             )
@@ -347,6 +349,193 @@ class AnalysisServiceTests(unittest.TestCase):
             artifacts.assessment.context_completeness.parser_success_by_tool,
             {"terraform": 1.0},
         )
+
+    def test_evaluate_parse_batch_preserves_non_mutating_metadata_without_evidence(
+        self,
+    ) -> None:
+        batch = ParseBatchResult(
+            files=[
+                ParsedFileResult(
+                    file_name="empty-plan.json",
+                    tool="terraform",
+                    status="parsed",
+                    changes=[
+                        UnifiedChange(
+                            source_file="empty-plan.json",
+                            tool="terraform",
+                            resource_id="terraform-plan",
+                            action="no-op",
+                            summary="Terraform plan has no resource changes.",
+                            metadata={
+                                "plan_format_version": "1.2",
+                                "terraform_version": "1.8.5",
+                                "plan_unsupported_fields": ["plan.planned_values"],
+                            },
+                        )
+                    ],
+                )
+            ]
+        )
+
+        assessment = evaluate_parse_batch(batch, evidence_items=[])
+
+        self.assertEqual(assessment.score, 0)
+        self.assertEqual(assessment.severity, "low")
+        self.assertEqual(len(assessment.contributors), 1)
+        self.assertEqual(assessment.contributors[0].resource_id, "terraform-plan")
+        self.assertEqual(assessment.contributors[0].contribution, 0)
+        self.assertEqual(
+            assessment.contributors[0].metadata["plan_unsupported_fields"],
+            ["plan.planned_values"],
+        )
+        self.assertIn("no planned change", assessment.top_risk)
+
+    def test_evaluate_parse_batch_extracts_mutating_batch_when_evidence_empty(
+        self,
+    ) -> None:
+        batch = ParseBatchResult(
+            files=[
+                ParsedFileResult(
+                    file_name="plan.json",
+                    tool="terraform",
+                    status="parsed",
+                    changes=[
+                        UnifiedChange(
+                            source_file="plan.json",
+                            tool="terraform",
+                            resource_id="module.network.aws_security_group.main",
+                            action="modify",
+                            summary="Terraform changed an AWS security group.",
+                            metadata={
+                                "module_address": "module.network",
+                                "plan_unsupported_fields": ["plan.planned_values"],
+                            },
+                        )
+                    ],
+                )
+            ]
+        )
+
+        assessment = evaluate_parse_batch(
+            batch,
+            evidence_items=[],
+            completion_client=lambda **_: '{"change_scores": []}',
+        )
+
+        self.assertEqual(len(assessment.contributors), 1)
+        self.assertIsNotNone(assessment.contributors[0].evidence_id)
+        self.assertEqual(
+            assessment.contributors[0].resource_id,
+            "module.network.aws_security_group.main",
+        )
+        self.assertEqual(
+            assessment.contributors[0].metadata["plan_unsupported_fields"],
+            ["plan.planned_values"],
+        )
+        self.assertGreater(assessment.score, 0)
+
+    def test_evaluate_parse_batch_preserves_parser_metadata_for_evidence_scoring(
+        self,
+    ) -> None:
+        batch = ParseBatchResult(
+            files=[
+                ParsedFileResult(
+                    file_name="plan.json",
+                    tool="terraform",
+                    status="parsed",
+                    changes=[
+                        UnifiedChange(
+                            source_file="plan.json",
+                            tool="terraform",
+                            resource_id="module.network.aws_security_group.main",
+                            action="modify",
+                            summary="Terraform changed an AWS security group.",
+                            metadata={
+                                "module_address": "module.network",
+                                "provider_name": "registry.terraform.io/hashicorp/aws",
+                                "plan_unsupported_fields": ["plan.planned_values"],
+                            },
+                        )
+                    ],
+                )
+            ]
+        )
+
+        assessment = evaluate_parse_batch(
+            batch,
+            evidence_items=extract_batch_evidence(batch),
+            completion_client=lambda **_: '{"change_scores": []}',
+        )
+
+        self.assertEqual(
+            assessment.contributors[0].metadata["module_address"],
+            "module.network",
+        )
+        self.assertEqual(
+            assessment.contributors[0].metadata["plan_unsupported_fields"],
+            ["plan.planned_values"],
+        )
+
+    def test_evaluate_parse_batch_preserves_mixed_non_mutating_metadata(
+        self,
+    ) -> None:
+        batch = ParseBatchResult(
+            files=[
+                ParsedFileResult(
+                    file_name="plan.json",
+                    tool="terraform",
+                    status="parsed",
+                    changes=[
+                        UnifiedChange(
+                            source_file="plan.json",
+                            tool="terraform",
+                            resource_id="data.aws_ami.selected",
+                            action="read",
+                            summary="Terraform read selected AMI.",
+                            metadata={
+                                "actions": ["read"],
+                                "unknown_after_apply": ["id"],
+                                "plan_unsupported_fields": ["plan.planned_values"],
+                            },
+                        ),
+                        UnifiedChange(
+                            source_file="plan.json",
+                            tool="terraform",
+                            resource_id="aws_security_group.main",
+                            action="modify",
+                            summary="Terraform changed an AWS security group.",
+                            metadata={"module_address": "module.network"},
+                        ),
+                    ],
+                )
+            ]
+        )
+
+        assessment = evaluate_parse_batch(
+            batch,
+            evidence_items=extract_batch_evidence(batch),
+            completion_client=lambda **_: '{"change_scores": []}',
+        )
+
+        contributors = {
+            contributor.resource_id: contributor
+            for contributor in assessment.contributors
+        }
+        self.assertEqual(
+            set(contributors), {"aws_security_group.main", "data.aws_ami.selected"}
+        )
+        self.assertEqual(contributors["data.aws_ami.selected"].contribution, 0)
+        self.assertIsNone(contributors["data.aws_ami.selected"].evidence_id)
+        self.assertEqual(
+            contributors["data.aws_ami.selected"].metadata["plan_unsupported_fields"],
+            ["plan.planned_values"],
+        )
+        self.assertEqual(
+            contributors["data.aws_ami.selected"].metadata["unknown_after_apply"],
+            ["id"],
+        )
+        self.assertIsNotNone(contributors["aws_security_group.main"].evidence_id)
+        self.assertGreater(assessment.score, 0)
 
     def test_build_analysis_artifacts_tracks_topology_timestamp_and_tool_success_rates(
         self,
@@ -548,7 +737,7 @@ class AnalysisServiceTests(unittest.TestCase):
                 [
                     (
                         "plan.json",
-                        b'{"resource_changes": [{"address": "aws_security_group.main", "change": {"actions": ["modify"]}}]}',
+                        b'{"resource_changes": [{"address": "aws_security_group.main", "change": {"actions": ["update"]}}]}',
                     )
                 ]
             )
@@ -629,7 +818,7 @@ class AnalysisServiceTests(unittest.TestCase):
                 [
                     (
                         "plan.json",
-                        b'{"resource_changes": [{"address": "aws_security_group.main", "change": {"actions": ["modify"]}}]}',
+                        b'{"resource_changes": [{"address": "aws_security_group.main", "change": {"actions": ["update"]}}]}',
                     )
                 ]
             )
@@ -937,7 +1126,7 @@ class AnalysisServiceTests(unittest.TestCase):
                 [
                     (
                         "plan.json",
-                        b'{"resource_changes": [{"address": "aws_security_group.main", "change": {"actions": ["modify"]}}]}',
+                        b'{"resource_changes": [{"address": "aws_security_group.main", "change": {"actions": ["update"]}}]}',
                     )
                 ]
             )

--- a/tests/test_services/test_evidence_extractor.py
+++ b/tests/test_services/test_evidence_extractor.py
@@ -18,7 +18,7 @@ SCENARIOS = [
         "label": "terraform security group modify",
         "parser": parse_terraform,
         "file_name": "plan.json",
-        "raw": b'{"resource_changes": [{"address": "aws_security_group.main", "change": {"actions": ["modify"]}}]}',
+        "raw": b'{"resource_changes": [{"address": "aws_security_group.main", "change": {"actions": ["update"]}}]}',
         "expected_source_ref": "terraform://plan.json#aws_security_group.main?action=modify",
         "expected_severity": "high",
     },
@@ -42,8 +42,16 @@ SCENARIOS = [
         "label": "terraform destroy compute",
         "parser": parse_terraform,
         "file_name": "compute.json",
-        "raw": b'{"resource_changes": [{"address": "aws_instance.web", "change": {"actions": ["destroy"]}}]}',
+        "raw": b'{"resource_changes": [{"address": "aws_instance.web", "change": {"actions": ["delete"]}}]}',
         "expected_source_ref": "terraform://compute.json#aws_instance.web?action=destroy",
+        "expected_severity": "high",
+    },
+    {
+        "label": "terraform replace compute",
+        "parser": parse_terraform,
+        "file_name": "replace.json",
+        "raw": b'{"resource_changes": [{"address": "aws_instance.web", "change": {"actions": ["delete", "create"], "replace_paths": [["ami"]]}}]}',
+        "expected_source_ref": "terraform://replace.json#aws_instance.web?action=replace",
         "expected_severity": "high",
     },
     {
@@ -181,8 +189,8 @@ class EvidenceExtractorTests(unittest.TestCase):
     def setUp(self) -> None:
         self.extractor = EvidenceExtractor()
 
-    def test_extract_covers_twenty_parser_fixture_scenarios(self) -> None:
-        self.assertEqual(len(SCENARIOS), 20)
+    def test_extract_covers_mutating_parser_fixture_scenarios(self) -> None:
+        self.assertEqual(len(SCENARIOS), 21)
 
         observed_tools: set[str] = set()
 
@@ -216,6 +224,53 @@ class EvidenceExtractorTests(unittest.TestCase):
         self.assertEqual(
             observed_tools,
             {"terraform", "kubernetes", "ansible", "jenkins", "cloudformation"},
+        )
+
+    def test_extract_skips_non_mutating_terraform_plan_changes(self) -> None:
+        for file_name, raw in (
+            ("empty-plan.json", b'{"resource_changes": []}'),
+            (
+                "data.json",
+                b'{"resource_changes": [{"address": "data.aws_ami.latest", "mode": "data", "change": {"actions": ["read"]}}]}',
+            ),
+        ):
+            with self.subTest(file_name=file_name):
+                changes = parse_terraform(file_name, raw)
+
+                self.assertEqual(len(changes), 1)
+                self.assertEqual(self.extractor.extract(changes[0]), [])
+
+    def test_extract_batch_evidence_filters_non_mutating_terraform_changes(
+        self,
+    ) -> None:
+        changes = parse_terraform(
+            "mixed-plan.json",
+            (
+                b'{"resource_changes": ['
+                b'{"address": "aws_security_group.unchanged", "change": {"actions": ["no-op"]}},'
+                b'{"address": "data.aws_ami.latest", "mode": "data", "change": {"actions": ["read"]}},'
+                b'{"address": "aws_security_group.updated", "change": {"actions": ["update"]}}'
+                b"]}"
+            ),
+        )
+        batch = ParseBatchResult(
+            files=[
+                ParsedFileResult(
+                    file_name="mixed-plan.json",
+                    tool="terraform",
+                    status="parsed",
+                    changes=changes,
+                )
+            ]
+        )
+
+        evidence_items = extract_batch_evidence(batch)
+
+        self.assertEqual(
+            [item.source_ref for item in evidence_items],
+            [
+                "terraform://mixed-plan.json#aws_security_group.updated?action=modify",
+            ],
         )
 
     def test_extract_batch_evidence_preserves_duplicate_parser_changes(self) -> None:

--- a/tests/test_services/test_github_app_service.py
+++ b/tests/test_services/test_github_app_service.py
@@ -516,7 +516,7 @@ class GitHubAppServiceTests(unittest.TestCase):
         load_pull_request_artifacts.return_value = [
             (
                 "plan.json",
-                b'{"resource_changes": [{"address": "aws_security_group.main", "change": {"actions": ["modify"]}}]}',
+                b'{"resource_changes": [{"address": "aws_security_group.main", "change": {"actions": ["update"]}}]}',
             )
         ]
         generate_narrative.return_value = NarrativeResult(

--- a/tests/test_services/test_report_service.py
+++ b/tests/test_services/test_report_service.py
@@ -26,6 +26,7 @@ from analysis.risk_scorer import RiskAssessment, RiskContributor
 from evidence.models import EvidenceItem, Finding
 from llm.narrator import NarrativeResult
 from parsers.base import ParseBatchResult, ParseIssue, ParsedFileResult, UnifiedChange
+from parsers.terraform_parser import parse_terraform
 
 
 class ReportServiceTests(unittest.TestCase):
@@ -220,6 +221,11 @@ class ReportServiceTests(unittest.TestCase):
                             resource_id="aws_security_group.main",
                             action="modify",
                             summary="Terraform changed a security group.",
+                            metadata={
+                                "module_address": "module.network",
+                                "redacted_fields": ["ingress.0.description"],
+                                "plan_unsupported_fields": ["plan.planned_values"],
+                            },
                         )
                     ],
                 )
@@ -248,6 +254,11 @@ class ReportServiceTests(unittest.TestCase):
                     action="modify",
                     contribution=12,
                     summary="Terraform changed a security group.",
+                    metadata={
+                        "module_address": "module.network",
+                        "redacted_fields": ["ingress.0.description"],
+                        "plan_unsupported_fields": ["plan.planned_values"],
+                    },
                 )
             ],
             interaction_risks=[],
@@ -369,6 +380,10 @@ class ReportServiceTests(unittest.TestCase):
         self.assertEqual(
             persisted["contributors"][0]["evidence_id"], persisted_evidence_id
         )
+        self.assertEqual(
+            persisted["contributors"][0]["metadata"]["module_address"],
+            "module.network",
+        )
 
         fetched = report_service_module.fetch_analysis_report(persisted["id"])
         self.assertIsNotNone(fetched)
@@ -404,6 +419,10 @@ class ReportServiceTests(unittest.TestCase):
         self.assertEqual(
             fetched["contributors"][0]["evidence_id"], persisted_evidence_id
         )
+        self.assertEqual(
+            fetched["contributors"][0]["metadata"]["plan_unsupported_fields"],
+            ["plan.planned_values"],
+        )
         self.assertNotIn("prompt", json.dumps(fetched))
 
         history = report_service_module.fetch_analysis_history()
@@ -413,6 +432,111 @@ class ReportServiceTests(unittest.TestCase):
         self.assertEqual(history[0]["top_risk_contributors"], [persisted_evidence_id])
         self.assertEqual(history[0]["report_schema_version"], "v2")
         self.assertEqual(history[0]["rollback_plan"]["complexity"], "medium")
+        self.assertEqual(
+            history[0]["contributors"][0]["metadata"]["redacted_fields"],
+            ["ingress.0.description"],
+        )
+
+    def test_empty_plan_unsupported_fields_from_real_parser_survive_report_fetch(
+        self,
+    ) -> None:
+        changes = parse_terraform(
+            "empty-plan.json",
+            b'{"planned_values": {}, "resource_changes": []}',
+        )
+        self.assertEqual(len(changes), 1)
+        self.assertEqual(
+            changes[0].metadata["plan_unsupported_fields"],
+            ["plan.planned_values"],
+        )
+        parse_batch = ParseBatchResult(
+            files=[
+                ParsedFileResult(
+                    file_name="empty-plan.json",
+                    tool="terraform",
+                    status="parsed",
+                    changes=changes,
+                )
+            ]
+        )
+        assessment = RiskAssessment(
+            score=0,
+            severity="low",
+            recommendation="go",
+            top_risk="Terraform plan contains no planned resource mutations.",
+            top_risk_contributors=["ev-empty"],
+            contributors=[
+                RiskContributor(
+                    evidence_id="ev-empty",
+                    source_file=changes[0].source_file,
+                    tool=changes[0].tool,
+                    resource_id=changes[0].resource_id,
+                    action=changes[0].action,
+                    contribution=0,
+                    summary=changes[0].summary,
+                    metadata=changes[0].metadata,
+                )
+            ],
+            interaction_risks=[],
+            partial_context=False,
+            warnings=[],
+        )
+        narrative = NarrativeResult(
+            opening_sentence="GO: Terraform plan has no planned resource mutations.",
+            explanation="The submitted plan is a valid empty Terraform plan.",
+            guidance=[],
+            degraded=False,
+            warnings=[],
+        )
+        evidence_items = [
+            EvidenceItem(
+                evidence_id="ev-empty",
+                analysis_id=0,
+                finding_id="pending:empty-plan",
+                source_type="artifact",
+                source_ref="terraform://empty-plan.json#terraform-plan?action=no-op",
+                summary=changes[0].summary,
+                severity_hint="low",
+                deterministic=True,
+                confidence=1.0,
+                related_change_ids=[changes[0].change_id],
+            )
+        ]
+        findings = [
+            Finding(
+                finding_id="finding-empty",
+                analysis_id=0,
+                title="LOW: empty Terraform plan",
+                description="The Terraform plan is valid and contains no mutations.",
+                severity="low",
+                category="terraform/plan",
+                deterministic=True,
+                confidence=1.0,
+                uncertainty_note=None,
+                evidence_refs=["ev-empty"],
+                skill_id=None,
+            )
+        ]
+
+        persisted = report_service_module.persist_analysis_report(
+            parse_batch,
+            assessment,
+            narrative,
+            findings=findings,
+            evidence_items=evidence_items,
+        )
+
+        fetched = report_service_module.fetch_analysis_report(persisted["id"])
+        self.assertIsNotNone(fetched)
+        self.assertEqual(
+            fetched["contributors"][0]["metadata"]["plan_unsupported_fields"],
+            ["plan.planned_values"],
+        )
+        history = report_service_module.fetch_analysis_history()
+        self.assertEqual(
+            history[0]["contributors"][0]["metadata"]["plan_unsupported_fields"],
+            ["plan.planned_values"],
+        )
 
     def test_persist_analysis_report_allows_repeated_scans_with_same_logical_ids(
         self,

--- a/tests/test_ui/test_history_page.py
+++ b/tests/test_ui/test_history_page.py
@@ -92,6 +92,11 @@ class HistoryPageRenderingTests(unittest.TestCase):
                             resource_id="aws_security_group.main",
                             action="modify",
                             summary="Security group exposure risk",
+                            metadata={
+                                "module_address": "module.network",
+                                "redacted_fields": ["ingress.0.description"],
+                                "plan_unsupported_fields": ["plan.planned_values"],
+                            },
                         )
                     ],
                 )
@@ -111,6 +116,11 @@ class HistoryPageRenderingTests(unittest.TestCase):
                     action="modify",
                     contribution=20,
                     summary="Security group exposure risk",
+                    metadata={
+                        "module_address": "module.network",
+                        "redacted_fields": ["ingress.0.description"],
+                        "plan_unsupported_fields": ["plan.planned_values"],
+                    },
                 )
             ],
             interaction_risks=[],
@@ -462,6 +472,9 @@ class HistoryPageRenderingTests(unittest.TestCase):
         self.assertIn("Context completeness", response.text)
         self.assertIn("Blast radius", response.text)
         self.assertIn("Audit metadata", response.text)
+        self.assertIn("Module: module.network", response.text)
+        self.assertIn("Redacted fields: ingress.0.description", response.text)
+        self.assertIn("Unsupported plan fields: plan.planned_values", response.text)
         self.assertNotIn('"data-dw-modal-root":"1"', response.text)
 
     def test_history_detail_route_shows_topology_freshness_badge(self) -> None:

--- a/tests/test_ui/test_upload_panel.py
+++ b/tests/test_ui/test_upload_panel.py
@@ -6,6 +6,7 @@ import unittest
 from unittest.mock import patch
 
 from ui.components.upload_panel import (
+    build_feedback_rerender_handler,
     format_submission_manifest_fallback_summary,
     format_submission_manifest_partial_notice,
     format_submission_manifest_summary,
@@ -15,6 +16,40 @@ from ui.components.upload_panel import (
     uploads_allowed,
     run_uploaded_analysis,
 )
+from parsers.base import ParseBatchResult, ParsedFileResult, UnifiedChange
+from ui.components.change_table import (
+    format_change_metadata_lines,
+    render_change_table,
+)
+
+
+class FakeUiElement:
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback) -> bool:
+        return False
+
+    def classes(self, *_args) -> "FakeUiElement":
+        return self
+
+
+class FakeUi:
+    def __init__(self) -> None:
+        self.labels: list[str] = []
+
+    def card(self) -> FakeUiElement:
+        return FakeUiElement()
+
+    def column(self) -> FakeUiElement:
+        return FakeUiElement()
+
+    def row(self) -> FakeUiElement:
+        return FakeUiElement()
+
+    def label(self, text: object) -> FakeUiElement:
+        self.labels.append(str(text))
+        return FakeUiElement()
 
 
 class UploadPanelTests(unittest.TestCase):
@@ -147,6 +182,239 @@ class UploadPanelTests(unittest.TestCase):
             ),
             "Fallback submission artifacts: plan.json (accepted), broken.tf (failed), .env (sensitive)",
         )
+
+    def test_change_metadata_formatter_surfaces_terraform_metadata(self) -> None:
+        self.assertEqual(
+            format_change_metadata_lines(
+                {
+                    "module_address": "module.network",
+                    "provider_name": "registry.terraform.io/hashicorp/aws",
+                    "actions": ["delete", "create"],
+                    "unknown_after_apply": ["arn"],
+                    "redacted_fields": ["ingress.0.description"],
+                    "unsupported_fields": ["plan.planned_values"],
+                    "plan_unsupported_fields": ["plan.resource_drift"],
+                }
+            ),
+            [
+                "Module: module.network",
+                "Provider: registry.terraform.io/hashicorp/aws",
+                "Actions: delete, create",
+                "Unknown after apply: arn",
+                "Redacted fields: ingress.0.description",
+                "Unsupported fields: plan.planned_values",
+                "Unsupported plan fields: plan.resource_drift",
+            ],
+        )
+
+    def test_change_metadata_formatter_does_not_truncate_sensitive_field_lists(
+        self,
+    ) -> None:
+        lines = format_change_metadata_lines(
+            {
+                "redacted_fields": [
+                    "field.one",
+                    "field.two",
+                    "field.three",
+                    "field.four",
+                    "field.five",
+                ],
+                "unsupported_fields": [
+                    "plan.one",
+                    "plan.two",
+                    "plan.three",
+                    "plan.four",
+                    "plan.five",
+                ],
+            }
+        )
+
+        self.assertIn(
+            "Redacted fields: field.one, field.two, field.three, field.four, field.five",
+            lines,
+        )
+        self.assertIn(
+            "Unsupported fields: plan.one, plan.two, plan.three, plan.four, plan.five",
+            lines,
+        )
+        self.assertNotIn("+1 more", "\n".join(lines))
+
+    def test_feedback_rerender_preserves_parse_batch_metadata_table(self) -> None:
+        rendered_labels: list[list[str]] = []
+        report = {"id": 1}
+        parse_batch = ParseBatchResult(
+            files=[
+                ParsedFileResult(
+                    file_name="plan.json",
+                    tool="terraform",
+                    status="parsed",
+                    changes=[
+                        UnifiedChange(
+                            source_file="plan.json",
+                            tool="terraform",
+                            resource_id="module.network.aws_security_group.main",
+                            action="modify",
+                            summary="Terraform changed an AWS security group.",
+                            metadata={
+                                "module_address": "module.network",
+                                "plan_unsupported_fields": ["plan.planned_values"],
+                            },
+                        ),
+                        UnifiedChange(
+                            source_file="plan.json",
+                            tool="terraform",
+                            resource_id="aws_instance.unchanged",
+                            action="no-op",
+                            summary="Terraform has no change for aws_instance.unchanged.",
+                        ),
+                    ],
+                )
+            ]
+        )
+        timer_state = {"remaining": 37}
+
+        def render_result_card(current_report, **kwargs) -> None:
+            self.assertEqual(current_report, report)
+            self.assertEqual(kwargs["remaining_seconds"], 37)
+            fake_ui = FakeUi()
+            with patch("ui.components.change_table.ui", fake_ui):
+                render_change_table(kwargs["parse_batch"])
+            rendered_labels.append(fake_ui.labels)
+
+        rerender = build_feedback_rerender_handler(
+            render_result_card,
+            report=report,
+            parse_batch=parse_batch,
+            timer_state=timer_state,
+        )
+        rerender()
+
+        self.assertEqual(len(rendered_labels), 1)
+        labels = rendered_labels[0]
+        self.assertIn("Normalized changes", labels)
+        self.assertIn("Module: module.network", labels)
+        self.assertIn("Unsupported plan fields: plan.planned_values", labels)
+        self.assertNotIn(
+            "Terraform has no change for aws_instance.unchanged.",
+            labels,
+        )
+
+    def test_change_table_surfaces_hidden_non_mutating_plan_metadata(self) -> None:
+        parse_batch = ParseBatchResult(
+            files=[
+                ParsedFileResult(
+                    file_name="plan.json",
+                    tool="terraform",
+                    status="parsed",
+                    changes=[
+                        UnifiedChange(
+                            source_file="plan.json",
+                            tool="terraform",
+                            resource_id="terraform-plan",
+                            action="no-op",
+                            summary="Terraform plan has no resource changes.",
+                            metadata={
+                                "plan_format_version": "1.2",
+                                "terraform_version": "1.7.5",
+                                "plan_unsupported_fields": ["plan.planned_values"],
+                            },
+                        )
+                    ],
+                )
+            ]
+        )
+        fake_ui = FakeUi()
+
+        with patch("ui.components.change_table.ui", fake_ui):
+            render_change_table(parse_batch)
+
+        self.assertIn("Normalized changes", fake_ui.labels)
+        self.assertIn("plan.json: Terraform metadata: 1.2 / 1.7.5", fake_ui.labels)
+        self.assertIn(
+            "plan.json: Unsupported plan fields: plan.planned_values",
+            fake_ui.labels,
+        )
+        self.assertIn("No mutating normalized changes available.", fake_ui.labels)
+        self.assertNotIn("Terraform plan has no resource changes.", fake_ui.labels)
+
+    def test_change_table_surfaces_hidden_non_mutating_metadata_by_file(
+        self,
+    ) -> None:
+        parse_batch = ParseBatchResult(
+            files=[
+                ParsedFileResult(
+                    file_name="plan-a.json",
+                    tool="terraform",
+                    status="parsed",
+                    changes=[
+                        UnifiedChange(
+                            source_file="plan-a.json",
+                            tool="terraform",
+                            resource_id="data.aws_ami.selected",
+                            action="read",
+                            summary="Read selected AMI.",
+                            metadata={
+                                "module_address": "module.compute",
+                                "provider_name": "registry.terraform.io/hashicorp/aws",
+                                "actions": ["read"],
+                                "unknown_after_apply": ["id"],
+                                "redacted_fields": ["filter.0.values"],
+                                "unsupported_fields": ["change.generated_config"],
+                                "plan_unsupported_fields": ["plan.planned_values"],
+                            },
+                        )
+                    ],
+                ),
+                ParsedFileResult(
+                    file_name="plan-b.json",
+                    tool="terraform",
+                    status="parsed",
+                    changes=[
+                        UnifiedChange(
+                            source_file="plan-b.json",
+                            tool="terraform",
+                            resource_id="aws_instance.unchanged",
+                            action="no-op",
+                            summary="Instance unchanged.",
+                            metadata={
+                                "provider_name": "registry.terraform.io/hashicorp/aws",
+                                "actions": ["no-op"],
+                                "plan_unsupported_fields": ["plan.checks"],
+                            },
+                        )
+                    ],
+                ),
+            ]
+        )
+        fake_ui = FakeUi()
+
+        with patch("ui.components.change_table.ui", fake_ui):
+            render_change_table(parse_batch)
+
+        self.assertIn("plan-a.json: Module: module.compute", fake_ui.labels)
+        self.assertIn(
+            "plan-a.json: Provider: registry.terraform.io/hashicorp/aws",
+            fake_ui.labels,
+        )
+        self.assertIn("plan-a.json: Actions: read", fake_ui.labels)
+        self.assertIn("plan-a.json: Unknown after apply: id", fake_ui.labels)
+        self.assertIn("plan-a.json: Redacted fields: filter.0.values", fake_ui.labels)
+        self.assertIn(
+            "plan-a.json: Unsupported fields: change.generated_config",
+            fake_ui.labels,
+        )
+        self.assertIn(
+            "plan-a.json: Unsupported plan fields: plan.planned_values",
+            fake_ui.labels,
+        )
+        self.assertIn("plan-b.json: Actions: no-op", fake_ui.labels)
+        self.assertIn(
+            "plan-b.json: Unsupported plan fields: plan.checks",
+            fake_ui.labels,
+        )
+        self.assertIn("No mutating normalized changes available.", fake_ui.labels)
+        self.assertNotIn("Read selected AMI.", fake_ui.labels)
+        self.assertNotIn("Instance unchanged.", fake_ui.labels)
 
 
 if __name__ == "__main__":

--- a/ui/components/change_table.py
+++ b/ui/components/change_table.py
@@ -4,7 +4,89 @@ from __future__ import annotations
 
 from nicegui import ui
 
-from parsers.base import ParseBatchResult
+from parsers.base import ParseBatchResult, is_non_mutating_action
+
+
+def _compact_list(value: object, *, limit: int | None = 4) -> str | None:
+    if not isinstance(value, list) or not value:
+        return None
+    items = [str(item) for item in value if str(item)]
+    if not items:
+        return None
+    if limit is None:
+        return ", ".join(items)
+    visible = items[:limit]
+    suffix = f" (+{len(items) - limit} more)" if len(items) > limit else ""
+    return ", ".join(visible) + suffix
+
+
+def format_change_metadata_lines(metadata: dict | None) -> list[str]:
+    """Return compact UI lines for parser-normalized Terraform metadata."""
+    if not isinstance(metadata, dict) or not metadata:
+        return []
+
+    lines: list[str] = []
+    module_address = metadata.get("module_address")
+    if module_address:
+        lines.append(f"Module: {module_address}")
+    provider_name = metadata.get("provider_name")
+    if provider_name:
+        lines.append(f"Provider: {provider_name}")
+    versions = [
+        str(value)
+        for value in (
+            metadata.get("plan_format_version"),
+            metadata.get("terraform_version"),
+        )
+        if value
+    ]
+    if versions:
+        lines.append("Terraform metadata: " + " / ".join(versions))
+
+    for label, key in (
+        ("Actions", "actions"),
+        ("Replace paths", "replace_paths"),
+        ("Unknown after apply", "unknown_after_apply"),
+        ("Redacted fields", "redacted_fields"),
+        ("Unsupported fields", "unsupported_fields"),
+        ("Unsupported plan fields", "plan_unsupported_fields"),
+    ):
+        rendered = _compact_list(
+            metadata.get(key),
+            limit=None
+            if key
+            in {"redacted_fields", "unsupported_fields", "plan_unsupported_fields"}
+            else 4,
+        )
+        if rendered:
+            lines.append(f"{label}: {rendered}")
+    return lines
+
+
+def _hidden_change_metadata_lines(
+    parse_batch: ParseBatchResult,
+    *,
+    visible_change_keys: set[tuple[str, str]],
+) -> list[str]:
+    lines: list[str] = []
+    seen_lines: set[str] = set()
+
+    for file_result in parse_batch.files:
+        if file_result.status != "parsed":
+            continue
+        for change in file_result.changes:
+            if change.tool != "terraform":
+                continue
+            if (change.source_file, change.change_id) in visible_change_keys:
+                continue
+            for metadata_line in format_change_metadata_lines(change.metadata):
+                rendered = f"{file_result.file_name}: {metadata_line}"
+                if rendered in seen_lines:
+                    continue
+                seen_lines.add(rendered)
+                lines.append(rendered)
+
+    return lines
 
 
 def render_change_table(parse_batch: ParseBatchResult) -> None:
@@ -17,9 +99,23 @@ def render_change_table(parse_batch: ParseBatchResult) -> None:
             for file_result in parse_batch.files
             if file_result.status == "parsed"
             for change in file_result.changes
+            if not (
+                change.tool == "terraform" and is_non_mutating_action(change.action)
+            )
         ]
+        visible_change_keys = {
+            (change.source_file, change.change_id) for change in changes
+        }
+        for metadata_line in _hidden_change_metadata_lines(
+            parse_batch,
+            visible_change_keys=visible_change_keys,
+        ):
+            ui.label(metadata_line).classes("text-xs dw-muted leading-5")
+
         if not changes:
-            ui.label("No normalized changes available.").classes("text-sm dw-muted")
+            ui.label("No mutating normalized changes available.").classes(
+                "text-sm dw-muted"
+            )
             return
 
         with ui.column().classes("w-full gap-2"):
@@ -32,6 +128,12 @@ def render_change_table(parse_batch: ParseBatchResult) -> None:
                         ui.label(
                             f"{change.source_file} · {change.resource_id}"
                         ).classes("text-xs dw-muted")
+                        for metadata_line in format_change_metadata_lines(
+                            change.metadata
+                        ):
+                            ui.label(metadata_line).classes(
+                                "text-xs dw-muted leading-5"
+                            )
                     ui.label(f"{change.tool} · {change.action}").classes(
                         "text-xs uppercase dw-muted"
                     )

--- a/ui/components/report_detail_page.py
+++ b/ui/components/report_detail_page.py
@@ -16,6 +16,7 @@ from services.feedback_service import (
     record_finding_feedback,
 )
 from ui.components.blast_radius_graph import render_blast_radius_panel
+from ui.components.change_table import format_change_metadata_lines
 from ui.components.context_completeness_panel import (
     render_context_completeness_panel,
 )
@@ -309,6 +310,12 @@ def _render_resource_breakdown(report: dict[str, Any]) -> None:
                             ui.label(contributor["reasoning"]).classes(
                                 "text-sm dw-muted leading-6"
                             )
+                            for metadata_line in format_change_metadata_lines(
+                                contributor.get("metadata") or {}
+                            ):
+                                ui.label(metadata_line).classes(
+                                    "text-xs dw-muted leading-5"
+                                )
                             for security_flag in contributor.get("security_flags", []):
                                 ui.label(security_flag).classes(
                                     "text-xs dw-danger-text"

--- a/ui/components/upload_panel.py
+++ b/ui/components/upload_panel.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Callable
+from typing import Any
 
 from nicegui import events, run, ui
 
@@ -32,6 +33,10 @@ from ui.components.project_workspace_switcher import (
     open_create_project_dialog as show_create_project_dialog,
 )
 from ui.components.blast_radius_graph import render_blast_radius_panel
+from ui.components.change_table import (
+    format_change_metadata_lines,
+    render_change_table,
+)
 from ui.components.report_detail_page import (
     format_submission_manifest_fallback_summary,
     format_submission_manifest_partial_notice,
@@ -140,6 +145,25 @@ def should_clear_pending_uploads(
         and next_project_id is not None
         and previous_project_id != next_project_id
     )
+
+
+def build_feedback_rerender_handler(
+    render_result_card: Callable[..., None],
+    *,
+    report: dict[str, Any],
+    parse_batch: object,
+    timer_state: dict[str, int],
+) -> Callable[[], None]:
+    """Return a feedback callback that preserves parse metadata on rerender."""
+
+    def rerender() -> None:
+        render_result_card(
+            report,
+            remaining_seconds=timer_state["remaining"],
+            parse_batch=parse_batch,
+        )
+
+    return rerender
 
 
 def build_upload_panel(
@@ -331,7 +355,7 @@ def build_upload_panel(
         result_mount.clear()
 
     def render_result_card(
-        report: dict, *, remaining_seconds: int | None = None
+        report: dict, *, remaining_seconds: int | None = None, parse_batch=None
     ) -> None:
         token = int(state["result_token"]) + 1
         state["result_token"] = token
@@ -430,6 +454,8 @@ def build_upload_panel(
                     )
                 context = report.get("context_completeness") or {}
                 render_topology_freshness_banner(context)
+                if parse_batch is not None:
+                    render_change_table(parse_batch)
                 findings = report.get("findings", [])
                 evidence_items = report.get("evidence_items", [])
                 artifact_names = list(report.get("audit", {}).get("files_analyzed", []))
@@ -444,10 +470,11 @@ def build_upload_panel(
                         )
                         render_reviewer_feedback_panel(
                             report,
-                            on_feedback_change=lambda current_report=report: (
-                                render_result_card(
-                                    current_report, timer_state["remaining"]
-                                )
+                            on_feedback_change=build_feedback_rerender_handler(
+                                render_result_card,
+                                report=report,
+                                parse_batch=parse_batch,
+                                timer_state=timer_state,
                             ),
                         )
                 render_context_completeness_panel(context)
@@ -482,6 +509,12 @@ def build_upload_panel(
                                     ui.label(contributor["reasoning"]).classes(
                                         "text-xs dw-muted leading-5"
                                     )
+                                    for metadata_line in format_change_metadata_lines(
+                                        contributor.get("metadata") or {}
+                                    ):
+                                        ui.label(metadata_line).classes(
+                                            "text-xs dw-muted leading-5"
+                                        )
                                 render_risk_badge(contributor["severity"])
             ui.timer(1.0, update_countdown)
         update_countdown()
@@ -606,6 +639,7 @@ def build_upload_panel(
                 remaining_seconds=persisted_report.get(
                     "dashboard_display_duration_seconds"
                 ),
+                parse_batch=parse_batch,
             )
             state["files"] = []
             state["summary"] = build_pending_analysis([])


### PR DESCRIPTION
Terraform plan JSON now carries first-class parser metadata through intake, evidence, scoring, persistence, CLI, API, and review UI surfaces so Story 2.2 can rely on concrete plan semantics instead of source-file inference.

Constraint: Story 2.2 requires unsupported and redacted Terraform fields to be explicit while preserving the local-first advisory posture.

Rejected: Treat non-mutating Terraform entries as evidence findings | read and no-op entries must remain visible as metadata without inflating risk.

Confidence: high

Scope-risk: moderate

Directive: Do not collapse Terraform plan actions back to legacy modify/destroy vocabulary without revalidating parser, scoring, persistence, and UI metadata tests.

Tested: Focused parser/service/API regressions; affected parser/service/API suites; ruff check and format check; full unittest discovery; ci-local with Bandit active; pip-audit; Playwright UI review; git diff --check

Not-tested: VoiceOver-specific UI review

## What does this PR do?

<!-- Brief description of changes -->

## Type of change
- [ ] Feature (new functionality)
- [ ] Bugfix (non-breaking fix)
- [ ] Release preparation
- [ ] Hotfix (critical production fix)
- [ ] Docs / refactor / chore

## Checklist
- [ ] I have followed the branch naming convention
- [ ] Tests pass locally (`pytest tests/ -v`)
- [ ] Linting passes (`ruff check .`)
- [ ] Docker build succeeds
- [ ] I have updated docs if needed
- [ ] No secrets or .env values committed

## Related issue
Closes #