### PR TITLE
Expose report schema versions to machine consumers

### DIFF
--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -1,5 +1,5 @@
 # generated: 2026-05-01
-# last_updated: 2026-05-12
+# last_updated: 2026-05-13
 # project: deploywhisper
 # project_key: NOKEY
 # tracking_system: file-system
@@ -35,7 +35,7 @@
 # - Dev moves story to review, then runs code-review
 
 generated: 2026-05-01
-last_updated: 2026-05-12
+last_updated: 2026-05-13
 project: deploywhisper
 project_key: NOKEY
 tracking_system: file-system
@@ -66,7 +66,7 @@ development_status:
   2-5-evidence-law-runtime-gate: review
   2-6-confidence-uncertainty-and-insufficient-context: done
   2-7-narrative-after-scoring-and-degraded-fallback: done
-  2-8-report-schema-versioning: ready-for-dev
+  2-8-report-schema-versioning: done
   2-9-durable-report-persistence-and-audit-metadata: ready-for-dev
   epic-2-retrospective: optional
 

--- a/_bmad-output/planning-artifacts/prd.md
+++ b/_bmad-output/planning-artifacts/prd.md
@@ -8,7 +8,7 @@
 **License posture:** Fully open-source (MIT). Self-hosted only. No SaaS product. No hosted control plane. No open-core split. No paid enterprise-only features.  
 **Strategic posture:** Become the open-source safety standard for human-written and AI-generated infrastructure changes before production.
 **v1.0 tightening:** Restores testable performance targets, adds legal/ethical safeguards for sample incident packs, and defines conflict-handling rules for external scanner evidence.
-
+All milestones in this section are part of DeployWhisper V1 scope. The milestone labels describe implementation order and maturity gates, not separate product versions. No item in this section should be interpreted as V2, paid, post-V1, or SaaS-only scope.
 ---
 
 ## 1. Executive Summary
@@ -2485,9 +2485,11 @@ A CNCF reviewer can inspect governance, maintainers, CODEOWNERS, release process
 
 ---
 
-## 32. Scope by Phase
+## 32. V1 Delivery Milestones
 
-### 32.1 Phase 0 - Open-source and execution foundation
+All milestones in this section are part of DeployWhisper V1 scope. The milestone labels describe implementation order and maturity gates, not separate product versions. No item in this section should be interpreted as V2, paid, post-V1, or SaaS-only scope.
+
+### 32.1 V1 Foundation - Open-source and execution foundation
 
 Focus:
 
@@ -2502,7 +2504,7 @@ Focus:
 - Add security policy.
 - Add first demo and examples.
 
-### 32.2 Phase 1 - Trusted Advisory Core
+### 32.2 V1 Core - Trusted Advisory Core
 
 Focus:
 
@@ -2518,7 +2520,7 @@ Focus:
 - CLI/API/web report baseline.
 - Documentation for first analysis and report interpretation.
 
-### 32.3 Phase 1.5 - Workflow, docs, and benchmark proof
+### 32.3 V1 Workflow proof - Workflow, docs, and benchmark proof
 
 Focus:
 
@@ -2533,7 +2535,7 @@ Focus:
 - Sample incident pack.
 - Outcome capture v1.
 
-### 32.4 Phase 2 - Context moat
+### 32.4 V1 Context Expansion - Context moat
 
 Focus:
 
@@ -2548,7 +2550,7 @@ Focus:
 - Deployment outcome learning.
 - External scanner contextualization expansion.
 
-### 32.5 Phase 3 - Agent-native and integration expansion
+### 32.5 V1 Agent and Adapter Expansion - Agent-native and integration expansion
 
 Focus:
 
@@ -2561,7 +2563,7 @@ Focus:
 - 40+ verified Skills.
 - AI safety documentation.
 
-### 32.6 Phase 4 - CNCF and scale readiness
+### 32.6 V1 GA and CNCF Readiness - CNCF and scale readiness
 
 Focus:
 
@@ -2582,7 +2584,7 @@ Focus:
 
 ## 33. Epics
 
-| Epic | Phase | Purpose | Requirement families |
+| Epic | V1 milestone | Purpose | Requirement families |
 |---|---|---|---|
 | Epic 0: Open Governance, Traceability, and Maintainer Ownership | Phase 0 | Remove ambiguity, map owners, prepare community growth | GOV, OSS, traceability, NFR-OSS |
 | Epic 1: Project, Workspace, and RBAC Foundation | Phase 0/1 | Define core boundaries before persistence and connectors harden | PRJ, ADM, NFR-SEC |
@@ -2604,7 +2606,7 @@ Focus:
 
 ## 34. Release Exit Criteria
 
-### 34.1 Phase 0 exit
+### 34.1 V1 Foundation exit
 
 - PRD updated with full open-source and self-hosted-only commitment.
 - Open-core, SaaS, hosted-control-plane, and paid-feature references removed.
@@ -2618,7 +2620,7 @@ Focus:
 - Demo media and sample artifacts available.
 - Documentation IA, quickstart, first-analysis guide, self-hosted install guide, Evidence Law guide, and docs contribution guide exist.
 
-### 34.2 Phase 1 exit
+### 34.2 V1 Core exit
 
 - Mixed-artifact analysis works reliably.
 - Reports contain project scope, evidence, confidence, and uncertainty.
@@ -2631,7 +2633,7 @@ Focus:
 - Report interpretation, Evidence Law, evidence model, project model, configuration, and troubleshooting docs are published.
 - Senior reviewers consider high/critical findings credible in friendly-user workflows.
 
-### 34.3 Phase 1.5 exit
+### 34.3 V1 Workflow proof exit
 
 - GitHub workflow integration live and documented.
 - PR summaries used in real reviews.
@@ -2646,7 +2648,7 @@ Focus:
 - Sample incident pack available.
 - GitHub integration, benchmark, Skills authoring, and day-zero incident docs are published and linked from relevant workflows.
 
-### 34.4 Phase 2 exit
+### 34.4 V1 Context Expansion exit
 
 - Terraform plan and state context improve blast-radius quality.
 - Kubernetes live-state connector available as optional read-only context.
@@ -2658,7 +2660,7 @@ Focus:
 - External scanner contextualization produces useful deployment-risk context.
 - Connector, incident memory, context graph, outcome-capture, and scanner-ingestion docs are published.
 
-### 34.5 Phase 3 exit
+### 34.5 V1 Agent and Adapter Expansion exit
 
 - MCP server alpha or equivalent agent interface available.
 - Agent JSON output stable.
@@ -2669,7 +2671,7 @@ Focus:
 - 40+ verified Skills.
 - Agent, MCP, GitLab/Jenkins/Atlantis/GitOps, integration, and policy-adapter documentation published.
 
-### 34.6 Phase 4 exit
+### 34.6 V1 GA and CNCF Readiness exit
 
 - PostgreSQL path available.
 - Async worker path available.

--- a/api/routes/analyses.py
+++ b/api/routes/analyses.py
@@ -48,6 +48,22 @@ router = APIRouter(prefix="/api/v1/analyses", tags=["analyses"], route_class=Api
 READ_CHUNK_BYTES = 1024 * 1024
 
 
+def _list_report_schema_meta(reports: list[dict]) -> dict[str, object]:
+    versions = sorted(
+        {
+            str(report.get("report_schema_version"))
+            for report in reports
+            if report.get("report_schema_version") is not None
+        }
+    )
+    return {
+        "report_schema_version": versions[0]
+        if len(versions) == 1
+        else REPORT_SCHEMA_VERSION,
+        "report_schema_versions": versions,
+    }
+
+
 def _project_api_error(exc: ValueError) -> ApiError:
     code = getattr(exc, "code", "invalid_project_request")
     status_code = 404 if code in {"project_not_found", "workspace_not_found"} else 400
@@ -346,10 +362,11 @@ def list_analyses(
         ):
             raise _project_scope_forbidden_error() from exc
         raise _project_api_error(exc) from exc
+    reports = page_payload["items"]
     return AnalysisListResponse(
-        data=[AnalysisReportData(**report) for report in page_payload["items"]],
+        data=[AnalysisReportData(**report) for report in reports],
         meta=build_report_meta(
-            report_schema_version=REPORT_SCHEMA_VERSION,
+            **_list_report_schema_meta(reports),
             count=len(page_payload["items"]),
             total_count=page_payload["total_count"],
             page=page_payload["page"],
@@ -565,7 +582,7 @@ def get_analysis(
     return AnalysisDetailResponse(
         data=AnalysisReportData(**report),
         meta=build_report_meta(
-            id=report_id, report_schema_version=REPORT_SCHEMA_VERSION
+            id=report_id, report_schema_version=report["report_schema_version"]
         ),
     )
 

--- a/api/routes/analyses.py
+++ b/api/routes/analyses.py
@@ -37,6 +37,7 @@ from services.report_service import REPORT_SCHEMA_VERSION
 from services.report_service import configure_report_share
 from services.report_service import fetch_analysis_report
 from services.report_service import fetch_filtered_analysis_history_page
+from services.report_service import normalize_report_schema_version
 from services.project_service import (
     ensure_default_project,
     has_restricted_project_scope,
@@ -49,12 +50,15 @@ READ_CHUNK_BYTES = 1024 * 1024
 
 
 def _list_report_schema_meta(reports: list[dict]) -> dict[str, object]:
+    def schema_major(schema_version: str) -> int:
+        return int(schema_version[1:]) if schema_version.startswith("v") else 0
+
     versions = sorted(
         {
-            str(report.get("report_schema_version"))
+            normalize_report_schema_version(report.get("report_schema_version"))
             for report in reports
-            if report.get("report_schema_version") is not None
-        }
+        },
+        key=schema_major,
     )
     return {
         "report_schema_version": versions[0]

--- a/api/routes/analyses.py
+++ b/api/routes/analyses.py
@@ -70,7 +70,9 @@ def _list_report_schema_meta(reports: list[dict]) -> dict[str, object]:
 
 def _project_api_error(exc: ValueError) -> ApiError:
     code = getattr(exc, "code", "invalid_project_request")
-    status_code = 404 if code in {"project_not_found", "workspace_not_found"} else 400
+    status_code = getattr(exc, "status_code", None) or (
+        404 if code in {"project_not_found", "workspace_not_found"} else 400
+    )
     return ApiError(
         status_code=status_code,
         code=code,
@@ -586,7 +588,10 @@ def get_analysis(
     return AnalysisDetailResponse(
         data=AnalysisReportData(**report),
         meta=build_report_meta(
-            id=report_id, report_schema_version=report["report_schema_version"]
+            id=report_id,
+            report_schema_version=normalize_report_schema_version(
+                report.get("report_schema_version")
+            ),
         ),
     )
 

--- a/api/schemas.py
+++ b/api/schemas.py
@@ -109,7 +109,15 @@ class PendingAnalysis(BaseModel):
 
 class CountMetaPayload(MetaPayload):
     report_schema_version: str = Field(
-        ..., description="Report schema version used by returned report payloads"
+        ...,
+        description=(
+            "Report schema version used by returned report payloads when uniform; "
+            "inspect report_schema_versions when multiple versions are present"
+        ),
+    )
+    report_schema_versions: list[str] = Field(
+        default_factory=list,
+        description="Distinct report schema versions present in returned items",
     )
     count: int = Field(..., description="Count of returned items")
     total_count: int | None = Field(
@@ -972,6 +980,10 @@ class ShareSummaryContextData(BaseModel):
 
 class ShareSummaryJsonPayloadData(BaseModel):
     version: str = Field(..., description="Share-summary payload version")
+    report_schema_version: str = Field(
+        ...,
+        description="Report schema version used by the source persisted report",
+    )
     report_id: int | None = Field(default=None, description="Persisted report ID")
     report_link: str | None = Field(default=None, description="Deep link to the report")
     rollback_link: str | None = Field(

--- a/docs/ci-advisory-consumption.md
+++ b/docs/ci-advisory-consumption.md
@@ -6,7 +6,7 @@ DeployWhisper remains advisory in automation contexts.
 - `data.advisory.requires_attention` tells the pipeline or PR bot whether humans should take a closer look
 - `data.share_summary` provides a ready-to-render PR / approval-thread summary in both `markdown` and `plain_text`
 - `data.share_summary.markdown` is capped at 1,500 characters for GitHub PR comment fit
-- `data.share_summary.json_payload` provides the machine-friendly summary variant, including top findings, evidence count, context completeness, and report / rollback links
+- `data.share_summary.json_payload` provides the machine-friendly summary variant, including `report_schema_version`, top findings, evidence count, context completeness, and report / rollback links
 - Share-summary report links always resolve to an absolute `/reports/{id}` URL; set `APP_BASE_URL` when you need those links to point at a public/reverse-proxied DeployWhisper instance instead of the local app host/port
 - Sensitive shared reports can opt into password protection and file-name redaction through `POST /api/v1/analyses/{id}/share`
 - The share-configuration API is disabled unless `DEPLOYWHISPER_SHARE_TOKEN` is set; callers must send that value in `X-DeployWhisper-Share-Token`
@@ -37,6 +37,7 @@ payload = json.load(open("advisory.json", encoding="utf-8"))
 advisory = payload["data"]["advisory"]
 summary = payload["data"]["share_summary"]
 print(summary["markdown"])
+print(summary["json_payload"]["report_schema_version"])
 print(summary["json_payload"]["rollback_link"])
 print("DeployWhisper blocking decision:", advisory["should_block"])
 PY

--- a/docs/schemas/report-v2.md
+++ b/docs/schemas/report-v2.md
@@ -30,10 +30,19 @@ This schema version applies to:
     "app": "DeployWhisper",
     "version": "0.1.0",
     "api_version": "v1",
-    "report_schema_version": "v2"
+    "report_schema_version": "v2",
+    "report_schema_versions": ["v2"]
   }
 }
 ```
+
+Analysis list responses may contain reports written under different report
+schema versions. In that case, `meta.report_schema_version` remains the response
+reader/envelope schema version and `meta.report_schema_versions` lists the
+distinct item schema versions in numeric major-version order, such as
+`["v1", "v2"]`. Consumers that need item-level branching should inspect
+`data[*].report_schema_version` or `meta.report_schema_versions` instead of
+assuming a uniform list.
 
 ### Advisory and share-summary shape
 

--- a/docs/schemas/report-v2.md
+++ b/docs/schemas/report-v2.md
@@ -1,6 +1,6 @@
 # Report Schema v2
 
-`report_schema_version: "v2"` is the canonical persisted report contract for DeployWhisper Story 1.8.
+`report_schema_version: "v2"` is the canonical persisted report contract for DeployWhisper Story 2.8.
 
 ## Scope
 
@@ -9,13 +9,16 @@ This schema version applies to:
 - persisted `analysis_reports` rows
 - API analysis payloads and report retrieval payloads
 - CLI analysis payloads
+- share-summary JSON payloads used by PR, benchmark, and agent consumers
 
 ## Core guarantees
 
 1. Every persisted report stores `report_schema_version`.
-2. API envelopes include `report_schema_version` in `meta`.
-3. Stored reports remain readable across upgrades by version-aware readers.
-4. Newer readers are expected to read older schemas when the older schema major version is less than or equal to the reader version.
+2. API and CLI envelopes include `report_schema_version` in `meta`.
+3. Machine-friendly share-summary payloads include `report_schema_version`
+   alongside their own share payload `version`.
+4. Stored reports remain readable across upgrades by version-aware readers.
+5. Newer readers are expected to read older schemas when the older schema major version is less than or equal to the reader version.
 
 ## Envelope examples
 
@@ -28,6 +31,67 @@ This schema version applies to:
     "version": "0.1.0",
     "api_version": "v1",
     "report_schema_version": "v2"
+  }
+}
+```
+
+### Advisory and share-summary shape
+
+API and CLI analysis responses include advisory fields for automation and PR
+comment consumers. `data.advisory.should_block` remains `false`; downstream
+systems may use `requires_attention` and `uncertainty_flags` to decide whether
+to notify humans, but DeployWhisper's canonical contract remains advisory-first.
+
+The share-summary JSON payload has its own `version` because PR comments,
+benchmark reports, and agent integrations may evolve their compact summary shape
+separately from the persisted report. It still carries `report_schema_version`
+so consumers know which full report contract backs the summary.
+
+The share-summary payload `version` remains `v1` for this change because adding
+`report_schema_version` is an additive field. Additive fields are compatible with
+share-summary `v1`; consumers that validate the compact summary should ignore
+unknown fields and branch on `report_schema_version` when they need the backing
+full-report contract.
+
+```json
+{
+  "advisory": {
+    "advisory_only": true,
+    "should_block": false,
+    "requires_attention": true,
+    "severity": "high",
+    "recommendation": "no-go",
+    "partial_context": true,
+    "narrative_degraded": true,
+    "uncertainty_flags": ["partial_context", "narrative_degraded"]
+  },
+  "share_summary": {
+    "advisory_only": true,
+    "should_block": false,
+    "json_payload": {
+      "version": "v1",
+      "report_schema_version": "v2",
+      "report_id": 42,
+      "report_link": "https://deploywhisper.example.com/reports/42",
+      "rollback_link": "https://deploywhisper.example.com/reports/42",
+      "verdict_banner": "DeployWhisper HIGH - NO-GO",
+      "headline": "NO-GO: Security group exposure risk",
+      "top_findings": [
+        {
+          "title": "HIGH: public ingress exposure",
+          "severity": "high",
+          "evidence_count": 2,
+          "confidence": 1.0
+        }
+      ],
+      "evidence_count": 4,
+      "context_completeness": {
+        "score": 0.22,
+        "label": "LIMITED CONTEXT",
+        "summary": "LIMITED CONTEXT (0.22) - reviewer verification required."
+      },
+      "advisory_summary": "This result requires additional human review before release."
+    }
   }
 }
 ```
@@ -247,10 +311,13 @@ without storing raw plan internals in a separate contract.
 - report-level confidence derived from available context
 - persisted rollback plans with time estimates and complexity rationale
 - degraded narrative visibility fields
+- advisory-only automation fields for API, CLI, PR, benchmark, and agent consumers
+- share-summary JSON payloads include the source `report_schema_version`
 - submission manifest payloads that record accepted, excluded, failed, partial, sensitive, provenance, and redaction status
 - durable submission manifest fallback identity/status metadata for malformed-manifest recovery
 - parser-normalized change metadata for Terraform plan JSON format and Terraform versions, module paths, replacement paths, unknown-after-apply fields, redacted fields, and unsupported resource/change/plan fields
 
-Story 2.6 adds report-level confidence, context uncertainty, evidence coverage,
-context TODOs, and insufficient-context signals as additive `v2` fields. Broader
-schema-version policy changes remain deferred to Story 2.8.
+Story 2.6 added report-level confidence, context uncertainty, evidence coverage,
+context TODOs, and insufficient-context signals as additive `v2` fields. Story
+2.8 makes the report schema version explicit for API, CLI, PR, benchmark, and
+agent-facing machine consumers.

--- a/docs/schemas/report-v2.md
+++ b/docs/schemas/report-v2.md
@@ -44,6 +44,12 @@ distinct item schema versions in numeric major-version order, such as
 `data[*].report_schema_version` or `meta.report_schema_versions` instead of
 assuming a uniform list.
 
+Readers canonicalize valid schema versions to `vN` form, so values such as
+`v02` are emitted as `v2`. Blank historical values are treated as legacy `v1`;
+non-empty malformed markers are rejected as invalid, and versions newer than the
+current reader schema are rejected until the runtime supports that report
+contract.
+
 ### Advisory and share-summary shape
 
 API and CLI analysis responses include advisory fields for automation and PR

--- a/services/analysis_service.py
+++ b/services/analysis_service.py
@@ -33,7 +33,12 @@ from services.project_service import (
     resolve_project_reference,
     resolve_workspace_reference,
 )
-from services.report_service import build_share_report_link, persist_analysis_report
+from services.report_service import (
+    REPORT_SCHEMA_VERSION,
+    build_share_report_link,
+    normalize_report_schema_version,
+    persist_analysis_report,
+)
 from services.settings_service import resolve_provider_runtime
 from services.submission_manifest import build_submission_manifest
 from services.topology_service import (
@@ -231,6 +236,10 @@ class ShareSummaryContext(BaseModel):
 
 class ShareSummaryJsonPayload(BaseModel):
     version: str = Field(default="v1", description="Share-summary payload version")
+    report_schema_version: str = Field(
+        default=REPORT_SCHEMA_VERSION,
+        description="Report schema version used by the source persisted report",
+    )
     report_id: int | None = Field(default=None, description="Persisted report ID")
     report_link: str | None = Field(default=None, description="Deep link to the report")
     rollback_link: str | None = Field(
@@ -806,6 +815,9 @@ def build_share_summary(report: dict) -> ShareSummary:
         else "Standard approval flow is sufficient."
     )
     json_payload = ShareSummaryJsonPayload(
+        report_schema_version=normalize_report_schema_version(
+            report.get("report_schema_version")
+        ),
         report_id=report_id,
         report_link=report_link,
         rollback_link=rollback_link,

--- a/services/analysis_service.py
+++ b/services/analysis_service.py
@@ -36,8 +36,8 @@ from services.project_service import (
 from services.report_service import (
     REPORT_SCHEMA_VERSION,
     build_share_report_link,
-    normalize_report_schema_version,
     persist_analysis_report,
+    readable_report_schema_version,
 )
 from services.settings_service import resolve_provider_runtime
 from services.submission_manifest import build_submission_manifest
@@ -815,7 +815,7 @@ def build_share_summary(report: dict) -> ShareSummary:
         else "Standard approval flow is sufficient."
     )
     json_payload = ShareSummaryJsonPayload(
-        report_schema_version=normalize_report_schema_version(
+        report_schema_version=readable_report_schema_version(
             report.get("report_schema_version")
         ),
         report_id=report_id,

--- a/services/report_service.py
+++ b/services/report_service.py
@@ -2052,7 +2052,16 @@ def _evidence_items_with_report_context(
 
 def normalize_report_schema_version(schema_version: object | None) -> str:
     """Return a stable schema version for stored or in-memory reports."""
-    normalized = str(schema_version or "").strip()
+    if schema_version is None:
+        normalized = ""
+    elif isinstance(schema_version, str):
+        normalized = schema_version.strip()
+    else:
+        raise ReportSchemaVersionError(
+            "invalid_report_schema_version",
+            f"Unsupported report schema version: {schema_version!r}",
+            status_code=400,
+        )
     if not normalized:
         return LEGACY_REPORT_SCHEMA_VERSION
     if normalized.startswith("v") and normalized[1:].isdigit():
@@ -3024,10 +3033,14 @@ def fetch_filtered_analysis_history_page(
             serialized_reports = [
                 _serialize_report(report, include_evidence=False) for report in reports
             ]
-            serialized_all_reports = [
-                _serialize_report(report, include_evidence=False)
-                for report in all_reports
-            ]
+            serialized_all_reports = []
+            for report in all_reports:
+                try:
+                    serialized_all_reports.append(
+                        _serialize_report(report, include_evidence=False)
+                    )
+                except ReportSchemaVersionError:
+                    continue
             return (
                 _attach_previous_scan_diffs(serialized_reports, serialized_all_reports),
                 total_count,

--- a/services/report_service.py
+++ b/services/report_service.py
@@ -132,6 +132,16 @@ _LEGACY_CONTEXT_CORE_FIELDS = {
 }
 
 
+class ReportSchemaVersionError(ValueError):
+    """Raised when a stored report schema version cannot be safely read."""
+
+    def __init__(self, code: str, message: str, status_code: int = 409) -> None:
+        super().__init__(message)
+        self.code = code
+        self.message = message
+        self.status_code = status_code
+
+
 def _resolve_project_id(
     *,
     project_id: int | None = None,
@@ -2040,14 +2050,33 @@ def _evidence_items_with_report_context(
     ]
 
 
-def normalize_report_schema_version(schema_version: str | None) -> str:
+def normalize_report_schema_version(schema_version: object | None) -> str:
     """Return a stable schema version for stored or in-memory reports."""
-    normalized = (schema_version or "").strip()
+    normalized = str(schema_version or "").strip()
     if not normalized:
         return LEGACY_REPORT_SCHEMA_VERSION
     if normalized.startswith("v") and normalized[1:].isdigit():
-        return normalized
-    return LEGACY_REPORT_SCHEMA_VERSION
+        major = int(normalized[1:])
+        if major >= 1:
+            return f"v{major}"
+    raise ReportSchemaVersionError(
+        "invalid_report_schema_version",
+        f"Unsupported report schema version: {normalized}",
+        status_code=400,
+    )
+
+
+def readable_report_schema_version(schema_version: object | None) -> str:
+    normalized = normalize_report_schema_version(schema_version)
+    if not can_read_report_schema(REPORT_SCHEMA_VERSION, normalized):
+        raise ReportSchemaVersionError(
+            "unsupported_report_schema_version",
+            (
+                f"Report schema version {normalized} is newer than reader schema "
+                f"{REPORT_SCHEMA_VERSION}."
+            ),
+        )
+    return normalized
 
 
 def _report_schema_major(schema_version: str) -> int:
@@ -2473,7 +2502,7 @@ def _serialize_report(report, *, include_evidence: bool = True) -> dict:
         "severity": report.severity,
         "recommendation": report.recommendation,
         "top_risk": report.top_risk,
-        "report_schema_version": normalize_report_schema_version(
+        "report_schema_version": readable_report_schema_version(
             getattr(report, "report_schema_version", None)
         ),
         "top_risk_contributors": json.loads(

--- a/services/report_service.py
+++ b/services/report_service.py
@@ -2042,7 +2042,12 @@ def _evidence_items_with_report_context(
 
 def normalize_report_schema_version(schema_version: str | None) -> str:
     """Return a stable schema version for stored or in-memory reports."""
-    return schema_version or LEGACY_REPORT_SCHEMA_VERSION
+    normalized = (schema_version or "").strip()
+    if not normalized:
+        return LEGACY_REPORT_SCHEMA_VERSION
+    if normalized.startswith("v") and normalized[1:].isdigit():
+        return normalized
+    return LEGACY_REPORT_SCHEMA_VERSION
 
 
 def _report_schema_major(schema_version: str) -> int:

--- a/tests/test_api/test_analyses.py
+++ b/tests/test_api/test_analyses.py
@@ -201,6 +201,20 @@ class AnalysesApiTests(unittest.TestCase):
             {"v1", "v2"},
         )
 
+    def test_list_analyses_rejects_newer_report_schema_versions(self) -> None:
+        with sqlite3.connect(self.db_path) as conn:
+            conn.execute(
+                "UPDATE analysis_reports SET report_schema_version = 'v3' WHERE id = ?",
+                (self.persisted["id"],),
+            )
+
+        response = self.client.get("/api/v1/analyses")
+
+        self.assertEqual(response.status_code, 409)
+        self.assertEqual(
+            response.json()["error"]["code"], "unsupported_report_schema_version"
+        )
+
     def test_list_analyses_defaults_to_unassigned_scope(self) -> None:
         project = project_service_module.create_project(
             project_key="payments",
@@ -269,7 +283,23 @@ class AnalysesApiTests(unittest.TestCase):
         self.assertEqual(payload["data"]["report_schema_version"], "v1")
         self.assertEqual(payload["meta"]["report_schema_version"], "v1")
 
-    def test_get_analysis_meta_normalizes_malformed_report_schema_as_legacy(
+    def test_get_analysis_canonicalizes_zero_padded_report_schema_version(
+        self,
+    ) -> None:
+        with sqlite3.connect(self.db_path) as conn:
+            conn.execute(
+                "UPDATE analysis_reports SET report_schema_version = 'v02' WHERE id = ?",
+                (self.persisted["id"],),
+            )
+
+        response = self.client.get(f"/api/v1/analyses/{self.persisted['id']}")
+
+        self.assertEqual(response.status_code, 200)
+        payload = response.json()
+        self.assertEqual(payload["data"]["report_schema_version"], "v2")
+        self.assertEqual(payload["meta"]["report_schema_version"], "v2")
+
+    def test_get_analysis_rejects_malformed_report_schema_version(
         self,
     ) -> None:
         with sqlite3.connect(self.db_path) as conn:
@@ -280,10 +310,24 @@ class AnalysesApiTests(unittest.TestCase):
 
         response = self.client.get(f"/api/v1/analyses/{self.persisted['id']}")
 
-        self.assertEqual(response.status_code, 200)
-        payload = response.json()
-        self.assertEqual(payload["data"]["report_schema_version"], "v1")
-        self.assertEqual(payload["meta"]["report_schema_version"], "v1")
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(
+            response.json()["error"]["code"], "invalid_report_schema_version"
+        )
+
+    def test_get_analysis_rejects_newer_report_schema_version(self) -> None:
+        with sqlite3.connect(self.db_path) as conn:
+            conn.execute(
+                "UPDATE analysis_reports SET report_schema_version = 'v3' WHERE id = ?",
+                (self.persisted["id"],),
+            )
+
+        response = self.client.get(f"/api/v1/analyses/{self.persisted['id']}")
+
+        self.assertEqual(response.status_code, 409)
+        self.assertEqual(
+            response.json()["error"]["code"], "unsupported_report_schema_version"
+        )
 
     def test_get_analysis_rejects_unknown_project_reference(self) -> None:
         response = self.client.get(

--- a/tests/test_api/test_analyses.py
+++ b/tests/test_api/test_analyses.py
@@ -138,6 +138,20 @@ class AnalysesApiTests(unittest.TestCase):
         self.assertEqual(payload["meta"]["page"], 1)
         self.assertEqual(payload["meta"]["page_size"], 50)
 
+    def test_list_analyses_meta_matches_legacy_report_schema(self) -> None:
+        with sqlite3.connect(self.db_path) as conn:
+            conn.execute(
+                "UPDATE analysis_reports SET report_schema_version = '' WHERE id = ?",
+                (self.persisted["id"],),
+            )
+
+        response = self.client.get("/api/v1/analyses")
+
+        self.assertEqual(response.status_code, 200)
+        payload = response.json()
+        self.assertEqual(payload["data"][0]["report_schema_version"], "v1")
+        self.assertEqual(payload["meta"]["report_schema_version"], "v1")
+
     def test_list_analyses_defaults_to_unassigned_scope(self) -> None:
         project = project_service_module.create_project(
             project_key="payments",
@@ -191,6 +205,20 @@ class AnalysesApiTests(unittest.TestCase):
         self.assertEqual(payload["data"]["report_schema_version"], "v2")
         self.assertEqual(payload["data"]["audit"]["llm_provider"], "ollama")
         self.assertEqual(payload["data"]["blast_radius"]["direct_count"], 0)
+
+    def test_get_analysis_meta_matches_legacy_report_schema(self) -> None:
+        with sqlite3.connect(self.db_path) as conn:
+            conn.execute(
+                "UPDATE analysis_reports SET report_schema_version = '' WHERE id = ?",
+                (self.persisted["id"],),
+            )
+
+        response = self.client.get(f"/api/v1/analyses/{self.persisted['id']}")
+
+        self.assertEqual(response.status_code, 200)
+        payload = response.json()
+        self.assertEqual(payload["data"]["report_schema_version"], "v1")
+        self.assertEqual(payload["meta"]["report_schema_version"], "v1")
 
     def test_get_analysis_rejects_unknown_project_reference(self) -> None:
         response = self.client.get(
@@ -636,6 +664,10 @@ class AnalysesApiTests(unittest.TestCase):
         self.assertLessEqual(len(payload["data"]["share_summary"]["markdown"]), 1500)
         self.assertEqual(
             payload["data"]["share_summary"]["json_payload"]["version"], "v1"
+        )
+        self.assertEqual(
+            payload["data"]["share_summary"]["json_payload"]["report_schema_version"],
+            "v2",
         )
         self.assertEqual(
             payload["data"]["share_summary"]["json_payload"]["report_id"],

--- a/tests/test_api/test_analyses.py
+++ b/tests/test_api/test_analyses.py
@@ -133,6 +133,7 @@ class AnalysesApiTests(unittest.TestCase):
         self.assertEqual(response.status_code, 200)
         payload = response.json()
         self.assertEqual(payload["meta"]["report_schema_version"], "v2")
+        self.assertEqual(payload["meta"]["report_schema_versions"], ["v2"])
         self.assertEqual(payload["meta"]["count"], 1)
         self.assertEqual(payload["meta"]["total_count"], 1)
         self.assertEqual(payload["meta"]["page"], 1)
@@ -151,6 +152,54 @@ class AnalysesApiTests(unittest.TestCase):
         payload = response.json()
         self.assertEqual(payload["data"][0]["report_schema_version"], "v1")
         self.assertEqual(payload["meta"]["report_schema_version"], "v1")
+        self.assertEqual(payload["meta"]["report_schema_versions"], ["v1"])
+
+    def test_list_analyses_meta_reports_mixed_schema_versions(self) -> None:
+        report_service_module.persist_analysis_report(
+            ParseBatchResult(
+                files=[
+                    ParsedFileResult(
+                        file_name="next-plan.json",
+                        tool="terraform",
+                        status="parsed",
+                        changes=[],
+                    )
+                ]
+            ),
+            RiskAssessment(
+                score=10,
+                severity="low",
+                recommendation="go",
+                top_risk="Second report.",
+                contributors=[],
+                interaction_risks=[],
+                partial_context=False,
+                warnings=[],
+            ),
+            NarrativeResult(
+                opening_sentence="GO: second report.",
+                explanation="Second report.",
+                guidance=[],
+                degraded=False,
+                warnings=[],
+            ),
+        )
+        with sqlite3.connect(self.db_path) as conn:
+            conn.execute(
+                "UPDATE analysis_reports SET report_schema_version = '' WHERE id = ?",
+                (self.persisted["id"],),
+            )
+
+        response = self.client.get("/api/v1/analyses")
+
+        self.assertEqual(response.status_code, 200)
+        payload = response.json()
+        self.assertEqual(payload["meta"]["report_schema_version"], "v2")
+        self.assertEqual(payload["meta"]["report_schema_versions"], ["v1", "v2"])
+        self.assertEqual(
+            {report["report_schema_version"] for report in payload["data"]},
+            {"v1", "v2"},
+        )
 
     def test_list_analyses_defaults_to_unassigned_scope(self) -> None:
         project = project_service_module.create_project(
@@ -210,6 +259,22 @@ class AnalysesApiTests(unittest.TestCase):
         with sqlite3.connect(self.db_path) as conn:
             conn.execute(
                 "UPDATE analysis_reports SET report_schema_version = '' WHERE id = ?",
+                (self.persisted["id"],),
+            )
+
+        response = self.client.get(f"/api/v1/analyses/{self.persisted['id']}")
+
+        self.assertEqual(response.status_code, 200)
+        payload = response.json()
+        self.assertEqual(payload["data"]["report_schema_version"], "v1")
+        self.assertEqual(payload["meta"]["report_schema_version"], "v1")
+
+    def test_get_analysis_meta_normalizes_malformed_report_schema_as_legacy(
+        self,
+    ) -> None:
+        with sqlite3.connect(self.db_path) as conn:
+            conn.execute(
+                "UPDATE analysis_reports SET report_schema_version = 'legacy' WHERE id = ?",
                 (self.persisted["id"],),
             )
 

--- a/tests/test_cli/test_analyze.py
+++ b/tests/test_cli/test_analyze.py
@@ -630,6 +630,10 @@ class AnalyzeCliTests(unittest.TestCase):
             payload["data"]["share_summary"]["json_payload"]["version"], "v1"
         )
         self.assertEqual(
+            payload["data"]["share_summary"]["json_payload"]["report_schema_version"],
+            "v2",
+        )
+        self.assertEqual(
             payload["data"]["share_summary"]["json_payload"]["report_id"],
             payload["data"]["persisted_report"]["id"],
         )

--- a/tests/test_docs/test_report_schema_documentation.py
+++ b/tests/test_docs/test_report_schema_documentation.py
@@ -1,0 +1,56 @@
+"""Tests for report schema documentation coverage."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import unittest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+REPORT_SCHEMA_GUIDE = REPO_ROOT / "docs" / "schemas" / "report-v2.md"
+
+
+class ReportSchemaDocumentationTests(unittest.TestCase):
+    def test_report_v2_guide_covers_machine_consumers_and_contract_fields(
+        self,
+    ) -> None:
+        self.assertTrue(REPORT_SCHEMA_GUIDE.exists(), "Report v2 guide is missing.")
+        content = REPORT_SCHEMA_GUIDE.read_text(encoding="utf-8").lower()
+
+        for consumer in (
+            "persisted `analysis_reports` rows",
+            "api analysis payloads",
+            "cli analysis payloads",
+            "share-summary json payloads",
+            "pr comment",
+            "benchmark",
+            "agent",
+        ):
+            with self.subTest(consumer=consumer):
+                self.assertIn(consumer, content)
+
+        for field in (
+            '"report_schema_version"',
+            '"findings"',
+            '"evidence_items"',
+            '"context_completeness"',
+            '"narrative_available"',
+            '"narrative_degraded"',
+            '"narrative_failure_notice"',
+            '"advisory_only"',
+            '"should_block"',
+        ):
+            with self.subTest(field=field):
+                self.assertIn(field, content)
+
+    def test_report_v2_guide_documents_share_summary_v1_additive_compatibility(
+        self,
+    ) -> None:
+        content = REPORT_SCHEMA_GUIDE.read_text(encoding="utf-8").lower()
+
+        self.assertIn("share-summary payload `version` remains `v1`", content)
+        self.assertIn("additive fields are compatible", content)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_docs/test_report_schema_documentation.py
+++ b/tests/test_docs/test_report_schema_documentation.py
@@ -33,6 +33,7 @@ class ReportSchemaDocumentationTests(unittest.TestCase):
             '"report_schema_version"',
             '"findings"',
             '"evidence_items"',
+            '"report_schema_versions"',
             '"context_completeness"',
             '"narrative_available"',
             '"narrative_degraded"',

--- a/tests/test_services/test_analysis_service.py
+++ b/tests/test_services/test_analysis_service.py
@@ -1232,6 +1232,17 @@ class AnalysisServiceTests(unittest.TestCase):
         self.assertEqual(summary.json_payload.version, "v1")
         self.assertEqual(summary.json_payload.report_schema_version, "v3")
 
+    def test_build_share_summary_normalizes_malformed_report_schema_as_legacy(
+        self,
+    ) -> None:
+        report = self._share_report_payload()
+        report["report_schema_version"] = "legacy"
+
+        summary = build_share_summary(report)
+
+        self.assertEqual(summary.json_payload.version, "v1")
+        self.assertEqual(summary.json_payload.report_schema_version, "v1")
+
     def test_build_share_summary_falls_back_to_deterministic_headline_without_narrative(
         self,
     ) -> None:

--- a/tests/test_services/test_analysis_service.py
+++ b/tests/test_services/test_analysis_service.py
@@ -185,6 +185,7 @@ class AnalysisServiceTests(unittest.TestCase):
     def _share_report_payload(self) -> dict:
         return {
             "id": 17,
+            "report_schema_version": "v2",
             "severity": "medium",
             "recommendation": "caution",
             "top_risk": "Terraform changed a security group.",
@@ -1199,6 +1200,7 @@ class AnalysisServiceTests(unittest.TestCase):
         self.assertIn("Advisory only", summary.plain_text)
         self.assertFalse(summary.should_block)
         self.assertLessEqual(len(summary.markdown), 1500)
+        self.assertEqual(summary.json_payload.report_schema_version, "v2")
         self.assertEqual(summary.json_payload.report_id, 17)
         self.assertEqual(len(summary.json_payload.top_findings), 3)
         self.assertEqual(summary.json_payload.evidence_count, 5)
@@ -1209,6 +1211,26 @@ class AnalysisServiceTests(unittest.TestCase):
         self.assertEqual(
             summary.json_payload.context_completeness.label, "STRONG CONTEXT"
         )
+
+    def test_build_share_summary_normalizes_missing_report_schema_as_legacy(
+        self,
+    ) -> None:
+        report = self._share_report_payload()
+        report.pop("report_schema_version")
+
+        summary = build_share_summary(report)
+
+        self.assertEqual(summary.json_payload.version, "v1")
+        self.assertEqual(summary.json_payload.report_schema_version, "v1")
+
+    def test_build_share_summary_preserves_source_report_schema_version(self) -> None:
+        report = self._share_report_payload()
+        report["report_schema_version"] = "v3"
+
+        summary = build_share_summary(report)
+
+        self.assertEqual(summary.json_payload.version, "v1")
+        self.assertEqual(summary.json_payload.report_schema_version, "v3")
 
     def test_build_share_summary_falls_back_to_deterministic_headline_without_narrative(
         self,

--- a/tests/test_services/test_analysis_service.py
+++ b/tests/test_services/test_analysis_service.py
@@ -1223,25 +1223,21 @@ class AnalysisServiceTests(unittest.TestCase):
         self.assertEqual(summary.json_payload.version, "v1")
         self.assertEqual(summary.json_payload.report_schema_version, "v1")
 
-    def test_build_share_summary_preserves_source_report_schema_version(self) -> None:
+    def test_build_share_summary_rejects_newer_report_schema_version(self) -> None:
         report = self._share_report_payload()
         report["report_schema_version"] = "v3"
 
-        summary = build_share_summary(report)
+        with self.assertRaises(ValueError):
+            build_share_summary(report)
 
-        self.assertEqual(summary.json_payload.version, "v1")
-        self.assertEqual(summary.json_payload.report_schema_version, "v3")
-
-    def test_build_share_summary_normalizes_malformed_report_schema_as_legacy(
+    def test_build_share_summary_rejects_malformed_report_schema_version(
         self,
     ) -> None:
         report = self._share_report_payload()
         report["report_schema_version"] = "legacy"
 
-        summary = build_share_summary(report)
-
-        self.assertEqual(summary.json_payload.version, "v1")
-        self.assertEqual(summary.json_payload.report_schema_version, "v1")
+        with self.assertRaises(ValueError):
+            build_share_summary(report)
 
     def test_build_share_summary_falls_back_to_deterministic_headline_without_narrative(
         self,

--- a/tests/test_services/test_report_service.py
+++ b/tests/test_services/test_report_service.py
@@ -6609,6 +6609,8 @@ class ReportServiceTests(unittest.TestCase):
         )
         with self.assertRaises(ValueError):
             report_service_module.normalize_report_schema_version("legacy")
+        with self.assertRaises(ValueError):
+            report_service_module.normalize_report_schema_version(False)
         self.assertEqual(
             report_service_module.readable_report_schema_version("v2"), "v2"
         )
@@ -8052,6 +8054,40 @@ class ReportServiceTests(unittest.TestCase):
             by_id[int(second["id"])]["previous_scan_diff"]["previous_report_id"],
             first["id"],
         )
+
+    def test_filtered_history_ignores_unreadable_off_page_reports_for_diffs(
+        self,
+    ) -> None:
+        readable = self._persist_comparison_report(
+            score=30,
+            severity="low",
+            recommendation="go",
+            top_risk="Readable review",
+            findings=[],
+            evidence_items=[],
+        )
+        unreadable = self._persist_comparison_report(
+            score=90,
+            severity="critical",
+            recommendation="no-go",
+            top_risk="Future schema review",
+            findings=[],
+            evidence_items=[],
+        )
+        with database_module.SessionLocal() as session:
+            report = analysis_reports_repository_module.get_analysis_report(
+                session, int(unreadable["id"]), include_evidence=True
+            )
+            assert report is not None
+            report.report_schema_version = "v3"
+            session.commit()
+
+        history = report_service_module.fetch_filtered_analysis_history_page(
+            severity="low"
+        )
+
+        self.assertEqual(history["total_count"], 1)
+        self.assertEqual(history["items"][0]["id"], readable["id"])
 
     def test_previous_scan_diffs_compute_history_signature_once_per_report(
         self,

--- a/tests/test_services/test_report_service.py
+++ b/tests/test_services/test_report_service.py
@@ -6602,11 +6602,18 @@ class ReportServiceTests(unittest.TestCase):
             report_service_module.normalize_report_schema_version(None), "v1"
         )
         self.assertEqual(
-            report_service_module.normalize_report_schema_version("legacy"), "v1"
+            report_service_module.normalize_report_schema_version("v02"), "v2"
         )
         self.assertEqual(
             report_service_module.normalize_report_schema_version("v10"), "v10"
         )
+        with self.assertRaises(ValueError):
+            report_service_module.normalize_report_schema_version("legacy")
+        self.assertEqual(
+            report_service_module.readable_report_schema_version("v2"), "v2"
+        )
+        with self.assertRaises(ValueError):
+            report_service_module.readable_report_schema_version("v3")
         self.assertTrue(report_service_module.can_read_report_schema("v3", "v2"))
         self.assertFalse(report_service_module.can_read_report_schema("v2", "v3"))
 

--- a/tests/test_services/test_report_service.py
+++ b/tests/test_services/test_report_service.py
@@ -6601,6 +6601,12 @@ class ReportServiceTests(unittest.TestCase):
         self.assertEqual(
             report_service_module.normalize_report_schema_version(None), "v1"
         )
+        self.assertEqual(
+            report_service_module.normalize_report_schema_version("legacy"), "v1"
+        )
+        self.assertEqual(
+            report_service_module.normalize_report_schema_version("v10"), "v10"
+        )
         self.assertTrue(report_service_module.can_read_report_schema("v3", "v2"))
         self.assertFalse(report_service_module.can_read_report_schema("v2", "v3"))
 


### PR DESCRIPTION
## Summary
- add report_schema_version to share-summary JSON while keeping share-summary payload version v1 as an additive-compatible shape
- normalize missing report schema versions as legacy v1 and align API detail/list metadata with returned report versions
- update schema/advisory docs and add regression coverage for docs, API, CLI, and service paths

## Validation
- ./.venv/bin/ruff check .
- ./.venv/bin/ruff format --check .
- ./.venv/bin/bandit -r api/ analysis/ services/ parsers/ llm/ models/ cli/ ui/ evidence/ --severity-level high --confidence-level high -x tests/
- ./.venv/bin/python -m unittest discover -q

## Notes
- UI validation not applicable; no UI surface changed.
- _bmad-output/planning-artifacts/prd.md has unrelated unstaged local edits and is not included in this branch commit.