### PR TITLE
Expose uncertainty when context is incomplete

### DIFF
--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -1,5 +1,5 @@
 # generated: 2026-05-01
-# last_updated: 2026-05-10
+# last_updated: 2026-05-11
 # project: deploywhisper
 # project_key: NOKEY
 # tracking_system: file-system
@@ -35,7 +35,7 @@
 # - Dev moves story to review, then runs code-review
 
 generated: 2026-05-01
-last_updated: 2026-05-10
+last_updated: 2026-05-11
 project: deploywhisper
 project_key: NOKEY
 tracking_system: file-system
@@ -64,7 +64,7 @@ development_status:
   2-3-evidence-item-model-and-extraction: done
   2-4-finding-model-and-evidence-links: done
   2-5-evidence-law-runtime-gate: review
-  2-6-confidence-uncertainty-and-insufficient-context: ready-for-dev
+  2-6-confidence-uncertainty-and-insufficient-context: done
   2-7-narrative-after-scoring-and-degraded-fallback: ready-for-dev
   2-8-report-schema-versioning: ready-for-dev
   2-9-durable-report-persistence-and-audit-metadata: ready-for-dev

--- a/analysis/risk_scorer.py
+++ b/analysis/risk_scorer.py
@@ -20,6 +20,7 @@ from parsers.base import (
     normalize_change_action,
 )
 from services.settings_service import resolve_provider_runtime
+from services.topology_service import STALE_AFTER_DAYS
 
 RiskSeverity = Literal["low", "medium", "high", "critical"]
 DeployRecommendation = Literal["go", "caution", "no-go"]
@@ -36,6 +37,14 @@ SEVERITY_SCORE: dict[RiskSeverity, int] = {
     "high": 72,
     "critical": 92,
 }
+INSUFFICIENT_CONTEXT_WARNING = (
+    "Insufficient context: missing or stale topology, parser coverage, evidence "
+    "coverage, or incident history requires reviewer verification before treating "
+    "this result as low risk."
+)
+CONTEXT_REGENERATION_TODO = (
+    "Re-run analysis after improving topology, parser, evidence, or incident context."
+)
 ACTION_BASE_SEVERITY = {
     "no-op": "low",
     "apply": "low",
@@ -106,6 +115,9 @@ class RiskAssessment(BaseModel):
     recommendation: DeployRecommendation = Field(
         ..., description="Advisory recommendation"
     )
+    confidence: float = Field(
+        default=1.0, ge=0.0, le=1.0, description="Overall verdict confidence"
+    )
     top_risk: str = Field(..., description="Most important risk summary")
     top_risk_contributors: list[str] = Field(
         default_factory=list,
@@ -127,6 +139,71 @@ class RiskAssessment(BaseModel):
         default="heuristic-only",
         description="Whether the structured risk assessment was heuristic-only or LLM-assisted",
     )
+
+
+def _context_confidence_level(context_score: float) -> str:
+    if context_score >= 0.85:
+        return "high"
+    if context_score >= 0.7:
+        return "medium"
+    return "low"
+
+
+def _context_followup_todos(context: ContextCompleteness) -> list[str]:
+    todos = list(context.context_todos)
+    if context.topology_freshness_days is None:
+        todos.append("Import or refresh topology context for this project/workspace.")
+    elif context.topology_freshness_days > STALE_AFTER_DAYS:
+        todos.append("Refresh stale topology context for this project/workspace.")
+    if context.incident_index_size == 0:
+        todos.append("Import relevant incident history for this project/workspace.")
+    if context.parser_success_rate < 1.0:
+        todos.append("Review parser errors and resubmit supported artifacts.")
+    if context.evidence_success_rate < 1.0:
+        todos.append("Review evidence extraction gaps for supported artifacts.")
+    if not todos:
+        todos.append(CONTEXT_REGENERATION_TODO)
+    return list(dict.fromkeys(todos))
+
+
+def apply_context_uncertainty(assessment: RiskAssessment) -> RiskAssessment:
+    """Apply context completeness constraints to the overall verdict."""
+    context = assessment.context_completeness
+    if context.context_score < 0.7:
+        context.insufficient_context = True
+        if not context.uncertainty:
+            context.uncertainty = (
+                "Insufficient context: missing or stale topology, parser coverage, "
+                "evidence coverage, or incident history prevents a confident "
+                "low-risk verdict."
+            )
+    context.confidence_level = (
+        "low"
+        if context.insufficient_context
+        else _context_confidence_level(context.context_score)
+    )
+    if context.insufficient_context and not context.context_todos:
+        context.context_todos = _context_followup_todos(context)
+    assessment.confidence = round(
+        min(float(assessment.confidence), context.context_score),
+        2,
+    )
+    if not context.insufficient_context:
+        return assessment
+
+    if INSUFFICIENT_CONTEXT_WARNING not in assessment.warnings:
+        assessment.warnings.append(INSUFFICIENT_CONTEXT_WARNING)
+    if assessment.recommendation == "go":
+        assessment.recommendation = "caution"
+    if assessment.severity == "low":
+        assessment.severity = "medium"
+        assessment.score = max(assessment.score, SEVERITY_SCORE["medium"])
+    if not assessment.top_risk.startswith("INSUFFICIENT CONTEXT:"):
+        assessment.top_risk = (
+            "INSUFFICIENT CONTEXT: Missing or stale context prevents a confident "
+            f"low-risk verdict. {assessment.top_risk}"
+        )
+    return assessment
 
 
 def _normalize_action(action: str) -> str:

--- a/api/schemas.py
+++ b/api/schemas.py
@@ -286,6 +286,9 @@ class PersistedReportData(BaseModel):
     risk_score: int
     severity: str
     recommendation: str
+    confidence: float = Field(
+        ..., ge=0.0, le=1.0, description="Overall verdict confidence"
+    )
     top_risk: str
     report_schema_version: str = Field(
         ..., description="Persisted report schema version"
@@ -730,6 +733,12 @@ class ContextCompletenessData(BaseModel):
     incident_index_size: int = Field(
         default=0, description="Number of incidents available for similarity matching"
     )
+    evidence_success_rate: float = Field(
+        default=1.0,
+        ge=0.0,
+        le=1.0,
+        description="Fraction of material changes represented by evidence items",
+    )
     parser_success_rate: float = Field(
         default=1.0, description="Fraction of analyzed files parsed successfully"
     )
@@ -740,6 +749,21 @@ class ContextCompletenessData(BaseModel):
     context_score: float = Field(
         default=1.0, description="Aggregate context completeness score between 0 and 1"
     )
+    confidence_level: Literal["high", "medium", "low"] = Field(
+        default="high",
+        description="Human-readable confidence level derived from context completeness",
+    )
+    uncertainty: str | None = Field(
+        default=None, description="Reviewer-facing uncertainty explanation"
+    )
+    context_todos: list[str] = Field(
+        default_factory=list,
+        description="Actionable context improvements for future reports",
+    )
+    insufficient_context: bool = Field(
+        default=False,
+        description="Whether context is too weak for a confident low-risk verdict",
+    )
 
 
 class AssessmentData(BaseModel):
@@ -747,6 +771,9 @@ class AssessmentData(BaseModel):
     severity: RiskSeverity = Field(..., description="Severity classification")
     recommendation: DeployRecommendation = Field(
         ..., description="Advisory recommendation"
+    )
+    confidence: float = Field(
+        ..., ge=0.0, le=1.0, description="Overall verdict confidence"
     )
     top_risk: str = Field(..., description="Most important risk summary")
     top_risk_contributors: list[str] = Field(
@@ -1212,6 +1239,7 @@ def build_analysis_run_data(
             score=assessment.score,
             severity=assessment.severity,
             recommendation=assessment.recommendation,
+            confidence=assessment.confidence,
             top_risk=assessment.top_risk,
             top_risk_contributors=list(assessment.top_risk_contributors),
             context_completeness=_copy_model(

--- a/docs/schemas/report-v2.md
+++ b/docs/schemas/report-v2.md
@@ -74,7 +74,29 @@ without storing raw plan internals in a separate contract.
   "report_schema_version": "v2",
   "severity": "high",
   "recommendation": "no-go",
+  "confidence": 0.62,
   "top_risk": "Security group exposure risk",
+  "context_completeness": {
+    "topology_freshness_days": null,
+    "topology_last_imported_at": null,
+    "incident_index_size": 0,
+    "evidence_success_rate": 0.5,
+    "parser_success_rate": 0.5,
+    "parser_success_by_tool": {
+      "terraform": 1.0,
+      "unsupported": 0.0
+    },
+    "context_score": 0.22,
+    "confidence_level": "low",
+    "uncertainty": "Insufficient context: missing or stale topology, parser coverage, evidence coverage, or incident history prevents a confident low-risk verdict.",
+    "context_todos": [
+      "Import or refresh topology context for this project/workspace.",
+      "Import relevant incident history for this project/workspace.",
+      "Review evidence extraction gaps for supported artifacts.",
+      "Review parser errors and resubmit supported artifacts."
+    ],
+    "insufficient_context": true
+  },
   "rollback_plan": {
     "complexity": "medium",
     "complexity_score": 3,
@@ -212,9 +234,14 @@ without storing raw plan internals in a separate contract.
 
 - Explicit `report_schema_version`
 - evidence-backed findings and `evidence_items`
-- context completeness and traceable contributors
+- context completeness, context TODOs, insufficient-context signals, and traceable contributors
+- report-level confidence derived from available context
 - persisted rollback plans with time estimates and complexity rationale
 - degraded narrative visibility fields
 - submission manifest payloads that record accepted, excluded, failed, partial, sensitive, provenance, and redaction status
 - durable submission manifest fallback identity/status metadata for malformed-manifest recovery
 - parser-normalized change metadata for Terraform plan JSON format and Terraform versions, module paths, replacement paths, unknown-after-apply fields, redacted fields, and unsupported resource/change/plan fields
+
+Story 2.6 adds report-level confidence, context uncertainty, evidence coverage,
+context TODOs, and insufficient-context signals as additive `v2` fields. Broader
+schema-version policy changes remain deferred to Story 2.8.

--- a/evidence/models.py
+++ b/evidence/models.py
@@ -9,6 +9,7 @@ from pydantic import BaseModel, ConfigDict, Field, field_validator, model_valida
 
 RiskSeverity = Literal["low", "medium", "high", "critical"]
 DeployRecommendation = Literal["go", "caution", "no-go"]
+ContextConfidenceLevel = Literal["high", "medium", "low"]
 EvidenceSourceType = Literal[
     "artifact",
     "topology",
@@ -73,9 +74,14 @@ class ContextCompleteness(BaseModel):
     topology_freshness_days: int | None = Field(default=None, ge=0)
     topology_last_imported_at: str | None = Field(default=None, min_length=1)
     incident_index_size: int = Field(default=0, ge=0)
+    evidence_success_rate: float = Field(default=1.0, ge=0.0, le=1.0)
     parser_success_rate: float = Field(default=1.0, ge=0.0, le=1.0)
     parser_success_by_tool: dict[str, float] = Field(default_factory=dict)
     context_score: float = Field(default=1.0, ge=0.0, le=1.0)
+    confidence_level: ContextConfidenceLevel = Field(default="high")
+    uncertainty: str | None = Field(default=None, min_length=1)
+    context_todos: list[str] = Field(default_factory=list)
+    insufficient_context: bool = Field(default=False)
 
     @field_validator("parser_success_by_tool")
     @classmethod
@@ -96,6 +102,11 @@ class ContextCompleteness(BaseModel):
                 )
             cleaned[normalized_name] = numeric_score
         return cleaned
+
+    @field_validator("context_todos")
+    @classmethod
+    def _validate_context_todos(cls, value: list[str]) -> list[str]:
+        return _validate_string_list(value)
 
 
 class SkillReference(BaseModel):

--- a/models/repositories/analysis_reports.py
+++ b/models/repositories/analysis_reports.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import math
 import re
 from datetime import UTC, datetime, timedelta
 from typing import Any
@@ -39,6 +40,13 @@ def _normalize_report_severity(severity: str) -> str:
     if normalized_severity not in _FINDING_SEVERITY_ORDER:
         raise ValueError(f"Unsupported report severity {severity!r}.")
     return normalized_severity
+
+
+def _normalize_risk_confidence(confidence: float) -> float:
+    normalized = float(confidence)
+    if not math.isfinite(normalized) or normalized < 0.0 or normalized > 1.0:
+        raise ValueError("Risk confidence must be between 0 and 1.")
+    return normalized
 
 
 def _verdict_label(value: str | None) -> str | None:
@@ -316,6 +324,7 @@ def create_analysis_report(
     severity: str,
     recommendation: str,
     top_risk: str,
+    risk_confidence: float = 1.0,
     report_schema_version: str,
     parse_summary: str,
     narrative_opening: str,
@@ -343,6 +352,7 @@ def create_analysis_report(
     evidence_payload: list[dict[str, Any]] | None = None,
 ) -> AnalysisReport:
     severity = _normalize_report_severity(severity)
+    risk_confidence = _normalize_risk_confidence(risk_confidence)
     evidence_payload = [
         _normalize_evidence_payload(evidence) for evidence in evidence_payload or []
     ]
@@ -424,7 +434,7 @@ def create_analysis_report(
         overall_severity=severity,
         recommendation=recommendation,
         score=risk_score,
-        confidence=1.0,
+        confidence=risk_confidence,
         top_risk_contributors_json=top_risk_contributors_json,
         context_completeness_json=context_completeness_json,
     )

--- a/services/analysis_service.py
+++ b/services/analysis_service.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import math
 from datetime import UTC, datetime
 from typing import Any
 from pydantic import BaseModel, Field
@@ -14,7 +15,11 @@ from analysis.incident_matcher import (
     load_incident_candidates,
 )
 from analysis.risk_engine import score_evidence
-from analysis.risk_scorer import RiskAssessment, score_changes
+from analysis.risk_scorer import (
+    RiskAssessment,
+    apply_context_uncertainty,
+    score_changes,
+)
 from analysis.rollback_planner import RollbackPlan, generate_rollback_plan
 from evidence.extractor import extract_batch_evidence
 from evidence.mappers import build_findings
@@ -289,6 +294,84 @@ def _incident_score(incident_index_size: int) -> float:
     return min(incident_index_size / 10, 1.0)
 
 
+def _context_confidence_level(context_score: float) -> str:
+    if context_score >= 0.85:
+        return "high"
+    if context_score >= 0.7:
+        return "medium"
+    return "low"
+
+
+def _context_todos(
+    *,
+    evidence_success_rate: float,
+    topology_freshness_days: int | None,
+    incident_index_size: int,
+    parser_success_rate: float,
+) -> list[str]:
+    todos: list[str] = []
+    if topology_freshness_days is None:
+        todos.append("Import or refresh topology context for this project/workspace.")
+    elif topology_freshness_days > STALE_AFTER_DAYS:
+        todos.append("Refresh stale topology context for this project/workspace.")
+    if incident_index_size == 0:
+        todos.append("Import relevant incident history for this project/workspace.")
+    if parser_success_rate < 1.0:
+        todos.append("Review parser errors and resubmit supported artifacts.")
+    if evidence_success_rate < 1.0:
+        todos.append("Review evidence extraction gaps for supported artifacts.")
+    return todos
+
+
+def _context_uncertainty(
+    *,
+    context_score: float,
+    evidence_success_rate: float,
+    topology_freshness_days: int | None,
+    incident_index_size: int,
+    parser_success_rate: float,
+) -> str | None:
+    if context_score < 0.7:
+        return (
+            "Insufficient context: missing or stale topology, parser coverage, "
+            "evidence coverage, or incident history prevents a confident "
+            "low-risk verdict."
+        )
+    weak_signals: list[str] = []
+    if topology_freshness_days is None:
+        weak_signals.append("topology context is unavailable")
+    elif topology_freshness_days > STALE_AFTER_DAYS:
+        weak_signals.append("topology context is stale")
+    if incident_index_size == 0:
+        weak_signals.append("incident history is unavailable")
+    if parser_success_rate < 1.0:
+        weak_signals.append("parser coverage is partial")
+    if evidence_success_rate < 1.0:
+        weak_signals.append("evidence coverage is partial")
+    if not weak_signals:
+        return None
+    return "Uncertainty: " + "; ".join(weak_signals) + "."
+
+
+def _evidence_success_rate(
+    changes: list[UnifiedChange], evidence_items: list[EvidenceItem]
+) -> float:
+    material_change_ids = {
+        change.change_id
+        for change in changes
+        if change.change_id and not is_non_mutating_action(change.action)
+    }
+    if not material_change_ids:
+        return 1.0
+    covered_change_ids = {
+        change_id
+        for item in evidence_items
+        for change_id in item.related_change_ids
+        if change_id in material_change_ids
+    }
+    return len(covered_change_ids) / len(material_change_ids)
+
+
 def _parser_success_by_tool(parse_batch: ParseBatchResult) -> dict[str, float]:
     tool_totals: dict[str, int] = {}
     tool_successes: dict[str, int] = {}
@@ -307,6 +390,7 @@ def _parser_success_by_tool(parse_batch: ParseBatchResult) -> dict[str, float]:
 def _build_context_completeness(
     parse_batch: ParseBatchResult,
     *,
+    evidence_items: list[EvidenceItem] | None = None,
     project_id: int | None = None,
     project_key: str | None = None,
     workspace_id: int | None = None,
@@ -330,28 +414,45 @@ def _build_context_completeness(
                 workspace_key=workspace_key,
             )
         )
-    parser_success_rate = round(
-        parse_batch.parsed_count / max(len(parse_batch.files), 1),
-        2,
+    raw_parser_success_rate = parse_batch.parsed_count / max(len(parse_batch.files), 1)
+    parser_success_rate = round(raw_parser_success_rate, 2)
+    evidence_success_rate = _evidence_success_rate(
+        _collect_changes(parse_batch), list(evidence_items or [])
     )
-    context_score = round(
-        min(
-            1.0,
-            (
-                parser_success_rate * 0.45
-                + _freshness_score(topology_freshness_days) * 0.35
-                + _incident_score(incident_index_size) * 0.20
-            ),
+    raw_context_score = min(
+        1.0,
+        (
+            raw_parser_success_rate * 0.35
+            + _freshness_score(topology_freshness_days) * 0.25
+            + _incident_score(incident_index_size) * 0.20
+            + evidence_success_rate * 0.20
         ),
-        2,
+    )
+    context_score = round(raw_context_score, 2)
+    context_todos = _context_todos(
+        evidence_success_rate=evidence_success_rate,
+        topology_freshness_days=topology_freshness_days,
+        incident_index_size=incident_index_size,
+        parser_success_rate=raw_parser_success_rate,
     )
     return ContextCompleteness(
         topology_freshness_days=topology_freshness_days,
         topology_last_imported_at=topology_status.updated_at,
         incident_index_size=incident_index_size,
         parser_success_rate=parser_success_rate,
+        evidence_success_rate=round(evidence_success_rate, 2),
         parser_success_by_tool=_parser_success_by_tool(parse_batch),
         context_score=context_score,
+        confidence_level=_context_confidence_level(raw_context_score),
+        uncertainty=_context_uncertainty(
+            context_score=raw_context_score,
+            evidence_success_rate=evidence_success_rate,
+            topology_freshness_days=topology_freshness_days,
+            incident_index_size=incident_index_size,
+            parser_success_rate=raw_parser_success_rate,
+        ),
+        context_todos=context_todos,
+        insufficient_context=raw_context_score < 0.7,
     )
 
 
@@ -437,10 +538,18 @@ def build_advisory_summary(
     assessment: RiskAssessment, narrative: NarrativeResult
 ) -> AdvisorySummary:
     uncertainty_flags: list[str] = []
+    context_uncertainty = bool(assessment.context_completeness.uncertainty)
+    context_todos = bool(assessment.context_completeness.context_todos)
     if assessment.partial_context:
         uncertainty_flags.append("partial_context")
     if assessment.context_completeness.context_score < 0.7:
         uncertainty_flags.append("low_context_completeness")
+    if assessment.context_completeness.insufficient_context:
+        uncertainty_flags.append("insufficient_context")
+    if context_uncertainty:
+        uncertainty_flags.append("context_uncertainty")
+    if context_todos:
+        uncertainty_flags.append("context_todos")
     if assessment.warnings:
         uncertainty_flags.append("assessment_warnings")
     if narrative.degraded:
@@ -455,6 +564,9 @@ def build_advisory_summary(
             assessment.recommendation != "go"
             or assessment.partial_context
             or assessment.context_completeness.context_score < 0.7
+            or assessment.context_completeness.insufficient_context
+            or context_uncertainty
+            or context_todos
             or bool(assessment.warnings)
             or narrative.degraded
         ),
@@ -483,8 +595,19 @@ def _has_partial_context_signal(report: dict) -> bool:
     if isinstance(manifest, dict) and manifest.get("partial_analysis"):
         return True
     context = dict(report.get("context_completeness") or {})
+    if bool(context.get("insufficient_context")):
+        return True
+    if str(context.get("uncertainty") or "").strip():
+        return True
+    if _context_todo_items(context.get("context_todos")):
+        return True
     try:
         if float(context.get("parser_success_rate", 1.0)) < 1.0:
+            return True
+    except (TypeError, ValueError):
+        pass
+    try:
+        if float(context.get("evidence_success_rate", 1.0)) < 1.0:
             return True
     except (TypeError, ValueError):
         pass
@@ -509,23 +632,69 @@ def _finding_evidence_count(
     return len(finding.get("evidence_refs") or [])
 
 
-def _context_summary(context: dict) -> ShareSummaryContext:
-    score = round(float(context.get("context_score", 1.0)), 2)
-    partial_context = False
+def _context_number(
+    context: dict,
+    key: str,
+    *,
+    missing_default: float,
+    invalid_default: float = 0.0,
+) -> float:
+    if key not in context:
+        return missing_default
     try:
-        partial_context = float(context.get("parser_success_rate", 1.0)) < 1.0
+        value = float(context.get(key))
     except (TypeError, ValueError):
-        partial_context = False
-    label = "LIMITED CONTEXT" if score < 0.7 or partial_context else "STRONG CONTEXT"
-    summary = f"{label} ({score:.2f})" + (
-        " - one or more artifacts failed to parse cleanly."
-        if partial_context
-        else (
-            " - supporting topology or incident history may be stale."
-            if score < 0.7
-            else " - supporting topology and parser coverage look healthy."
-        )
+        return invalid_default
+    if not math.isfinite(value):
+        return invalid_default
+    return max(0.0, min(value, 1.0))
+
+
+def _context_todo_items(value: object) -> list[str]:
+    if not isinstance(value, list | tuple):
+        return []
+    return [str(item).strip() for item in value if str(item).strip()]
+
+
+def _context_summary(context: dict) -> ShareSummaryContext:
+    score = round(_context_number(context, "context_score", missing_default=1.0), 2)
+    partial_context = (
+        _context_number(context, "parser_success_rate", missing_default=1.0) < 1.0
     )
+    partial_evidence = (
+        _context_number(context, "evidence_success_rate", missing_default=1.0) < 1.0
+    )
+    insufficient_context = bool(context.get("insufficient_context"))
+    uncertainty = str(context.get("uncertainty") or "").strip()
+    context_todos = bool(_context_todo_items(context.get("context_todos")))
+    label = (
+        "LIMITED CONTEXT"
+        if (
+            score < 0.7
+            or partial_context
+            or partial_evidence
+            or insufficient_context
+            or uncertainty
+            or context_todos
+        )
+        else "STRONG CONTEXT"
+    )
+    if uncertainty:
+        summary = f"{label} ({score:.2f}) - {uncertainty}"
+    else:
+        summary = f"{label} ({score:.2f})" + (
+            " - one or more artifacts failed to parse cleanly."
+            if partial_context
+            else (
+                " - evidence coverage is partial."
+                if partial_evidence
+                else (
+                    " - supporting topology or incident history may be stale."
+                    if score < 0.7 or insufficient_context
+                    else " - supporting topology, evidence, parser, and incident context look healthy."
+                )
+            )
+        )
     return ShareSummaryContext(score=score, label=label, summary=summary)
 
 
@@ -612,18 +781,22 @@ def build_share_summary(report: dict) -> ShareSummary:
     rollback_link = report_link
     partial_context = _has_partial_context_signal(report)
     if partial_context and context_summary.label != "LIMITED CONTEXT":
+        uncertainty = str(
+            dict(report.get("context_completeness") or {}).get("uncertainty") or ""
+        ).strip()
         context_summary = ShareSummaryContext(
             score=context_summary.score,
             label="LIMITED CONTEXT",
             summary=(
-                f"LIMITED CONTEXT ({context_summary.score:.2f})"
-                " - one or more submitted artifacts were not analyzed."
+                f"LIMITED CONTEXT ({context_summary.score:.2f}) - "
+                + (uncertainty or "one or more submitted artifacts were not analyzed.")
             ),
         )
     requires_attention = (
         recommendation != "go"
         or context_summary.score < 0.7
         or partial_context
+        or context_summary.label == "LIMITED CONTEXT"
         or not bool(report.get("narrative_available", True))
         or bool(report.get("warnings"))
     )
@@ -761,11 +934,13 @@ def build_analysis_artifacts(
     )
     assessment.context_completeness = _build_context_completeness(
         parse_batch,
+        evidence_items=evidence_items,
         project_id=project_id,
         project_key=project_key,
         workspace_id=workspace_id,
         workspace_key=workspace_key,
     )
+    assessment = apply_context_uncertainty(assessment)
     findings = build_findings(
         assessment=assessment,
         evidence_items=evidence_items,

--- a/services/report_service.py
+++ b/services/report_service.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import math
 import os
 import secrets
 import hashlib
@@ -16,10 +17,14 @@ from pydantic import ValidationError
 
 from analysis.blast_radius import BlastRadiusResult
 from analysis.rollback_planner import RollbackPlan
-from analysis.risk_scorer import RiskAssessment, RiskContributor
+from analysis.risk_scorer import (
+    RiskAssessment,
+    RiskContributor,
+    apply_context_uncertainty,
+)
 from api.schemas import IntakeItem, PendingAnalysis
 from evidence.mappers import classify_finding_evidence
-from evidence.models import EvidenceItem, Finding
+from evidence.models import ContextCompleteness, EvidenceItem, Finding
 from llm.narrator import NarrativeResult
 
 from models.database import SessionLocal
@@ -52,6 +57,7 @@ from services.submission_manifest import (
     normalize_manifest_redaction_status,
     normalize_submission_manifest_payload,
 )
+from services.topology_service import STALE_AFTER_DAYS
 
 LEGACY_REPORT_SCHEMA_VERSION = "v1"
 REPORT_SCHEMA_VERSION = "v2"
@@ -95,6 +101,31 @@ _VERDICT_PREFIX_PATTERN = re.compile(
 _FINDING_SEVERITY_ORDER = {"low": 1, "medium": 2, "high": 3, "critical": 4}
 _SEVERITY_SCORE_FLOOR = {"low": 0, "medium": 42, "high": 70, "critical": 90}
 _SEVERITY_SCORE_CEILING = {"low": 39, "medium": 69, "high": 89, "critical": 100}
+_CONTEXT_JSON_MALFORMED_WARNING = "Context completeness metadata was unavailable because persisted JSON was malformed."
+_CONTEXT_JSON_SHAPE_WARNING = (
+    "Context completeness metadata was unavailable because persisted JSON had an "
+    "unexpected shape."
+)
+_CONTEXT_JSON_INCOMPLETE_WARNING = "Context completeness metadata was unavailable because persisted values were incomplete."
+_CONTEXT_JSON_INVALID_WARNING = "Context completeness metadata was unavailable because persisted values were invalid."
+_CONFIDENCE_INVALID_WARNING = (
+    "Report confidence metadata was invalid and was reset to 0.0."
+)
+_CONTEXT_UNAVAILABLE_UNCERTAINTY = (
+    "Context completeness metadata was unavailable; reviewer verification is "
+    "required before trusting this report."
+)
+_CONTEXT_UNAVAILABLE_TODO = (
+    "Re-run analysis to regenerate context completeness metadata."
+)
+_LEGACY_CONTEXT_CORE_FIELDS = {
+    "topology_freshness_days",
+    "topology_last_imported_at",
+    "incident_index_size",
+    "parser_success_rate",
+    "parser_success_by_tool",
+    "context_score",
+}
 
 
 def _resolve_project_id(
@@ -2023,6 +2054,203 @@ def _load_submission_manifest_fallback_payload(
     return fallback_items
 
 
+def _load_context_completeness_payload(
+    raw_value: str | None,
+) -> tuple[dict, str | None]:
+    if raw_value is None or not str(raw_value).strip():
+        return _unavailable_context_completeness(), _CONTEXT_JSON_INVALID_WARNING
+    try:
+        decoded = json.loads(raw_value)
+    except json.JSONDecodeError:
+        return _unavailable_context_completeness(), _CONTEXT_JSON_MALFORMED_WARNING
+    if not isinstance(decoded, dict):
+        return _unavailable_context_completeness(), _CONTEXT_JSON_SHAPE_WARNING
+    decoded = _upgrade_legacy_context_completeness_payload(decoded)
+    if decoded is None:
+        return _unavailable_context_completeness(), _CONTEXT_JSON_INCOMPLETE_WARNING
+    try:
+        return (
+            ContextCompleteness.model_validate(decoded).model_dump(mode="json"),
+            None,
+        )
+    except (TypeError, ValueError, ValidationError):
+        return _unavailable_context_completeness(), _CONTEXT_JSON_INVALID_WARNING
+
+
+def _context_confidence_level_from_score(context_score: float) -> str:
+    if context_score >= 0.85:
+        return "high"
+    if context_score >= 0.7:
+        return "medium"
+    return "low"
+
+
+def _context_float_value(
+    decoded: dict,
+    key: str,
+    *,
+    missing_default: float,
+    invalid_default: float = 0.0,
+) -> float:
+    if key not in decoded:
+        return missing_default
+    try:
+        value = float(decoded.get(key))
+    except (TypeError, ValueError):
+        return invalid_default
+    if not math.isfinite(value):
+        return invalid_default
+    return max(0.0, min(value, 1.0))
+
+
+def _context_int_value(decoded: dict, key: str) -> int:
+    try:
+        value = int(decoded.get(key, 0) or 0)
+    except (TypeError, ValueError):
+        return 0
+    return max(value, 0)
+
+
+def _context_todo_items(value: object) -> list[str]:
+    if not isinstance(value, list | tuple):
+        return []
+    return [str(item) for item in value if str(item).strip()]
+
+
+def _normalize_context_completeness_payload(decoded: dict) -> dict:
+    context_score = _context_float_value(decoded, "context_score", missing_default=1.0)
+    parser_success_rate = _context_float_value(
+        decoded, "parser_success_rate", missing_default=1.0
+    )
+    evidence_success_rate = _context_float_value(
+        decoded, "evidence_success_rate", missing_default=1.0
+    )
+    incident_index_size = _context_int_value(decoded, "incident_index_size")
+    topology_freshness_days = decoded.get("topology_freshness_days")
+    if topology_freshness_days is None:
+        topology_gap = "missing"
+    else:
+        try:
+            topology_freshness_days = int(topology_freshness_days)
+            topology_gap = (
+                "stale" if topology_freshness_days > STALE_AFTER_DAYS else None
+            )
+        except (TypeError, ValueError):
+            topology_freshness_days = None
+            topology_gap = "missing"
+
+    normalized = dict(decoded)
+    normalized["context_score"] = context_score
+    normalized["parser_success_rate"] = parser_success_rate
+    normalized["evidence_success_rate"] = evidence_success_rate
+    normalized["incident_index_size"] = incident_index_size
+    normalized["topology_freshness_days"] = topology_freshness_days
+
+    insufficient_context = context_score < 0.7
+    normalized["insufficient_context"] = insufficient_context
+    normalized["confidence_level"] = (
+        "low"
+        if insufficient_context
+        else _context_confidence_level_from_score(context_score)
+    )
+
+    todos = _context_todo_items(normalized.get("context_todos"))
+    if topology_gap == "missing" and not any(
+        "topology" in item.lower() for item in todos
+    ):
+        todos.append("Import or refresh topology context for this project/workspace.")
+    if topology_gap == "stale" and not any(
+        "topology" in item.lower() for item in todos
+    ):
+        todos.append("Refresh stale topology context for this project/workspace.")
+    if incident_index_size == 0 and not any(
+        "incident" in item.lower() for item in todos
+    ):
+        todos.append("Import relevant incident history for this project/workspace.")
+    if parser_success_rate < 1.0 and not any(
+        "parser" in item.lower() for item in todos
+    ):
+        todos.append("Review parser errors and resubmit supported artifacts.")
+    if evidence_success_rate < 1.0 and not any(
+        "evidence" in item.lower() for item in todos
+    ):
+        todos.append("Review evidence extraction gaps for supported artifacts.")
+    if insufficient_context and not todos:
+        todos.append(_CONTEXT_UNAVAILABLE_TODO)
+    normalized["context_todos"] = todos
+
+    uncertainty = str(normalized.get("uncertainty") or "").strip()
+    if insufficient_context and not uncertainty:
+        uncertainty = (
+            "Insufficient context: persisted context metadata was normalized "
+            "because stored values were internally inconsistent."
+        )
+    normalized["uncertainty"] = uncertainty or None
+    return normalized
+
+
+def _upgrade_legacy_context_completeness_payload(decoded: dict) -> dict | None:
+    required_keys = set(ContextCompleteness.model_fields)
+    if required_keys.issubset(decoded):
+        return _normalize_context_completeness_payload(decoded)
+    if not _LEGACY_CONTEXT_CORE_FIELDS.issubset(decoded):
+        return None
+
+    try:
+        legacy_context_score = float(decoded["context_score"])
+    except (TypeError, ValueError):
+        return None
+    if not math.isfinite(legacy_context_score):
+        return None
+
+    upgraded = dict(decoded)
+    upgraded.setdefault("evidence_success_rate", 1.0)
+    upgraded.setdefault("uncertainty", None)
+    upgraded.setdefault("context_todos", [])
+    upgraded.setdefault("insufficient_context", False)
+    return _normalize_context_completeness_payload(upgraded)
+
+
+def _unavailable_context_completeness() -> dict:
+    return ContextCompleteness(
+        incident_index_size=0,
+        evidence_success_rate=0.0,
+        parser_success_rate=0.0,
+        parser_success_by_tool={},
+        context_score=0.0,
+        confidence_level="low",
+        uncertainty=_CONTEXT_UNAVAILABLE_UNCERTAINTY,
+        context_todos=[_CONTEXT_UNAVAILABLE_TODO],
+        insufficient_context=True,
+    ).model_dump(mode="json")
+
+
+def _load_report_confidence(value: Any) -> tuple[float, str | None]:
+    if value is None:
+        return 0.0, _CONFIDENCE_INVALID_WARNING
+    try:
+        confidence = float(value)
+    except (TypeError, ValueError):
+        return 0.0, _CONFIDENCE_INVALID_WARNING
+    if not math.isfinite(confidence) or confidence < 0.0 or confidence > 1.0:
+        return 0.0, _CONFIDENCE_INVALID_WARNING
+    return confidence, None
+
+
+def _clamp_confidence_to_context(
+    confidence: float, context_completeness: dict
+) -> float:
+    if not context_completeness.get("insufficient_context"):
+        return confidence
+    try:
+        context_score = float(context_completeness.get("context_score", 0.0))
+    except (TypeError, ValueError):
+        context_score = 0.0
+    if not math.isfinite(context_score):
+        context_score = 0.0
+    return round(min(confidence, max(0.0, min(context_score, 1.0))), 2)
+
+
 def _serialize_report(report, *, include_evidence: bool = True) -> dict:
     created_at = report.created_at
     if created_at.tzinfo is None:
@@ -2047,6 +2275,21 @@ def _serialize_report(report, *, include_evidence: bool = True) -> dict:
     )
     if manifest_warning is not None and manifest_warning not in warnings:
         warnings.append(manifest_warning)
+    confidence, confidence_warning = _load_report_confidence(
+        report.risk_assessment.confidence
+        if report.risk_assessment is not None
+        else None
+    )
+    if confidence_warning is not None and confidence_warning not in warnings:
+        warnings.append(confidence_warning)
+    context_completeness, context_warning = _load_context_completeness_payload(
+        report.risk_assessment.context_completeness_json
+        if report.risk_assessment is not None
+        else None
+    )
+    if context_warning is not None and context_warning not in warnings:
+        warnings.append(context_warning)
+    confidence = _clamp_confidence_to_context(confidence, context_completeness)
     evidence_items: list[dict[str, Any]] = []
     if include_evidence:
         seen_evidence_ids: set[str] = set()
@@ -2130,11 +2373,8 @@ def _serialize_report(report, *, include_evidence: bool = True) -> dict:
             if report.risk_assessment is not None
             else "[]"
         ),
-        "context_completeness": json.loads(
-            report.risk_assessment.context_completeness_json
-            if report.risk_assessment is not None
-            else "{}"
-        ),
+        "confidence": confidence,
+        "context_completeness": context_completeness,
         "blast_radius": (
             json.loads(report.blast_radius_json or "{}")
             or _default_blast_radius_payload()
@@ -2208,6 +2448,7 @@ def persist_analysis_report(
     submitted_artifacts: list[tuple[str, bytes | None]] | None = None,
 ) -> dict:
     """Persist the completed analysis before the UI treats it as final."""
+    assessment = apply_context_uncertainty(assessment)
     assessment, findings = _repair_assessment_evidence_links(
         assessment,
         findings,
@@ -2320,6 +2561,7 @@ def persist_analysis_report(
                 risk_score=assessment.score,
                 severity=assessment.severity,
                 recommendation=assessment.recommendation,
+                risk_confidence=assessment.confidence,
                 top_risk=assessment.top_risk,
                 report_schema_version=REPORT_SCHEMA_VERSION,
                 parse_summary=_build_parse_summary(parse_batch),

--- a/tests/test_analysis/test_risk_scorer.py
+++ b/tests/test_analysis/test_risk_scorer.py
@@ -5,11 +5,46 @@ from __future__ import annotations
 import json
 import unittest
 
-from analysis.risk_scorer import score_changes, score_parse_batch
+from analysis.risk_scorer import (
+    RiskAssessment,
+    apply_context_uncertainty,
+    score_changes,
+    score_parse_batch,
+)
 from parsers.base import ParseBatchResult, ParsedFileResult, ParseIssue, UnifiedChange
 
 
 class RiskScorerTests(unittest.TestCase):
+    def test_apply_context_uncertainty_normalizes_low_context_metadata(self) -> None:
+        assessment = RiskAssessment(
+            score=10,
+            severity="low",
+            recommendation="go",
+            top_risk="No deterministic issue detected.",
+            context_completeness={
+                "context_score": 0.52,
+                "confidence_level": "high",
+                "context_todos": [],
+            },
+            partial_context=False,
+        )
+
+        normalized = apply_context_uncertainty(assessment)
+
+        self.assertEqual(normalized.confidence, 0.52)
+        self.assertEqual(normalized.context_completeness.confidence_level, "low")
+        self.assertTrue(normalized.context_completeness.insufficient_context)
+        self.assertEqual(normalized.recommendation, "caution")
+        self.assertEqual(normalized.severity, "medium")
+        self.assertIn(
+            "Import or refresh topology context for this project/workspace.",
+            normalized.context_completeness.context_todos,
+        )
+        self.assertIn(
+            "Import relevant incident history for this project/workspace.",
+            normalized.context_completeness.context_todos,
+        )
+
     def test_score_changes_returns_explainable_contributors(self) -> None:
         assessment = score_changes(
             [

--- a/tests/test_api/test_analyses.py
+++ b/tests/test_api/test_analyses.py
@@ -588,12 +588,25 @@ class AnalysesApiTests(unittest.TestCase):
         self.assertEqual(payload["meta"]["accepted_artifact_count"], 1)
         self.assertEqual(payload["data"]["intake"]["items"][0]["status"], "ready")
         self.assertEqual(payload["data"]["assessment"]["source"], "heuristic+llm")
+        self.assertLess(payload["data"]["assessment"]["confidence"], 0.7)
         self.assertIn("context_completeness", payload["data"]["assessment"])
+        self.assertTrue(
+            payload["data"]["assessment"]["context_completeness"][
+                "insufficient_context"
+            ]
+        )
+        self.assertTrue(
+            payload["data"]["assessment"]["context_completeness"]["context_todos"]
+        )
         self.assertEqual(
             payload["data"]["assessment"]["top_risk_contributors"], ["ev-001"]
         )
         self.assertEqual(
             payload["data"]["persisted_report"]["project"]["project_key"], "payments"
+        )
+        self.assertEqual(
+            payload["data"]["persisted_report"]["confidence"],
+            payload["data"]["assessment"]["confidence"],
         )
         self.assertEqual(
             payload["data"]["assessment"]["contributors"][0]["evidence_id"], "ev-001"

--- a/tests/test_api/test_schemas.py
+++ b/tests/test_api/test_schemas.py
@@ -1,0 +1,48 @@
+"""Tests for API response schemas."""
+
+from __future__ import annotations
+
+import unittest
+
+from pydantic import ValidationError
+
+from api.schemas import PersistedReportData
+
+
+class ApiSchemaTests(unittest.TestCase):
+    def _persisted_report_payload(self) -> dict:
+        return {
+            "id": 17,
+            "project": {
+                "id": 1,
+                "project_key": "default",
+                "display_name": "Default",
+                "created_at": "2026-05-11T00:00:00Z",
+                "updated_at": "2026-05-11T00:00:00Z",
+            },
+            "risk_score": 42,
+            "severity": "medium",
+            "recommendation": "caution",
+            "top_risk": "Terraform changed a security group.",
+            "report_schema_version": "v2",
+            "parse_summary": "Parsed 1 file.",
+            "narrative_opening": "CAUTION: review the security group update.",
+            "created_at": "2026-05-11T00:00:00Z",
+            "audit": {"files_analyzed": ["plan.json"]},
+        }
+
+    def test_persisted_report_requires_explicit_confidence(self) -> None:
+        with self.assertRaises(ValidationError):
+            PersistedReportData.model_validate(self._persisted_report_payload())
+
+    def test_persisted_report_accepts_bounded_confidence(self) -> None:
+        payload = self._persisted_report_payload()
+        payload["confidence"] = 0.52
+
+        report = PersistedReportData.model_validate(payload)
+
+        self.assertEqual(report.confidence, 0.52)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_models/test_evidence_models.py
+++ b/tests/test_models/test_evidence_models.py
@@ -22,9 +22,13 @@ class EvidenceModelTests(unittest.TestCase):
             topology_freshness_days=3,
             topology_last_imported_at="2026-04-20T12:00:00Z",
             incident_index_size=7,
+            evidence_success_rate=0.67,
             parser_success_rate=0.75,
             parser_success_by_tool={"terraform": 1.0, "kubernetes": 0.5},
             context_score=0.8,
+            confidence_level="medium",
+            uncertainty="Kubernetes parser coverage was partial.",
+            context_todos=["Refresh Kubernetes context."],
         )
 
         self.assertEqual(
@@ -33,9 +37,14 @@ class EvidenceModelTests(unittest.TestCase):
                 "topology_freshness_days": 3,
                 "topology_last_imported_at": "2026-04-20T12:00:00Z",
                 "incident_index_size": 7,
+                "evidence_success_rate": 0.67,
                 "parser_success_rate": 0.75,
                 "parser_success_by_tool": {"terraform": 1.0, "kubernetes": 0.5},
                 "context_score": 0.8,
+                "confidence_level": "medium",
+                "uncertainty": "Kubernetes parser coverage was partial.",
+                "context_todos": ["Refresh Kubernetes context."],
+                "insufficient_context": False,
             },
         )
 

--- a/tests/test_services/test_analysis_service.py
+++ b/tests/test_services/test_analysis_service.py
@@ -12,6 +12,7 @@ from analysis.risk_scorer import RiskAssessment, RiskContributor
 from analysis.blast_radius import BlastRadiusResult
 from analysis.rollback_planner import RollbackPlan
 from evidence.extractor import extract_batch_evidence
+from evidence.models import EvidenceItem
 from llm.narrator import NarrativeResult
 from parsers.base import ParseBatchResult, ParsedFileResult, UnifiedChange
 from services.analysis_service import (
@@ -176,6 +177,10 @@ class AnalysisServiceTests(unittest.TestCase):
 
         self.assertEqual(seen_partial_context, [True])
         self.assertTrue(artifacts.assessment.partial_context)
+        self.assertEqual(artifacts.assessment.recommendation, "caution")
+        self.assertLess(artifacts.assessment.confidence, 0.7)
+        self.assertTrue(artifacts.assessment.context_completeness.insufficient_context)
+        self.assertIn("INSUFFICIENT CONTEXT", artifacts.assessment.top_risk)
 
     def _share_report_payload(self) -> dict:
         return {
@@ -343,12 +348,216 @@ class AnalysisServiceTests(unittest.TestCase):
         self.assertEqual(artifacts.findings[0].confidence, 1.0)
         self.assertAlmostEqual(
             artifacts.assessment.context_completeness.context_score,
-            0.45,
+            0.55,
+        )
+        self.assertEqual(artifacts.assessment.confidence, 0.55)
+        self.assertEqual(artifacts.assessment.recommendation, "caution")
+        self.assertTrue(artifacts.assessment.context_completeness.insufficient_context)
+        self.assertEqual(
+            artifacts.assessment.context_completeness.confidence_level,
+            "low",
+        )
+        self.assertIn(
+            "insufficient context",
+            artifacts.assessment.context_completeness.uncertainty.lower(),
+        )
+        self.assertIn(
+            "Import or refresh topology context for this project/workspace.",
+            artifacts.assessment.context_completeness.context_todos,
+        )
+        self.assertIn(
+            "Import relevant incident history for this project/workspace.",
+            artifacts.assessment.context_completeness.context_todos,
+        )
+        self.assertEqual(
+            artifacts.assessment.context_completeness.evidence_success_rate,
+            1.0,
         )
         self.assertEqual(
             artifacts.assessment.context_completeness.parser_success_by_tool,
             {"terraform": 1.0},
         )
+
+    def test_build_context_completeness_uses_raw_score_for_thresholds(self) -> None:
+        batch = ParseBatchResult(
+            files=[
+                ParsedFileResult(
+                    file_name="plan.json",
+                    tool="terraform",
+                    status="parsed",
+                    changes=[
+                        UnifiedChange(
+                            source_file="plan.json",
+                            tool="terraform",
+                            resource_id="aws_security_group.main",
+                            action="modify",
+                            summary="Terraform changed a security group.",
+                        ),
+                        UnifiedChange(
+                            source_file="plan.json",
+                            tool="terraform",
+                            resource_id="aws_security_group.extra",
+                            action="modify",
+                            summary="Terraform changed another security group.",
+                        ),
+                    ],
+                )
+            ]
+        )
+        evidence_items = extract_batch_evidence(batch)[:1]
+
+        with (
+            patch(
+                "services.analysis_service.get_topology_status",
+                return_value=SimpleNamespace(updated_at="2026-05-10T00:00:00Z"),
+            ),
+            patch("services.analysis_service._freshness_score", return_value=0.984),
+            patch(
+                "services.analysis_service.load_incident_candidates", return_value=[]
+            ),
+        ):
+            context = build_analysis_artifacts.__globals__[
+                "_build_context_completeness"
+            ](batch, evidence_items=evidence_items)
+
+        self.assertEqual(context.context_score, 0.7)
+        self.assertEqual(context.confidence_level, "low")
+        self.assertTrue(context.insufficient_context)
+        self.assertIn("evidence coverage", context.uncertainty)
+        self.assertIn(
+            "Review evidence extraction gaps for supported artifacts.",
+            context.context_todos,
+        )
+
+    def test_build_context_completeness_counts_distinct_evidence_coverage(
+        self,
+    ) -> None:
+        batch = ParseBatchResult(
+            files=[
+                ParsedFileResult(
+                    file_name="plan.json",
+                    tool="terraform",
+                    status="parsed",
+                    changes=[
+                        UnifiedChange(
+                            change_id="change-1",
+                            source_file="plan.json",
+                            tool="terraform",
+                            resource_id="aws_security_group.main",
+                            action="modify",
+                            summary="Terraform changed a security group.",
+                        ),
+                        UnifiedChange(
+                            change_id="change-2",
+                            source_file="plan.json",
+                            tool="terraform",
+                            resource_id="aws_db_instance.primary",
+                            action="modify",
+                            summary="Terraform changed a database.",
+                        ),
+                    ],
+                )
+            ]
+        )
+        duplicate_evidence = [
+            EvidenceItem(
+                evidence_id="ev-1",
+                analysis_id=0,
+                finding_id="pending:change-1",
+                source_type="artifact",
+                source_ref="artifact://plan.json#aws_security_group.main",
+                artifact="plan.json",
+                location="plan.json#aws_security_group.main",
+                resource="aws_security_group.main",
+                operation="modify",
+                summary="Security group changed.",
+                severity_hint="medium",
+                deterministic=True,
+                confidence=1.0,
+                related_change_ids=["change-1"],
+            ),
+            EvidenceItem(
+                evidence_id="ev-2",
+                analysis_id=0,
+                finding_id="pending:change-1",
+                source_type="artifact",
+                source_ref="artifact://plan.json#aws_security_group.main?duplicate=1",
+                artifact="plan.json",
+                location="plan.json#aws_security_group.main",
+                resource="aws_security_group.main",
+                operation="modify",
+                summary="Security group changed again.",
+                severity_hint="medium",
+                deterministic=True,
+                confidence=1.0,
+                related_change_ids=["change-1"],
+            ),
+        ]
+
+        with (
+            patch(
+                "services.analysis_service.get_topology_status",
+                return_value=SimpleNamespace(updated_at="2026-05-10T00:00:00Z"),
+            ),
+            patch(
+                "services.analysis_service.load_incident_candidates",
+                return_value=[object()] * 10,
+            ),
+        ):
+            context = build_analysis_artifacts.__globals__[
+                "_build_context_completeness"
+            ](batch, evidence_items=duplicate_evidence)
+
+        self.assertEqual(context.evidence_success_rate, 0.5)
+        self.assertIn(
+            "Review evidence extraction gaps for supported artifacts.",
+            context.context_todos,
+        )
+        self.assertIn("evidence coverage", context.uncertainty)
+
+    def test_build_context_completeness_uses_raw_parser_rate_for_tiny_gap(
+        self,
+    ) -> None:
+        files = [
+            ParsedFileResult(
+                file_name=f"plan-{index}.json",
+                tool="terraform",
+                status="parsed",
+                changes=[],
+            )
+            for index in range(999)
+        ]
+        files.append(
+            ParsedFileResult(
+                file_name="bad.yaml",
+                tool="kubernetes",
+                status="failed",
+                changes=[],
+            )
+        )
+        batch = ParseBatchResult(files=files)
+
+        with (
+            patch(
+                "services.analysis_service.get_topology_status",
+                return_value=SimpleNamespace(updated_at="2026-05-10T00:00:00Z"),
+            ),
+            patch(
+                "services.analysis_service.load_incident_candidates",
+                return_value=[object()] * 10,
+            ),
+        ):
+            context = build_analysis_artifacts.__globals__[
+                "_build_context_completeness"
+            ](batch, evidence_items=[])
+
+        self.assertEqual(context.parser_success_rate, 1.0)
+        self.assertFalse(context.insufficient_context)
+        self.assertIn(
+            "Review parser errors and resubmit supported artifacts.",
+            context.context_todos,
+        )
+        self.assertIn("parser coverage", context.uncertainty)
 
     def test_evaluate_parse_batch_preserves_non_mutating_metadata_without_evidence(
         self,
@@ -935,6 +1144,44 @@ class AnalysisServiceTests(unittest.TestCase):
         self.assertTrue(advisory.requires_attention)
         self.assertIn("low_context_completeness", advisory.uncertainty_flags)
 
+    def test_build_advisory_summary_requires_attention_for_uncertain_context(
+        self,
+    ) -> None:
+        assessment = RiskAssessment(
+            score=18,
+            severity="low",
+            recommendation="go",
+            top_risk="Low risk example",
+            contributors=[],
+            interaction_risks=[],
+            context_completeness={
+                "topology_freshness_days": 0,
+                "incident_index_size": 0,
+                "parser_success_rate": 1.0,
+                "evidence_success_rate": 1.0,
+                "context_score": 0.8,
+                "uncertainty": "Uncertainty: incident history is unavailable.",
+                "context_todos": [
+                    "Import relevant incident history for this project/workspace."
+                ],
+            },
+            partial_context=False,
+            warnings=[],
+        )
+        narrative = NarrativeResult(
+            opening_sentence="GO: low risk example.",
+            explanation="All good.",
+            guidance=[],
+            degraded=False,
+            warnings=[],
+        )
+
+        advisory = build_advisory_summary(assessment, narrative)
+
+        self.assertTrue(advisory.requires_attention)
+        self.assertIn("context_uncertainty", advisory.uncertainty_flags)
+        self.assertIn("context_todos", advisory.uncertainty_flags)
+
     def test_build_share_summary_returns_thread_ready_markdown_and_json_payload(
         self,
     ) -> None:
@@ -998,6 +1245,109 @@ class AnalysisServiceTests(unittest.TestCase):
         self.assertEqual(
             summary.json_payload.context_completeness.label, "LIMITED CONTEXT"
         )
+
+    def test_build_share_summary_uses_insufficient_context_at_rounded_boundary(
+        self,
+    ) -> None:
+        report = self._share_report_payload()
+        report["context_completeness"] = {
+            "context_score": 0.7,
+            "parser_success_rate": 1.0,
+            "evidence_success_rate": 1.0,
+            "insufficient_context": True,
+            "uncertainty": "Insufficient context: raw score was below threshold.",
+        }
+
+        summary = build_share_summary(report)
+
+        self.assertEqual(
+            summary.json_payload.context_completeness.label, "LIMITED CONTEXT"
+        )
+        self.assertIn("raw score was below threshold", summary.plain_text)
+        self.assertIn("requires additional human review", summary.plain_text.lower())
+
+    def test_build_share_summary_describes_evidence_gap_without_artifact_parse_wording(
+        self,
+    ) -> None:
+        report = self._share_report_payload()
+        report["context_completeness"] = {
+            "context_score": 0.74,
+            "parser_success_rate": 1.0,
+            "evidence_success_rate": 0.5,
+            "insufficient_context": False,
+            "uncertainty": "Uncertainty: evidence coverage is partial.",
+        }
+
+        summary = build_share_summary(report)
+
+        self.assertEqual(
+            summary.json_payload.context_completeness.label, "LIMITED CONTEXT"
+        )
+        self.assertIn("evidence coverage is partial", summary.plain_text)
+        self.assertNotIn("submitted artifacts were not analyzed", summary.plain_text)
+
+    def test_build_share_summary_degrades_malformed_context_score(
+        self,
+    ) -> None:
+        report = self._share_report_payload()
+        report["context_completeness"] = {
+            "context_score": "oops",
+            "parser_success_rate": 1.0,
+            "evidence_success_rate": 1.0,
+            "insufficient_context": False,
+        }
+
+        summary = build_share_summary(report)
+
+        self.assertEqual(summary.json_payload.context_completeness.score, 0.0)
+        self.assertEqual(
+            summary.json_payload.context_completeness.label, "LIMITED CONTEXT"
+        )
+        self.assertIn("requires additional human review", summary.plain_text.lower())
+
+    def test_build_share_summary_requires_attention_for_context_uncertainty(
+        self,
+    ) -> None:
+        report = self._share_report_payload()
+        report["recommendation"] = "go"
+        report["context_completeness"] = {
+            "context_score": 0.82,
+            "parser_success_rate": 1.0,
+            "evidence_success_rate": 1.0,
+            "insufficient_context": False,
+            "uncertainty": "Uncertainty: topology context is stale.",
+            "context_todos": [
+                "Refresh stale topology context for this project/workspace."
+            ],
+        }
+
+        summary = build_share_summary(report)
+
+        self.assertEqual(
+            summary.json_payload.context_completeness.label, "LIMITED CONTEXT"
+        )
+        self.assertIn("topology context is stale", summary.plain_text)
+        self.assertIn("requires additional human review", summary.plain_text.lower())
+
+    def test_build_share_summary_ignores_scalar_context_todos(
+        self,
+    ) -> None:
+        report = self._share_report_payload()
+        report["recommendation"] = "go"
+        report["context_completeness"] = {
+            "context_score": 0.92,
+            "parser_success_rate": 1.0,
+            "evidence_success_rate": 1.0,
+            "insufficient_context": False,
+            "context_todos": "Review parser errors and resubmit supported artifacts.",
+        }
+
+        summary = build_share_summary(report)
+
+        self.assertEqual(
+            summary.json_payload.context_completeness.label, "STRONG CONTEXT"
+        )
+        self.assertNotIn("requires additional human review", summary.plain_text.lower())
 
     def test_build_share_summary_requires_attention_for_manifest_partial_analysis(
         self,

--- a/tests/test_services/test_report_service.py
+++ b/tests/test_services/test_report_service.py
@@ -130,6 +130,16 @@ class ReportServiceTests(unittest.TestCase):
                         )
 
         with database_module.SessionLocal() as session:
+            with self.assertRaisesRegex(ValueError, "Risk confidence"):
+                analysis_reports_repository_module.create_analysis_report(
+                    session,
+                    **report_kwargs,
+                    risk_confidence=1.5,
+                    findings_payload=[],
+                    evidence_payload=[],
+                )
+
+        with database_module.SessionLocal() as session:
             with self.assertRaisesRegex(ValueError, "missing evidence item ev-missing"):
                 analysis_reports_repository_module.create_analysis_report(
                     session,
@@ -3700,6 +3710,7 @@ class ReportServiceTests(unittest.TestCase):
             score=42,
             severity="medium",
             recommendation="caution",
+            confidence=0.84,
             top_risk="Terraform aws_security_group.main is the highest-impact change.",
             top_risk_contributors=["ev-001"],
             context_completeness={
@@ -3823,6 +3834,7 @@ class ReportServiceTests(unittest.TestCase):
         self.assertEqual(persisted["assessment_source"], "heuristic-only")
         self.assertEqual(persisted["narrative_source"], "llm")
         self.assertEqual(persisted["report_schema_version"], "v2")
+        self.assertEqual(persisted["confidence"], 0.84)
         self.assertEqual(persisted["narrative_provider"], "ollama")
         self.assertEqual(persisted["narrative_model"], "ollama/llama3")
         self.assertEqual(persisted["skills_applied"], ["git", "terraform"])
@@ -3954,6 +3966,68 @@ class ReportServiceTests(unittest.TestCase):
             history[0]["contributors"][0]["metadata"]["redacted_fields"],
             ["ingress.0.description"],
         )
+
+    def test_persist_analysis_report_applies_context_uncertainty_downgrade(
+        self,
+    ) -> None:
+        parse_batch = ParseBatchResult(
+            files=[
+                ParsedFileResult(
+                    file_name="plan.json",
+                    tool="terraform",
+                    status="parsed",
+                    changes=[
+                        UnifiedChange(
+                            source_file="plan.json",
+                            tool="terraform",
+                            resource_id="aws_security_group.main",
+                            action="modify",
+                            summary="Terraform changed a security group.",
+                        )
+                    ],
+                )
+            ]
+        )
+        assessment = RiskAssessment(
+            score=12,
+            severity="low",
+            recommendation="go",
+            confidence=1.0,
+            top_risk="Terraform change looks low risk.",
+            context_completeness={
+                "topology_freshness_days": None,
+                "incident_index_size": 0,
+                "parser_success_rate": 1.0,
+                "evidence_success_rate": 1.0,
+                "context_score": 0.52,
+            },
+            contributors=[],
+            interaction_risks=[],
+            partial_context=False,
+            warnings=[],
+        )
+        narrative = NarrativeResult(
+            opening_sentence="CAUTION: context is incomplete.",
+            explanation="Reviewer verification is required before trusting low risk.",
+            guidance=[],
+            degraded=False,
+            warnings=[],
+        )
+
+        persisted = report_service_module.persist_analysis_report(
+            parse_batch,
+            assessment,
+            narrative,
+            audit_context={"source_interface": "api"},
+        )
+
+        self.assertEqual(persisted["risk_score"], 42)
+        self.assertEqual(persisted["severity"], "medium")
+        self.assertEqual(persisted["recommendation"], "caution")
+        self.assertEqual(persisted["confidence"], 0.52)
+        self.assertTrue(persisted["context_completeness"]["insufficient_context"])
+        self.assertIn("INSUFFICIENT CONTEXT", persisted["top_risk"])
+        self.assertIn("Insufficient context", persisted["warnings"][0])
 
     def test_empty_plan_unsupported_fields_from_real_parser_survive_report_fetch(
         self,
@@ -5136,6 +5210,284 @@ class ReportServiceTests(unittest.TestCase):
             "Submission manifest metadata was unavailable because persisted JSON had an unexpected shape.",
             fetched["warnings"],
         )
+
+    def test_fetch_report_degrades_on_malformed_context_completeness_json(
+        self,
+    ) -> None:
+        report = self._persist_shareable_report()
+        with sqlite3.connect(self.db_path) as connection:
+            connection.execute(
+                "UPDATE risk_assessments SET context_completeness_json = ? "
+                "WHERE analysis_id = ?",
+                ("{not-valid-json", report["id"]),
+            )
+
+        fetched = report_service_module.fetch_analysis_report(report["id"])
+
+        self.assertIsNotNone(fetched)
+        assert fetched is not None
+        self.assertEqual(fetched["context_completeness"]["context_score"], 0.0)
+        self.assertTrue(fetched["context_completeness"]["insufficient_context"])
+        self.assertIn(
+            "Re-run analysis to regenerate context completeness metadata.",
+            fetched["context_completeness"]["context_todos"],
+        )
+        self.assertIn(
+            "Context completeness metadata was unavailable because persisted JSON was malformed.",
+            fetched["warnings"],
+        )
+
+    def test_fetch_report_degrades_on_wrong_shape_context_completeness_json(
+        self,
+    ) -> None:
+        report = self._persist_shareable_report()
+        with sqlite3.connect(self.db_path) as connection:
+            connection.execute(
+                "UPDATE risk_assessments SET context_completeness_json = ? "
+                "WHERE analysis_id = ?",
+                ("[]", report["id"]),
+            )
+
+        fetched = report_service_module.fetch_analysis_report(report["id"])
+
+        self.assertIsNotNone(fetched)
+        assert fetched is not None
+        self.assertEqual(fetched["context_completeness"]["context_score"], 0.0)
+        self.assertTrue(fetched["context_completeness"]["insufficient_context"])
+        self.assertIn(
+            "Re-run analysis to regenerate context completeness metadata.",
+            fetched["context_completeness"]["context_todos"],
+        )
+        self.assertIn(
+            "Context completeness metadata was unavailable because persisted JSON had an unexpected shape.",
+            fetched["warnings"],
+        )
+
+    def test_fetch_report_degrades_on_incomplete_context_completeness_json(
+        self,
+    ) -> None:
+        report = self._persist_shareable_report()
+        with sqlite3.connect(self.db_path) as connection:
+            connection.execute(
+                "UPDATE risk_assessments SET context_completeness_json = ? "
+                "WHERE analysis_id = ?",
+                (json.dumps({"context_score": 0.96}), report["id"]),
+            )
+
+        fetched = report_service_module.fetch_analysis_report(report["id"])
+
+        self.assertIsNotNone(fetched)
+        assert fetched is not None
+        self.assertEqual(fetched["context_completeness"]["context_score"], 0.0)
+        self.assertTrue(fetched["context_completeness"]["insufficient_context"])
+        self.assertEqual(fetched["context_completeness"]["confidence_level"], "low")
+        self.assertEqual(fetched["confidence"], 0.0)
+        self.assertIn(
+            "Context completeness metadata was unavailable because persisted values were incomplete.",
+            fetched["warnings"],
+        )
+
+    def test_fetch_report_upgrades_legacy_context_completeness_json(
+        self,
+    ) -> None:
+        report = self._persist_shareable_report()
+        legacy_context = {
+            "topology_freshness_days": 3,
+            "topology_last_imported_at": "2026-05-08T00:00:00Z",
+            "incident_index_size": 8,
+            "parser_success_rate": 1.0,
+            "parser_success_by_tool": {"terraform": 1.0},
+            "context_score": 0.82,
+        }
+        with sqlite3.connect(self.db_path) as connection:
+            connection.execute(
+                "UPDATE risk_assessments SET confidence = ?, context_completeness_json = ? "
+                "WHERE analysis_id = ?",
+                (0.82, json.dumps(legacy_context), report["id"]),
+            )
+
+        fetched = report_service_module.fetch_analysis_report(report["id"])
+
+        self.assertIsNotNone(fetched)
+        assert fetched is not None
+        context = fetched["context_completeness"]
+        self.assertEqual(context["context_score"], 0.82)
+        self.assertFalse(context["insufficient_context"])
+        self.assertEqual(context["evidence_success_rate"], 1.0)
+        self.assertEqual(context["confidence_level"], "medium")
+        self.assertEqual(fetched["confidence"], 0.82)
+        self.assertNotIn(
+            "Context completeness metadata was unavailable because persisted values were incomplete.",
+            fetched["warnings"],
+        )
+
+    def test_fetch_report_normalizes_scalar_todos_and_missing_topology_guidance(
+        self,
+    ) -> None:
+        report = self._persist_shareable_report()
+        context = {
+            "topology_freshness_days": None,
+            "topology_last_imported_at": None,
+            "incident_index_size": 8,
+            "evidence_success_rate": 1.0,
+            "parser_success_rate": 1.0,
+            "parser_success_by_tool": {"terraform": 1.0},
+            "context_score": 0.92,
+            "confidence_level": "high",
+            "uncertainty": None,
+            "context_todos": "Review parser errors and resubmit supported artifacts.",
+            "insufficient_context": False,
+        }
+        with sqlite3.connect(self.db_path) as connection:
+            connection.execute(
+                "UPDATE risk_assessments SET confidence = ?, context_completeness_json = ? "
+                "WHERE analysis_id = ?",
+                (0.92, json.dumps(context), report["id"]),
+            )
+
+        fetched = report_service_module.fetch_analysis_report(report["id"])
+
+        self.assertIsNotNone(fetched)
+        assert fetched is not None
+        todos = fetched["context_completeness"]["context_todos"]
+        self.assertEqual(
+            todos,
+            ["Import or refresh topology context for this project/workspace."],
+        )
+        self.assertNotIn("R", todos)
+        self.assertNotIn(
+            "Review parser errors and resubmit supported artifacts.",
+            todos,
+        )
+        self.assertNotIn(
+            "Refresh stale topology context for this project/workspace.",
+            todos,
+        )
+
+    def test_fetch_report_normalizes_inconsistent_context_completeness_json(
+        self,
+    ) -> None:
+        report = self._persist_shareable_report()
+        inconsistent_context = {
+            "topology_freshness_days": 3,
+            "topology_last_imported_at": "2026-05-08T00:00:00Z",
+            "incident_index_size": 8,
+            "evidence_success_rate": 1.0,
+            "parser_success_rate": 1.0,
+            "parser_success_by_tool": {"terraform": 1.0},
+            "context_score": 0.52,
+            "confidence_level": "high",
+            "uncertainty": None,
+            "context_todos": [],
+            "insufficient_context": False,
+        }
+        with sqlite3.connect(self.db_path) as connection:
+            connection.execute(
+                "UPDATE risk_assessments SET confidence = ?, context_completeness_json = ? "
+                "WHERE analysis_id = ?",
+                (1.0, json.dumps(inconsistent_context), report["id"]),
+            )
+
+        fetched = report_service_module.fetch_analysis_report(report["id"])
+        shared = report_service_module.fetch_shared_analysis_report(report["id"])
+
+        self.assertIsNotNone(fetched)
+        self.assertIsNotNone(shared)
+        assert fetched is not None
+        assert shared is not None
+        for payload in (fetched, shared):
+            context = payload["context_completeness"]
+            self.assertEqual(context["context_score"], 0.52)
+            self.assertTrue(context["insufficient_context"])
+            self.assertEqual(context["confidence_level"], "low")
+            self.assertIn("Insufficient context", context["uncertainty"])
+            self.assertIn(
+                "Re-run analysis to regenerate context completeness metadata.",
+                context["context_todos"],
+            )
+            self.assertEqual(payload["confidence"], 0.52)
+
+    def test_fetch_report_degrades_on_partially_populated_context_json(
+        self,
+    ) -> None:
+        report = self._persist_shareable_report()
+        legacy_context = {
+            "evidence_success_rate": 1.0,
+            "confidence_level": "high",
+            "context_todos": [],
+            "insufficient_context": False,
+        }
+        with sqlite3.connect(self.db_path) as connection:
+            connection.execute(
+                "UPDATE risk_assessments SET confidence = ?, context_completeness_json = ? "
+                "WHERE analysis_id = ?",
+                (1.0, json.dumps(legacy_context), report["id"]),
+            )
+
+        fetched = report_service_module.fetch_analysis_report(report["id"])
+
+        self.assertIsNotNone(fetched)
+        assert fetched is not None
+        self.assertEqual(fetched["context_completeness"]["context_score"], 0.0)
+        self.assertTrue(fetched["context_completeness"]["insufficient_context"])
+        self.assertEqual(fetched["context_completeness"]["confidence_level"], "low")
+        self.assertEqual(fetched["confidence"], 0.0)
+        self.assertIn(
+            "Context completeness metadata was unavailable because persisted values were incomplete.",
+            fetched["warnings"],
+        )
+
+    def test_fetch_report_degrades_when_risk_assessment_is_missing(self) -> None:
+        report = self._persist_shareable_report()
+        with sqlite3.connect(self.db_path) as connection:
+            connection.execute(
+                "DELETE FROM risk_assessments WHERE analysis_id = ?",
+                (report["id"],),
+            )
+
+        fetched = report_service_module.fetch_analysis_report(report["id"])
+
+        self.assertIsNotNone(fetched)
+        assert fetched is not None
+        self.assertEqual(fetched["confidence"], 0.0)
+        self.assertEqual(fetched["context_completeness"]["context_score"], 0.0)
+        self.assertTrue(fetched["context_completeness"]["insufficient_context"])
+        self.assertIn(
+            "Report confidence metadata was invalid and was reset to 0.0.",
+            fetched["warnings"],
+        )
+        self.assertIn(
+            "Context completeness metadata was unavailable because persisted values were invalid.",
+            fetched["warnings"],
+        )
+
+    def test_missing_context_completeness_loader_falls_back_to_limited_context(
+        self,
+    ) -> None:
+        context, warning = report_service_module._load_context_completeness_payload(
+            None
+        )
+
+        self.assertEqual(context["context_score"], 0.0)
+        self.assertEqual(context["confidence_level"], "low")
+        self.assertTrue(context["insufficient_context"])
+        self.assertEqual(
+            warning,
+            "Context completeness metadata was unavailable because persisted values were invalid.",
+        )
+
+    def test_invalid_report_confidence_loader_falls_back_to_unavailable(self) -> None:
+        for value in (None, "invalid", float("nan"), float("inf"), -0.1, 1.1):
+            with self.subTest(value=value):
+                confidence, warning = report_service_module._load_report_confidence(
+                    value
+                )
+
+                self.assertEqual(confidence, 0.0)
+                self.assertEqual(
+                    warning,
+                    "Report confidence metadata was invalid and was reset to 0.0.",
+                )
 
     def test_fetch_shared_analysis_report_requires_password_when_configured(
         self,

--- a/tests/test_ui/test_app_shell.py
+++ b/tests/test_ui/test_app_shell.py
@@ -283,6 +283,7 @@ class DashboardShellTests(unittest.TestCase):
             severity="critical",
             recommendation="no-go",
             top_risk="Security group exposure risk",
+            confidence=0.52,
             contributors=[
                 RiskContributor(
                     source_file="plan.json",
@@ -396,15 +397,15 @@ class DashboardShellTests(unittest.TestCase):
         self.assertIn("Risk score", response.text)
         self.assertIn("dw-verdict-score-value", response.text)
         self.assertIn('"text":"90"', response.text)
-        self.assertIn("STRONG CONTEXT", response.text)
+        self.assertIn("LIMITED CONTEXT", response.text)
         self.assertNotIn("Know the risk before", response.text)
         self.assertEqual(response.text.count("5-second verdict"), 1)
         self.assertIn("Risk scoring: heuristic+llm", response.text)
         self.assertIn("Narrative: llm", response.text)
         self.assertIn("Provider: ollama / ollama/llama3", response.text)
         self.assertIn("Skills: git, terraform", response.text)
-        self.assertIn("HIGH CONFIDENCE", response.text)
-        self.assertIn('"title":"Confidence 1.00"', response.text)
+        self.assertIn("LOW CONFIDENCE", response.text)
+        self.assertIn('"title":"Confidence 0.52"', response.text)
         self.assertIn("Last scan: plan.json · CRITICAL · NO-GO", response.text)
         self.assertIn(
             "1 saved briefing is shaping the current advisory view.", response.text
@@ -685,6 +686,7 @@ class DashboardShellTests(unittest.TestCase):
                 "topology_freshness_days": 45,
                 "topology_last_imported_at": "2026-04-18T11:22:33Z",
                 "incident_index_size": 0,
+                "evidence_success_rate": 1.0,
                 "parser_success_rate": 1.0,
                 "parser_success_by_tool": {"terraform": 1.0},
                 "context_score": 0.52,
@@ -733,6 +735,9 @@ class DashboardShellTests(unittest.TestCase):
 
         self.assertEqual(response.status_code, 200)
         self.assertIn("LIMITED CONTEXT", response.text)
+        self.assertIn("LOW CONFIDENCE", response.text)
+        self.assertIn('"title":"Confidence 0.52"', response.text)
+        self.assertIn("INSUFFICIENT CONTEXT", response.text)
         self.assertIn("Topology freshness", response.text)
         self.assertIn("45 days old", response.text)
         self.assertIn("STALE 30+", response.text)
@@ -743,7 +748,9 @@ class DashboardShellTests(unittest.TestCase):
         self.assertIn("Terraform", response.text)
         self.assertIn("Fix in settings", response.text)
         self.assertIn(
-            "Context warning: supporting topology or incident history may be stale.",
+            "Insufficient context: missing or stale topology, parser coverage, "
+            "evidence coverage, or incident history prevents a confident low-risk "
+            "verdict.",
             response.text,
         )
 

--- a/tests/test_ui/test_context_completeness_panel.py
+++ b/tests/test_ui/test_context_completeness_panel.py
@@ -20,9 +20,15 @@ def context_panel_test_page() -> None:
             "topology_freshness_days": 45,
             "topology_last_imported_at": "2026-04-18T11:22:33Z",
             "incident_index_size": 7,
+            "evidence_success_rate": 0.5,
             "parser_success_rate": 0.5,
             "parser_success_by_tool": {"terraform": 1.0, "kubernetes": 0.0},
             "context_score": 0.52,
+            "uncertainty": "Insufficient context: evidence coverage is partial.",
+            "context_todos": [
+                "Review evidence extraction gaps for supported artifacts.",
+                "Review parser errors and resubmit supported artifacts.",
+            ],
         }
     )
 
@@ -43,7 +49,21 @@ class ContextCompletenessPanelRenderingTests(unittest.TestCase):
         self.assertIn("Terraform", response.text)
         self.assertIn("Kubernetes", response.text)
         self.assertIn(
-            "Context warning: supporting topology or incident history may be stale.",
+            "Insufficient context: evidence coverage is partial.",
+            response.text,
+        )
+        self.assertIn("Evidence coverage", response.text)
+        self.assertIn(
+            "Review how much topology, evidence, parser, and incident context supported this report.",
+            response.text,
+        )
+        self.assertIn(
+            "Higher scores indicate stronger topology freshness, evidence coverage, parser coverage, and incident context.",
+            response.text,
+        )
+        self.assertIn("Context TODOs", response.text)
+        self.assertIn(
+            "Review evidence extraction gaps for supported artifacts.",
             response.text,
         )
         self.assertIn("/settings", response.text)
@@ -73,6 +93,146 @@ class ContextCompletenessPanelRenderingTests(unittest.TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertIn("Fix in settings", response.text)
         self.assertIn("/settings", response.text)
+
+    def test_context_panel_uses_insufficient_context_flag_at_rounded_boundary(
+        self,
+    ) -> None:
+        @ui.page("/_test/context-panel-rounded-low")
+        def rounded_low_context_panel_test_page() -> None:
+            from ui.components.context_completeness_panel import (
+                render_context_completeness_panel,
+            )
+
+            render_context_completeness_panel(
+                {
+                    "topology_freshness_days": 0,
+                    "topology_last_imported_at": "2026-05-11T11:22:33Z",
+                    "incident_index_size": 10,
+                    "evidence_success_rate": 1.0,
+                    "parser_success_rate": 1.0,
+                    "parser_success_by_tool": {"terraform": 1.0},
+                    "context_score": 0.7,
+                    "insufficient_context": True,
+                    "uncertainty": "Insufficient context: raw score was below threshold.",
+                }
+            )
+
+        response = self.client.get("/_test/context-panel-rounded-low")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(
+            "Insufficient context: raw score was below threshold.",
+            response.text,
+        )
+        self.assertIn("LIMITED CONTEXT", response.text)
+        self.assertIn("Review context TODOs", response.text)
+
+    def test_context_panel_warns_when_uncertainty_exists_above_low_threshold(
+        self,
+    ) -> None:
+        @ui.page("/_test/context-panel-uncertainty")
+        def uncertainty_context_panel_test_page() -> None:
+            from ui.components.context_completeness_panel import (
+                render_context_completeness_panel,
+            )
+
+            render_context_completeness_panel(
+                {
+                    "topology_freshness_days": 0,
+                    "topology_last_imported_at": "2026-05-11T11:22:33Z",
+                    "incident_index_size": 10,
+                    "evidence_success_rate": 0.5,
+                    "parser_success_rate": 1.0,
+                    "parser_success_by_tool": {"terraform": 1.0},
+                    "context_score": 0.74,
+                    "insufficient_context": False,
+                    "uncertainty": "Uncertainty: evidence coverage is partial.",
+                    "context_todos": [
+                        "Review evidence extraction gaps for supported artifacts."
+                    ],
+                }
+            )
+
+        response = self.client.get("/_test/context-panel-uncertainty")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("Uncertainty: evidence coverage is partial.", response.text)
+        self.assertIn("LIMITED CONTEXT", response.text)
+        self.assertIn("Review evidence", response.text)
+        self.assertIn("#context-todos", response.text)
+        self.assertIn(
+            "Review evidence extraction gaps for supported artifacts.",
+            response.text,
+        )
+
+    def test_context_panel_degrades_malformed_numeric_context_values(
+        self,
+    ) -> None:
+        @ui.page("/_test/context-panel-malformed")
+        def malformed_context_panel_test_page() -> None:
+            from ui.components.context_completeness_panel import (
+                render_context_completeness_panel,
+            )
+
+            render_context_completeness_panel(
+                {
+                    "topology_freshness_days": 0,
+                    "topology_last_imported_at": "2026-05-11T11:22:33Z",
+                    "incident_index_size": "many",
+                    "evidence_success_rate": "bad",
+                    "parser_success_rate": "bad",
+                    "parser_success_by_tool": {"terraform": 1.0},
+                    "context_score": "oops",
+                    "insufficient_context": False,
+                    "uncertainty": "Uncertainty: context metadata was malformed.",
+                    "context_todos": [
+                        "Review parser errors and resubmit supported artifacts."
+                    ],
+                }
+            )
+
+        response = self.client.get("/_test/context-panel-malformed")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("LIMITED CONTEXT", response.text)
+        self.assertIn("Context score", response.text)
+        self.assertIn("0.00 / 1.00", response.text)
+        self.assertIn("Review artifacts", response.text)
+        self.assertIn("Uncertainty: context metadata was malformed.", response.text)
+
+    def test_context_panel_ignores_scalar_context_todos(
+        self,
+    ) -> None:
+        @ui.page("/_test/context-panel-scalar-todos")
+        def scalar_todos_context_panel_test_page() -> None:
+            from ui.components.context_completeness_panel import (
+                render_context_completeness_panel,
+            )
+
+            render_context_completeness_panel(
+                {
+                    "topology_freshness_days": 0,
+                    "topology_last_imported_at": "2026-05-11T11:22:33Z",
+                    "incident_index_size": 10,
+                    "evidence_success_rate": 1.0,
+                    "parser_success_rate": 1.0,
+                    "parser_success_by_tool": {"terraform": 1.0},
+                    "context_score": 0.92,
+                    "insufficient_context": False,
+                    "context_todos": "Review parser errors and resubmit supported artifacts.",
+                }
+            )
+
+        response = self.client.get("/_test/context-panel-scalar-todos")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("STRONG CONTEXT", response.text)
+        self.assertNotIn("LIMITED CONTEXT", response.text)
+        self.assertNotIn("Context TODOs", response.text)
+        self.assertNotIn(
+            "Review parser errors and resubmit supported artifacts.",
+            response.text,
+        )
 
 
 if __name__ == "__main__":

--- a/tests/test_ui/test_history_page.py
+++ b/tests/test_ui/test_history_page.py
@@ -45,6 +45,18 @@ class HistoryPageHelpersTests(unittest.TestCase):
         self.assertIn("dw-danger-text", recommendation_classes("no-go"))
         self.assertIn("dw-success-text", recommendation_classes("go"))
 
+    def test_history_row_confidence_does_not_fallback_to_finding_confidence(
+        self,
+    ) -> None:
+        from ui.components.analysis_history_row import _report_confidence
+
+        self.assertIsNone(_report_confidence({"findings": [{"confidence": 1.0}]}))
+        self.assertIsNone(
+            _report_confidence(
+                {"confidence": "invalid", "findings": [{"confidence": 1.0}]}
+            )
+        )
+
 
 class HistoryPageRenderingTests(unittest.TestCase):
     def setUp(self) -> None:
@@ -78,6 +90,8 @@ class HistoryPageRenderingTests(unittest.TestCase):
         opening_sentence: str = "Ingress widens access to production resources.",
         finding_description: str = "Security group exposure risk",
         context_completeness: dict | None = None,
+        assessment_confidence: float = 1.0,
+        finding_confidence: float = 1.0,
     ) -> dict:
         parse_batch = ParseBatchResult(
             files=[
@@ -108,6 +122,7 @@ class HistoryPageRenderingTests(unittest.TestCase):
             recommendation=recommendation,
             top_risk=top_risk,
             context_completeness=context_completeness or {},
+            confidence=assessment_confidence,
             contributors=[
                 RiskContributor(
                     evidence_id="ev-001",
@@ -171,7 +186,7 @@ class HistoryPageRenderingTests(unittest.TestCase):
                     severity=severity,
                     category="networking/ingress",
                     deterministic=True,
-                    confidence=1.0,
+                    confidence=finding_confidence,
                     uncertainty_note=None,
                     evidence_refs=["ev-001"],
                     skill_id=None,
@@ -421,10 +436,20 @@ class HistoryPageRenderingTests(unittest.TestCase):
         self.assertIn("45 days old", response.text)
         self.assertIn("STALE 30+", response.text)
         self.assertIn("/settings#topology-context", response.text)
-        self.assertIn("HIGH CONFIDENCE", response.text)
-        self.assertIn('"title":"Confidence 1.00"', response.text)
+        self.assertIn("MEDIUM CONFIDENCE", response.text)
+        self.assertIn('"title":"Confidence 0.82"', response.text)
         self.assertIn("Risk: heuristic+llm", response.text)
         self.assertIn("Narrative: llm", response.text)
+
+    def test_history_page_renders_report_level_confidence(self) -> None:
+        self._persist_report(assessment_confidence=0.52, finding_confidence=1.0)
+
+        response = self.client.get("/history")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("LOW CONFIDENCE", response.text)
+        self.assertIn('"title":"Confidence 0.52"', response.text)
+        self.assertNotIn('"title":"Confidence 1.00"', response.text)
 
     def test_history_page_renders_calibration_snapshot_from_backtest_feed(self) -> None:
         report = self._persist_report(
@@ -493,6 +518,15 @@ class HistoryPageRenderingTests(unittest.TestCase):
         self.assertIn("Redacted fields: ingress.0.description", response.text)
         self.assertIn("Unsupported plan fields: plan.planned_values", response.text)
         self.assertNotIn('"data-dw-modal-root":"1"', response.text)
+
+    def test_history_detail_route_renders_report_level_confidence(self) -> None:
+        self._persist_report(assessment_confidence=0.52, finding_confidence=1.0)
+
+        response = self.client.get("/history/1")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("LOW CONFIDENCE", response.text)
+        self.assertIn('"title":"Confidence 0.52"', response.text)
 
     def test_history_detail_route_shows_topology_freshness_badge(self) -> None:
         self._persist_report(

--- a/tests/test_ui/test_verdict_card.py
+++ b/tests/test_ui/test_verdict_card.py
@@ -1,0 +1,32 @@
+"""Tests for verdict-card confidence and context warning helpers."""
+
+from __future__ import annotations
+
+import unittest
+
+from ui.components.verdict_card import _has_limited_context, _primary_confidence
+
+
+class VerdictCardHelperTests(unittest.TestCase):
+    def test_primary_confidence_does_not_fallback_to_finding_confidence(self) -> None:
+        for report in (
+            {"findings": [{"confidence": 1.0}]},
+            {"confidence": "invalid", "findings": [{"confidence": 1.0}]},
+        ):
+            with self.subTest(report=report):
+                self.assertIsNone(_primary_confidence(report))
+
+    def test_limited_context_treats_uncertainty_as_warning_signal(self) -> None:
+        self.assertTrue(
+            _has_limited_context(
+                {
+                    "context_score": 0.74,
+                    "insufficient_context": False,
+                    "uncertainty": "Uncertainty: evidence coverage is partial.",
+                }
+            )
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/ui/components/analysis_history_row.py
+++ b/ui/components/analysis_history_row.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from nicegui import ui
 
-from ui.formatters.confidence import render_confidence_badge
+from ui.formatters.confidence import coerce_confidence, render_confidence_badge
 from ui.formatters.datetime import format_history_timestamp
 from ui.formatters.recommendations import render_recommendation_label
 from ui.formatters.risk_labels import render_risk_badge
@@ -36,6 +36,10 @@ def _freshness_badge_style(level: str) -> str:
         "letter-spacing:0.04em;"
         "text-transform:uppercase;"
     )
+
+
+def _report_confidence(report: dict) -> float | None:
+    return coerce_confidence(report.get("confidence"))
 
 
 def render_analysis_history_row(
@@ -123,10 +127,10 @@ def render_analysis_history_row(
                             != recommendation_transition.split(" → ")[1]
                         ):
                             ui.label(recommendation_transition).classes("dw-muted")
-                findings = report.get("findings", [])
-                if findings:
+                confidence = _report_confidence(report)
+                if confidence is not None:
                     with ui.row().classes("w-full items-center gap-2 flex-wrap"):
-                        render_confidence_badge(findings[0]["confidence"])
+                        render_confidence_badge(confidence)
                 provenance = (
                     f"Risk: {report.get('assessment_source') or 'unknown'} · "
                     f"Narrative: {report.get('narrative_source') or 'unknown'}"

--- a/ui/components/context_completeness_panel.py
+++ b/ui/components/context_completeness_panel.py
@@ -10,6 +10,7 @@ from ui.components.review_accessibility import (
     register_review_accessibility,
 )
 from ui.formatters.context_completeness import (
+    context_number,
     context_score,
     render_context_completeness_badge,
 )
@@ -20,7 +21,10 @@ def _topology_age_text(context: dict) -> str:
     freshness = context.get("topology_freshness_days")
     if freshness is None:
         return "Unknown"
-    freshness_days = int(freshness)
+    try:
+        freshness_days = int(freshness)
+    except (TypeError, ValueError):
+        return "Unknown"
     if freshness_days == 0:
         return "Imported today"
     unit = "day" if freshness_days == 1 else "days"
@@ -52,7 +56,40 @@ def _topology_needs_settings_fix(context: dict) -> bool:
     freshness = context.get("topology_freshness_days")
     if freshness is None:
         return True
-    return int(freshness) > STALE_AFTER_DAYS
+    try:
+        return int(freshness) > STALE_AFTER_DAYS
+    except (TypeError, ValueError):
+        return True
+
+
+def _context_int(context: dict, key: str) -> int:
+    try:
+        return max(int(context.get(key, 0) or 0), 0)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _context_todo_items(value: object) -> list[str]:
+    if not isinstance(value, list | tuple):
+        return []
+    return [str(item).strip() for item in value if str(item).strip()]
+
+
+def _context_warning_action(context: dict, link_target: str) -> tuple[str, str]:
+    todos = " ".join(
+        item.lower() for item in _context_todo_items(context.get("context_todos"))
+    )
+    if _topology_needs_settings_fix(context) or "topology" in todos:
+        return "Fix in settings", link_target
+    if "evidence" in todos:
+        return "Review evidence", "#context-todos"
+    parser_success_rate = context_number(context.get("parser_success_rate"), 1.0)
+    if "parser" in todos or parser_success_rate < 1.0:
+        return "Review artifacts", "#context-todos"
+    incident_index_size = _context_int(context, "incident_index_size")
+    if incident_index_size == 0 or "incident" in todos:
+        return "Review incidents", "#context-todos"
+    return "Review context TODOs", "#context-todos"
 
 
 def render_context_completeness_panel(
@@ -63,10 +100,19 @@ def render_context_completeness_panel(
     """Render reviewer-facing context completeness details."""
     register_review_accessibility()
     details = context or {}
-    parser_success_by_tool = dict(details.get("parser_success_by_tool") or {})
-    low_context = float(details.get("context_score", 1.0)) < 0.7
-    stale_topology = _topology_needs_settings_fix(details)
+    raw_parser_success_by_tool = details.get("parser_success_by_tool")
+    parser_success_by_tool = (
+        dict(raw_parser_success_by_tool)
+        if isinstance(raw_parser_success_by_tool, dict)
+        else {}
+    )
+    context_todos = _context_todo_items(details.get("context_todos"))
+    uncertainty = str(details.get("uncertainty") or "").strip()
     score = context_score(details)
+    low_context = bool(details.get("insufficient_context")) or score < 0.7
+    show_context_warning = low_context or bool(uncertainty)
+    stale_topology = _topology_needs_settings_fix(details)
+    action_label, action_target = _context_warning_action(details, link_target)
 
     with ui.card().classes("w-full dw-panel shadow-none p-4") as panel:
         decorate_review_section(panel, section="context", label="Context completeness")
@@ -74,7 +120,7 @@ def render_context_completeness_panel(
             with ui.column().classes("gap-2 min-w-0 flex-1"):
                 ui.label("Context completeness").classes("text-lg font-medium dw-text")
                 ui.label(
-                    "Review how much topology, incident history, and parser coverage supported this report."
+                    "Review how much topology, evidence, parser, and incident context supported this report."
                 ).classes("text-sm dw-muted leading-6")
             render_context_completeness_badge(details)
         with ui.card().classes("w-full dw-panel-soft shadow-none mt-3"):
@@ -91,17 +137,18 @@ def render_context_completeness_panel(
                     "</div>"
                 )
                 ui.label(
-                    "Higher scores indicate stronger topology freshness, parser coverage, and incident context."
+                    "Higher scores indicate stronger topology freshness, evidence coverage, parser coverage, and incident context."
                 ).classes("text-xs dw-muted leading-5")
 
-        if low_context:
+        if show_context_warning:
             with ui.row().classes(
                 "w-full items-center justify-between gap-3 flex-wrap mt-3 rounded-[18px] border border-[color:var(--dw-accent-line)] bg-[color:var(--dw-accent-soft)] px-4 py-3"
             ):
                 ui.label(
-                    "Context warning: supporting topology or incident history may be stale."
+                    uncertainty
+                    or "Context warning: supporting topology, evidence, parser, or incident context may be incomplete."
                 ).classes("text-sm font-semibold dw-accent-text")
-                ui.link("Fix in settings", link_target).classes(
+                ui.link(action_label, action_target).classes(
                     "text-sm font-semibold dw-accent-text"
                 )
         elif stale_topology:
@@ -128,14 +175,35 @@ def render_context_completeness_panel(
             )
             _metric_card(
                 "Incident index",
-                str(int(details.get("incident_index_size", 0))),
+                str(_context_int(details, "incident_index_size")),
                 "Stored incidents available for similarity matching.",
             )
             _metric_card(
+                "Evidence coverage",
+                f"{context_number(details.get('evidence_success_rate'), 0.0):.2f}",
+                "Fraction of material changes represented by extracted evidence.",
+            )
+            _metric_card(
                 "Parser success",
-                f"{float(details.get('parser_success_rate', 1.0)):.2f}",
+                f"{context_number(details.get('parser_success_rate'), 0.0):.2f}",
                 "Overall fraction of analyzed artifacts parsed successfully.",
             )
+
+        if uncertainty or context_todos:
+            with ui.card().classes("w-full dw-panel-soft shadow-none mt-3"):
+                with ui.column().classes("gap-2 p-3"):
+                    ui.label("Context TODOs").props("id=context-todos").classes(
+                        "text-sm font-semibold dw-text"
+                    )
+                    if uncertainty:
+                        ui.label(uncertainty).classes("text-xs dw-muted leading-5")
+                    if context_todos:
+                        for todo in context_todos:
+                            ui.label(todo).classes("text-xs dw-muted leading-5")
+                    else:
+                        ui.label(
+                            "No context follow-up actions were generated."
+                        ).classes("text-xs dw-muted")
 
         with ui.card().classes("w-full dw-panel-soft shadow-none mt-3"):
             with ui.column().classes("gap-2 p-3"):

--- a/ui/components/report_detail_page.py
+++ b/ui/components/report_detail_page.py
@@ -24,6 +24,7 @@ from ui.components.findings_table import render_findings_table
 from ui.components.review_accessibility import decorate_review_section
 from ui.components.rollback_plan import render_rollback_plan
 from ui.components.topology_freshness_banner import render_topology_freshness_banner
+from ui.formatters.confidence import coerce_confidence, render_confidence_badge
 from ui.formatters.datetime import format_history_timestamp
 from ui.formatters.narrative import (
     extract_llm_notice,
@@ -596,6 +597,9 @@ def render_report_detail_page(
                         render_recommendation_label(
                             report["recommendation"], size="base"
                         )
+                        confidence = coerce_confidence(report.get("confidence"))
+                        if confidence is not None:
+                            render_confidence_badge(confidence)
                         ui.label(
                             format_history_timestamp(report["created_at"])
                         ).classes("text-sm dw-muted")

--- a/ui/components/upload_panel.py
+++ b/ui/components/upload_panel.py
@@ -56,6 +56,7 @@ from ui.project_authorization import (
 from ui.components.topology_freshness_banner import render_topology_freshness_banner
 from services.settings_service import check_provider_readiness
 from ui.components.findings_table import render_findings_table
+from ui.formatters.confidence import coerce_confidence, render_confidence_badge
 from ui.formatters.narrative import (
     extract_llm_notice,
     extract_submission_manifest_notice,
@@ -396,6 +397,9 @@ def build_upload_panel(
                         render_recommendation_label(
                             report["recommendation"], size="base"
                         )
+                        confidence = coerce_confidence(report.get("confidence"))
+                        if confidence is not None:
+                            render_confidence_badge(confidence)
                     countdown_label = ui.label("").classes("text-xs dw-muted")
                 ui.label(report["top_risk"]).classes(
                     "text-lg font-medium dw-text leading-6"

--- a/ui/components/verdict_card.py
+++ b/ui/components/verdict_card.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from nicegui import ui
 
-from ui.formatters.confidence import render_confidence_badge
+from ui.formatters.confidence import coerce_confidence, render_confidence_badge
 from ui.formatters.context_completeness import render_context_completeness_badge
 from ui.formatters.narrative import extract_llm_notice
 from ui.formatters.recommendations import render_recommendation_label
@@ -17,13 +17,28 @@ from ui.components.review_accessibility import (
 
 
 def _primary_confidence(report: dict) -> float | None:
-    findings = report.get("findings", [])
-    if not findings:
-        return None
+    return coerce_confidence(report.get("confidence"))
+
+
+def _has_limited_context(context: dict) -> bool:
+    if bool(context.get("insufficient_context")):
+        return True
+    if str(context.get("uncertainty") or "").strip():
+        return True
     try:
-        return float(findings[0]["confidence"])
-    except (KeyError, TypeError, ValueError):
-        return None
+        return float(context.get("context_score", 1.0)) < 0.7
+    except (TypeError, ValueError):
+        return False
+
+
+def _context_warning_text(context: dict) -> str:
+    uncertainty = str(context.get("uncertainty") or "").strip()
+    if uncertainty:
+        return uncertainty
+    return (
+        "Context warning: supporting topology, evidence, parser, or incident context "
+        "may be incomplete."
+    )
 
 
 def render_verdict_card(report: dict) -> None:
@@ -69,7 +84,7 @@ def render_verdict_card(report: dict) -> None:
             ui.label("Narrative note: " + llm_notice).classes(
                 "text-sm dw-warning-text leading-5 mt-2"
             )
-        if float(context.get("context_score", 1.0)) < 0.7:
-            ui.label(
-                "Context warning: supporting topology or incident history may be stale."
-            ).classes("text-sm dw-warning-text font-semibold leading-5 mt-1")
+        if _has_limited_context(context):
+            ui.label(_context_warning_text(context)).classes(
+                "text-sm dw-warning-text font-semibold leading-5 mt-1"
+            )

--- a/ui/formatters/confidence.py
+++ b/ui/formatters/confidence.py
@@ -2,7 +2,21 @@
 
 from __future__ import annotations
 
+import math
+
 from nicegui import ui
+
+
+def coerce_confidence(value: object) -> float | None:
+    if value is None:
+        return None
+    try:
+        confidence = float(value)
+    except (TypeError, ValueError):
+        return None
+    if not math.isfinite(confidence) or confidence < 0.0 or confidence > 1.0:
+        return None
+    return confidence
 
 
 def confidence_bucket(confidence: float) -> str:

--- a/ui/formatters/context_completeness.py
+++ b/ui/formatters/context_completeness.py
@@ -2,16 +2,25 @@
 
 from __future__ import annotations
 
+import math
+
 from nicegui import ui
+
+
+def context_number(value: object, default: float = 0.0) -> float:
+    try:
+        numeric_value = float(value)
+    except (TypeError, ValueError):
+        return default
+    if not math.isfinite(numeric_value):
+        return default
+    return max(0.0, min(numeric_value, 1.0))
 
 
 def context_score(context: dict | None) -> float:
     if not context:
         return 0.0
-    try:
-        return round(float(context.get("context_score", 0.0)), 2)
-    except (TypeError, ValueError):
-        return 0.0
+    return round(context_number(context.get("context_score"), 0.0), 2)
 
 
 def context_completeness_bucket(score: float) -> str:
@@ -20,6 +29,23 @@ def context_completeness_bucket(score: float) -> str:
     if score >= 0.60:
         return "partial"
     return "limited"
+
+
+def _context_todo_items(value: object) -> list[str]:
+    if not isinstance(value, list | tuple):
+        return []
+    return [str(item).strip() for item in value if str(item).strip()]
+
+
+def context_completeness_bucket_for_context(context: dict | None) -> str:
+    if context and (
+        bool(context.get("insufficient_context"))
+        or str(context.get("confidence_level", "")).lower() == "low"
+        or bool(str(context.get("uncertainty") or "").strip())
+        or bool(_context_todo_items(context.get("context_todos")))
+    ):
+        return "limited"
+    return context_completeness_bucket(context_score(context))
 
 
 def _context_style(bucket: str) -> str:
@@ -45,7 +71,7 @@ def _context_style(bucket: str) -> str:
 
 def render_context_completeness_badge(context: dict | None):
     score = context_score(context)
-    bucket = context_completeness_bucket(score)
+    bucket = context_completeness_bucket_for_context(context)
     bucket_label = {
         "strong": "Strong context",
         "partial": "Partial context",
@@ -54,7 +80,7 @@ def render_context_completeness_badge(context: dict | None):
     badge = ui.label(f"{bucket_label.upper()} · {score:.2f}").style(
         _context_style(bucket)
     )
-    parser_success = float((context or {}).get("parser_success_rate", 1.0))
+    parser_success = context_number((context or {}).get("parser_success_rate"), 1.0)
     freshness = (context or {}).get("topology_freshness_days")
     freshness_text = "unknown" if freshness is None else str(freshness)
     badge.props(


### PR DESCRIPTION
Story 2.6 requires low-context analysis to surface confidence, uncertainty, context completeness, TODOs, and insufficient-context verdict signals across the shared report path. The implementation keeps the advisory-first behavior while failing closed for malformed persisted context and missing confidence metadata.

Constraint: Story 2.6 is additive to report schema v2; broader schema-version policy remains Story 2.8.

Rejected: Use finding confidence as the UI fallback | it can hide missing report-level confidence and overstate certainty.

Confidence: high

Scope-risk: moderate

Directive: Do not treat missing or malformed context metadata as strong context; degrade to limited context and zero confidence instead.

Tested: ./.venv/bin/python -m unittest discover -q; bash scripts/ci-local.sh; APP_PORT=18080 npm run test:ui-review; ./.venv/bin/ruff check .; ./.venv/bin/ruff format --check .; git diff --check

Not-tested: Manual browser exploration beyond automated UI review lane

## What does this PR do?

<!-- Brief description of changes -->

## Type of change
- [ ] Feature (new functionality)
- [ ] Bugfix (non-breaking fix)
- [ ] Release preparation
- [ ] Hotfix (critical production fix)
- [ ] Docs / refactor / chore

## Checklist
- [ ] I have followed the branch naming convention
- [ ] Tests pass locally (`pytest tests/ -v`)
- [ ] Linting passes (`ruff check .`)
- [ ] Docker build succeeds
- [ ] I have updated docs if needed
- [ ] No secrets or .env values committed

## Related issue
Closes #