### PR TITLE
Enforce Evidence Law persistence invariants

### DIFF
--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -1,5 +1,5 @@
 # generated: 2026-05-01
-# last_updated: 2026-05-08
+# last_updated: 2026-05-10
 # project: deploywhisper
 # project_key: NOKEY
 # tracking_system: file-system
@@ -35,7 +35,7 @@
 # - Dev moves story to review, then runs code-review
 
 generated: 2026-05-01
-last_updated: 2026-05-08
+last_updated: 2026-05-10
 project: deploywhisper
 project_key: NOKEY
 tracking_system: file-system
@@ -63,7 +63,7 @@ development_status:
   2-2-terraform-plan-json-intake: review
   2-3-evidence-item-model-and-extraction: done
   2-4-finding-model-and-evidence-links: done
-  2-5-evidence-law-runtime-gate: ready-for-dev
+  2-5-evidence-law-runtime-gate: review
   2-6-confidence-uncertainty-and-insufficient-context: ready-for-dev
   2-7-narrative-after-scoring-and-degraded-fallback: ready-for-dev
   2-8-report-schema-versioning: ready-for-dev

--- a/docs/evidence-model.md
+++ b/docs/evidence-model.md
@@ -38,6 +38,12 @@ Story 2.4 extends findings with explicit support context:
 - `evidence_refs` remains the durable link from each finding to the persisted evidence items that support it
 - When a finding has mixed support, deterministic linked evidence takes precedence in the displayed classification so reviewers can see that at least one hard evidence item supports the finding.
 
+Story 2.5 enforces Evidence Law at report persistence time:
+
+- high and critical findings must link to at least one deterministic evidence item
+- the shared report service downgrades unsupported high/critical findings to medium, caps their confidence at `0.85`, reconciles unsupported report-level severe verdicts to caution, and records an Evidence Law warning
+- the report repository rejects direct persistence payloads that try to save high/critical findings or report-level high/critical verdicts without linked deterministic severe evidence
+
 ## Persistence Shape
 
 The additive persistence layer extends `analysis_reports` with four new tables:

--- a/models/repositories/analysis_reports.py
+++ b/models/repositories/analysis_reports.py
@@ -3,12 +3,14 @@
 from __future__ import annotations
 
 import json
+import re
 from datetime import UTC, datetime, timedelta
 from typing import Any
 
 from sqlalchemy import func, select
 from sqlalchemy.orm import Session, selectinload
 
+from evidence.models import EvidenceItem as EvidenceItemPayload
 from evidence.models import Finding as FindingPayload
 from models.tables import (
     AnalysisReport,
@@ -17,41 +19,279 @@ from models.tables import (
     RiskAssessment as PersistedRiskAssessment,
 )
 
+_FINDING_SEVERITY_ORDER = {"low": 1, "medium": 2, "high": 3, "critical": 4}
+_SEVERITY_SCORE_FLOOR = {"low": 0, "medium": 42, "high": 70, "critical": 90}
+_SEVERITY_SCORE_CEILING = {"low": 39, "medium": 69, "high": 89, "critical": 100}
+_VERDICT_PREFIX_PATTERN = re.compile(
+    r"^\s*(critical|high|medium|low|no-go|go|caution)"
+    r"(?:\s*:\s*|\s+-\s+|"
+    r"\s+(?=(?:because|due|risk|risks|finding|findings|claim|claims|unsupported|"
+    r"severe|exposure|exposures|verdict|verdicts|deployment|database|"
+    r"ingress|review|reviews|blocked|blocker|blockers|issue|issues|"
+    r"incident|incidents|outage|outages|rollback|access|network|"
+    r"security|permission|policy|blast|radius)\b))",
+    flags=re.IGNORECASE,
+)
+
+
+def _normalize_report_severity(severity: str) -> str:
+    normalized_severity = str(severity).strip().lower()
+    if normalized_severity not in _FINDING_SEVERITY_ORDER:
+        raise ValueError(f"Unsupported report severity {severity!r}.")
+    return normalized_severity
+
+
+def _verdict_label(value: str | None) -> str | None:
+    match = _VERDICT_PREFIX_PATTERN.match(str(value or ""))
+    if match is None:
+        return None
+    return match.group(1).lower()
+
+
+def _verdict_text_contradicts_metadata(
+    value: str | None,
+    report_severity: str,
+    report_recommendation: str,
+) -> bool:
+    label = _verdict_label(value)
+    if label is None:
+        return False
+    recommendation = str(report_recommendation).strip().lower()
+    if label in _FINDING_SEVERITY_ORDER:
+        return label != report_severity
+    if label in {"go", "caution", "no-go"}:
+        return label != recommendation
+    return False
+
+
+def _recommendation_for_severity(severity: str) -> str:
+    if severity in {"high", "critical"}:
+        return "no-go"
+    if severity == "medium":
+        return "caution"
+    return "go"
+
+
+def _recommendation_matches_severity(recommendation: str, severity: str) -> bool:
+    if severity in {"high", "critical"}:
+        return recommendation == "no-go"
+    if severity == "medium":
+        return recommendation in {"go", "caution"}
+    return recommendation == "go"
+
+
+def _validate_report_verdict_text(
+    report_severity: str,
+    report_recommendation: str,
+    *values: str | None,
+) -> None:
+    if any(
+        _verdict_text_contradicts_metadata(
+            value,
+            report_severity,
+            report_recommendation,
+        )
+        for value in values
+    ):
+        raise ValueError("Report verdict text contradicts severity metadata.")
+
+
+def _validate_top_risk_contributor_refs(
+    top_risk_contributors_json: str,
+    evidence_finding_by_id: dict[str, PersistedFinding],
+    report_severity: str,
+) -> None:
+    try:
+        top_risk_contributors = json.loads(top_risk_contributors_json or "[]")
+    except json.JSONDecodeError as exc:
+        raise ValueError("Top-risk contributors must be valid JSON.") from exc
+    if not isinstance(top_risk_contributors, list) or any(
+        not isinstance(evidence_id, str) or not evidence_id.strip()
+        for evidence_id in top_risk_contributors
+    ):
+        raise ValueError("Top-risk contributors must be a list of evidence IDs.")
+    if len(top_risk_contributors) != len(set(top_risk_contributors)):
+        raise ValueError("Top-risk contributors must not repeat evidence IDs.")
+    if report_severity in {"high", "critical"} and not top_risk_contributors:
+        raise ValueError(
+            "High/critical reports must persist top-risk contributor evidence IDs."
+        )
+    missing_evidence_ids = [
+        evidence_id
+        for evidence_id in top_risk_contributors
+        if evidence_id not in evidence_finding_by_id
+    ]
+    if missing_evidence_ids:
+        raise ValueError(
+            "Top-risk contributor "
+            f"{missing_evidence_ids[0]} does not reference persisted evidence."
+        )
+    owner_ids = {
+        evidence_finding_by_id[evidence_id].finding_id
+        for evidence_id in top_risk_contributors
+    }
+    if len(owner_ids) > 1:
+        raise ValueError("Top-risk contributors must belong to one persisted finding.")
+    if report_severity in {"high", "critical"} and any(
+        evidence_finding_by_id[evidence_id].severity != report_severity
+        for evidence_id in top_risk_contributors
+    ):
+        raise ValueError(
+            "Top-risk contributors must reference the report's severe finding."
+        )
+
 
 def _validate_finding_evidence_refs(
     finding_rows: list[tuple[PersistedFinding, list[str]]],
     evidence_payload: list[dict[str, Any]] | None,
-) -> dict[str, str]:
-    evidence_ids: set[str] = set()
+    report_severity: str,
+    report_score: int,
+    report_recommendation: str,
+) -> dict[str, PersistedFinding]:
+    evidence_by_id: dict[str, dict[str, Any]] = {}
     for evidence in evidence_payload or []:
         evidence_id = str(evidence["evidence_id"])
-        if evidence_id in evidence_ids:
+        if evidence_id in evidence_by_id:
             raise ValueError(
                 f"Duplicate evidence item {evidence_id} in report payload."
             )
-        evidence_ids.add(evidence_id)
+        evidence_by_id[evidence_id] = evidence
 
-    evidence_owner_by_id: dict[str, str] = {}
+    evidence_claims_by_id: dict[str, list[PersistedFinding]] = {}
+    evidence_finding_by_id: dict[str, PersistedFinding] = {}
     for persisted_finding, evidence_refs in finding_rows:
         if len(evidence_refs) != len(set(evidence_refs)):
             raise ValueError(
                 f"Finding {persisted_finding.finding_id} repeats evidence refs."
             )
         for evidence_id in evidence_refs:
-            if evidence_id not in evidence_ids:
+            if evidence_id not in evidence_by_id:
                 raise ValueError(
                     "Finding "
                     f"{persisted_finding.finding_id} references missing evidence item "
                     f"{evidence_id}."
                 )
-            evidence_owner_by_id.setdefault(evidence_id, persisted_finding.finding_id)
-    unclaimed_evidence_ids = evidence_ids - set(evidence_owner_by_id)
+            evidence_claims_by_id.setdefault(evidence_id, []).append(persisted_finding)
+        if persisted_finding.severity in {"high", "critical"}:
+            linked_deterministic_classifications = {
+                _evidence_classification(evidence_by_id[evidence_id])
+                for evidence_id in evidence_refs
+                if evidence_id in evidence_by_id
+                and _is_deterministic_evidence(evidence_by_id[evidence_id])
+            }
+            if not linked_deterministic_classifications:
+                raise ValueError(
+                    "Finding "
+                    f"{persisted_finding.finding_id} has {persisted_finding.severity} "
+                    "severity without linked deterministic evidence."
+                )
+            if (
+                not persisted_finding.deterministic
+                or persisted_finding.evidence_classification
+                not in linked_deterministic_classifications
+            ):
+                raise ValueError(
+                    "Finding "
+                    f"{persisted_finding.finding_id} metadata contradicts linked "
+                    "deterministic evidence."
+                )
+
+    for evidence_id, claimants in evidence_claims_by_id.items():
+        evidence_owner_id = str(evidence_by_id[evidence_id].get("finding_id") or "")
+        owner = next(
+            (
+                persisted_finding
+                for persisted_finding in claimants
+                if persisted_finding.finding_id == evidence_owner_id
+            ),
+            None,
+        )
+        if owner is None:
+            if len(claimants) == 1:
+                owner = claimants[0]
+            else:
+                raise ValueError(
+                    f"Evidence item {evidence_id} has ambiguous finding ownership."
+                )
+        evidence_finding_by_id[evidence_id] = owner
+
+    strongest_supported_severity = max(
+        (
+            _FINDING_SEVERITY_ORDER[persisted_finding.severity]
+            for persisted_finding, evidence_refs in finding_rows
+            if persisted_finding.severity in {"high", "critical"}
+            and any(
+                _is_deterministic_evidence(evidence_by_id[evidence_id])
+                for evidence_id in evidence_refs
+                if evidence_id in evidence_by_id
+            )
+        ),
+        default=0,
+    )
+    if (
+        report_severity in {"high", "critical"}
+        and strongest_supported_severity < (_FINDING_SEVERITY_ORDER[report_severity])
+    ):
+        raise ValueError(
+            "Report has high/critical severity without a linked deterministic severe "
+            "finding."
+        )
+    if (
+        strongest_supported_severity >= _FINDING_SEVERITY_ORDER["high"]
+        and _FINDING_SEVERITY_ORDER[report_severity] < strongest_supported_severity
+    ):
+        raise ValueError(
+            "Report severity understates linked deterministic severe finding."
+        )
+    if (
+        not _recommendation_matches_severity(
+            report_recommendation,
+            report_severity,
+        )
+        or report_score < _SEVERITY_SCORE_FLOOR[report_severity]
+        or report_score > _SEVERITY_SCORE_CEILING[report_severity]
+    ):
+        raise ValueError("Report has severity with inconsistent verdict metadata.")
+    unclaimed_evidence_ids = set(evidence_by_id) - set(evidence_finding_by_id)
     if unclaimed_evidence_ids:
         evidence_id = sorted(unclaimed_evidence_ids)[0]
         raise ValueError(
             f"Evidence item {evidence_id} is not referenced by any persisted finding."
         )
-    return evidence_owner_by_id
+    return evidence_finding_by_id
+
+
+def _is_deterministic_evidence(evidence: dict[str, Any]) -> bool:
+    determinism_level = str(evidence.get("determinism_level") or "deterministic")
+    return (
+        evidence.get("deterministic") is True and determinism_level == "deterministic"
+    )
+
+
+def _evidence_classification(evidence: dict[str, Any]) -> str:
+    source_kind = str(evidence.get("source_kind") or evidence.get("source_type") or "")
+    if source_kind == "external_scanner":
+        return "external"
+    if source_kind == "user_context":
+        return "user_provided"
+    determinism_level = str(evidence.get("determinism_level") or "deterministic")
+    if determinism_level == "heuristic":
+        return "derived"
+    if determinism_level == "inferred":
+        return "model_inferred"
+    return "deterministic" if _is_deterministic_evidence(evidence) else "model_inferred"
+
+
+def _normalize_evidence_payload(evidence: dict[str, Any]) -> dict[str, Any]:
+    if "deterministic" not in evidence:
+        return EvidenceItemPayload.model_validate(evidence).model_dump(mode="json")
+    strict_evidence = {
+        **evidence,
+        "deterministic": evidence.get("deterministic")
+        if isinstance(evidence.get("deterministic"), bool)
+        else False,
+    }
+    return EvidenceItemPayload.model_validate(strict_evidence).model_dump(mode="json")
 
 
 def _report_load_options(*, include_evidence: bool) -> list:
@@ -102,6 +342,10 @@ def create_analysis_report(
     findings_payload: list[dict[str, Any]] | None = None,
     evidence_payload: list[dict[str, Any]] | None = None,
 ) -> AnalysisReport:
+    severity = _normalize_report_severity(severity)
+    evidence_payload = [
+        _normalize_evidence_payload(evidence) for evidence in evidence_payload or []
+    ]
     report = AnalysisReport(
         project_id=project_id,
         workspace_id=workspace_id,
@@ -156,9 +400,24 @@ def create_analysis_report(
             )
         )
 
-    evidence_owner_by_id = _validate_finding_evidence_refs(
+    evidence_finding_by_id = _validate_finding_evidence_refs(
         finding_rows,
         evidence_payload,
+        severity,
+        risk_score,
+        recommendation,
+    )
+    _validate_report_verdict_text(
+        severity,
+        recommendation,
+        top_risk,
+        narrative_opening,
+        narrative_explanation,
+    )
+    _validate_top_risk_contributor_refs(
+        top_risk_contributors_json,
+        evidence_finding_by_id,
+        severity,
     )
 
     report.risk_assessment = PersistedRiskAssessment(
@@ -179,8 +438,12 @@ def create_analysis_report(
             for persisted_finding in report.findings
         }
         for evidence in evidence_payload:
-            owner_id = evidence_owner_by_id.get(str(evidence["evidence_id"]))
-            owner = finding_by_id.get(owner_id) if owner_id is not None else None
+            owner_finding = evidence_finding_by_id.get(str(evidence["evidence_id"]))
+            owner = (
+                finding_by_id.get(owner_finding.finding_id)
+                if owner_finding is not None
+                else None
+            )
             if owner is None:
                 raise ValueError(
                     "Evidence item "
@@ -224,7 +487,7 @@ def create_analysis_report(
                     redaction_status=str(evidence.get("redaction_status") or "none"),
                     summary=str(evidence["summary"]),
                     severity_hint=str(evidence["severity_hint"]),
-                    deterministic=bool(evidence["deterministic"]),
+                    deterministic=evidence["deterministic"],
                     confidence=float(evidence["confidence"]),
                     related_change_ids_json=json.dumps(
                         evidence.get("related_change_ids", [])

--- a/services/report_service.py
+++ b/services/report_service.py
@@ -82,6 +82,19 @@ _SEVERITY_PREFIX_PATTERN = re.compile(
     r"^\s*(critical|high|medium|low|info|warning|caution)\s*[:\-]\s*",
     flags=re.IGNORECASE,
 )
+_VERDICT_PREFIX_PATTERN = re.compile(
+    r"^\s*(critical|high|medium|low|no-go|go|caution)"
+    r"(?:\s*:\s*|\s+-\s+|"
+    r"\s+(?=(?:because|due|risk|risks|finding|findings|claim|claims|unsupported|"
+    r"severe|exposure|exposures|verdict|verdicts|deployment|database|"
+    r"ingress|review|reviews|blocked|blocker|blockers|issue|issues|"
+    r"incident|incidents|outage|outages|rollback|access|network|"
+    r"security|permission|policy|blast|radius)\b))",
+    flags=re.IGNORECASE,
+)
+_FINDING_SEVERITY_ORDER = {"low": 1, "medium": 2, "high": 3, "critical": 4}
+_SEVERITY_SCORE_FLOOR = {"low": 0, "medium": 42, "high": 70, "critical": 90}
+_SEVERITY_SCORE_CEILING = {"low": 39, "medium": 69, "high": 89, "critical": 100}
 
 
 def _resolve_project_id(
@@ -1095,6 +1108,22 @@ def _scope_report_entities(
         evidence_item.evidence_id: evidence_item
         for evidence_item in evidence_items or []
     }
+    evidence_claim_owner_by_id: dict[str, str] = {}
+    for evidence_item in evidence_items or []:
+        claimants = [
+            finding
+            for finding in findings or []
+            if evidence_item.evidence_id in finding.evidence_refs
+        ]
+        if claimants:
+            owner = max(
+                claimants,
+                key=lambda finding: _FINDING_SEVERITY_ORDER.get(
+                    finding.severity,
+                    0,
+                ),
+            )
+            evidence_claim_owner_by_id[evidence_item.evidence_id] = owner.finding_id
 
     def _scoped_finding_updates(finding: Finding) -> dict[str, Any]:
         matched_evidence_items = [
@@ -1118,6 +1147,14 @@ def _scope_report_entities(
             updates["evidence_classification"] = "model_inferred"
         return updates
 
+    def _scoped_evidence_finding_id(evidence_item: EvidenceItem) -> str:
+        owner_id = evidence_item.finding_id
+        if owner_id not in finding_id_map:
+            owner_id = evidence_claim_owner_by_id.get(
+                evidence_item.evidence_id, owner_id
+            )
+        return finding_id_map.get(owner_id, owner_id)
+
     scoped_findings = (
         [
             finding.model_copy(update=_scoped_finding_updates(finding))
@@ -1131,10 +1168,7 @@ def _scope_report_entities(
             evidence_item.model_copy(
                 update={
                     "evidence_id": evidence_id_map[evidence_item.evidence_id],
-                    "finding_id": finding_id_map.get(
-                        evidence_item.finding_id,
-                        evidence_item.finding_id,
-                    ),
+                    "finding_id": _scoped_evidence_finding_id(evidence_item),
                 }
             )
             for evidence_item in evidence_items
@@ -1226,6 +1260,552 @@ def _finding_with_evidence_ref(
             matched_evidence_items
         )
     return finding.model_copy(update=updates)
+
+
+def _has_linked_deterministic_evidence(
+    finding: Finding,
+    evidence_by_id: dict[str, EvidenceItem],
+) -> bool:
+    return any(
+        (evidence_item := evidence_by_id.get(evidence_ref)) is not None
+        and evidence_item.deterministic
+        and evidence_item.determinism_level == "deterministic"
+        for evidence_ref in finding.evidence_refs
+    )
+
+
+def _linked_deterministic_evidence_refs(
+    finding: Finding,
+    evidence_by_id: dict[str, EvidenceItem],
+) -> list[str]:
+    return [
+        evidence_ref
+        for evidence_ref in finding.evidence_refs
+        if (evidence_item := evidence_by_id.get(evidence_ref)) is not None
+        and evidence_item.deterministic
+        and evidence_item.determinism_level == "deterministic"
+    ]
+
+
+def _top_risk_contributors_match_finding(
+    contributor_refs: list[str],
+    finding: Finding,
+    evidence_by_id: dict[str, EvidenceItem],
+) -> bool:
+    deterministic_refs = set(
+        _linked_deterministic_evidence_refs(finding, evidence_by_id)
+    )
+    return bool(contributor_refs) and set(contributor_refs).issubset(deterministic_refs)
+
+
+def _downgraded_finding_without_deterministic_evidence(
+    finding: Finding,
+    evidence_by_id: dict[str, EvidenceItem],
+) -> Finding:
+    matched_evidence_items = [
+        evidence_by_id[evidence_ref]
+        for evidence_ref in finding.evidence_refs
+        if evidence_ref in evidence_by_id
+    ]
+    downgraded_title = _VERDICT_PREFIX_PATTERN.sub("", finding.title).strip()
+    if downgraded_title:
+        downgraded_title = f"MEDIUM: {downgraded_title}"
+    else:
+        downgraded_title = f"MEDIUM: {finding.description}"
+    downgrade_note = (
+        "Evidence Law downgraded this finding to medium because it does not link to "
+        "deterministic evidence."
+    )
+    return finding.model_copy(
+        update={
+            "title": downgraded_title,
+            "explanation": downgrade_note,
+            "guidance": [
+                "Review the available linked evidence before deployment.",
+                "Add deterministic evidence before treating this finding as severe.",
+            ],
+            "severity": "medium",
+            "deterministic": False,
+            "confidence": min(finding.confidence, 0.85),
+            "evidence_classification": (
+                classify_finding_evidence(matched_evidence_items)
+                if matched_evidence_items
+                else "model_inferred"
+            ),
+            "uncertainty_note": (
+                finding.uncertainty_note
+                or "Severity was downgraded because high/critical claims require linked deterministic evidence."
+            ),
+        }
+    )
+
+
+def _finding_with_supported_deterministic_evidence(
+    finding: Finding,
+    evidence_by_id: dict[str, EvidenceItem],
+) -> Finding:
+    matched_evidence_items = [
+        evidence_by_id[evidence_ref]
+        for evidence_ref in finding.evidence_refs
+        if evidence_ref in evidence_by_id
+    ]
+    return finding.model_copy(
+        update={
+            "deterministic": True,
+            "evidence_classification": classify_finding_evidence(
+                matched_evidence_items
+            ),
+        }
+    )
+
+
+def _highest_severity_finding(findings: list[Finding]) -> Finding:
+    return max(
+        findings,
+        key=lambda finding: _FINDING_SEVERITY_ORDER.get(finding.severity, 0),
+    )
+
+
+def _finding_risk_summary(finding: Finding) -> str:
+    title = _VERDICT_PREFIX_PATTERN.sub("", finding.title).strip()
+    title = title or finding.description
+    description = finding.description.strip()
+    if description and description != title:
+        return f"{finding.severity.upper()}: {title} - {description}"
+    return f"{finding.severity.upper()}: {title}"
+
+
+def _recommendation_for_severity(severity: str) -> str:
+    if severity in {"high", "critical"}:
+        return "no-go"
+    if severity == "medium":
+        return "caution"
+    return "go"
+
+
+def _recommendation_matches_severity(recommendation: str, severity: str) -> bool:
+    if severity in {"high", "critical"}:
+        return recommendation == "no-go"
+    if severity == "medium":
+        return recommendation in {"go", "caution"}
+    return recommendation == "go"
+
+
+def _reconciled_score_for_severity(score: int, severity: str) -> int:
+    return min(
+        max(score, _SEVERITY_SCORE_FLOOR[severity]),
+        _SEVERITY_SCORE_CEILING[severity],
+    )
+
+
+def _score_matches_severity(score: int, severity: str) -> bool:
+    return _SEVERITY_SCORE_FLOOR[severity] <= score <= _SEVERITY_SCORE_CEILING[severity]
+
+
+def _verdict_label(value: str | None) -> str | None:
+    match = _VERDICT_PREFIX_PATTERN.match(str(value or ""))
+    if match is None:
+        return None
+    return match.group(1).lower()
+
+
+def _verdict_text_contradicts_metadata(
+    value: str | None,
+    severity: str,
+    recommendation: str,
+) -> bool:
+    label = _verdict_label(value)
+    if label is None:
+        return False
+    normalized_severity = str(severity).strip().lower()
+    normalized_recommendation = str(recommendation).strip().lower()
+    if normalized_severity not in _FINDING_SEVERITY_ORDER:
+        return False
+    if label in _FINDING_SEVERITY_ORDER:
+        return label != normalized_severity
+    if label in {"go", "caution", "no-go"}:
+        return label != normalized_recommendation
+    return False
+
+
+def _sanitized_risk_summary(value: str | None, severity: str) -> str:
+    summary = _VERDICT_PREFIX_PATTERN.sub("", str(value or "")).strip()
+    if not summary:
+        summary = "Evidence Law reconciled report verdict text."
+    return f"{severity.upper()}: {summary}"
+
+
+def _contributors_for_evidence_refs(
+    contributors: list[RiskContributor],
+    evidence_refs: list[str],
+) -> list[RiskContributor]:
+    supported_refs = set(evidence_refs)
+    return [
+        contributor
+        for contributor in contributors
+        if contributor.evidence_id in supported_refs
+        or _is_neutral_parser_metadata_contributor(contributor)
+    ]
+
+
+def _is_neutral_parser_metadata_contributor(contributor: RiskContributor) -> bool:
+    return (
+        contributor.evidence_id is None
+        and contributor.contribution <= 0
+        and contributor.severity not in {"high", "critical"}
+        and bool(contributor.metadata)
+    )
+
+
+def _apply_evidence_law_runtime_gate(
+    assessment: RiskAssessment,
+    findings: list[Finding] | None,
+    evidence_items: list[EvidenceItem] | None,
+) -> tuple[RiskAssessment, list[Finding] | None, list[str], str | None]:
+    """Downgrade severe findings that lack linked deterministic evidence."""
+    evidence_by_id = {
+        evidence_item.evidence_id: evidence_item
+        for evidence_item in evidence_items or []
+    }
+    updated_findings: list[Finding] = []
+    downgraded_ids: list[str] = []
+    for finding in findings or []:
+        if finding.severity in {
+            "high",
+            "critical",
+        } and _has_linked_deterministic_evidence(
+            finding,
+            evidence_by_id,
+        ):
+            updated_findings.append(
+                _finding_with_supported_deterministic_evidence(
+                    finding,
+                    evidence_by_id,
+                )
+            )
+            continue
+        if finding.severity in {"high", "critical"}:
+            updated_finding = _downgraded_finding_without_deterministic_evidence(
+                finding,
+                evidence_by_id,
+            )
+            updated_findings.append(updated_finding)
+            downgraded_ids.append(finding.finding_id)
+            continue
+        updated_findings.append(finding)
+
+    supported_severe_findings = [
+        finding
+        for finding in updated_findings
+        if finding.severity in {"high", "critical"}
+        and _has_linked_deterministic_evidence(finding, evidence_by_id)
+    ]
+    unsupported_report_severity = (
+        assessment.severity in {"high", "critical"} and not supported_severe_findings
+    )
+    top_supported_finding = (
+        _highest_severity_finding(supported_severe_findings)
+        if supported_severe_findings
+        else None
+    )
+    overclaimed_report_severity = (
+        assessment.severity in {"high", "critical"}
+        and top_supported_finding is not None
+        and _FINDING_SEVERITY_ORDER[assessment.severity]
+        > _FINDING_SEVERITY_ORDER[top_supported_finding.severity]
+    )
+    underclaimed_report_severity = (
+        top_supported_finding is not None
+        and _FINDING_SEVERITY_ORDER[assessment.severity]
+        < _FINDING_SEVERITY_ORDER[top_supported_finding.severity]
+    )
+    inconsistent_supported_report_metadata = (
+        top_supported_finding is not None
+        and assessment.severity in {"high", "critical"}
+        and (
+            not _recommendation_matches_severity(
+                assessment.recommendation,
+                assessment.severity,
+            )
+            or not _score_matches_severity(assessment.score, assessment.severity)
+        )
+    )
+    inconsistent_top_risk_contributors = (
+        top_supported_finding is not None
+        and assessment.severity in {"high", "critical"}
+        and not _top_risk_contributors_match_finding(
+            assessment.top_risk_contributors,
+            top_supported_finding,
+            evidence_by_id,
+        )
+    )
+    expected_report_recommendation = _recommendation_for_severity(assessment.severity)
+    inconsistent_report_recommendation = not _recommendation_matches_severity(
+        assessment.recommendation,
+        assessment.severity,
+    )
+    inconsistent_report_score = not _score_matches_severity(
+        assessment.score,
+        assessment.severity,
+    )
+    stale_top_risk_verdict_text = _verdict_text_contradicts_metadata(
+        assessment.top_risk,
+        assessment.severity,
+        expected_report_recommendation
+        if inconsistent_report_recommendation
+        else assessment.recommendation,
+    )
+
+    if (
+        not downgraded_ids
+        and not unsupported_report_severity
+        and not overclaimed_report_severity
+        and not underclaimed_report_severity
+        and not inconsistent_supported_report_metadata
+        and not inconsistent_top_risk_contributors
+        and not inconsistent_report_recommendation
+        and not inconsistent_report_score
+        and not stale_top_risk_verdict_text
+    ):
+        return (
+            assessment,
+            updated_findings if findings is not None else findings,
+            [],
+            None,
+        )
+
+    warnings: list[str] = []
+    report_adjustment_warning: str | None = None
+    if downgraded_ids:
+        warnings.append(
+            "Evidence Law downgraded high/critical findings without linked deterministic "
+            f"evidence: {', '.join(downgraded_ids)}."
+        )
+    if unsupported_report_severity:
+        report_adjustment_warning = (
+            "Evidence Law downgraded a high/critical report verdict because no "
+            "supported severe finding had linked deterministic evidence."
+        )
+        warnings.append(report_adjustment_warning)
+    if overclaimed_report_severity and top_supported_finding is not None:
+        report_adjustment_warning = (
+            "Evidence Law downgraded a high/critical report verdict to match the "
+            f"highest linked deterministic finding severity: {top_supported_finding.severity}."
+        )
+        warnings.append(report_adjustment_warning)
+    if underclaimed_report_severity and top_supported_finding is not None:
+        report_adjustment_warning = (
+            "Evidence Law promoted report verdict to match the highest linked "
+            f"deterministic finding severity: {top_supported_finding.severity}."
+        )
+        warnings.append(report_adjustment_warning)
+    if stale_top_risk_verdict_text:
+        stale_text_warning = (
+            "Evidence Law refreshed report verdict text to match reconciled severity "
+            "metadata."
+        )
+        if report_adjustment_warning is None:
+            report_adjustment_warning = stale_text_warning
+        warnings.append(stale_text_warning)
+    if inconsistent_report_recommendation:
+        recommendation_warning = (
+            "Evidence Law reconciled report recommendation to match severity metadata."
+        )
+        if report_adjustment_warning is None:
+            report_adjustment_warning = recommendation_warning
+        warnings.append(recommendation_warning)
+    if inconsistent_report_score:
+        score_warning = (
+            "Evidence Law reconciled report score to match severity metadata."
+        )
+        if report_adjustment_warning is None:
+            report_adjustment_warning = score_warning
+        warnings.append(score_warning)
+    assessment_updates: dict[str, Any] = {
+        "warnings": list(dict.fromkeys([*assessment.warnings, *warnings]))
+    }
+    if unsupported_report_severity:
+        downgraded_target = (
+            f"unsupported severe finding(s) {', '.join(downgraded_ids)}"
+            if downgraded_ids
+            else "unsupported severe report verdict"
+        )
+        assessment_updates.update(
+            {
+                "score": _reconciled_score_for_severity(assessment.score, "medium"),
+                "severity": "medium",
+                "recommendation": "caution",
+                "top_risk": (
+                    f"MEDIUM: Evidence Law downgraded {downgraded_target} "
+                    "pending deterministic evidence."
+                ),
+                "top_risk_contributors": [],
+                "contributors": [],
+            }
+        )
+    elif top_supported_finding is not None and (
+        downgraded_ids
+        or overclaimed_report_severity
+        or underclaimed_report_severity
+        or inconsistent_supported_report_metadata
+        or inconsistent_top_risk_contributors
+        or stale_top_risk_verdict_text
+    ):
+        supported_contributors: list[str] = []
+        for evidence_ref in _linked_deterministic_evidence_refs(
+            top_supported_finding,
+            evidence_by_id,
+        ):
+            if evidence_ref not in supported_contributors:
+                supported_contributors.append(evidence_ref)
+        assessment_updates.update(
+            {
+                "score": _reconciled_score_for_severity(
+                    assessment.score,
+                    top_supported_finding.severity,
+                ),
+                "severity": top_supported_finding.severity
+                if (overclaimed_report_severity or underclaimed_report_severity)
+                else assessment.severity,
+                "recommendation": _recommendation_for_severity(
+                    top_supported_finding.severity
+                    if (overclaimed_report_severity or underclaimed_report_severity)
+                    else assessment.severity
+                ),
+                "top_risk": _finding_risk_summary(top_supported_finding),
+                "top_risk_contributors": supported_contributors,
+                "contributors": _contributors_for_evidence_refs(
+                    list(assessment.contributors),
+                    supported_contributors,
+                ),
+            }
+        )
+    elif downgraded_ids:
+        assessment_updates.update(
+            {
+                "score": _reconciled_score_for_severity(assessment.score, "medium"),
+                "severity": "medium",
+                "recommendation": "caution",
+                "top_risk": (
+                    "MEDIUM: Evidence Law downgraded unsupported severe finding(s) "
+                    f"{', '.join(downgraded_ids)} pending deterministic evidence."
+                ),
+                "top_risk_contributors": [],
+                "contributors": [],
+            }
+        )
+    elif stale_top_risk_verdict_text:
+        assessment_updates.update(
+            {
+                "top_risk": _sanitized_risk_summary(
+                    assessment.top_risk,
+                    assessment.severity,
+                ),
+                "score": _reconciled_score_for_severity(
+                    assessment.score,
+                    assessment.severity,
+                ),
+                "recommendation": expected_report_recommendation
+                if inconsistent_report_recommendation
+                else assessment.recommendation,
+                "top_risk_contributors": []
+                if stale_top_risk_verdict_text and not assessment.top_risk_contributors
+                else assessment.top_risk_contributors,
+                "contributors": assessment.contributors,
+            }
+        )
+    elif inconsistent_report_recommendation or inconsistent_report_score:
+        assessment_updates.update(
+            {
+                "score": _reconciled_score_for_severity(
+                    assessment.score,
+                    assessment.severity,
+                ),
+                "recommendation": expected_report_recommendation
+                if inconsistent_report_recommendation
+                else assessment.recommendation,
+            }
+        )
+    return (
+        assessment.model_copy(update=assessment_updates),
+        updated_findings if findings is not None else findings,
+        downgraded_ids,
+        report_adjustment_warning,
+    )
+
+
+def _narrative_with_evidence_law_runtime_gate(
+    narrative: NarrativeResult,
+    assessment: RiskAssessment,
+    downgraded_ids: list[str],
+    report_adjustment_warning: str | None,
+    findings: list[Finding] | None,
+) -> NarrativeResult:
+    stale_narrative_verdict_text = any(
+        _verdict_text_contradicts_metadata(
+            value,
+            assessment.severity,
+            assessment.recommendation,
+        )
+        for value in (narrative.opening_sentence, narrative.explanation)
+    )
+    if (
+        not downgraded_ids
+        and report_adjustment_warning is None
+        and not stale_narrative_verdict_text
+    ):
+        return narrative
+    remaining_severe = any(
+        finding.severity in {"high", "critical"} for finding in findings or []
+    )
+    warnings: list[str] = []
+    if downgraded_ids:
+        warnings.append(
+            "Evidence Law downgraded unsupported severe finding(s) pending deterministic "
+            f"evidence: {', '.join(downgraded_ids)}."
+        )
+    if report_adjustment_warning is not None:
+        warnings.append(report_adjustment_warning)
+    if stale_narrative_verdict_text:
+        warnings.append(
+            "Evidence Law refreshed report narrative to match reconciled severity "
+            "metadata."
+        )
+    if not warnings:
+        warnings.append(
+            report_adjustment_warning
+            or "Evidence Law reconciled the report verdict to linked deterministic severe evidence."
+        )
+    warning = " ".join(warnings)
+    remaining_severe_findings = [
+        finding
+        for finding in findings or []
+        if finding.severity in {"high", "critical"}
+    ]
+    if remaining_severe:
+        top_remaining_finding = _highest_severity_finding(remaining_severe_findings)
+        opening_sentence = (
+            "NO-GO: deterministic severe risk remains; unsupported or inconsistent "
+            "severe claim(s) were reconciled."
+        )
+        explanation = (
+            "Deterministic severe risk remains: "
+            f"{_finding_risk_summary(top_remaining_finding)}. {warning}"
+        )
+    else:
+        opening_sentence = (
+            "CAUTION: severe risk claims need deterministic evidence."
+            if assessment.recommendation == "caution"
+            else f"{assessment.recommendation.upper()}: report verdict matches available deterministic evidence."
+        )
+        explanation = warning
+    return narrative.model_copy(
+        update={
+            "opening_sentence": opening_sentence,
+            "explanation": explanation,
+            "warnings": list(dict.fromkeys([*narrative.warnings, *warnings])),
+        }
+    )
 
 
 def _repair_assessment_evidence_links(
@@ -1632,6 +2212,23 @@ def persist_analysis_report(
         assessment,
         findings,
         evidence_items,
+    )
+    (
+        assessment,
+        findings,
+        downgraded_finding_ids,
+        report_adjustment_warning,
+    ) = _apply_evidence_law_runtime_gate(
+        assessment,
+        findings,
+        evidence_items,
+    )
+    narrative = _narrative_with_evidence_law_runtime_gate(
+        narrative,
+        assessment,
+        downgraded_finding_ids,
+        report_adjustment_warning,
+        findings,
     )
     assessment, findings, evidence_items = _scope_report_entities(
         assessment,

--- a/tests/e2e/report_review.keyboard.spec.js
+++ b/tests/e2e/report_review.keyboard.spec.js
@@ -144,9 +144,11 @@ test.describe("review keyboard flow", () => {
     expect(seen).toEqual(REVIEW_ORDER);
 
     await page.goto("/history", { waitUntil: "networkidle" });
-    await expect(page.locator(".dw-history-card")).toHaveCount(1);
+    await expect(page.locator(".dw-history-card")).toHaveCount(2);
+    await expect(page.getByText("Rescan diff")).toBeVisible();
+    await expect(page.getByText("+48 risk vs report #1")).toBeVisible();
     await page.locator(".dw-history-card").first().click();
-    await expect(page).toHaveURL(/\/history\/1$/);
+    await expect(page).toHaveURL(/\/history\/2$/);
     await page.waitForFunction(() => window.dwReviewAccessibilityInstalled === true);
     await expect(page.getByText("Analysis report detail")).toBeVisible();
     await expect(page.getByText("Back to History")).toBeVisible();
@@ -161,7 +163,10 @@ test.describe("review keyboard flow", () => {
       page.locator('[data-dw-review-section="blast-radius"]')
     ).toBeVisible();
     await expect(page.locator('[data-dw-review-section="rollback"]')).toBeVisible();
-    await page.getByRole("button", { name: "Back to History" }).click();
-    await expect(page).toHaveURL(/\/history$/);
+    await page.goto("/history/2/compare", { waitUntil: "networkidle" });
+    await expect(page.getByText("Comparison with report #1")).toBeVisible();
+    await expect(page.getByText("Risk score delta")).toBeVisible();
+    await expect(page.getByText("+48")).toBeVisible();
+    await expect(page.getByText(/MEDIUM.*CRITICAL/)).toBeVisible();
   });
 });

--- a/tests/e2e/seeded_server.py
+++ b/tests/e2e/seeded_server.py
@@ -104,6 +104,91 @@ def _seed_review_report(report_service_module) -> None:
             )
         ]
     )
+    previous_assessment = RiskAssessment(
+        score=42,
+        severity="medium",
+        recommendation="caution",
+        top_risk="Initial security group review",
+        top_risk_contributors=["ev-prev"],
+        contributors=[
+            RiskContributor(
+                evidence_id="ev-prev",
+                source_file="plan.json",
+                tool="terraform",
+                resource_id="aws_security_group.main",
+                action="modify",
+                contribution=20,
+                summary="Initial security group review.",
+                severity="medium",
+            )
+        ],
+        interaction_risks=[],
+        context_completeness=ContextCompleteness(
+            topology_freshness_days=12,
+            topology_last_imported_at="2026-04-18T11:22:33+00:00",
+            incident_index_size=4,
+            parser_success_rate=1.0,
+            parser_success_by_tool={"terraform": 1.0},
+            context_score=0.92,
+        ),
+        partial_context=False,
+        warnings=[],
+        source="heuristic+llm",
+    )
+    previous_narrative = NarrativeResult(
+        opening_sentence="CAUTION: review the security group change.",
+        explanation="Initial review of the security group change.",
+        guidance=["Inspect the evidence backing the finding."],
+        degraded=False,
+        warnings=[],
+        source="llm",
+        provider="ollama",
+        model="ollama/llama3",
+        local_mode=True,
+        skills_applied=["git", "terraform"],
+    )
+    report_service_module.persist_analysis_report(
+        parse_batch,
+        previous_assessment,
+        previous_narrative,
+        findings=[
+            Finding(
+                finding_id="finding-prev",
+                analysis_id=0,
+                title="MEDIUM: aws_security_group.main",
+                description="Initial security group review",
+                severity="medium",
+                category="networking/ingress",
+                deterministic=True,
+                confidence=1.0,
+                uncertainty_note=None,
+                evidence_refs=["ev-prev"],
+                skill_id=None,
+            )
+        ],
+        evidence_items=[
+            EvidenceItem(
+                evidence_id="ev-prev",
+                analysis_id=0,
+                finding_id="finding-prev",
+                source_type="artifact",
+                source_ref="artifact://plan.json#line=10",
+                summary="Security group ingress remains under review.",
+                severity_hint="medium",
+                deterministic=True,
+                confidence=1.0,
+                related_change_ids=["aws_security_group.main"],
+            )
+        ],
+        artifact_snapshots={
+            "plan.json": b'{"resource":"aws_security_group.main","cidr_blocks":["10.0.0.0/8"]}\n'
+        },
+        audit_context={
+            "source_interface": "ui",
+            "trigger_type": "dashboard_upload",
+        },
+        project_key="payments",
+    )
     assessment = RiskAssessment(
         score=88,
         severity="critical",

--- a/tests/test_services/test_report_filters.py
+++ b/tests/test_services/test_report_filters.py
@@ -14,6 +14,7 @@ import models.repositories.analysis_reports as analysis_reports_repository_modul
 import models.tables as tables_module
 import services.report_service as report_service_module
 from analysis.risk_scorer import RiskAssessment, RiskContributor
+from evidence.models import EvidenceItem, Finding
 from llm.narrator import NarrativeResult
 from parsers.base import ParseBatchResult, ParsedFileResult, UnifiedChange
 
@@ -43,6 +44,9 @@ class ReportFilterTests(unittest.TestCase):
         top_risk: str,
         source_interface: str = "ui",
     ) -> None:
+        evidence_id = f"ev-{severity}"
+        finding_id = f"finding-{severity}"
+        severe_report = severity in {"high", "critical"}
         parse_batch = ParseBatchResult(
             files=[
                 ParsedFileResult(
@@ -66,8 +70,10 @@ class ReportFilterTests(unittest.TestCase):
             severity=severity,
             recommendation=recommendation,
             top_risk=top_risk,
+            top_risk_contributors=[evidence_id] if severe_report else [],
             contributors=[
                 RiskContributor(
+                    evidence_id=evidence_id if severe_report else None,
                     source_file="plan.json",
                     tool="terraform",
                     resource_id="aws_security_group.main",
@@ -92,6 +98,41 @@ class ReportFilterTests(unittest.TestCase):
             assessment,
             narrative,
             audit_context={"source_interface": source_interface},
+            findings=[
+                Finding(
+                    finding_id=finding_id,
+                    analysis_id=0,
+                    title=f"{severity.upper()}: {top_risk}",
+                    description=top_risk,
+                    severity=severity,
+                    category="networking/ingress",
+                    deterministic=True,
+                    confidence=1.0,
+                    uncertainty_note=None,
+                    evidence_refs=[evidence_id],
+                    skill_id=None,
+                )
+            ]
+            if severe_report
+            else None,
+            evidence_items=[
+                EvidenceItem(
+                    evidence_id=evidence_id,
+                    analysis_id=0,
+                    finding_id=finding_id,
+                    source_type="artifact",
+                    source_ref=(
+                        "terraform://plan.json#aws_security_group.main?action=modify"
+                    ),
+                    summary=top_risk,
+                    severity_hint=severity,
+                    deterministic=True,
+                    confidence=1.0,
+                    related_change_ids=["change-1"],
+                )
+            ]
+            if severe_report
+            else None,
         )
 
     def test_fetch_filtered_analysis_history_filters_by_severity_and_search(

--- a/tests/test_services/test_report_service.py
+++ b/tests/test_services/test_report_service.py
@@ -99,6 +99,22 @@ class ReportServiceTests(unittest.TestCase):
             "skill_id": None,
         }
 
+        with database_module.SessionLocal() as session:
+            report = analysis_reports_repository_module.create_analysis_report(
+                session,
+                **{
+                    **report_kwargs,
+                    "recommendation": "go",
+                    "top_risk": "Medium security group review.",
+                    "narrative_opening": "GO: medium security group review.",
+                    "narrative_explanation": "Medium severity remains advisory.",
+                },
+                findings_payload=[],
+                evidence_payload=[],
+            )
+            self.assertEqual(report.severity, "medium")
+            self.assertEqual(report.recommendation, "go")
+
         for invalid_fields in (
             {"guidance": "Review ingress before deployment."},
             {"evidence_classification": "unsupported"},
@@ -127,6 +143,122 @@ class ReportServiceTests(unittest.TestCase):
                     evidence_payload=[],
                 )
 
+        heuristic_evidence = {
+            "evidence_id": "ev-heuristic",
+            "analysis_id": 0,
+            "finding_id": "finding-high",
+            "source_type": "artifact",
+            "source_ref": "terraform://plan.json#aws_security_group.main?action=modify",
+            "summary": "Security group exposure",
+            "severity_hint": "high",
+            "deterministic": False,
+            "determinism_level": "heuristic",
+            "confidence": 0.7,
+            "related_change_ids": ["chg-001"],
+        }
+        with database_module.SessionLocal() as session:
+            with self.assertRaisesRegex(
+                ValueError,
+                "without linked deterministic evidence",
+            ):
+                analysis_reports_repository_module.create_analysis_report(
+                    session,
+                    **report_kwargs,
+                    findings_payload=[
+                        {
+                            **finding,
+                            "finding_id": "finding-high",
+                            "severity": "high",
+                            "evidence_refs": ["ev-heuristic"],
+                        }
+                    ],
+                    evidence_payload=[heuristic_evidence],
+                )
+        string_false_evidence = {
+            **heuristic_evidence,
+            "evidence_id": "ev-string-false",
+            "deterministic": "false",
+            "determinism_level": "deterministic",
+        }
+        with database_module.SessionLocal() as session:
+            with self.assertRaisesRegex(
+                ValueError,
+                "without linked deterministic evidence",
+            ):
+                analysis_reports_repository_module.create_analysis_report(
+                    session,
+                    **report_kwargs,
+                    findings_payload=[
+                        {
+                            **finding,
+                            "finding_id": "finding-string-false",
+                            "severity": "high",
+                            "evidence_refs": ["ev-string-false"],
+                        }
+                    ],
+                    evidence_payload=[string_false_evidence],
+                )
+        string_true_evidence = {
+            **heuristic_evidence,
+            "evidence_id": "ev-string-true",
+            "deterministic": "true",
+            "determinism_level": "deterministic",
+        }
+        with database_module.SessionLocal() as session:
+            with self.assertRaisesRegex(
+                ValueError,
+                "without linked deterministic evidence",
+            ):
+                analysis_reports_repository_module.create_analysis_report(
+                    session,
+                    **report_kwargs,
+                    findings_payload=[
+                        {
+                            **finding,
+                            "finding_id": "finding-string-true",
+                            "severity": "high",
+                            "evidence_refs": ["ev-string-true"],
+                        }
+                    ],
+                    evidence_payload=[string_true_evidence],
+                )
+        with database_module.SessionLocal() as session:
+            with self.assertRaisesRegex(
+                ValueError,
+                "without a linked deterministic severe finding",
+            ):
+                analysis_reports_repository_module.create_analysis_report(
+                    session,
+                    **{
+                        **report_kwargs,
+                        "risk_score": 72,
+                        "severity": "high",
+                        "recommendation": "no-go",
+                        "top_risk": "Unsupported severe report.",
+                    },
+                    findings_payload=[],
+                    evidence_payload=[],
+                )
+        for unnormalized_severity in ("HIGH", " high "):
+            with self.subTest(unnormalized_severity=unnormalized_severity):
+                with database_module.SessionLocal() as session:
+                    with self.assertRaisesRegex(
+                        ValueError,
+                        "without a linked deterministic severe finding",
+                    ):
+                        analysis_reports_repository_module.create_analysis_report(
+                            session,
+                            **{
+                                **report_kwargs,
+                                "risk_score": 72,
+                                "severity": unnormalized_severity,
+                                "recommendation": "no-go",
+                                "top_risk": "Unsupported severe report.",
+                            },
+                            findings_payload=[],
+                            evidence_payload=[],
+                        )
+
         evidence = {
             "evidence_id": "ev-001",
             "analysis_id": 0,
@@ -139,6 +271,534 @@ class ReportServiceTests(unittest.TestCase):
             "confidence": 1.0,
             "related_change_ids": ["chg-001"],
         }
+        with database_module.SessionLocal() as session:
+            with self.assertRaisesRegex(
+                ValueError,
+                "without a linked deterministic severe finding",
+            ):
+                analysis_reports_repository_module.create_analysis_report(
+                    session,
+                    **{
+                        **report_kwargs,
+                        "risk_score": 72,
+                        "severity": "high",
+                        "recommendation": "no-go",
+                        "top_risk": "Unsupported severe report.",
+                    },
+                    findings_payload=[
+                        {
+                            **finding,
+                            "evidence_refs": ["ev-001"],
+                        }
+                    ],
+                    evidence_payload=[evidence],
+                )
+        string_false_medium_evidence = {
+            **evidence,
+            "evidence_id": "ev-string-false-medium",
+            "deterministic": "false",
+            "determinism_level": "deterministic",
+        }
+        with database_module.SessionLocal() as session:
+            report = analysis_reports_repository_module.create_analysis_report(
+                session,
+                **report_kwargs,
+                findings_payload=[
+                    {
+                        **finding,
+                        "finding_id": "finding-string-false-medium",
+                        "evidence_refs": ["ev-string-false-medium"],
+                    }
+                ],
+                evidence_payload=[string_false_medium_evidence],
+            )
+            stored_evidence = report.findings[0].evidence_items[0]
+            self.assertFalse(stored_evidence.deterministic)
+            self.assertEqual(stored_evidence.determinism_level, "inferred")
+        string_true_medium_evidence = {
+            **evidence,
+            "evidence_id": "ev-string-true-medium",
+            "deterministic": "true",
+            "determinism_level": "deterministic",
+        }
+        with database_module.SessionLocal() as session:
+            report = analysis_reports_repository_module.create_analysis_report(
+                session,
+                **report_kwargs,
+                findings_payload=[
+                    {
+                        **finding,
+                        "finding_id": "finding-string-true-medium",
+                        "evidence_refs": ["ev-string-true-medium"],
+                    }
+                ],
+                evidence_payload=[string_true_medium_evidence],
+            )
+            stored_evidence = report.findings[0].evidence_items[0]
+            self.assertFalse(stored_evidence.deterministic)
+            self.assertEqual(stored_evidence.determinism_level, "inferred")
+        missing_deterministic_evidence = {
+            key: value for key, value in evidence.items() if key != "deterministic"
+        }
+        with database_module.SessionLocal() as session:
+            with self.assertRaises(ValidationError):
+                analysis_reports_repository_module.create_analysis_report(
+                    session,
+                    **report_kwargs,
+                    findings_payload=[
+                        {
+                            **finding,
+                            "finding_id": "finding-missing-deterministic",
+                            "evidence_refs": ["ev-001"],
+                        }
+                    ],
+                    evidence_payload=[missing_deterministic_evidence],
+                )
+        high_evidence = {
+            **evidence,
+            "evidence_id": "ev-high",
+            "finding_id": "finding-supported-high",
+            "severity_hint": "high",
+        }
+        with database_module.SessionLocal() as session:
+            with self.assertRaisesRegex(
+                ValueError,
+                "Top-risk contributor ev-missing does not reference persisted evidence",
+            ):
+                analysis_reports_repository_module.create_analysis_report(
+                    session,
+                    **{
+                        **report_kwargs,
+                        "risk_score": 72,
+                        "severity": "high",
+                        "recommendation": "no-go",
+                        "top_risk": "HIGH: supported severe report.",
+                        "narrative_opening": "NO-GO: supported severe report.",
+                        "narrative_explanation": "Deterministic severe evidence supports the report.",
+                        "top_risk_contributors_json": '["ev-missing"]',
+                    },
+                    findings_payload=[
+                        {
+                            **finding,
+                            "finding_id": "finding-supported-high",
+                            "severity": "high",
+                            "evidence_refs": ["ev-high"],
+                        }
+                    ],
+                    evidence_payload=[high_evidence],
+                )
+        with database_module.SessionLocal() as session:
+            with self.assertRaisesRegex(
+                ValueError,
+                "High/critical reports must persist top-risk contributor evidence IDs",
+            ):
+                analysis_reports_repository_module.create_analysis_report(
+                    session,
+                    **{
+                        **report_kwargs,
+                        "risk_score": 72,
+                        "severity": "high",
+                        "recommendation": "no-go",
+                        "top_risk": "HIGH: supported severe report.",
+                        "narrative_opening": "NO-GO: supported severe report.",
+                        "narrative_explanation": "Deterministic severe evidence supports the report.",
+                    },
+                    findings_payload=[
+                        {
+                            **finding,
+                            "finding_id": "finding-supported-high",
+                            "severity": "high",
+                            "evidence_refs": ["ev-high"],
+                        }
+                    ],
+                    evidence_payload=[high_evidence],
+                )
+        with database_module.SessionLocal() as session:
+            with self.assertRaisesRegex(
+                ValueError,
+                "Top-risk contributors must belong to one persisted finding",
+            ):
+                analysis_reports_repository_module.create_analysis_report(
+                    session,
+                    **{
+                        **report_kwargs,
+                        "risk_score": 72,
+                        "severity": "high",
+                        "recommendation": "no-go",
+                        "top_risk": "HIGH: supported severe report.",
+                        "narrative_opening": "NO-GO: supported severe report.",
+                        "narrative_explanation": "Deterministic severe evidence supports the report.",
+                        "top_risk_contributors_json": '["ev-high", "ev-medium-cross"]',
+                    },
+                    findings_payload=[
+                        {
+                            **finding,
+                            "finding_id": "finding-supported-high",
+                            "severity": "high",
+                            "evidence_refs": ["ev-high"],
+                        },
+                        {
+                            **finding,
+                            "finding_id": "finding-medium-cross",
+                            "severity": "medium",
+                            "evidence_refs": ["ev-medium-cross"],
+                        },
+                    ],
+                    evidence_payload=[
+                        high_evidence,
+                        {
+                            **evidence,
+                            "evidence_id": "ev-medium-cross",
+                            "finding_id": "finding-medium-cross",
+                        },
+                    ],
+                )
+        with database_module.SessionLocal() as session:
+            report = analysis_reports_repository_module.create_analysis_report(
+                session,
+                **{
+                    **report_kwargs,
+                    "top_risk": "Shared evidence ownership is canonical.",
+                    "narrative_opening": "CAUTION: shared evidence ownership.",
+                    "narrative_explanation": (
+                        "The evidence owner is explicit even when references are shared."
+                    ),
+                },
+                findings_payload=[
+                    {
+                        **finding,
+                        "finding_id": "finding-shared-one",
+                        "evidence_refs": ["ev-shared"],
+                    },
+                    {
+                        **finding,
+                        "finding_id": "finding-shared-two",
+                        "evidence_refs": ["ev-shared"],
+                    },
+                ],
+                evidence_payload=[
+                    {
+                        **evidence,
+                        "evidence_id": "ev-shared",
+                        "finding_id": "finding-shared-one",
+                    }
+                ],
+            )
+            self.assertEqual(
+                [json.loads(item.evidence_refs_json) for item in report.findings],
+                [["ev-shared"], ["ev-shared"]],
+            )
+            self.assertEqual(
+                report.findings[0].evidence_items[0].evidence_id,
+                "ev-shared",
+            )
+        with database_module.SessionLocal() as session:
+            with self.assertRaisesRegex(
+                ValueError,
+                "Evidence item ev-shared has ambiguous finding ownership",
+            ):
+                analysis_reports_repository_module.create_analysis_report(
+                    session,
+                    **{
+                        **report_kwargs,
+                        "top_risk": "Shared evidence ownership is ambiguous.",
+                        "narrative_opening": "CAUTION: shared evidence ownership.",
+                        "narrative_explanation": (
+                            "Each shared evidence item needs a canonical owner."
+                        ),
+                    },
+                    findings_payload=[
+                        {
+                            **finding,
+                            "finding_id": "finding-shared-one",
+                            "evidence_refs": ["ev-shared"],
+                        },
+                        {
+                            **finding,
+                            "finding_id": "finding-shared-two",
+                            "evidence_refs": ["ev-shared"],
+                        },
+                    ],
+                    evidence_payload=[
+                        {
+                            **evidence,
+                            "evidence_id": "ev-shared",
+                            "finding_id": "finding-unreferenced-owner",
+                        }
+                    ],
+                )
+        with database_module.SessionLocal() as session:
+            with self.assertRaisesRegex(
+                ValueError,
+                "without a linked deterministic severe finding",
+            ):
+                analysis_reports_repository_module.create_analysis_report(
+                    session,
+                    **{
+                        **report_kwargs,
+                        "risk_score": 92,
+                        "severity": "critical",
+                        "recommendation": "no-go",
+                        "top_risk": "Unsupported critical report.",
+                    },
+                    findings_payload=[
+                        {
+                            **finding,
+                            "finding_id": "finding-supported-high",
+                            "severity": "high",
+                            "evidence_refs": ["ev-high"],
+                        }
+                    ],
+                    evidence_payload=[high_evidence],
+                )
+        with database_module.SessionLocal() as session:
+            with self.assertRaisesRegex(
+                ValueError,
+                "contradicts linked deterministic evidence",
+            ):
+                analysis_reports_repository_module.create_analysis_report(
+                    session,
+                    **{
+                        **report_kwargs,
+                        "risk_score": 72,
+                        "severity": "high",
+                        "recommendation": "no-go",
+                        "top_risk": "Supported severe report.",
+                    },
+                    findings_payload=[
+                        {
+                            **finding,
+                            "finding_id": "finding-supported-high",
+                            "severity": "high",
+                            "deterministic": False,
+                            "evidence_classification": "model_inferred",
+                            "evidence_refs": ["ev-high"],
+                        }
+                    ],
+                    evidence_payload=[high_evidence],
+                )
+        with database_module.SessionLocal() as session:
+            with self.assertRaisesRegex(
+                ValueError,
+                "inconsistent verdict metadata",
+            ):
+                analysis_reports_repository_module.create_analysis_report(
+                    session,
+                    **{
+                        **report_kwargs,
+                        "risk_score": 42,
+                        "severity": "high",
+                        "recommendation": "go",
+                        "top_risk": "Supported severe report.",
+                    },
+                    findings_payload=[
+                        {
+                            **finding,
+                            "finding_id": "finding-supported-high",
+                            "severity": "high",
+                            "evidence_refs": ["ev-high"],
+                        }
+                    ],
+                    evidence_payload=[high_evidence],
+                )
+        with database_module.SessionLocal() as session:
+            with self.assertRaisesRegex(
+                ValueError,
+                "understates linked deterministic severe finding",
+            ):
+                analysis_reports_repository_module.create_analysis_report(
+                    session,
+                    **{
+                        **report_kwargs,
+                        "risk_score": 42,
+                        "severity": "medium",
+                        "recommendation": "caution",
+                        "top_risk": "Underclaimed supported severe report.",
+                    },
+                    findings_payload=[
+                        {
+                            **finding,
+                            "finding_id": "finding-supported-high",
+                            "severity": "high",
+                            "evidence_refs": ["ev-high"],
+                        }
+                    ],
+                    evidence_payload=[high_evidence],
+                )
+        with database_module.SessionLocal() as session:
+            with self.assertRaisesRegex(
+                ValueError,
+                "Report verdict text contradicts severity metadata",
+            ):
+                analysis_reports_repository_module.create_analysis_report(
+                    session,
+                    **{
+                        **report_kwargs,
+                        "top_risk": "CRITICAL: stale severe copy.",
+                        "narrative_opening": "NO-GO: stale severe copy.",
+                        "narrative_explanation": "Unsupported stale severe copy.",
+                    },
+                    findings_payload=[],
+                    evidence_payload=[],
+                )
+        with database_module.SessionLocal() as session:
+            with self.assertRaisesRegex(
+                ValueError,
+                "Report verdict text contradicts severity metadata",
+            ):
+                analysis_reports_repository_module.create_analysis_report(
+                    session,
+                    **{
+                        **report_kwargs,
+                        "risk_score": 72,
+                        "severity": "high",
+                        "recommendation": "no-go",
+                        "top_risk": "MEDIUM: stale non-severe copy.",
+                        "narrative_opening": "CAUTION: stale non-severe copy.",
+                        "narrative_explanation": "Supported severe report.",
+                    },
+                    findings_payload=[
+                        {
+                            **finding,
+                            "finding_id": "finding-supported-high",
+                            "severity": "high",
+                            "evidence_refs": ["ev-high"],
+                        }
+                    ],
+                    evidence_payload=[high_evidence],
+                )
+        with database_module.SessionLocal() as session:
+            with self.assertRaisesRegex(
+                ValueError,
+                "inconsistent verdict metadata",
+            ):
+                analysis_reports_repository_module.create_analysis_report(
+                    session,
+                    **{
+                        **report_kwargs,
+                        "recommendation": "no-go",
+                        "top_risk": "NO-GO: stale non-severe recommendation.",
+                        "narrative_opening": "NO-GO: stale non-severe recommendation.",
+                        "narrative_explanation": "No severe deterministic finding.",
+                    },
+                    findings_payload=[],
+                    evidence_payload=[],
+                )
+        with database_module.SessionLocal() as session:
+            with self.assertRaisesRegex(
+                ValueError,
+                "Report verdict text contradicts severity metadata",
+            ):
+                analysis_reports_repository_module.create_analysis_report(
+                    session,
+                    **{
+                        **report_kwargs,
+                        "top_risk": "GO: stale go copy.",
+                        "narrative_opening": "GO: stale go copy.",
+                        "narrative_explanation": "Review is still required.",
+                    },
+                    findings_payload=[],
+                    evidence_payload=[],
+                )
+        for stale_verdict_text in (
+            "NO-GO deployment review.",
+            "CRITICAL database exposure remains.",
+        ):
+            with self.subTest(stale_verdict_text=stale_verdict_text):
+                with database_module.SessionLocal() as session:
+                    with self.assertRaisesRegex(
+                        ValueError,
+                        "Report verdict text contradicts severity metadata",
+                    ):
+                        analysis_reports_repository_module.create_analysis_report(
+                            session,
+                            **{
+                                **report_kwargs,
+                                "top_risk": stale_verdict_text,
+                            },
+                            findings_payload=[],
+                            evidence_payload=[],
+                        )
+        with database_module.SessionLocal() as session:
+            with self.assertRaisesRegex(
+                ValueError,
+                "inconsistent verdict metadata",
+            ):
+                analysis_reports_repository_module.create_analysis_report(
+                    session,
+                    **{
+                        **report_kwargs,
+                        "risk_score": 95,
+                        "top_risk": "Review remains cautionary.",
+                    },
+                    findings_payload=[],
+                    evidence_payload=[],
+                )
+        with database_module.SessionLocal() as session:
+            report = analysis_reports_repository_module.create_analysis_report(
+                session,
+                **{
+                    **report_kwargs,
+                    "top_risk": "High availability rollout requires review.",
+                    "narrative_opening": "Go live review is pending.",
+                    "narrative_explanation": (
+                        "Critical path implementation detail remains under review."
+                    ),
+                },
+                findings_payload=[],
+                evidence_payload=[],
+            )
+            self.assertEqual(
+                report.top_risk,
+                "High availability rollout requires review.",
+            )
+            self.assertEqual(report.narrative_opening, "Go live review is pending.")
+            self.assertEqual(
+                report.narrative_explanation,
+                "Critical path implementation detail remains under review.",
+            )
+        external_evidence = {
+            "evidence_id": "ev-external-high",
+            "analysis_id": 0,
+            "finding_id": "finding-external-high",
+            "source_type": "external_scanner",
+            "source_ref": "scanner://sast.json#rule.high?action=flag",
+            "summary": "External scanner flagged a high risk.",
+            "severity_hint": "high",
+            "deterministic": True,
+            "confidence": 1.0,
+            "related_change_ids": ["chg-001"],
+        }
+        with database_module.SessionLocal() as session:
+            report = analysis_reports_repository_module.create_analysis_report(
+                session,
+                **{
+                    **report_kwargs,
+                    "risk_score": 72,
+                    "severity": "high",
+                    "recommendation": "no-go",
+                    "top_risk": "HIGH: External scanner high risk.",
+                    "narrative_opening": "NO-GO: External scanner high risk.",
+                    "narrative_explanation": "External scanner evidence is deterministic.",
+                    "top_risk_contributors_json": '["ev-external-high"]',
+                },
+                findings_payload=[
+                    {
+                        **finding,
+                        "finding_id": "finding-external-high",
+                        "title": "HIGH: External scanner high risk.",
+                        "severity": "high",
+                        "deterministic": True,
+                        "evidence_classification": "external",
+                        "evidence_refs": ["ev-external-high"],
+                    }
+                ],
+                evidence_payload=[external_evidence],
+            )
+            self.assertEqual(
+                report.findings[0].evidence_classification,
+                "external",
+            )
         with database_module.SessionLocal() as session:
             with self.assertRaisesRegex(
                 ValueError,
@@ -169,29 +829,27 @@ class ReportServiceTests(unittest.TestCase):
                 )
 
         with database_module.SessionLocal() as session:
-            report = analysis_reports_repository_module.create_analysis_report(
-                session,
-                **report_kwargs,
-                findings_payload=[
-                    {
-                        **finding,
-                        "finding_id": "finding-one",
-                        "evidence_refs": ["ev-001"],
-                    },
-                    {
-                        **finding,
-                        "finding_id": "finding-two",
-                        "evidence_refs": ["ev-001"],
-                    },
-                ],
-                evidence_payload=[evidence],
-            )
-
-        self.assertEqual(len(report.findings), 2)
-        self.assertEqual(
-            [json.loads(finding.evidence_refs_json) for finding in report.findings],
-            [["ev-001"], ["ev-001"]],
-        )
+            with self.assertRaisesRegex(
+                ValueError,
+                "Evidence item ev-001 has ambiguous finding ownership",
+            ):
+                analysis_reports_repository_module.create_analysis_report(
+                    session,
+                    **report_kwargs,
+                    findings_payload=[
+                        {
+                            **finding,
+                            "finding_id": "finding-one",
+                            "evidence_refs": ["ev-001"],
+                        },
+                        {
+                            **finding,
+                            "finding_id": "finding-two",
+                            "evidence_refs": ["ev-001"],
+                        },
+                    ],
+                    evidence_payload=[evidence],
+                )
 
     def test_scope_report_entities_downgrades_stripped_evidence_classification(
         self,
@@ -316,6 +974,210 @@ class ReportServiceTests(unittest.TestCase):
         self.assertEqual(
             [finding.evidence_classification for finding in scoped_findings],
             ["deterministic", "deterministic"],
+        )
+
+    def test_persist_analysis_report_preserves_shared_evidence_references(
+        self,
+    ) -> None:
+        parse_batch = ParseBatchResult(
+            files=[
+                ParsedFileResult(
+                    file_name="plan.json",
+                    tool="terraform",
+                    status="parsed",
+                    changes=[
+                        UnifiedChange(
+                            source_file="plan.json",
+                            tool="terraform",
+                            resource_id="aws_security_group.main",
+                            action="modify",
+                            summary="Terraform changed a security group.",
+                        )
+                    ],
+                )
+            ]
+        )
+        assessment = RiskAssessment(
+            score=42,
+            severity="medium",
+            recommendation="caution",
+            top_risk="Two findings share one deterministic evidence item.",
+            contributors=[],
+            interaction_risks=[],
+            partial_context=False,
+            warnings=[],
+        )
+        narrative = NarrativeResult(
+            opening_sentence="CAUTION: shared evidence review.",
+            explanation="One artifact supports multiple related findings.",
+            guidance=[],
+            degraded=False,
+            warnings=[],
+        )
+
+        report = report_service_module.persist_analysis_report(
+            parse_batch,
+            assessment,
+            narrative,
+            findings=[
+                Finding(
+                    finding_id="finding-shared-one",
+                    analysis_id=0,
+                    title="MEDIUM: shared evidence one",
+                    description="First finding shares deterministic evidence.",
+                    severity="medium",
+                    category="networking/ingress",
+                    deterministic=False,
+                    confidence=0.8,
+                    uncertainty_note=None,
+                    evidence_classification="model_inferred",
+                    evidence_refs=["ev-shared"],
+                    skill_id=None,
+                ),
+                Finding(
+                    finding_id="finding-shared-two",
+                    analysis_id=0,
+                    title="MEDIUM: shared evidence two",
+                    description="Second finding shares deterministic evidence.",
+                    severity="medium",
+                    category="networking/ingress",
+                    deterministic=False,
+                    confidence=0.8,
+                    uncertainty_note=None,
+                    evidence_classification="model_inferred",
+                    evidence_refs=["ev-shared"],
+                    skill_id=None,
+                ),
+            ],
+            evidence_items=[
+                EvidenceItem(
+                    evidence_id="ev-shared",
+                    analysis_id=0,
+                    finding_id="pending:change-1",
+                    source_type="artifact",
+                    source_ref="terraform://plan.json#aws_security_group.main",
+                    summary="Shared deterministic support.",
+                    severity_hint="medium",
+                    deterministic=True,
+                    confidence=1.0,
+                    source_kind="artifact",
+                    determinism_level="deterministic",
+                )
+            ],
+        )
+
+        persisted_evidence_id = report["evidence_items"][0]["evidence_id"]
+        self.assertEqual(
+            [finding["evidence_refs"] for finding in report["findings"]],
+            [[persisted_evidence_id], [persisted_evidence_id]],
+        )
+        self.assertEqual(
+            report["evidence_items"][0]["finding_id"],
+            report["findings"][0]["finding_id"],
+        )
+
+    def test_persist_analysis_report_prefers_severe_owner_for_generated_shared_evidence(
+        self,
+    ) -> None:
+        parse_batch = ParseBatchResult(
+            files=[
+                ParsedFileResult(
+                    file_name="plan.json",
+                    tool="terraform",
+                    status="parsed",
+                    changes=[
+                        UnifiedChange(
+                            source_file="plan.json",
+                            tool="terraform",
+                            resource_id="aws_security_group.main",
+                            action="modify",
+                            summary="Terraform changed a security group.",
+                        )
+                    ],
+                )
+            ]
+        )
+        assessment = RiskAssessment(
+            score=72,
+            severity="high",
+            recommendation="no-go",
+            top_risk="HIGH: shared deterministic evidence supports severe ingress risk.",
+            top_risk_contributors=["ev-shared"],
+            contributors=[],
+            interaction_risks=[],
+            partial_context=False,
+            warnings=[],
+        )
+        narrative = NarrativeResult(
+            opening_sentence="NO-GO: shared evidence supports severe ingress risk.",
+            explanation="The same artifact supports related medium and high findings.",
+            guidance=[],
+            degraded=False,
+            warnings=[],
+        )
+
+        report = report_service_module.persist_analysis_report(
+            parse_batch,
+            assessment,
+            narrative,
+            findings=[
+                Finding(
+                    finding_id="finding-shared-medium",
+                    analysis_id=0,
+                    title="MEDIUM: shared evidence context",
+                    description="Medium finding appears first and shares evidence.",
+                    severity="medium",
+                    category="networking/ingress",
+                    deterministic=False,
+                    confidence=0.8,
+                    uncertainty_note=None,
+                    evidence_classification="model_inferred",
+                    evidence_refs=["ev-shared"],
+                    skill_id=None,
+                ),
+                Finding(
+                    finding_id="finding-shared-high",
+                    analysis_id=0,
+                    title="HIGH: shared evidence severe risk",
+                    description="High finding also links the deterministic evidence.",
+                    severity="high",
+                    category="networking/ingress",
+                    deterministic=False,
+                    confidence=0.9,
+                    uncertainty_note=None,
+                    evidence_classification="model_inferred",
+                    evidence_refs=["ev-shared"],
+                    skill_id=None,
+                ),
+            ],
+            evidence_items=[
+                EvidenceItem(
+                    evidence_id="ev-shared",
+                    analysis_id=0,
+                    finding_id="pending:change-1",
+                    source_type="artifact",
+                    source_ref="terraform://plan.json#aws_security_group.main",
+                    summary="Shared deterministic severe support.",
+                    severity_hint="high",
+                    deterministic=True,
+                    confidence=1.0,
+                    source_kind="artifact",
+                    determinism_level="deterministic",
+                )
+            ],
+        )
+
+        high_finding = next(
+            finding for finding in report["findings"] if finding["severity"] == "high"
+        )
+        persisted_evidence_id = report["evidence_items"][0]["evidence_id"]
+        self.assertEqual(
+            report["evidence_items"][0]["finding_id"], high_finding["finding_id"]
+        )
+        self.assertEqual(report["top_risk_contributors"], [persisted_evidence_id])
+        self.assertEqual(
+            [finding["evidence_refs"] for finding in report["findings"]],
+            [[persisted_evidence_id], [persisted_evidence_id]],
         )
 
     def test_report_finding_maps_resolves_shared_evidence_refs(self) -> None:
@@ -461,6 +1323,1698 @@ class ReportServiceTests(unittest.TestCase):
             report["contributors"][0]["evidence_id"], persisted_evidence_id
         )
         self.assertEqual(report["top_risk_contributors"], [persisted_evidence_id])
+
+    def test_persist_analysis_report_downgrades_severe_finding_without_deterministic_evidence(
+        self,
+    ) -> None:
+        parse_batch = ParseBatchResult(
+            files=[
+                ParsedFileResult(
+                    file_name="plan.json",
+                    tool="terraform",
+                    status="parsed",
+                    changes=[],
+                )
+            ]
+        )
+        assessment = RiskAssessment(
+            score=72,
+            severity="high",
+            recommendation="no-go",
+            top_risk="Inferred severe risk.",
+            top_risk_contributors=["ev-stale"],
+            contributors=[
+                RiskContributor(
+                    evidence_id="ev-stale",
+                    source_file="plan.json",
+                    tool="terraform",
+                    resource_id="aws_security_group.main",
+                    action="modify",
+                    contribution=28,
+                    summary="Stale unsupported severe contributor.",
+                    severity="high",
+                    reasoning="Unsupported severe claim.",
+                )
+            ],
+            interaction_risks=[],
+            partial_context=False,
+            warnings=[],
+        )
+        narrative = NarrativeResult(
+            opening_sentence="NO-GO: inferred severe risk.",
+            explanation="The narrative is not deterministic evidence.",
+            guidance=[],
+            degraded=False,
+            warnings=[],
+        )
+
+        report = report_service_module.persist_analysis_report(
+            parse_batch,
+            assessment,
+            narrative,
+            findings=[
+                Finding(
+                    finding_id="finding-inferred-high",
+                    analysis_id=0,
+                    title="HIGH: inferred production exposure",
+                    description="Model-inferred exposure without deterministic support.",
+                    explanation="Critical ingress exposure requires immediate action.",
+                    guidance=["Require human review before applying the change."],
+                    severity="high",
+                    category="networking/ingress",
+                    deterministic=False,
+                    confidence=0.92,
+                    uncertainty_note=None,
+                    evidence_classification="model_inferred",
+                    evidence_refs=[],
+                    skill_id=None,
+                )
+            ],
+            evidence_items=[],
+        )
+
+        self.assertEqual(report["findings"][0]["severity"], "medium")
+        self.assertEqual(
+            report["findings"][0]["title"], "MEDIUM: inferred production exposure"
+        )
+        self.assertFalse(report["findings"][0]["deterministic"])
+        self.assertLessEqual(report["findings"][0]["confidence"], 0.85)
+        self.assertEqual(
+            report["findings"][0]["explanation"],
+            "Evidence Law downgraded this finding to medium because it does not link to deterministic evidence.",
+        )
+        self.assertEqual(
+            report["findings"][0]["guidance"],
+            [
+                "Review the available linked evidence before deployment.",
+                "Add deterministic evidence before treating this finding as severe.",
+            ],
+        )
+        self.assertNotIn("Critical ingress", report["findings"][0]["explanation"])
+        self.assertNotIn(
+            "Require human review",
+            " ".join(report["findings"][0]["guidance"]),
+        )
+        self.assertEqual(report["severity"], "medium")
+        self.assertEqual(report["recommendation"], "caution")
+        self.assertLessEqual(report["risk_score"], 69)
+        self.assertEqual(report["top_risk_contributors"], [])
+        self.assertEqual(report["contributors"], [])
+        self.assertNotIn("NO-GO", report["narrative_opening"])
+        self.assertIn("CAUTION", report["narrative_opening"])
+        self.assertIn("Evidence Law downgraded", report["narrative_explanation"])
+        self.assertIn("Evidence Law downgraded", " ".join(report["warnings"]))
+
+    def test_persist_analysis_report_downgrades_severe_report_without_findings(
+        self,
+    ) -> None:
+        parse_batch = ParseBatchResult(
+            files=[
+                ParsedFileResult(
+                    file_name="plan.json",
+                    tool="terraform",
+                    status="parsed",
+                    changes=[],
+                )
+            ]
+        )
+        assessment = RiskAssessment(
+            score=91,
+            severity="critical",
+            recommendation="no-go",
+            top_risk="Report-level severe risk without evidence.",
+            contributors=[],
+            interaction_risks=[],
+            partial_context=False,
+            warnings=[],
+        )
+        narrative = NarrativeResult(
+            opening_sentence="NO-GO: unsupported report-level risk.",
+            explanation="Unsupported report-level risk.",
+            guidance=[],
+            degraded=False,
+            warnings=[],
+        )
+
+        report = report_service_module.persist_analysis_report(
+            parse_batch,
+            assessment,
+            narrative,
+        )
+
+        self.assertEqual(report["findings"], [])
+        self.assertEqual(report["severity"], "medium")
+        self.assertEqual(report["recommendation"], "caution")
+        self.assertLessEqual(report["risk_score"], 69)
+        self.assertNotIn("NO-GO", report["narrative_opening"])
+        self.assertIn("CAUTION", report["narrative_opening"])
+        self.assertIn("unsupported severe report verdict", report["top_risk"])
+        self.assertIn("Evidence Law downgraded", " ".join(report["warnings"]))
+
+    def test_persist_analysis_report_repoints_partial_downgrade_summary_to_supported_severe_finding(
+        self,
+    ) -> None:
+        parse_batch = ParseBatchResult(
+            files=[
+                ParsedFileResult(
+                    file_name="plan.json",
+                    tool="terraform",
+                    status="parsed",
+                    changes=[],
+                )
+            ]
+        )
+        assessment = RiskAssessment(
+            score=82,
+            severity="high",
+            recommendation="no-go",
+            top_risk="HIGH: unsupported inferred exposure.",
+            contributors=[],
+            interaction_risks=[],
+            partial_context=False,
+            warnings=[],
+        )
+        narrative = NarrativeResult(
+            opening_sentence="NO-GO: unsupported inferred exposure.",
+            explanation="Unsupported inferred exposure is the severe issue.",
+            guidance=[],
+            degraded=False,
+            warnings=[],
+        )
+
+        report = report_service_module.persist_analysis_report(
+            parse_batch,
+            assessment,
+            narrative,
+            findings=[
+                Finding(
+                    finding_id="finding-unsupported",
+                    analysis_id=0,
+                    title="HIGH: unsupported inferred exposure",
+                    description="Unsupported inferred exposure.",
+                    severity="high",
+                    category="networking/ingress",
+                    deterministic=False,
+                    confidence=0.94,
+                    uncertainty_note=None,
+                    evidence_classification="model_inferred",
+                    evidence_refs=[],
+                    skill_id=None,
+                ),
+                Finding(
+                    finding_id="finding-supported",
+                    analysis_id=0,
+                    title="HIGH: aws_security_group.main",
+                    description="Deterministic security group exposure.",
+                    severity="high",
+                    category="networking/ingress",
+                    deterministic=True,
+                    confidence=1.0,
+                    uncertainty_note=None,
+                    evidence_refs=["ev-supported"],
+                    skill_id=None,
+                ),
+            ],
+            evidence_items=[
+                EvidenceItem(
+                    evidence_id="ev-supported",
+                    analysis_id=0,
+                    finding_id="pending:change-1",
+                    source_type="artifact",
+                    source_ref=(
+                        "terraform://plan.json#aws_security_group.main?action=modify"
+                    ),
+                    summary="Terraform changed a security group.",
+                    severity_hint="high",
+                    deterministic=True,
+                    confidence=1.0,
+                    related_change_ids=["change-1"],
+                )
+            ],
+        )
+
+        severities_by_title = {
+            finding["title"]: finding["severity"] for finding in report["findings"]
+        }
+        self.assertEqual(
+            severities_by_title["MEDIUM: unsupported inferred exposure"],
+            "medium",
+        )
+        self.assertEqual(severities_by_title["HIGH: aws_security_group.main"], "high")
+        self.assertEqual(report["severity"], "high")
+        self.assertEqual(report["recommendation"], "no-go")
+        self.assertIn("aws_security_group.main", report["top_risk"])
+        self.assertNotIn("unsupported inferred exposure", report["top_risk"])
+        self.assertIn("deterministic severe risk remains", report["narrative_opening"])
+        self.assertIn("Evidence Law downgraded", report["narrative_explanation"])
+
+    def test_persist_analysis_report_clears_stale_severe_top_risk_on_medium_assessment(
+        self,
+    ) -> None:
+        parse_batch = ParseBatchResult(
+            files=[
+                ParsedFileResult(
+                    file_name="plan.json",
+                    tool="terraform",
+                    status="parsed",
+                    changes=[],
+                )
+            ]
+        )
+        assessment = RiskAssessment(
+            score=52,
+            severity="medium",
+            recommendation="caution",
+            top_risk="CRITICAL: unsupported no-go claim.",
+            contributors=[],
+            interaction_risks=[],
+            partial_context=False,
+            warnings=[],
+        )
+        narrative = NarrativeResult(
+            opening_sentence="NO-GO: unsupported no-go claim.",
+            explanation="CRITICAL unsupported no-go claim.",
+            guidance=[],
+            degraded=False,
+            warnings=[],
+        )
+
+        report = report_service_module.persist_analysis_report(
+            parse_batch,
+            assessment,
+            narrative,
+            findings=[
+                Finding(
+                    finding_id="finding-unsupported-critical",
+                    analysis_id=0,
+                    title="CRITICAL: unsupported no-go claim",
+                    description="Unsupported critical claim without deterministic evidence.",
+                    severity="critical",
+                    category="networking/ingress",
+                    deterministic=False,
+                    confidence=0.96,
+                    uncertainty_note=None,
+                    evidence_classification="model_inferred",
+                    evidence_refs=[],
+                    skill_id=None,
+                )
+            ],
+            evidence_items=[],
+        )
+
+        self.assertEqual(report["severity"], "medium")
+        self.assertEqual(report["recommendation"], "caution")
+        self.assertIn("Evidence Law downgraded", report["top_risk"])
+        self.assertNotIn("CRITICAL", report["top_risk"])
+        self.assertNotIn("NO-GO", report["narrative_opening"])
+        self.assertNotIn("CRITICAL", report["narrative_explanation"])
+
+    def test_persist_analysis_report_sanitizes_stale_severe_copy_without_findings(
+        self,
+    ) -> None:
+        parse_batch = ParseBatchResult(
+            files=[
+                ParsedFileResult(
+                    file_name="plan.json",
+                    tool="terraform",
+                    status="parsed",
+                    changes=[],
+                )
+            ]
+        )
+        assessment = RiskAssessment(
+            score=52,
+            severity="medium",
+            recommendation="caution",
+            top_risk="CRITICAL: stale no-go copy.",
+            contributors=[],
+            interaction_risks=[],
+            partial_context=False,
+            warnings=[],
+        )
+        narrative = NarrativeResult(
+            opening_sentence="NO-GO: stale no-go copy.",
+            explanation="CRITICAL stale no-go copy.",
+            guidance=[],
+            degraded=False,
+            warnings=[],
+        )
+
+        report = report_service_module.persist_analysis_report(
+            parse_batch,
+            assessment,
+            narrative,
+            findings=[],
+            evidence_items=[],
+        )
+
+        self.assertEqual(report["severity"], "medium")
+        self.assertEqual(report["recommendation"], "caution")
+        self.assertIn("MEDIUM", report["top_risk"])
+        self.assertNotIn("CRITICAL", report["top_risk"])
+        self.assertIn("CAUTION", report["narrative_opening"])
+        self.assertNotIn("NO-GO", report["narrative_opening"])
+        self.assertNotIn("CRITICAL", report["narrative_explanation"])
+        self.assertIn("Evidence Law", " ".join(report["warnings"]))
+
+    def test_persist_analysis_report_reconciles_non_severe_recommendation_text(
+        self,
+    ) -> None:
+        parse_batch = ParseBatchResult(
+            files=[
+                ParsedFileResult(
+                    file_name="plan.json",
+                    tool="terraform",
+                    status="parsed",
+                    changes=[],
+                )
+            ]
+        )
+        assessment = RiskAssessment(
+            score=95,
+            severity="medium",
+            recommendation="no-go",
+            top_risk="NO-GO: stale recommendation copy.",
+            contributors=[],
+            interaction_risks=[],
+            partial_context=False,
+            warnings=[],
+        )
+        narrative = NarrativeResult(
+            opening_sentence="NO-GO: stale recommendation copy.",
+            explanation="NO-GO stale recommendation copy.",
+            guidance=[],
+            degraded=False,
+            warnings=[],
+        )
+
+        report = report_service_module.persist_analysis_report(
+            parse_batch,
+            assessment,
+            narrative,
+            findings=[],
+            evidence_items=[],
+        )
+
+        self.assertEqual(report["severity"], "medium")
+        self.assertEqual(report["recommendation"], "caution")
+        self.assertEqual(report["risk_score"], 69)
+        self.assertIn("MEDIUM", report["top_risk"])
+        self.assertNotIn("NO-GO", report["top_risk"])
+        self.assertIn("CAUTION", report["narrative_opening"])
+        self.assertNotIn("NO-GO", report["narrative_opening"])
+        self.assertNotIn("NO-GO", report["narrative_explanation"])
+        self.assertIn(
+            "recommendation to match severity",
+            " ".join(report["warnings"]),
+        )
+        self.assertIn("score to match severity", " ".join(report["warnings"]))
+
+    def test_persist_analysis_report_preserves_medium_go_recommendation(
+        self,
+    ) -> None:
+        parse_batch = ParseBatchResult(
+            files=[
+                ParsedFileResult(
+                    file_name="plan.json",
+                    tool="terraform",
+                    status="parsed",
+                    changes=[],
+                )
+            ]
+        )
+        assessment = RiskAssessment(
+            score=42,
+            severity="medium",
+            recommendation="go",
+            top_risk="Medium security group review.",
+            contributors=[],
+            interaction_risks=[],
+            partial_context=False,
+            warnings=[],
+        )
+        narrative = NarrativeResult(
+            opening_sentence="GO: medium security group review.",
+            explanation="Medium severity remains advisory.",
+            guidance=[],
+            degraded=False,
+            warnings=[],
+        )
+
+        report = report_service_module.persist_analysis_report(
+            parse_batch,
+            assessment,
+            narrative,
+            findings=[],
+            evidence_items=[],
+        )
+
+        self.assertEqual(report["severity"], "medium")
+        self.assertEqual(report["recommendation"], "go")
+        self.assertEqual(report["risk_score"], 42)
+        self.assertEqual(report["top_risk"], "Medium security group review.")
+        self.assertEqual(
+            report["narrative_opening"],
+            "GO: medium security group review.",
+        )
+        self.assertNotIn("Evidence Law", " ".join(report["warnings"]))
+
+    def test_persist_analysis_report_preserves_medium_go_recommendation_when_reconciling_score(
+        self,
+    ) -> None:
+        parse_batch = ParseBatchResult(
+            files=[
+                ParsedFileResult(
+                    file_name="plan.json",
+                    tool="terraform",
+                    status="parsed",
+                    changes=[],
+                )
+            ]
+        )
+        assessment = RiskAssessment(
+            score=95,
+            severity="medium",
+            recommendation="go",
+            top_risk="Medium security group review.",
+            contributors=[],
+            interaction_risks=[],
+            partial_context=False,
+            warnings=[],
+        )
+        narrative = NarrativeResult(
+            opening_sentence="GO: medium security group review.",
+            explanation="Medium severity remains advisory.",
+            guidance=[],
+            degraded=False,
+            warnings=[],
+        )
+
+        report = report_service_module.persist_analysis_report(
+            parse_batch,
+            assessment,
+            narrative,
+            findings=[],
+            evidence_items=[],
+        )
+
+        self.assertEqual(report["severity"], "medium")
+        self.assertEqual(report["recommendation"], "go")
+        self.assertEqual(report["risk_score"], 69)
+        self.assertEqual(report["top_risk"], "Medium security group review.")
+        self.assertIn("score to match severity", " ".join(report["warnings"]))
+        self.assertNotIn(
+            "recommendation to match severity", " ".join(report["warnings"])
+        )
+
+    def test_persist_analysis_report_preserves_hyphenated_verdict_prose(
+        self,
+    ) -> None:
+        parse_batch = ParseBatchResult(
+            files=[
+                ParsedFileResult(
+                    file_name="plan.json",
+                    tool="terraform",
+                    status="parsed",
+                    changes=[],
+                )
+            ]
+        )
+        assessment = RiskAssessment(
+            score=52,
+            severity="medium",
+            recommendation="caution",
+            top_risk="High availability rollout requires review.",
+            contributors=[],
+            interaction_risks=[],
+            partial_context=False,
+            warnings=[],
+        )
+        narrative = NarrativeResult(
+            opening_sentence="Go live review is pending.",
+            explanation="Critical path implementation detail remains under review.",
+            guidance=[],
+            degraded=False,
+            warnings=[],
+        )
+
+        report = report_service_module.persist_analysis_report(
+            parse_batch,
+            assessment,
+            narrative,
+            findings=[],
+            evidence_items=[],
+        )
+
+        self.assertEqual(
+            report["top_risk"], "High availability rollout requires review."
+        )
+        self.assertEqual(report["narrative_opening"], "Go live review is pending.")
+        self.assertEqual(
+            report["narrative_explanation"],
+            "Critical path implementation detail remains under review.",
+        )
+        self.assertNotIn("Evidence Law refreshed", " ".join(report["warnings"]))
+
+    def test_persist_analysis_report_promotes_downgraded_severe_finding_to_medium_assessment(
+        self,
+    ) -> None:
+        parse_batch = ParseBatchResult(
+            files=[
+                ParsedFileResult(
+                    file_name="plan.json",
+                    tool="terraform",
+                    status="parsed",
+                    changes=[],
+                )
+            ]
+        )
+        assessment = RiskAssessment(
+            score=18,
+            severity="low",
+            recommendation="go",
+            top_risk="CRITICAL: unsupported no-go claim.",
+            contributors=[],
+            interaction_risks=[],
+            partial_context=False,
+            warnings=[],
+        )
+        narrative = NarrativeResult(
+            opening_sentence="GO: unsupported no-go claim.",
+            explanation="CRITICAL unsupported no-go claim.",
+            guidance=[],
+            degraded=False,
+            warnings=[],
+        )
+
+        report = report_service_module.persist_analysis_report(
+            parse_batch,
+            assessment,
+            narrative,
+            findings=[
+                Finding(
+                    finding_id="finding-unsupported-critical",
+                    analysis_id=0,
+                    title="CRITICAL: unsupported no-go claim",
+                    description="Unsupported critical claim without deterministic evidence.",
+                    severity="critical",
+                    category="networking/ingress",
+                    deterministic=False,
+                    confidence=0.96,
+                    uncertainty_note=None,
+                    evidence_classification="model_inferred",
+                    evidence_refs=[],
+                    skill_id=None,
+                )
+            ],
+            evidence_items=[],
+        )
+
+        self.assertEqual(report["findings"][0]["severity"], "medium")
+        self.assertEqual(report["severity"], "medium")
+        self.assertEqual(report["recommendation"], "caution")
+        self.assertGreaterEqual(report["risk_score"], 42)
+        self.assertIn("Evidence Law downgraded", report["top_risk"])
+
+    def test_persist_analysis_report_reconciles_critical_verdict_to_supported_high_finding(
+        self,
+    ) -> None:
+        parse_batch = ParseBatchResult(
+            files=[
+                ParsedFileResult(
+                    file_name="plan.json",
+                    tool="terraform",
+                    status="parsed",
+                    changes=[],
+                )
+            ]
+        )
+        assessment = RiskAssessment(
+            score=95,
+            severity="critical",
+            recommendation="no-go",
+            top_risk="CRITICAL: unsupported inferred exposure.",
+            contributors=[],
+            interaction_risks=[],
+            partial_context=False,
+            warnings=[],
+        )
+        narrative = NarrativeResult(
+            opening_sentence="NO-GO: unsupported inferred exposure.",
+            explanation="Unsupported inferred exposure is the severe issue.",
+            guidance=[],
+            degraded=False,
+            warnings=[],
+        )
+
+        report = report_service_module.persist_analysis_report(
+            parse_batch,
+            assessment,
+            narrative,
+            findings=[
+                Finding(
+                    finding_id="finding-unsupported-critical",
+                    analysis_id=0,
+                    title="CRITICAL: unsupported inferred exposure",
+                    description="Unsupported inferred exposure.",
+                    severity="critical",
+                    category="networking/ingress",
+                    deterministic=False,
+                    confidence=0.97,
+                    uncertainty_note=None,
+                    evidence_classification="model_inferred",
+                    evidence_refs=[],
+                    skill_id=None,
+                ),
+                Finding(
+                    finding_id="finding-supported-high",
+                    analysis_id=0,
+                    title="HIGH: aws_security_group.main",
+                    description="Deterministic security group exposure.",
+                    severity="high",
+                    category="networking/ingress",
+                    deterministic=True,
+                    confidence=1.0,
+                    uncertainty_note=None,
+                    evidence_refs=["ev-supported-high"],
+                    skill_id=None,
+                ),
+            ],
+            evidence_items=[
+                EvidenceItem(
+                    evidence_id="ev-supported-high",
+                    analysis_id=0,
+                    finding_id="pending:change-1",
+                    source_type="artifact",
+                    source_ref=(
+                        "terraform://plan.json#aws_security_group.main?action=modify"
+                    ),
+                    summary="Terraform changed a security group.",
+                    severity_hint="high",
+                    deterministic=True,
+                    confidence=1.0,
+                    related_change_ids=["change-1"],
+                )
+            ],
+        )
+
+        self.assertEqual(report["severity"], "high")
+        self.assertEqual(report["recommendation"], "no-go")
+        self.assertLessEqual(report["risk_score"], 89)
+        self.assertIn("HIGH: aws_security_group.main", report["top_risk"])
+        self.assertNotIn("CRITICAL", report["top_risk"])
+        self.assertIn(
+            "highest linked deterministic finding severity: high",
+            report["narrative_explanation"],
+        )
+
+    def test_persist_analysis_report_reconciles_overclaimed_critical_verdict_without_finding_downgrade(
+        self,
+    ) -> None:
+        parse_batch = ParseBatchResult(
+            files=[
+                ParsedFileResult(
+                    file_name="plan.json",
+                    tool="terraform",
+                    status="parsed",
+                    changes=[],
+                )
+            ]
+        )
+        assessment = RiskAssessment(
+            score=94,
+            severity="critical",
+            recommendation="no-go",
+            top_risk="CRITICAL: reported verdict overstates the supported finding.",
+            contributors=[],
+            interaction_risks=[],
+            partial_context=False,
+            warnings=[],
+        )
+        narrative = NarrativeResult(
+            opening_sentence="NO-GO: critical report verdict.",
+            explanation="Critical report verdict overstates the supported finding.",
+            guidance=[],
+            degraded=False,
+            warnings=[],
+        )
+
+        report = report_service_module.persist_analysis_report(
+            parse_batch,
+            assessment,
+            narrative,
+            findings=[
+                Finding(
+                    finding_id="finding-supported-high",
+                    analysis_id=0,
+                    title="HIGH: aws_security_group.main",
+                    description="Deterministic security group exposure.",
+                    severity="high",
+                    category="networking/ingress",
+                    deterministic=True,
+                    confidence=1.0,
+                    uncertainty_note=None,
+                    evidence_refs=["ev-supported-high"],
+                    skill_id=None,
+                )
+            ],
+            evidence_items=[
+                EvidenceItem(
+                    evidence_id="ev-supported-high",
+                    analysis_id=0,
+                    finding_id="pending:change-1",
+                    source_type="artifact",
+                    source_ref=(
+                        "terraform://plan.json#aws_security_group.main?action=modify"
+                    ),
+                    summary="Terraform changed a security group.",
+                    severity_hint="high",
+                    deterministic=True,
+                    confidence=1.0,
+                    related_change_ids=["change-1"],
+                )
+            ],
+        )
+
+        self.assertEqual(report["severity"], "high")
+        self.assertEqual(report["recommendation"], "no-go")
+        self.assertLessEqual(report["risk_score"], 89)
+        self.assertIn("HIGH: aws_security_group.main", report["top_risk"])
+        self.assertIn("Evidence Law downgraded", report["narrative_explanation"])
+        self.assertNotIn(
+            "Critical report verdict overstates", report["narrative_explanation"]
+        )
+
+    def test_persist_analysis_report_promotes_underclaimed_verdict_to_supported_high_finding(
+        self,
+    ) -> None:
+        parse_batch = ParseBatchResult(
+            files=[
+                ParsedFileResult(
+                    file_name="plan.json",
+                    tool="terraform",
+                    status="parsed",
+                    changes=[],
+                )
+            ]
+        )
+        assessment = RiskAssessment(
+            score=42,
+            severity="medium",
+            recommendation="caution",
+            top_risk="Medium report verdict understates deterministic severe finding.",
+            contributors=[],
+            interaction_risks=[],
+            partial_context=False,
+            warnings=[],
+        )
+        narrative = NarrativeResult(
+            opening_sentence="CAUTION: medium report verdict.",
+            explanation="Medium report verdict understates deterministic severe finding.",
+            guidance=[],
+            degraded=False,
+            warnings=[],
+        )
+
+        report = report_service_module.persist_analysis_report(
+            parse_batch,
+            assessment,
+            narrative,
+            findings=[
+                Finding(
+                    finding_id="finding-supported-high",
+                    analysis_id=0,
+                    title="HIGH: aws_security_group.main",
+                    description="Deterministic security group exposure.",
+                    severity="high",
+                    category="networking/ingress",
+                    deterministic=True,
+                    confidence=1.0,
+                    uncertainty_note=None,
+                    evidence_refs=["ev-supported-high"],
+                    skill_id=None,
+                )
+            ],
+            evidence_items=[
+                EvidenceItem(
+                    evidence_id="ev-supported-high",
+                    analysis_id=0,
+                    finding_id="pending:change-1",
+                    source_type="artifact",
+                    source_ref=(
+                        "terraform://plan.json#aws_security_group.main?action=modify"
+                    ),
+                    summary="Terraform changed a security group.",
+                    severity_hint="high",
+                    deterministic=True,
+                    confidence=1.0,
+                    related_change_ids=["change-1"],
+                )
+            ],
+        )
+
+        self.assertEqual(report["severity"], "high")
+        self.assertEqual(report["recommendation"], "no-go")
+        self.assertGreaterEqual(report["risk_score"], 70)
+        self.assertIn("HIGH: aws_security_group.main", report["top_risk"])
+        self.assertIn("Evidence Law promoted", " ".join(report["warnings"]))
+        self.assertIn(
+            "Deterministic severe risk remains", report["narrative_explanation"]
+        )
+        self.assertNotIn(
+            "Medium report verdict understates",
+            report["narrative_explanation"],
+        )
+
+    def test_persist_analysis_report_refreshes_stale_non_severe_copy_for_supported_high(
+        self,
+    ) -> None:
+        parse_batch = ParseBatchResult(
+            files=[
+                ParsedFileResult(
+                    file_name="plan.json",
+                    tool="terraform",
+                    status="parsed",
+                    changes=[],
+                )
+            ]
+        )
+        assessment = RiskAssessment(
+            score=72,
+            severity="high",
+            recommendation="no-go",
+            top_risk="MEDIUM: stale non-severe copy.",
+            contributors=[],
+            interaction_risks=[],
+            partial_context=False,
+            warnings=[],
+        )
+        narrative = NarrativeResult(
+            opening_sentence="CAUTION: stale non-severe copy.",
+            explanation="Medium stale non-severe copy.",
+            guidance=[],
+            degraded=False,
+            warnings=[],
+        )
+
+        report = report_service_module.persist_analysis_report(
+            parse_batch,
+            assessment,
+            narrative,
+            findings=[
+                Finding(
+                    finding_id="finding-supported-high",
+                    analysis_id=0,
+                    title="HIGH: aws_security_group.main",
+                    description="Deterministic security group exposure.",
+                    severity="high",
+                    category="networking/ingress",
+                    deterministic=True,
+                    confidence=1.0,
+                    uncertainty_note=None,
+                    evidence_refs=["ev-supported-high"],
+                    skill_id=None,
+                )
+            ],
+            evidence_items=[
+                EvidenceItem(
+                    evidence_id="ev-supported-high",
+                    analysis_id=0,
+                    finding_id="pending:change-1",
+                    source_type="artifact",
+                    source_ref=(
+                        "terraform://plan.json#aws_security_group.main?action=modify"
+                    ),
+                    summary="Terraform changed a security group.",
+                    severity_hint="high",
+                    deterministic=True,
+                    confidence=1.0,
+                    related_change_ids=["change-1"],
+                )
+            ],
+        )
+
+        self.assertEqual(report["severity"], "high")
+        self.assertEqual(report["recommendation"], "no-go")
+        self.assertIn("HIGH: aws_security_group.main", report["top_risk"])
+        self.assertNotIn("MEDIUM", report["top_risk"])
+        self.assertIn("deterministic severe risk remains", report["narrative_opening"])
+        self.assertIn("aws_security_group.main", report["narrative_explanation"])
+
+    def test_persist_analysis_report_normalizes_supported_severe_finding_metadata(
+        self,
+    ) -> None:
+        parse_batch = ParseBatchResult(
+            files=[
+                ParsedFileResult(
+                    file_name="plan.json",
+                    tool="terraform",
+                    status="parsed",
+                    changes=[],
+                )
+            ]
+        )
+        assessment = RiskAssessment(
+            score=42,
+            severity="high",
+            recommendation="go",
+            top_risk="HIGH: aws_security_group.main",
+            contributors=[],
+            interaction_risks=[],
+            partial_context=False,
+            warnings=[],
+        )
+        narrative = NarrativeResult(
+            opening_sentence="NO-GO: deterministic severe risk.",
+            explanation="Linked deterministic evidence supports the severe finding.",
+            guidance=[],
+            degraded=False,
+            warnings=[],
+        )
+
+        report = report_service_module.persist_analysis_report(
+            parse_batch,
+            assessment,
+            narrative,
+            findings=[
+                Finding(
+                    finding_id="finding-supported-high",
+                    analysis_id=0,
+                    title="HIGH: aws_security_group.main",
+                    description="Deterministic security group exposure.",
+                    severity="high",
+                    category="networking/ingress",
+                    deterministic=False,
+                    confidence=0.91,
+                    uncertainty_note=None,
+                    evidence_classification="model_inferred",
+                    evidence_refs=["ev-supported-high"],
+                    skill_id=None,
+                )
+            ],
+            evidence_items=[
+                EvidenceItem(
+                    evidence_id="ev-supported-high",
+                    analysis_id=0,
+                    finding_id="pending:change-1",
+                    source_type="artifact",
+                    source_ref=(
+                        "terraform://plan.json#aws_security_group.main?action=modify"
+                    ),
+                    summary="Terraform changed a security group.",
+                    severity_hint="high",
+                    deterministic=True,
+                    confidence=1.0,
+                    related_change_ids=["change-1"],
+                )
+            ],
+        )
+
+        self.assertEqual(report["severity"], "high")
+        self.assertEqual(report["recommendation"], "no-go")
+        self.assertGreaterEqual(report["risk_score"], 70)
+        self.assertTrue(report["findings"][0]["deterministic"])
+        self.assertEqual(
+            report["findings"][0]["evidence_classification"],
+            "deterministic",
+        )
+
+    def test_persist_analysis_report_normalizes_supported_severe_finding_metadata_with_consistent_report(
+        self,
+    ) -> None:
+        parse_batch = ParseBatchResult(
+            files=[
+                ParsedFileResult(
+                    file_name="plan.json",
+                    tool="terraform",
+                    status="parsed",
+                    changes=[],
+                )
+            ]
+        )
+        assessment = RiskAssessment(
+            score=72,
+            severity="high",
+            recommendation="no-go",
+            top_risk="HIGH: aws_security_group.main",
+            contributors=[],
+            interaction_risks=[],
+            partial_context=False,
+            warnings=[],
+        )
+        narrative = NarrativeResult(
+            opening_sentence="NO-GO: deterministic severe risk.",
+            explanation="Linked deterministic evidence supports the severe finding.",
+            guidance=[],
+            degraded=False,
+            warnings=[],
+        )
+
+        report = report_service_module.persist_analysis_report(
+            parse_batch,
+            assessment,
+            narrative,
+            findings=[
+                Finding(
+                    finding_id="finding-supported-high",
+                    analysis_id=0,
+                    title="HIGH: aws_security_group.main",
+                    description="Deterministic security group exposure.",
+                    severity="high",
+                    category="networking/ingress",
+                    deterministic=False,
+                    confidence=0.91,
+                    uncertainty_note=None,
+                    evidence_classification="model_inferred",
+                    evidence_refs=["ev-supported-high"],
+                    skill_id=None,
+                )
+            ],
+            evidence_items=[
+                EvidenceItem(
+                    evidence_id="ev-supported-high",
+                    analysis_id=0,
+                    finding_id="pending:change-1",
+                    source_type="artifact",
+                    source_ref=(
+                        "terraform://plan.json#aws_security_group.main?action=modify"
+                    ),
+                    summary="Terraform changed a security group.",
+                    severity_hint="high",
+                    deterministic=True,
+                    confidence=1.0,
+                    related_change_ids=["change-1"],
+                )
+            ],
+        )
+
+        self.assertEqual(report["severity"], "high")
+        self.assertEqual(report["recommendation"], "no-go")
+        self.assertEqual(report["risk_score"], 72)
+        self.assertTrue(report["findings"][0]["deterministic"])
+        self.assertEqual(
+            report["findings"][0]["evidence_classification"],
+            "deterministic",
+        )
+
+    def test_persist_analysis_report_uses_highest_supported_severe_finding_for_partial_downgrade(
+        self,
+    ) -> None:
+        parse_batch = ParseBatchResult(
+            files=[
+                ParsedFileResult(
+                    file_name="plan.json",
+                    tool="terraform",
+                    status="parsed",
+                    changes=[],
+                )
+            ]
+        )
+        assessment = RiskAssessment(
+            score=92,
+            severity="critical",
+            recommendation="no-go",
+            top_risk="CRITICAL: unsupported inferred exposure.",
+            contributors=[],
+            interaction_risks=[],
+            partial_context=False,
+            warnings=[],
+        )
+        narrative = NarrativeResult(
+            opening_sentence="NO-GO: unsupported inferred exposure.",
+            explanation="Unsupported inferred exposure is the severe issue.",
+            guidance=[],
+            degraded=False,
+            warnings=[],
+        )
+
+        report = report_service_module.persist_analysis_report(
+            parse_batch,
+            assessment,
+            narrative,
+            findings=[
+                Finding(
+                    finding_id="finding-unsupported",
+                    analysis_id=0,
+                    title="CRITICAL: unsupported inferred exposure",
+                    description="Unsupported inferred exposure.",
+                    severity="critical",
+                    category="networking/ingress",
+                    deterministic=False,
+                    confidence=0.97,
+                    uncertainty_note=None,
+                    evidence_classification="model_inferred",
+                    evidence_refs=[],
+                    skill_id=None,
+                ),
+                Finding(
+                    finding_id="finding-supported-high",
+                    analysis_id=0,
+                    title="HIGH: aws_security_group.main",
+                    description="Deterministic security group exposure.",
+                    severity="high",
+                    category="networking/ingress",
+                    deterministic=True,
+                    confidence=1.0,
+                    uncertainty_note=None,
+                    evidence_refs=["ev-supported-high"],
+                    skill_id=None,
+                ),
+                Finding(
+                    finding_id="finding-supported-critical",
+                    analysis_id=0,
+                    title="CRITICAL: aws_iam_policy.admin",
+                    description="Deterministic admin policy exposure.",
+                    severity="critical",
+                    category="iam/rbac",
+                    deterministic=True,
+                    confidence=1.0,
+                    uncertainty_note=None,
+                    evidence_refs=["ev-supported-critical"],
+                    skill_id=None,
+                ),
+            ],
+            evidence_items=[
+                EvidenceItem(
+                    evidence_id="ev-supported-high",
+                    analysis_id=0,
+                    finding_id="pending:change-1",
+                    source_type="artifact",
+                    source_ref=(
+                        "terraform://plan.json#aws_security_group.main?action=modify"
+                    ),
+                    summary="Terraform changed a security group.",
+                    severity_hint="high",
+                    deterministic=True,
+                    confidence=1.0,
+                    related_change_ids=["change-1"],
+                ),
+                EvidenceItem(
+                    evidence_id="ev-supported-critical",
+                    analysis_id=0,
+                    finding_id="pending:change-2",
+                    source_type="artifact",
+                    source_ref="terraform://plan.json#aws_iam_policy.admin?action=modify",
+                    summary="Terraform changed an admin policy.",
+                    severity_hint="critical",
+                    deterministic=True,
+                    confidence=1.0,
+                    related_change_ids=["change-2"],
+                ),
+            ],
+        )
+
+        critical_evidence_id = next(
+            evidence["evidence_id"]
+            for evidence in report["evidence_items"]
+            if "aws_iam_policy.admin" in evidence["source_ref"]
+        )
+        self.assertIn("CRITICAL: aws_iam_policy.admin", report["top_risk"])
+        self.assertNotIn("HIGH: aws_security_group.main", report["top_risk"])
+        self.assertEqual(report["top_risk_contributors"], [critical_evidence_id])
+
+    def test_persist_analysis_report_explains_remaining_supported_severe_risk_after_partial_downgrade(
+        self,
+    ) -> None:
+        parse_batch = ParseBatchResult(
+            files=[
+                ParsedFileResult(
+                    file_name="plan.json",
+                    tool="terraform",
+                    status="parsed",
+                    changes=[],
+                )
+            ]
+        )
+        assessment = RiskAssessment(
+            score=82,
+            severity="high",
+            recommendation="no-go",
+            top_risk="HIGH: unsupported inferred exposure.",
+            contributors=[],
+            interaction_risks=[],
+            partial_context=False,
+            warnings=[],
+        )
+        narrative = NarrativeResult(
+            opening_sentence="NO-GO: unsupported inferred exposure.",
+            explanation="Unsupported inferred exposure is the severe issue.",
+            guidance=[],
+            degraded=False,
+            warnings=[],
+        )
+
+        report = report_service_module.persist_analysis_report(
+            parse_batch,
+            assessment,
+            narrative,
+            findings=[
+                Finding(
+                    finding_id="finding-unsupported",
+                    analysis_id=0,
+                    title="HIGH: unsupported inferred exposure",
+                    description="Unsupported inferred exposure.",
+                    severity="high",
+                    category="networking/ingress",
+                    deterministic=False,
+                    confidence=0.94,
+                    uncertainty_note=None,
+                    evidence_classification="model_inferred",
+                    evidence_refs=[],
+                    skill_id=None,
+                ),
+                Finding(
+                    finding_id="finding-supported",
+                    analysis_id=0,
+                    title="HIGH: aws_security_group.main",
+                    description="Deterministic security group exposure.",
+                    severity="high",
+                    category="networking/ingress",
+                    deterministic=True,
+                    confidence=1.0,
+                    uncertainty_note=None,
+                    evidence_refs=["ev-supported"],
+                    skill_id=None,
+                ),
+            ],
+            evidence_items=[
+                EvidenceItem(
+                    evidence_id="ev-supported",
+                    analysis_id=0,
+                    finding_id="pending:change-1",
+                    source_type="artifact",
+                    source_ref=(
+                        "terraform://plan.json#aws_security_group.main?action=modify"
+                    ),
+                    summary="Terraform changed a security group.",
+                    severity_hint="high",
+                    deterministic=True,
+                    confidence=1.0,
+                    related_change_ids=["change-1"],
+                )
+            ],
+        )
+
+        self.assertIn(
+            "Deterministic severe risk remains", report["narrative_explanation"]
+        )
+        self.assertIn("aws_security_group.main", report["narrative_explanation"])
+        self.assertIn("Evidence Law downgraded", report["narrative_explanation"])
+        self.assertNotIn(
+            "unsupported inferred exposure is the severe issue",
+            report["narrative_explanation"],
+        )
+
+    def test_persist_analysis_report_rewrites_severity_only_downgraded_title(
+        self,
+    ) -> None:
+        parse_batch = ParseBatchResult(
+            files=[
+                ParsedFileResult(
+                    file_name="plan.json",
+                    tool="terraform",
+                    status="parsed",
+                    changes=[],
+                )
+            ]
+        )
+        assessment = RiskAssessment(
+            score=72,
+            severity="high",
+            recommendation="no-go",
+            top_risk="Severity-only title.",
+            contributors=[],
+            interaction_risks=[],
+            partial_context=False,
+            warnings=[],
+        )
+        narrative = NarrativeResult(
+            opening_sentence="NO-GO: severity-only title.",
+            explanation="Severity-only title.",
+            guidance=[],
+            degraded=False,
+            warnings=[],
+        )
+
+        report = report_service_module.persist_analysis_report(
+            parse_batch,
+            assessment,
+            narrative,
+            findings=[
+                Finding(
+                    finding_id="finding-severity-only",
+                    analysis_id=0,
+                    title="HIGH:",
+                    description="Bare severity title must not survive downgrade.",
+                    severity="high",
+                    category="networking/ingress",
+                    deterministic=False,
+                    confidence=0.9,
+                    uncertainty_note=None,
+                    evidence_classification="model_inferred",
+                    evidence_refs=[],
+                    skill_id=None,
+                )
+            ],
+            evidence_items=[],
+        )
+
+        self.assertEqual(
+            report["findings"][0]["title"],
+            "MEDIUM: Bare severity title must not survive downgrade.",
+        )
+        self.assertNotIn("HIGH", report["findings"][0]["title"])
+
+    def test_persist_analysis_report_strips_verdict_prefix_from_downgraded_title(
+        self,
+    ) -> None:
+        parse_batch = ParseBatchResult(
+            files=[
+                ParsedFileResult(
+                    file_name="plan.json",
+                    tool="terraform",
+                    status="parsed",
+                    changes=[],
+                )
+            ]
+        )
+        assessment = RiskAssessment(
+            score=72,
+            severity="high",
+            recommendation="no-go",
+            top_risk="NO-GO: unsupported severe claim.",
+            contributors=[],
+            interaction_risks=[],
+            partial_context=False,
+            warnings=[],
+        )
+        narrative = NarrativeResult(
+            opening_sentence="NO-GO: unsupported severe claim.",
+            explanation="Unsupported severe claim.",
+            guidance=[],
+            degraded=False,
+            warnings=[],
+        )
+
+        report = report_service_module.persist_analysis_report(
+            parse_batch,
+            assessment,
+            narrative,
+            findings=[
+                Finding(
+                    finding_id="finding-verdict-title",
+                    analysis_id=0,
+                    title="NO-GO: unsupported severe claim",
+                    description="Unsupported severe claim.",
+                    severity="high",
+                    category="networking/ingress",
+                    deterministic=False,
+                    confidence=0.9,
+                    uncertainty_note=None,
+                    evidence_classification="model_inferred",
+                    evidence_refs=[],
+                    skill_id=None,
+                )
+            ],
+            evidence_items=[],
+        )
+
+        self.assertEqual(
+            report["findings"][0]["title"],
+            "MEDIUM: unsupported severe claim",
+        )
+        self.assertNotIn("NO-GO", report["findings"][0]["title"])
+
+    def test_persist_analysis_report_strips_unpunctuated_verdict_prefix_from_downgraded_title(
+        self,
+    ) -> None:
+        parse_batch = ParseBatchResult(
+            files=[
+                ParsedFileResult(
+                    file_name="plan.json",
+                    tool="terraform",
+                    status="parsed",
+                    changes=[],
+                )
+            ]
+        )
+        assessment = RiskAssessment(
+            score=72,
+            severity="high",
+            recommendation="no-go",
+            top_risk="NO-GO unsupported severe claim.",
+            contributors=[],
+            interaction_risks=[],
+            partial_context=False,
+            warnings=[],
+        )
+        narrative = NarrativeResult(
+            opening_sentence="NO-GO unsupported severe claim.",
+            explanation="CRITICAL risk remains without deterministic evidence.",
+            guidance=[],
+            degraded=False,
+            warnings=[],
+        )
+
+        report = report_service_module.persist_analysis_report(
+            parse_batch,
+            assessment,
+            narrative,
+            findings=[
+                Finding(
+                    finding_id="finding-unpunctuated-verdict-title",
+                    analysis_id=0,
+                    title="NO-GO unsupported severe claim",
+                    description="Unsupported severe claim.",
+                    severity="high",
+                    category="networking/ingress",
+                    deterministic=False,
+                    confidence=0.9,
+                    uncertainty_note=None,
+                    evidence_classification="model_inferred",
+                    evidence_refs=[],
+                    skill_id=None,
+                )
+            ],
+            evidence_items=[],
+        )
+
+        self.assertEqual(
+            report["findings"][0]["title"],
+            "MEDIUM: unsupported severe claim",
+        )
+        self.assertNotIn("NO-GO", report["findings"][0]["title"])
+        self.assertNotIn("NO-GO", report["narrative_opening"])
+        self.assertNotIn("CRITICAL risk remains", report["narrative_explanation"])
+
+    def test_persist_analysis_report_strips_plain_language_verdict_lead_ins(
+        self,
+    ) -> None:
+        parse_batch = ParseBatchResult(
+            files=[
+                ParsedFileResult(
+                    file_name="plan.json",
+                    tool="terraform",
+                    status="parsed",
+                    changes=[],
+                )
+            ]
+        )
+        assessment = RiskAssessment(
+            score=72,
+            severity="high",
+            recommendation="no-go",
+            top_risk="NO-GO deployment review remains blocked.",
+            contributors=[],
+            interaction_risks=[],
+            partial_context=False,
+            warnings=[],
+        )
+        narrative = NarrativeResult(
+            opening_sentence="NO-GO deployment review remains blocked.",
+            explanation="CRITICAL database exposure remains without deterministic evidence.",
+            guidance=[],
+            degraded=False,
+            warnings=[],
+        )
+
+        report = report_service_module.persist_analysis_report(
+            parse_batch,
+            assessment,
+            narrative,
+            findings=[
+                Finding(
+                    finding_id="finding-plain-language-verdict-title",
+                    analysis_id=0,
+                    title="HIGH ingress exposure requires review",
+                    description="Unsupported ingress exposure.",
+                    severity="high",
+                    category="networking/ingress",
+                    deterministic=False,
+                    confidence=0.9,
+                    uncertainty_note=None,
+                    evidence_classification="model_inferred",
+                    evidence_refs=[],
+                    skill_id=None,
+                )
+            ],
+            evidence_items=[],
+        )
+
+        self.assertEqual(
+            report["findings"][0]["title"],
+            "MEDIUM: ingress exposure requires review",
+        )
+        self.assertNotIn("HIGH", report["findings"][0]["title"])
+        self.assertNotIn("NO-GO", report["narrative_opening"])
+        self.assertNotIn("CRITICAL database exposure", report["narrative_explanation"])
+
+    def test_persist_analysis_report_preserves_severe_finding_with_deterministic_evidence(
+        self,
+    ) -> None:
+        parse_batch = ParseBatchResult(
+            files=[
+                ParsedFileResult(
+                    file_name="plan.json",
+                    tool="terraform",
+                    status="parsed",
+                    changes=[],
+                )
+            ]
+        )
+        assessment = RiskAssessment(
+            score=72,
+            severity="high",
+            recommendation="no-go",
+            top_risk="Deterministic severe risk.",
+            contributors=[],
+            interaction_risks=[],
+            partial_context=False,
+            warnings=[],
+        )
+        narrative = NarrativeResult(
+            opening_sentence="NO-GO: deterministic severe risk.",
+            explanation="The linked plan evidence supports the severe finding.",
+            guidance=[],
+            degraded=False,
+            warnings=[],
+        )
+
+        report = report_service_module.persist_analysis_report(
+            parse_batch,
+            assessment,
+            narrative,
+            findings=[
+                Finding(
+                    finding_id="finding-high",
+                    analysis_id=0,
+                    title="HIGH: aws_security_group.main",
+                    description="Security group changes can affect production ingress.",
+                    severity="high",
+                    category="networking/ingress",
+                    deterministic=True,
+                    confidence=1.0,
+                    uncertainty_note=None,
+                    evidence_refs=["ev-001"],
+                    skill_id=None,
+                )
+            ],
+            evidence_items=[
+                EvidenceItem(
+                    evidence_id="ev-001",
+                    analysis_id=0,
+                    finding_id="pending:change-1",
+                    source_type="artifact",
+                    source_ref=(
+                        "terraform://plan.json#aws_security_group.main?action=modify"
+                    ),
+                    summary="Terraform changed a security group.",
+                    severity_hint="high",
+                    deterministic=True,
+                    confidence=1.0,
+                    related_change_ids=["change-1"],
+                )
+            ],
+        )
+
+        self.assertEqual(report["findings"][0]["severity"], "high")
+        self.assertEqual(
+            report["findings"][0]["evidence_classification"],
+            "deterministic",
+        )
+        self.assertNotIn("Evidence Law downgraded", " ".join(report["warnings"]))
+
+    def test_persist_analysis_report_preserves_external_deterministic_severe_finding(
+        self,
+    ) -> None:
+        parse_batch = ParseBatchResult(
+            files=[
+                ParsedFileResult(
+                    file_name="scanner.json",
+                    tool="terraform",
+                    status="parsed",
+                    changes=[],
+                )
+            ]
+        )
+        assessment = RiskAssessment(
+            score=72,
+            severity="high",
+            recommendation="no-go",
+            top_risk="HIGH: External scanner high risk.",
+            contributors=[],
+            interaction_risks=[],
+            partial_context=False,
+            warnings=[],
+        )
+        narrative = NarrativeResult(
+            opening_sentence="NO-GO: external scanner high risk.",
+            explanation="External scanner evidence supports the severe finding.",
+            guidance=[],
+            degraded=False,
+            warnings=[],
+        )
+
+        report = report_service_module.persist_analysis_report(
+            parse_batch,
+            assessment,
+            narrative,
+            findings=[
+                Finding(
+                    finding_id="finding-external-high",
+                    analysis_id=0,
+                    title="HIGH: External scanner high risk.",
+                    description="External scanner reported a deterministic high risk.",
+                    severity="high",
+                    category="external/scanner",
+                    deterministic=False,
+                    confidence=0.91,
+                    uncertainty_note=None,
+                    evidence_classification="model_inferred",
+                    evidence_refs=["ev-external-high"],
+                    skill_id=None,
+                )
+            ],
+            evidence_items=[
+                EvidenceItem(
+                    evidence_id="ev-external-high",
+                    analysis_id=0,
+                    finding_id="pending:scanner-1",
+                    source_type="external_scanner",
+                    source_ref="scanner://sast.json#rule.high?action=flag",
+                    summary="External scanner flagged a high risk.",
+                    severity_hint="high",
+                    deterministic=True,
+                    confidence=1.0,
+                    related_change_ids=["scanner-1"],
+                )
+            ],
+        )
+
+        self.assertEqual(report["severity"], "high")
+        self.assertEqual(report["findings"][0]["severity"], "high")
+        self.assertTrue(report["findings"][0]["deterministic"])
+        self.assertEqual(report["findings"][0]["evidence_classification"], "external")
 
     def test_persist_analysis_report_rejects_unmatched_single_finding_evidence(
         self,
@@ -989,6 +3543,7 @@ class ReportServiceTests(unittest.TestCase):
             top_risk="prod/network/plan.json changed aws_security_group.main and is the highest-impact change.",
             contributors=[
                 RiskContributor(
+                    evidence_id="ev-001",
                     source_file="prod/network/plan.json",
                     tool="terraform",
                     resource_id="aws_security_group.main",
@@ -1312,13 +3867,15 @@ class ReportServiceTests(unittest.TestCase):
 
         fetched = report_service_module.fetch_analysis_report(persisted["id"])
         self.assertIsNotNone(fetched)
-        self.assertEqual(fetched["risk_score"], 42)
+        self.assertEqual(fetched["risk_score"], 70)
+        self.assertEqual(fetched["severity"], "high")
+        self.assertEqual(fetched["recommendation"], "no-go")
         self.assertEqual(fetched["audit"]["source_interface"], "api")
         self.assertEqual(fetched["audit"]["files_analyzed"], ["plan.json"])
-        self.assertEqual(
-            fetched["narrative_explanation"],
-            "The deployment widens database access and should be reviewed.",
+        self.assertIn(
+            "Deterministic severe risk remains", fetched["narrative_explanation"]
         )
+        self.assertIn("Evidence Law promoted", fetched["narrative_explanation"])
         self.assertEqual(fetched["assessment_source"], "heuristic-only")
         self.assertEqual(fetched["narrative_source"], "llm")
         self.assertEqual(fetched["report_schema_version"], "v2")
@@ -2756,7 +5313,8 @@ class ReportServiceTests(unittest.TestCase):
         assert comparison is not None
         self.assertEqual(comparison["previous_report"]["id"], previous["id"])
         self.assertEqual(comparison["current_report"]["id"], current["id"])
-        self.assertEqual(comparison["risk_score_delta"], 29)
+        self.assertEqual(comparison["current_report"]["risk_score"], 90)
+        self.assertEqual(comparison["risk_score_delta"], 48)
         self.assertEqual(
             comparison["findings"]["added"][0]["title"], "HIGH: aws_db_instance.main"
         )
@@ -3735,6 +6293,37 @@ class ReportServiceTests(unittest.TestCase):
             parse_batch,
             assessment,
             narrative,
+            findings=[
+                Finding(
+                    finding_id="finding-dashboard-high",
+                    analysis_id=0,
+                    title="HIGH: aws_security_group.main",
+                    description="Security group changes can affect production ingress.",
+                    severity="high",
+                    category="networking/ingress",
+                    deterministic=True,
+                    confidence=1.0,
+                    uncertainty_note=None,
+                    evidence_refs=["ev-dashboard-high"],
+                    skill_id=None,
+                )
+            ],
+            evidence_items=[
+                EvidenceItem(
+                    evidence_id="ev-dashboard-high",
+                    analysis_id=0,
+                    finding_id="pending:change-1",
+                    source_type="artifact",
+                    source_ref=(
+                        "terraform://plan.json#aws_security_group.main?action=modify"
+                    ),
+                    summary="Terraform changed a security group.",
+                    severity_hint="high",
+                    deterministic=True,
+                    confidence=1.0,
+                    related_change_ids=["change-1"],
+                )
+            ],
             audit_context={
                 "source_interface": "ui",
                 "trigger_type": "dashboard_upload",
@@ -3753,6 +6342,382 @@ class ReportServiceTests(unittest.TestCase):
         self.assertEqual(active["report_schema_version"], "v2")
         self.assertEqual(active["skills_applied"], ["git", "terraform"])
         self.assertGreater(active["dashboard_remaining_seconds"], 0)
+
+    def test_persist_analysis_report_backfills_supported_severe_top_risk_contributors(
+        self,
+    ) -> None:
+        parse_batch = ParseBatchResult(
+            files=[
+                ParsedFileResult(
+                    file_name="plan.json",
+                    tool="terraform",
+                    status="parsed",
+                    changes=[
+                        UnifiedChange(
+                            source_file="plan.json",
+                            tool="terraform",
+                            resource_id="aws_security_group.main",
+                            action="modify",
+                            summary="Terraform changed a security group.",
+                        )
+                    ],
+                )
+            ]
+        )
+        assessment = RiskAssessment(
+            score=75,
+            severity="high",
+            recommendation="no-go",
+            top_risk="HIGH: security group exposure risk.",
+            top_risk_contributors=[],
+            contributors=[
+                RiskContributor(
+                    evidence_id="ev-high",
+                    source_file="plan.json",
+                    tool="terraform",
+                    resource_id="aws_security_group.main",
+                    action="modify",
+                    contribution=75,
+                    summary="Terraform changed a security group.",
+                    severity="high",
+                    reasoning="Security group changes can affect production ingress.",
+                )
+            ],
+            interaction_risks=[],
+            partial_context=False,
+            warnings=[],
+        )
+        narrative = NarrativeResult(
+            opening_sentence="NO-GO: deterministic severe risk.",
+            explanation="The linked plan evidence supports the severe finding.",
+            guidance=[],
+            degraded=False,
+            warnings=[],
+        )
+
+        report = report_service_module.persist_analysis_report(
+            parse_batch,
+            assessment,
+            narrative,
+            findings=[
+                Finding(
+                    finding_id="finding-high",
+                    analysis_id=0,
+                    title="HIGH: aws_security_group.main",
+                    description="Security group changes can affect production ingress.",
+                    severity="high",
+                    category="networking/ingress",
+                    deterministic=True,
+                    confidence=1.0,
+                    uncertainty_note=None,
+                    evidence_refs=["ev-high"],
+                    skill_id=None,
+                )
+            ],
+            evidence_items=[
+                EvidenceItem(
+                    evidence_id="ev-high",
+                    analysis_id=0,
+                    finding_id="pending:change-1",
+                    source_type="artifact",
+                    source_ref=(
+                        "terraform://plan.json#aws_security_group.main?action=modify"
+                    ),
+                    summary="Terraform changed a security group.",
+                    severity_hint="high",
+                    deterministic=True,
+                    confidence=1.0,
+                    related_change_ids=["change-1"],
+                )
+            ],
+        )
+
+        persisted_evidence_id = report["evidence_items"][0]["evidence_id"]
+        self.assertEqual(report["top_risk_contributors"], [persisted_evidence_id])
+        self.assertEqual(
+            report["contributors"][0]["evidence_id"], persisted_evidence_id
+        )
+
+    def test_persist_analysis_report_rewrites_cross_finding_top_risk_contributors(
+        self,
+    ) -> None:
+        parse_batch = ParseBatchResult(
+            files=[
+                ParsedFileResult(
+                    file_name="plan.json",
+                    tool="terraform",
+                    status="parsed",
+                    changes=[
+                        UnifiedChange(
+                            source_file="plan.json",
+                            tool="terraform",
+                            resource_id="aws_security_group.main",
+                            action="modify",
+                            summary="Terraform changed a security group.",
+                        ),
+                        UnifiedChange(
+                            source_file="plan.json",
+                            tool="terraform",
+                            resource_id="aws_db_instance.primary",
+                            action="modify",
+                            summary="Terraform changed a database.",
+                        ),
+                    ],
+                )
+            ]
+        )
+        assessment = RiskAssessment(
+            score=92,
+            severity="critical",
+            recommendation="no-go",
+            top_risk="CRITICAL: security group exposure risk.",
+            top_risk_contributors=["ev-critical", "ev-high"],
+            contributors=[
+                RiskContributor(
+                    evidence_id="ev-critical",
+                    source_file="plan.json",
+                    tool="terraform",
+                    resource_id="aws_security_group.main",
+                    action="modify",
+                    contribution=80,
+                    summary="Terraform changed a security group.",
+                    severity="critical",
+                    reasoning="Critical ingress exposure.",
+                ),
+                RiskContributor(
+                    evidence_id="ev-high",
+                    source_file="plan.json",
+                    tool="terraform",
+                    resource_id="aws_db_instance.primary",
+                    action="modify",
+                    contribution=50,
+                    summary="Terraform changed a database.",
+                    severity="high",
+                    reasoning="High database exposure.",
+                ),
+                RiskContributor(
+                    source_file="plan.json",
+                    tool="terraform",
+                    resource_id="aws_iam_role.unlinked",
+                    action="modify",
+                    contribution=40,
+                    summary="Unlinked stale severe rationale.",
+                    severity="critical",
+                    reasoning="This contributor is not tied to selected evidence.",
+                ),
+                RiskContributor(
+                    source_file="plan.json",
+                    tool="terraform",
+                    resource_id="aws_iam_policy.unlinked",
+                    action="modify",
+                    contribution=0,
+                    summary="CRITICAL: unsupported inferred admin access.",
+                    reasoning="This zero-impact stale rationale is not parser metadata.",
+                ),
+                RiskContributor(
+                    source_file="plan.json",
+                    tool="terraform",
+                    resource_id="data.aws_ami.selected",
+                    action="read",
+                    contribution=0,
+                    summary="Terraform read a data source.",
+                    metadata={"unknown_after_apply": ["id"]},
+                ),
+            ],
+            interaction_risks=[],
+            partial_context=False,
+            warnings=[],
+        )
+        narrative = NarrativeResult(
+            opening_sentence="NO-GO: deterministic critical risk.",
+            explanation="The linked plan evidence supports the critical finding.",
+            guidance=[],
+            degraded=False,
+            warnings=[],
+        )
+
+        report = report_service_module.persist_analysis_report(
+            parse_batch,
+            assessment,
+            narrative,
+            findings=[
+                Finding(
+                    finding_id="finding-critical",
+                    analysis_id=0,
+                    title="CRITICAL: aws_security_group.main",
+                    description="Security group changes can affect production ingress.",
+                    severity="critical",
+                    category="networking/ingress",
+                    deterministic=True,
+                    confidence=1.0,
+                    uncertainty_note=None,
+                    evidence_refs=["ev-critical"],
+                    skill_id=None,
+                ),
+                Finding(
+                    finding_id="finding-high",
+                    analysis_id=0,
+                    title="HIGH: aws_db_instance.primary",
+                    description="Database changes can affect production data.",
+                    severity="high",
+                    category="data/service",
+                    deterministic=True,
+                    confidence=1.0,
+                    uncertainty_note=None,
+                    evidence_refs=["ev-high"],
+                    skill_id=None,
+                ),
+            ],
+            evidence_items=[
+                EvidenceItem(
+                    evidence_id="ev-critical",
+                    analysis_id=0,
+                    finding_id="pending:change-1",
+                    source_type="artifact",
+                    source_ref=(
+                        "terraform://plan.json#aws_security_group.main?action=modify"
+                    ),
+                    summary="Terraform changed a security group.",
+                    severity_hint="critical",
+                    deterministic=True,
+                    confidence=1.0,
+                    related_change_ids=["change-1"],
+                ),
+                EvidenceItem(
+                    evidence_id="ev-high",
+                    analysis_id=0,
+                    finding_id="pending:change-2",
+                    source_type="artifact",
+                    source_ref=(
+                        "terraform://plan.json#aws_db_instance.primary?action=modify"
+                    ),
+                    summary="Terraform changed a database.",
+                    severity_hint="high",
+                    deterministic=True,
+                    confidence=1.0,
+                    related_change_ids=["change-2"],
+                ),
+            ],
+        )
+
+        critical_evidence_id = next(
+            item["evidence_id"]
+            for item in report["evidence_items"]
+            if item["resource"] == "aws_security_group.main"
+        )
+        self.assertEqual(report["top_risk_contributors"], [critical_evidence_id])
+        self.assertEqual(
+            [contributor["evidence_id"] for contributor in report["contributors"]],
+            [critical_evidence_id, None],
+        )
+        self.assertNotIn(
+            "unsupported inferred admin access",
+            " ".join(
+                str(contributor.get("summary") or "")
+                for contributor in report["contributors"]
+            ),
+        )
+        self.assertEqual(
+            report["contributors"][1]["metadata"]["unknown_after_apply"],
+            ["id"],
+        )
+
+    def test_persist_analysis_report_preserves_medium_evidence_links_when_cleaning_verdict_text(
+        self,
+    ) -> None:
+        parse_batch = ParseBatchResult(
+            files=[
+                ParsedFileResult(
+                    file_name="plan.json",
+                    tool="terraform",
+                    status="parsed",
+                    changes=[
+                        UnifiedChange(
+                            source_file="plan.json",
+                            tool="terraform",
+                            resource_id="aws_security_group.main",
+                            action="modify",
+                            summary="Terraform changed a security group.",
+                        )
+                    ],
+                )
+            ]
+        )
+        assessment = RiskAssessment(
+            score=50,
+            severity="medium",
+            recommendation="caution",
+            top_risk="NO-GO because security group review remains pending.",
+            top_risk_contributors=["ev-medium"],
+            contributors=[
+                RiskContributor(
+                    evidence_id="ev-medium",
+                    source_file="plan.json",
+                    tool="terraform",
+                    resource_id="aws_security_group.main",
+                    action="modify",
+                    contribution=20,
+                    summary="Terraform changed a security group.",
+                    severity="medium",
+                    reasoning="Review remains pending.",
+                )
+            ],
+            interaction_risks=[],
+            partial_context=False,
+            warnings=[],
+        )
+        narrative = NarrativeResult(
+            opening_sentence="CRITICAL due to stale narrative copy.",
+            explanation="NO-GO because stale narrative copy remains.",
+            guidance=[],
+            degraded=False,
+            warnings=[],
+        )
+
+        report = report_service_module.persist_analysis_report(
+            parse_batch,
+            assessment,
+            narrative,
+            findings=[
+                Finding(
+                    finding_id="finding-medium",
+                    analysis_id=0,
+                    title="MEDIUM: aws_security_group.main",
+                    description="Security group changes require review.",
+                    severity="medium",
+                    category="networking/ingress",
+                    deterministic=True,
+                    confidence=1.0,
+                    uncertainty_note=None,
+                    evidence_refs=["ev-medium"],
+                    skill_id=None,
+                )
+            ],
+            evidence_items=[
+                EvidenceItem(
+                    evidence_id="ev-medium",
+                    analysis_id=0,
+                    finding_id="pending:change-1",
+                    source_type="artifact",
+                    source_ref=(
+                        "terraform://plan.json#aws_security_group.main?action=modify"
+                    ),
+                    summary="Terraform changed a security group.",
+                    severity_hint="medium",
+                    deterministic=True,
+                    confidence=1.0,
+                    related_change_ids=["change-1"],
+                )
+            ],
+        )
+
+        persisted_evidence_id = report["evidence_items"][0]["evidence_id"]
+        self.assertNotIn("NO-GO", report["top_risk"])
+        self.assertNotIn("CRITICAL due to", report["narrative_opening"])
+        self.assertEqual(report["top_risk_contributors"], [persisted_evidence_id])
+        self.assertEqual(
+            report["contributors"][0]["evidence_id"], persisted_evidence_id
+        )
 
     def test_fetch_filtered_history_page_omits_evidence_payloads(self) -> None:
         parse_batch = ParseBatchResult(

--- a/tests/test_services/test_report_trends.py
+++ b/tests/test_services/test_report_trends.py
@@ -14,6 +14,7 @@ import models.repositories.analysis_reports as analysis_reports_repository_modul
 import models.tables as tables_module
 import services.report_service as report_service_module
 from analysis.risk_scorer import RiskAssessment, RiskContributor
+from evidence.models import EvidenceItem, Finding
 from llm.narrator import NarrativeResult
 from parsers.base import ParseBatchResult, ParsedFileResult, UnifiedChange
 
@@ -43,6 +44,10 @@ class ReportTrendTests(unittest.TestCase):
         tool: str,
         source_interface: str = "ui",
     ) -> None:
+        evidence_id = f"ev-{tool}-{severity}"
+        finding_id = f"finding-{tool}-{severity}"
+        resource_id = f"{tool}/resource"
+        severe_report = severity in {"high", "critical"}
         parse_batch = ParseBatchResult(
             files=[
                 ParsedFileResult(
@@ -53,7 +58,7 @@ class ReportTrendTests(unittest.TestCase):
                         UnifiedChange(
                             source_file="input.json",
                             tool=tool,
-                            resource_id=f"{tool}/resource",
+                            resource_id=resource_id,
                             action="modify",
                             summary=f"{tool} change",
                         )
@@ -66,11 +71,13 @@ class ReportTrendTests(unittest.TestCase):
             severity=severity,
             recommendation=recommendation,
             top_risk=f"{tool} change",
+            top_risk_contributors=[evidence_id] if severe_report else [],
             contributors=[
                 RiskContributor(
+                    evidence_id=evidence_id if severe_report else None,
                     source_file="input.json",
                     tool=tool,
-                    resource_id=f"{tool}/resource",
+                    resource_id=resource_id,
                     action="modify",
                     contribution=12,
                     summary=f"{tool} change",
@@ -92,6 +99,39 @@ class ReportTrendTests(unittest.TestCase):
             assessment,
             narrative,
             audit_context={"source_interface": source_interface},
+            findings=[
+                Finding(
+                    finding_id=finding_id,
+                    analysis_id=0,
+                    title=f"{severity.upper()}: {tool} change",
+                    description=f"{tool} change",
+                    severity=severity,
+                    category="generic infrastructure",
+                    deterministic=True,
+                    confidence=1.0,
+                    uncertainty_note=None,
+                    evidence_refs=[evidence_id],
+                    skill_id=None,
+                )
+            ]
+            if severe_report
+            else None,
+            evidence_items=[
+                EvidenceItem(
+                    evidence_id=evidence_id,
+                    analysis_id=0,
+                    finding_id=finding_id,
+                    source_type="artifact",
+                    source_ref=f"{tool}://input.json#{resource_id}?action=modify",
+                    summary=f"{tool} change",
+                    severity_hint=severity,
+                    deterministic=True,
+                    confidence=1.0,
+                    related_change_ids=["change-1"],
+                )
+            ]
+            if severe_report
+            else None,
         )
 
     def test_fetch_risk_trends_summarizes_severity_and_tools(self) -> None:

--- a/tests/test_ui/test_app_shell.py
+++ b/tests/test_ui/test_app_shell.py
@@ -25,7 +25,7 @@ import ui.theme as theme_module
 from analysis.blast_radius import BlastRadiusResult, ImpactNode
 from analysis.rollback_planner import RollbackPlan, RollbackStep
 from analysis.risk_scorer import RiskAssessment, RiskContributor
-from evidence.models import Finding
+from evidence.models import EvidenceItem, Finding
 from fastapi.testclient import TestClient
 from llm.narrator import NarrativeResult
 from parsers.base import ParseBatchResult, ParseIssue, ParsedFileResult, UnifiedChange
@@ -364,6 +364,22 @@ class DashboardShellTests(unittest.TestCase):
                     skill_id=None,
                 )
             ],
+            evidence_items=[
+                EvidenceItem(
+                    evidence_id="ev-001",
+                    analysis_id=0,
+                    finding_id="pending:change-1",
+                    source_type="artifact",
+                    source_ref=(
+                        "terraform://plan.json#aws_security_group.main?action=modify"
+                    ),
+                    summary="Terraform changed a security group.",
+                    severity_hint="critical",
+                    deterministic=True,
+                    confidence=1.0,
+                    related_change_ids=["change-1"],
+                )
+            ],
             audit_context={
                 "source_interface": "ui",
                 "trigger_type": "dashboard_upload",
@@ -379,7 +395,7 @@ class DashboardShellTests(unittest.TestCase):
         self.assertIn("5-second verdict", response.text)
         self.assertIn("Risk score", response.text)
         self.assertIn("dw-verdict-score-value", response.text)
-        self.assertIn('"text":"88"', response.text)
+        self.assertIn('"text":"90"', response.text)
         self.assertIn("STRONG CONTEXT", response.text)
         self.assertNotIn("Know the risk before", response.text)
         self.assertEqual(response.text.count("5-second verdict"), 1)

--- a/tests/test_ui/test_history_page.py
+++ b/tests/test_ui/test_history_page.py
@@ -19,7 +19,7 @@ import services.project_service as project_service_module
 import ui.routes.history as history_module
 from analysis.risk_scorer import RiskAssessment, RiskContributor
 from analysis.rollback_planner import RollbackPlan, RollbackStep
-from evidence.models import Finding
+from evidence.models import EvidenceItem, Finding
 from fastapi.testclient import TestClient
 from llm.narrator import NarrativeResult
 from parsers.base import ParseBatchResult, ParsedFileResult, UnifiedChange
@@ -71,7 +71,7 @@ class HistoryPageRenderingTests(unittest.TestCase):
     def _persist_report(
         self,
         *,
-        score: int = 88,
+        score: int = 90,
         severity: str = "critical",
         recommendation: str = "no-go",
         top_risk: str = "Security group exposure risk",
@@ -110,6 +110,7 @@ class HistoryPageRenderingTests(unittest.TestCase):
             context_completeness=context_completeness or {},
             contributors=[
                 RiskContributor(
+                    evidence_id="ev-001",
                     source_file="plan.json",
                     tool="terraform",
                     resource_id="aws_security_group.main",
@@ -176,6 +177,22 @@ class HistoryPageRenderingTests(unittest.TestCase):
                     skill_id=None,
                 )
             ],
+            evidence_items=[
+                EvidenceItem(
+                    evidence_id="ev-001",
+                    analysis_id=0,
+                    finding_id="pending:change-1",
+                    source_type="artifact",
+                    source_ref=(
+                        "terraform://plan.json#aws_security_group.main?action=modify"
+                    ),
+                    summary="Terraform changed a security group.",
+                    severity_hint=severity,
+                    deterministic=True,
+                    confidence=1.0,
+                    related_change_ids=["change-1"],
+                )
+            ],
             audit_context={"source_interface": "ui"},
         )
 
@@ -222,7 +239,7 @@ class HistoryPageRenderingTests(unittest.TestCase):
         self.assertEqual(compare_response.status_code, 200)
         self.assertIn("Comparison with report #1", compare_response.text)
         self.assertIn("Risk score delta", compare_response.text)
-        self.assertIn("+46", compare_response.text)
+        self.assertIn("+48", compare_response.text)
         self.assertIn("MEDIUM → CRITICAL", compare_response.text)
         self.assertIn("Topology freshness", compare_response.text)
         self.assertIn("12 days old", compare_response.text)
@@ -273,7 +290,7 @@ class HistoryPageRenderingTests(unittest.TestCase):
         self.assertEqual(compare_response.status_code, 200)
         self.assertIn("Comparison with report #1", compare_response.text)
         self.assertIn("Risk score delta", compare_response.text)
-        self.assertIn("+46", compare_response.text)
+        self.assertIn("+48", compare_response.text)
         self.assertIn("MEDIUM → CRITICAL", compare_response.text)
         self.assertIn("Topology freshness", compare_response.text)
         self.assertIn("12 days old", compare_response.text)
@@ -454,7 +471,7 @@ class HistoryPageRenderingTests(unittest.TestCase):
 
         self.assertEqual(response.status_code, 200)
         self.assertIn("Rescan diff", response.text)
-        self.assertIn("+46 risk vs report #1", response.text)
+        self.assertIn("+48 risk vs report #1", response.text)
         self.assertIn("MEDIUM → CRITICAL", response.text)
         self.assertIn("CAUTION → NO-GO", response.text)
 


### PR DESCRIPTION
Story 2.5 closes the gap between advisory report generation and persisted report truth by ensuring high and critical verdicts remain backed by linked deterministic evidence across service and repository write paths. The implementation reconciles unsupported or stale severe verdict metadata, canonicalizes shared evidence ownership, and preserves browser-visible report review behavior with regression coverage.

Constraint: Story 2.5 requires high/critical persisted findings and report verdicts to have deterministic evidence support.
Constraint: Existing BMad implementation artifacts are partially ignored, so only tracked closeout files are committed.
Rejected: Trust service-only validation | direct repository writes can bypass service reconciliation.
Rejected: Reject all shared evidence references | service-supported shared evidence is required for multi-finding reports.
Confidence: high
Scope-risk: moderate
Directive: Do not relax severe-verdict persistence validation without adding direct repository and service regression coverage.
Tested: ./.venv/bin/python -m unittest discover -q; ./.venv/bin/ruff check .; ./.venv/bin/ruff format --check .; APP_PORT=18080 npm run test:ui-review; git diff --check
Not-tested: Manual browser exploratory testing outside the automated WebKit review flow

## What does this PR do?

<!-- Brief description of changes -->

## Type of change
- [ ] Feature (new functionality)
- [ ] Bugfix (non-breaking fix)
- [ ] Release preparation
- [ ] Hotfix (critical production fix)
- [ ] Docs / refactor / chore

## Checklist
- [ ] I have followed the branch naming convention
- [ ] Tests pass locally (`pytest tests/ -v`)
- [ ] Linting passes (`ruff check .`)
- [ ] Docker build succeeds
- [ ] I have updated docs if needed
- [ ] No secrets or .env values committed

## Related issue
Closes #