### PR TITLE
Ensure reports persist before success is returned

### DIFF
--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -67,7 +67,7 @@ development_status:
   2-6-confidence-uncertainty-and-insufficient-context: done
   2-7-narrative-after-scoring-and-degraded-fallback: done
   2-8-report-schema-versioning: done
-  2-9-durable-report-persistence-and-audit-metadata: ready-for-dev
+  2-9-durable-report-persistence-and-audit-metadata: done
   epic-2-retrospective: optional
 
   epic-3: in-progress

--- a/api/routes/analyses.py
+++ b/api/routes/analyses.py
@@ -23,6 +23,7 @@ from api.schemas import (
 )
 from config import settings
 from services.analysis_service import (
+    AnalysisPersistenceError,
     analyze_uploaded_files,
     build_advisory_summary,
     build_share_summary,
@@ -417,6 +418,7 @@ async def create_analysis(
         default=None, alias="X-DeployWhisper-Trigger-Type"
     ),
     trigger_id: str | None = Header(default=None, alias="X-DeployWhisper-Trigger-Id"),
+    actor: str | None = Header(default=None, alias="X-DeployWhisper-Actor"),
     authorization: dict[str, object] = Depends(_authorization_context),
 ) -> AnalysisRunResponse:
     if not files:
@@ -499,8 +501,16 @@ async def create_analysis(
                 "source_interface": "api",
                 "trigger_type": trigger_type or "api_request",
                 "trigger_id": trigger_id,
+                "actor": actor or "api_client",
             },
         )
+    except AnalysisPersistenceError as exc:
+        raise ApiError(
+            status_code=500,
+            code=exc.code,
+            message=str(exc),
+            details={"reason": exc.public_reason},
+        ) from exc
     except ValueError as exc:
         raise _project_api_error(exc) from exc
     advisory = build_advisory_summary(result.assessment, result.narrative)

--- a/api/routes/github_app.py
+++ b/api/routes/github_app.py
@@ -150,6 +150,8 @@ async def github_app_webhook(request: Request) -> dict[str, object]:
             "check_run_id": result.check_run_id,
             "report_id": result.report_id,
             "report_url": result.report_url,
+            "status": getattr(result, "status", "ok"),
+            "code": getattr(result, "code", None),
             "marketplace_url": config.marketplace_url,
             "install_url": config.install_url,
             "advisory_only": True,

--- a/api/schemas.py
+++ b/api/schemas.py
@@ -193,6 +193,26 @@ class AuditMetadataData(BaseModel):
     trigger_id: str | None = Field(
         default=None, description="Trigger identifier when available"
     )
+    actor: str = Field(
+        default="service_actor",
+        description="Actor or automation identity that submitted the analysis",
+    )
+    persisted_at: str | None = Field(
+        default=None,
+        description=(
+            "Persisted report row creation timestamp; emitted only after final "
+            "artifact persistence succeeds"
+        ),
+    )
+    redaction_status: str = Field(
+        default="unknown", description="Overall redaction state for persisted evidence"
+    )
+    redaction: dict[str, Any] = Field(
+        default_factory=dict, description="Detailed redaction metadata"
+    )
+    delivery: dict[str, Any] = Field(
+        default_factory=dict, description="Delivery metadata for the successful result"
+    )
 
 
 class SubmissionManifestItemData(BaseModel):
@@ -264,6 +284,10 @@ class SubmissionManifestFallbackItemData(BaseModel):
     )
     redaction_status: str = Field(
         default="none", description="Filename/content redaction outcome"
+    )
+    actor: str | None = Field(
+        default=None,
+        description="Fallback submitter identity retained outside manifest JSON",
     )
 
 

--- a/cli/analyze.py
+++ b/cli/analyze.py
@@ -32,6 +32,7 @@ from services.skill_registry_service import fetch_skill_registry_page
 from services.skill_test_harness_service import run_skill_test_suites
 from services.skill_test_harness_service import iter_built_in_skill_ids
 from services.analysis_service import (
+    AnalysisPersistenceError,
     analyze_uploaded_files,
     build_advisory_summary,
     build_share_summary,
@@ -469,6 +470,7 @@ def _run_analyze(
                         "DEPLOYWHISPER_TRIGGER_TYPE", "cli_command"
                     ),
                     "trigger_id": os.getenv("DEPLOYWHISPER_TRIGGER_ID"),
+                    "actor": os.getenv("DEPLOYWHISPER_ACTOR", "cli_local_user"),
                 },
             )
     except ValueError as exc:
@@ -482,6 +484,16 @@ def _run_analyze(
             stream=sys.stderr,
         )
         return 2
+    except AnalysisPersistenceError as exc:
+        _emit_json(
+            build_error(
+                code=exc.code,
+                message=str(exc),
+                details={"reason": exc.public_reason},
+            ),
+            stream=sys.stderr,
+        )
+        return 1
     except Exception as exc:  # noqa: BLE001
         _emit_json(
             build_error(

--- a/docs/schemas/report-v2.md
+++ b/docs/schemas/report-v2.md
@@ -19,6 +19,11 @@ This schema version applies to:
    alongside their own share payload `version`.
 4. Stored reports remain readable across upgrades by version-aware readers.
 5. Newer readers are expected to read older schemas when the older schema major version is less than or equal to the reader version.
+6. Successful analysis responses include a persisted report identifier and
+   audit metadata derived from durable report state. Persistence failures use an
+   explicit `report_persistence_failed` error/status instead of returning
+   success, with sanitized remediation text rather than raw storage-driver
+   details.
 
 ## Envelope examples
 
@@ -49,6 +54,48 @@ Readers canonicalize valid schema versions to `vN` form, so values such as
 non-empty malformed markers are rejected as invalid, and versions newer than the
 current reader schema are rejected until the runtime supports that report
 contract.
+
+### Durable audit metadata
+
+`data.persisted_report.audit` is emitted only after the report has been saved.
+It carries the source surface, trigger, actor, persisted row timestamp,
+redaction state, and delivery metadata for the successful response:
+
+```json
+{
+  "id": 42,
+  "audit": {
+    "source_interface": "api",
+    "trigger_type": "api_request",
+    "trigger_id": "sess-123",
+    "actor": "api-reviewer@example.com",
+    "persisted_at": "2026-05-13T12:00:00+00:00",
+    "redaction_status": "none",
+    "redaction": {
+      "filenames_redacted": false,
+      "sensitive_content_excluded": false
+    },
+    "delivery": {
+      "surface": "api",
+      "trigger_type": "api_request",
+      "trigger_id": "sess-123",
+      "report_id": 42,
+      "status": "persisted"
+    }
+  }
+}
+```
+
+The top-level `id` and `audit.delivery.report_id` identify the persisted
+report. `audit.persisted_at` matches `created_at`: it is the persisted report row
+creation timestamp, not a separate post-artifact timestamp. Successful delivery
+responses emit it only after artifact persistence completes. CLI submissions
+default the actor to `cli_local_user` unless `DEPLOYWHISPER_ACTOR` is set. API
+submissions may send `X-DeployWhisper-Actor`; otherwise the actor is
+`api_client`. GitHub App webhooks use `github:<sender-login>` when the webhook
+sender is available. Actor values are whitespace-normalized, stripped of control
+characters, bounded before persistence, and retained in the manifest fallback so
+the audit actor can still be recovered if manifest JSON is malformed.
 
 ### Advisory and share-summary shape
 
@@ -275,7 +322,8 @@ without storing raw plan internals in a separate contract.
       "intake_status": "ready",
       "parse_status": "parsed",
       "partial": false,
-      "redaction_status": "none"
+      "redaction_status": "none",
+      "actor": "api-reviewer@example.com"
     },
     {
       "name": ".env",
@@ -284,7 +332,8 @@ without storing raw plan internals in a separate contract.
       "intake_status": "sensitive",
       "parse_status": null,
       "partial": true,
-      "redaction_status": "sensitive_blocked"
+      "redaction_status": "sensitive_blocked",
+      "actor": "api-reviewer@example.com"
     }
   ],
   "findings": [],

--- a/integrations/github/app_service.py
+++ b/integrations/github/app_service.py
@@ -19,7 +19,7 @@ from urllib import error, parse, request
 
 from config import settings
 from services.project_service import ProjectResolutionError, resolve_project_reference
-from services.analysis_service import analyze_uploaded_files
+from services.analysis_service import AnalysisPersistenceError, analyze_uploaded_files
 from services.intake_service import (
     MAX_TOTAL_UPLOAD_BYTES,
     build_pending_analysis,
@@ -106,6 +106,8 @@ class GitHubWebhookResult:
     report_id: int | None
     report_url: str | None
     note: str
+    status: str = "ok"
+    code: str | None = None
 
 
 @dataclass(frozen=True)
@@ -325,10 +327,12 @@ def handle_github_app_webhook(
     installation_id = int(payload.get("installation", {}).get("id") or 0)
     repository = dict(payload.get("repository") or {})
     pull_request = dict(payload.get("pull_request") or {})
+    sender = dict(payload.get("sender") or {})
     owner = str(repository.get("owner", {}).get("login") or "").strip()
     repo_name = str(repository.get("name") or "").strip()
     pull_number = int(pull_request.get("number") or payload.get("number") or 0)
     head_sha = str(pull_request.get("head", {}).get("sha") or "").strip()
+    actor = str(sender.get("login") or "").strip()
     if (
         not installation_id
         or not owner
@@ -469,6 +473,7 @@ def handle_github_app_webhook(
                 "source_interface": "github_app",
                 "trigger_type": "github_app_pull_request",
                 "trigger_id": f"{owner}/{repo_name}#PR-{pull_number}",
+                "actor": f"github:{actor}" if actor else "github_app",
             },
         )
     except ProjectResolutionError as exc:
@@ -497,6 +502,37 @@ def handle_github_app_webhook(
             code=code,
             message=str(exc),
             config=config,
+        )
+    except AnalysisPersistenceError as exc:
+        note = f"{exc} Reason: {exc.public_reason}"
+        check_run_id = None
+        if config.checks_enabled:
+            try:
+                check_run_id = _create_check_run(
+                    owner=owner,
+                    repo_name=repo_name,
+                    head_sha=head_sha,
+                    installation_token=installation_token,
+                    conclusion="failure",
+                    title=DEFAULT_CHECK_RUN_NAME,
+                    summary=note,
+                    details_url=None,
+                    text=_check_run_text(details_url=None),
+                    api_base_url=config.api_base_url,
+                )
+            except GitHubAppRequestError:
+                note = f"{note} Failure check run could not be created."
+        return GitHubWebhookResult(
+            event=event_name,
+            action=action,
+            handled=True,
+            automatic_analysis_triggered=False,
+            check_run_id=check_run_id,
+            report_id=None,
+            report_url=None,
+            note=note,
+            status="failed",
+            code=exc.code,
         )
     report_id = int(result.persisted_report["id"])
     report_url = build_share_report_link(report_id)

--- a/services/analysis_service.py
+++ b/services/analysis_service.py
@@ -171,6 +171,22 @@ class AnalysisRunResult(AnalysisArtifacts):
     persisted_report: dict = Field(..., description="Persisted report metadata")
 
 
+class AnalysisPersistenceError(RuntimeError):
+    """Raised when report persistence fails after deterministic analysis completed."""
+
+    code = "report_persistence_failed"
+    public_reason = (
+        "Report persistence did not complete. Retry the analysis; if it repeats, "
+        "review local application logs and persistence configuration."
+    )
+
+    def __init__(self, reason: str) -> None:
+        super().__init__(
+            "Report persistence failed; final analysis success was not returned."
+        )
+        self.reason = reason
+
+
 class AdvisorySummary(BaseModel):
     advisory_only: bool = Field(
         ..., description="Whether the output is advisory rather than blocking"
@@ -1052,21 +1068,24 @@ def analyze_uploaded_files(
         workspace_key=workspace_key,
         completion_client=completion_client,
     )
-    persisted_report = persist_analysis_report(
-        artifacts.parse_batch,
-        artifacts.assessment,
-        artifacts.narrative,
-        blast_radius=artifacts.blast_radius,
-        rollback_plan=artifacts.rollback_plan,
-        findings=artifacts.findings,
-        evidence_items=artifacts.evidence_items,
-        artifact_snapshots={name: raw_content for name, raw_content in files},
-        submitted_artifacts=list(files),
-        project_id=resolved_project.id,
-        workspace_id=workspace_id,
-        workspace_key=workspace_key,
-        audit_context=audit_context,
-    )
+    try:
+        persisted_report = persist_analysis_report(
+            artifacts.parse_batch,
+            artifacts.assessment,
+            artifacts.narrative,
+            blast_radius=artifacts.blast_radius,
+            rollback_plan=artifacts.rollback_plan,
+            findings=artifacts.findings,
+            evidence_items=artifacts.evidence_items,
+            artifact_snapshots={name: raw_content for name, raw_content in files},
+            submitted_artifacts=list(files),
+            project_id=resolved_project.id,
+            workspace_id=workspace_id,
+            workspace_key=workspace_key,
+            audit_context=audit_context,
+        )
+    except Exception as exc:  # noqa: BLE001
+        raise AnalysisPersistenceError(str(exc)) from exc
     return AnalysisRunResult(
         **artifacts.model_dump(), persisted_report=persisted_report
     )

--- a/services/report_service.py
+++ b/services/report_service.py
@@ -119,6 +119,7 @@ _CONTEXT_UNAVAILABLE_UNCERTAINTY = (
     "Context completeness metadata was unavailable; reviewer verification is "
     "required before trusting this report."
 )
+_AUDIT_ACTOR_MAX_LENGTH = 120
 _CONTEXT_UNAVAILABLE_TODO = (
     "Re-run analysis to regenerate context completeness metadata."
 )
@@ -498,6 +499,9 @@ def _build_audit_metadata(
 ) -> dict[str, Any]:
     runtime = resolve_provider_runtime()
     context = audit_context or {}
+    source_interface = str(context.get("source_interface") or "service")
+    trigger_type = context.get("trigger_type")
+    trigger_id = context.get("trigger_id")
     return {
         "files_analyzed": [
             file_result.file_name
@@ -507,10 +511,129 @@ def _build_audit_metadata(
         "llm_provider": runtime["provider"],
         "llm_model": runtime["model"],
         "llm_local_mode": runtime["local_mode"],
-        "source_interface": context.get("source_interface"),
-        "trigger_type": context.get("trigger_type"),
-        "trigger_id": context.get("trigger_id"),
+        "source_interface": source_interface,
+        "trigger_type": trigger_type,
+        "trigger_id": trigger_id,
+        "actor": _normalize_audit_actor(context.get("actor"), source_interface),
     }
+
+
+def _default_audit_actor(source_interface: str | None) -> str:
+    surface = str(source_interface or "service").strip().lower()
+    defaults = {
+        "api": "api_client",
+        "cli": "cli_local_user",
+        "github_app": "github_app",
+        "ui": "ui_local_user",
+    }
+    return defaults.get(surface, f"{surface or 'service'}_actor")
+
+
+def _normalize_audit_actor(value: Any, source_interface: str | None) -> str:
+    fallback = _default_audit_actor(source_interface)
+    normalized = " ".join(str(value or fallback).split())
+    normalized = "".join(
+        character
+        for character in normalized
+        if not unicodedata.category(character).startswith("C")
+    ).strip()
+    if not normalized:
+        return fallback
+    return normalized[:_AUDIT_ACTOR_MAX_LENGTH]
+
+
+def _redaction_status_from_items(items: Any) -> str | None:
+    if not isinstance(items, list):
+        return None
+    item_statuses = {
+        normalize_manifest_redaction_status(item.get("redaction_status"))
+        for item in items
+        if isinstance(item, dict) and "redaction_status" in item
+    }
+    if not item_statuses:
+        return None
+    if "sensitive_blocked" in item_statuses:
+        return "sensitive_blocked"
+    if "redacted" in item_statuses:
+        return "redacted"
+    return "none"
+
+
+def _report_redaction_status(
+    submission_manifest: dict[str, Any] | None,
+    submission_manifest_fallback: list[dict[str, Any]] | None = None,
+) -> str:
+    if isinstance(submission_manifest, dict):
+        redaction = submission_manifest.get("redaction")
+        has_redaction_metadata = isinstance(redaction, dict) and any(
+            key in redaction
+            for key in ("filenames_redacted", "sensitive_content_excluded")
+        )
+        if isinstance(redaction, dict) and redaction.get("sensitive_content_excluded"):
+            return "sensitive_blocked"
+        item_status = _redaction_status_from_items(submission_manifest.get("items"))
+        if item_status == "sensitive_blocked":
+            return item_status
+        if isinstance(redaction, dict) and redaction.get("filenames_redacted"):
+            return "redacted"
+        if item_status == "redacted":
+            return item_status
+        if item_status == "none" or has_redaction_metadata:
+            return "none"
+    fallback_status = _redaction_status_from_items(submission_manifest_fallback)
+    return fallback_status or "unknown"
+
+
+def _report_redaction_metadata(
+    submission_manifest: dict[str, Any] | None,
+    submission_manifest_fallback: list[dict[str, Any]] | None,
+) -> dict[str, Any]:
+    if isinstance(submission_manifest, dict):
+        redaction = submission_manifest.get("redaction")
+        if isinstance(redaction, dict) and redaction:
+            return dict(redaction)
+    if submission_manifest_fallback:
+        statuses = {
+            normalize_manifest_redaction_status(item.get("redaction_status"))
+            for item in submission_manifest_fallback
+            if isinstance(item, dict) and "redaction_status" in item
+        }
+        if statuses:
+            return {
+                "filenames_redacted": "redacted" in statuses,
+                "sensitive_content_excluded": "sensitive_blocked" in statuses,
+            }
+    return {}
+
+
+def _delivery_metadata(
+    *,
+    source_interface: str | None,
+    trigger_type: str | None,
+    trigger_id: str | None,
+    report_id: int,
+) -> dict[str, Any]:
+    return {
+        "surface": source_interface,
+        "trigger_type": trigger_type,
+        "trigger_id": trigger_id,
+        "report_id": report_id,
+        "status": "persisted",
+    }
+
+
+def _cleanup_partial_report(report_id: int | None) -> None:
+    if report_id is None:
+        return
+    try:
+        with SessionLocal() as session:
+            delete_analysis_report(session, report_id)
+    except Exception:
+        pass
+    try:
+        delete_report_artifacts(report_id)
+    except Exception:
+        pass
 
 
 def _extract_narrative_failure_notice(warnings: list[str]) -> str | None:
@@ -2134,6 +2257,10 @@ def _load_submission_manifest_payload(
 def _submission_manifest_fallback_items(
     manifest: SubmissionManifest,
 ) -> list[dict[str, Any]]:
+    actor = _normalize_audit_actor(
+        (manifest.provenance or {}).get("actor"),
+        (manifest.provenance or {}).get("source_interface"),
+    )
     return [
         {
             "name": item.name,
@@ -2145,6 +2272,7 @@ def _submission_manifest_fallback_items(
             "redaction_status": normalize_manifest_redaction_status(
                 item.redaction_status
             ),
+            "actor": actor,
         }
         for item in manifest.items
     ]
@@ -2167,24 +2295,41 @@ def _load_submission_manifest_fallback_payload(
         status = str(item.get("status") or "").strip()
         if not name or not status:
             continue
-        fallback_items.append(
-            {
-                "name": name,
-                "tool": str(item.get("tool") or "unknown"),
-                "status": status,
-                "intake_status": str(item.get("intake_status") or "unknown"),
-                "parse_status": (
-                    str(item["parse_status"])
-                    if item.get("parse_status") is not None
-                    else None
-                ),
-                "partial": bool(item.get("partial", False)),
-                "redaction_status": normalize_manifest_redaction_status(
-                    item.get("redaction_status")
-                ),
-            }
-        )
+        fallback_item = {
+            "name": name,
+            "tool": str(item.get("tool") or "unknown"),
+            "status": status,
+            "intake_status": str(item.get("intake_status") or "unknown"),
+            "parse_status": (
+                str(item["parse_status"])
+                if item.get("parse_status") is not None
+                else None
+            ),
+            "partial": bool(item.get("partial", False)),
+        }
+        if "redaction_status" in item:
+            fallback_item["redaction_status"] = normalize_manifest_redaction_status(
+                item.get("redaction_status")
+            )
+        if "actor" in item:
+            fallback_item["actor"] = _normalize_audit_actor(
+                item.get("actor"),
+                None,
+            )
+        fallback_items.append(fallback_item)
     return fallback_items
+
+
+def _actor_from_submission_manifest_fallback(
+    fallback_items: list[dict[str, Any]] | None,
+) -> str | None:
+    for item in fallback_items or []:
+        if not isinstance(item, dict):
+            continue
+        actor = item.get("actor")
+        if actor:
+            return str(actor)
+    return None
 
 
 def _load_context_completeness_payload(
@@ -2388,17 +2533,6 @@ def _serialize_report(report, *, include_evidence: bool = True) -> dict:
     created_at = report.created_at
     if created_at.tzinfo is None:
         created_at = created_at.replace(tzinfo=UTC)
-    audit = {
-        "files_analyzed": json.loads(report.analyzed_files_json or "[]"),
-        "llm_provider": report.llm_provider,
-        "llm_model": report.llm_model,
-        "llm_local_mode": report.llm_local_mode == "true"
-        if report.llm_local_mode is not None
-        else None,
-        "source_interface": report.source_interface,
-        "trigger_type": report.trigger_type,
-        "trigger_id": report.trigger_id,
-    }
     warnings = json.loads(report.warnings_json or "[]")
     submission_manifest, manifest_warning = _load_submission_manifest_payload(
         getattr(report, "submission_manifest_json", None)
@@ -2406,6 +2540,49 @@ def _serialize_report(report, *, include_evidence: bool = True) -> dict:
     submission_manifest_fallback = _load_submission_manifest_fallback_payload(
         getattr(report, "submission_manifest_fallback_json", None)
     )
+    manifest_provenance = (
+        dict(submission_manifest.get("provenance") or {})
+        if isinstance(submission_manifest, dict)
+        else {}
+    )
+    source_interface = report.source_interface or manifest_provenance.get(
+        "source_interface"
+    )
+    trigger_type = report.trigger_type or manifest_provenance.get("trigger_type")
+    trigger_id = report.trigger_id or manifest_provenance.get("trigger_id")
+    actor = _normalize_audit_actor(
+        manifest_provenance.get("actor")
+        or _actor_from_submission_manifest_fallback(submission_manifest_fallback),
+        source_interface,
+    )
+    persisted_at = created_at.isoformat()
+    audit = {
+        "files_analyzed": json.loads(report.analyzed_files_json or "[]"),
+        "llm_provider": report.llm_provider,
+        "llm_model": report.llm_model,
+        "llm_local_mode": report.llm_local_mode == "true"
+        if report.llm_local_mode is not None
+        else None,
+        "source_interface": source_interface,
+        "trigger_type": trigger_type,
+        "trigger_id": trigger_id,
+        "actor": actor,
+        "persisted_at": persisted_at,
+        "redaction_status": _report_redaction_status(
+            submission_manifest,
+            submission_manifest_fallback,
+        ),
+        "redaction": _report_redaction_metadata(
+            submission_manifest,
+            submission_manifest_fallback,
+        ),
+        "delivery": _delivery_metadata(
+            source_interface=source_interface,
+            trigger_type=trigger_type,
+            trigger_id=trigger_id,
+            report_id=int(report.id),
+        ),
+    }
     if manifest_warning is not None and manifest_warning not in warnings:
         warnings.append(manifest_warning)
     confidence, confidence_warning = _load_report_confidence(
@@ -2545,7 +2722,7 @@ def _serialize_report(report, *, include_evidence: bool = True) -> dict:
         if report.llm_local_mode is not None
         else None,
         "skills_applied": json.loads(report.narrative_skills_json or "[]"),
-        "created_at": created_at.isoformat(),
+        "created_at": persisted_at,
         "warnings": warnings,
         "findings": [
             {
@@ -2666,6 +2843,10 @@ def persist_analysis_report(
         parse_batch=parse_batch,
         audit_context={
             **(audit_context or {}),
+            "source_interface": audit["source_interface"],
+            "trigger_type": audit["trigger_type"],
+            "trigger_id": audit["trigger_id"],
+            "actor": audit["actor"],
             "project_id": resolved_project.id,
             "project_key": resolved_project.project_key,
             "workspace_id": resolved_workspace.id if resolved_workspace else None,
@@ -2713,70 +2894,78 @@ def persist_analysis_report(
         )
 
     def operation():
-        with SessionLocal() as session:
-            report = create_analysis_report(
-                session,
-                project_id=resolved_project.id,
-                workspace_id=resolved_workspace_id,
-                risk_score=assessment.score,
-                severity=assessment.severity,
-                recommendation=assessment.recommendation,
-                risk_confidence=assessment.confidence,
-                top_risk=assessment.top_risk,
-                report_schema_version=REPORT_SCHEMA_VERSION,
-                parse_summary=_build_parse_summary(parse_batch),
-                narrative_opening=narrative.opening_sentence or "",
-                narrative_explanation=narrative.explanation or "",
-                narrative_degraded=narrative_degraded,
-                narrative_failure_notice=narrative.failure_notice,
-                warnings_json=json.dumps(combined_warnings),
-                contributors_json=json.dumps(
-                    [
-                        contributor.model_dump()
-                        for contributor in assessment.contributors
-                    ]
-                ),
-                analyzed_files_json=json.dumps(audit["files_analyzed"]),
-                submission_manifest_json=json.dumps(
-                    submission_manifest.model_dump(mode="json")
-                ),
-                submission_manifest_fallback_json=json.dumps(
-                    _submission_manifest_fallback_items(submission_manifest)
-                ),
-                blast_radius_json=json.dumps(
-                    blast_radius.model_dump(mode="json")
-                    if blast_radius is not None
-                    else {}
-                ),
-                rollback_plan_json=json.dumps(
-                    rollback_plan.model_dump(mode="json")
-                    if rollback_plan is not None
-                    else {}
-                ),
-                llm_provider=audit["llm_provider"],
-                llm_model=audit["llm_model"],
-                llm_local_mode="true" if audit["llm_local_mode"] else "false",
-                assessment_source=assessment.source,
-                narrative_source=narrative.source,
-                narrative_skills_json=json.dumps(narrative.skills_applied),
-                source_interface=audit["source_interface"],
-                trigger_type=audit["trigger_type"],
-                trigger_id=audit["trigger_id"],
-                dashboard_display_duration_seconds=dashboard_display_duration_seconds,
-                top_risk_contributors_json=json.dumps(assessment.top_risk_contributors),
-                context_completeness_json=json.dumps(
-                    assessment.context_completeness.model_dump(mode="json")
-                ),
-                findings_payload=[
-                    finding.model_dump(mode="json") for finding in (findings or [])
-                ],
-                evidence_payload=[
-                    evidence_item.model_dump(mode="json")
-                    for evidence_item in (evidence_items or [])
-                ],
-            )
-            save_report_artifacts(report.id, safe_artifact_snapshots)
-            return _serialize_report(report, include_evidence=True)
+        report_id: int | None = None
+        try:
+            with SessionLocal() as session:
+                report = create_analysis_report(
+                    session,
+                    project_id=resolved_project.id,
+                    workspace_id=resolved_workspace_id,
+                    risk_score=assessment.score,
+                    severity=assessment.severity,
+                    recommendation=assessment.recommendation,
+                    risk_confidence=assessment.confidence,
+                    top_risk=assessment.top_risk,
+                    report_schema_version=REPORT_SCHEMA_VERSION,
+                    parse_summary=_build_parse_summary(parse_batch),
+                    narrative_opening=narrative.opening_sentence or "",
+                    narrative_explanation=narrative.explanation or "",
+                    narrative_degraded=narrative_degraded,
+                    narrative_failure_notice=narrative.failure_notice,
+                    warnings_json=json.dumps(combined_warnings),
+                    contributors_json=json.dumps(
+                        [
+                            contributor.model_dump()
+                            for contributor in assessment.contributors
+                        ]
+                    ),
+                    analyzed_files_json=json.dumps(audit["files_analyzed"]),
+                    submission_manifest_json=json.dumps(
+                        submission_manifest.model_dump(mode="json")
+                    ),
+                    submission_manifest_fallback_json=json.dumps(
+                        _submission_manifest_fallback_items(submission_manifest)
+                    ),
+                    blast_radius_json=json.dumps(
+                        blast_radius.model_dump(mode="json")
+                        if blast_radius is not None
+                        else {}
+                    ),
+                    rollback_plan_json=json.dumps(
+                        rollback_plan.model_dump(mode="json")
+                        if rollback_plan is not None
+                        else {}
+                    ),
+                    llm_provider=audit["llm_provider"],
+                    llm_model=audit["llm_model"],
+                    llm_local_mode="true" if audit["llm_local_mode"] else "false",
+                    assessment_source=assessment.source,
+                    narrative_source=narrative.source,
+                    narrative_skills_json=json.dumps(narrative.skills_applied),
+                    source_interface=audit["source_interface"],
+                    trigger_type=audit["trigger_type"],
+                    trigger_id=audit["trigger_id"],
+                    dashboard_display_duration_seconds=dashboard_display_duration_seconds,
+                    top_risk_contributors_json=json.dumps(
+                        assessment.top_risk_contributors
+                    ),
+                    context_completeness_json=json.dumps(
+                        assessment.context_completeness.model_dump(mode="json")
+                    ),
+                    findings_payload=[
+                        finding.model_dump(mode="json") for finding in (findings or [])
+                    ],
+                    evidence_payload=[
+                        evidence_item.model_dump(mode="json")
+                        for evidence_item in (evidence_items or [])
+                    ],
+                )
+                report_id = int(report.id)
+                save_report_artifacts(report_id, safe_artifact_snapshots)
+                return _serialize_report(report, include_evidence=True)
+        except Exception:
+            _cleanup_partial_report(report_id)
+            raise
 
     return _run_with_schema_retry(operation)
 

--- a/services/submission_manifest.py
+++ b/services/submission_manifest.py
@@ -167,6 +167,7 @@ def build_submission_manifest(
         "source_interface": context.get("source_interface"),
         "trigger_type": context.get("trigger_type"),
         "trigger_id": context.get("trigger_id"),
+        "actor": context.get("actor"),
         "project_id": context.get("project_id"),
         "project_key": context.get("project_key"),
         "workspace_id": context.get("workspace_id"),

--- a/tests/test_api/test_analyses.py
+++ b/tests/test_api/test_analyses.py
@@ -16,6 +16,7 @@ import models.repositories.analysis_reports as analysis_reports_repository_modul
 import models.tables as tables_module
 import services.project_service as project_service_module
 import services.report_service as report_service_module
+from services.analysis_service import AnalysisPersistenceError
 from analysis.risk_scorer import RiskAssessment, RiskContributor
 from app import create_app
 from evidence.models import EvidenceItem
@@ -715,6 +716,7 @@ class AnalysesApiTests(unittest.TestCase):
                 "/api/v1/analyses",
                 files=files,
                 data={"project_key": "payments"},
+                headers={"X-DeployWhisper-Actor": "api-reviewer@example.com"},
             )
 
         self.assertEqual(response.status_code, 200)
@@ -788,6 +790,17 @@ class AnalysesApiTests(unittest.TestCase):
         )
         self.assertEqual(
             payload["data"]["persisted_report"]["audit"]["source_interface"], "api"
+        )
+        self.assertEqual(
+            payload["data"]["persisted_report"]["audit"]["actor"],
+            "api-reviewer@example.com",
+        )
+        self.assertEqual(
+            payload["data"]["persisted_report"]["audit"]["persisted_at"],
+            payload["data"]["persisted_report"]["created_at"],
+        )
+        self.assertEqual(
+            payload["data"]["persisted_report"]["audit"]["redaction_status"], "none"
         )
         self.assertEqual(
             payload["data"]["persisted_report"]["audit"]["trigger_type"], "api_request"
@@ -1963,6 +1976,36 @@ class AnalysesApiTests(unittest.TestCase):
         payload = response.json()
         self.assertEqual(payload["error"]["code"], "internal_error")
         self.assertEqual(payload["error"]["message"], "Internal server error.")
+
+    def test_analysis_persistence_failure_uses_actionable_error_envelope(self) -> None:
+        project_service_module.create_project(
+            project_key="payments-persist-failed",
+            display_name="Payments Persist Failed",
+        )
+        client = TestClient(create_app(), raise_server_exceptions=False)
+
+        with patch(
+            "api.routes.analyses.analyze_uploaded_files",
+            side_effect=AnalysisPersistenceError("database is read-only"),
+        ):
+            response = client.post(
+                "/api/v1/analyses",
+                files={"files": ("plan.json", b'{"resource_changes": []}')},
+                data={"project_key": "payments-persist-failed"},
+            )
+
+        self.assertEqual(response.status_code, 500)
+        payload = response.json()
+        self.assertEqual(payload["error"]["code"], "report_persistence_failed")
+        self.assertEqual(
+            payload["error"]["message"],
+            "Report persistence failed; final analysis success was not returned.",
+        )
+        self.assertEqual(
+            payload["error"]["details"]["reason"],
+            AnalysisPersistenceError.public_reason,
+        )
+        self.assertNotIn("database is read-only", response.text)
 
     def test_openapi_documents_analysis_submission_contract(self) -> None:
         response = self.client.get("/openapi.json")

--- a/tests/test_api/test_github_app.py
+++ b/tests/test_api/test_github_app.py
@@ -104,6 +104,8 @@ class GitHubAppRouteTests(unittest.TestCase):
                 "report_id": 17,
                 "report_url": "https://deploywhisper.example.com/reports/17",
                 "note": "ok",
+                "status": "ok",
+                "code": None,
             },
         )()
 
@@ -122,6 +124,57 @@ class GitHubAppRouteTests(unittest.TestCase):
         self.assertTrue(body["data"]["automatic_analysis_triggered"])
         self.assertEqual(body["data"]["check_run_id"], 7)
         self.assertEqual(body["data"]["report_id"], 17)
+        self.assertEqual(body["data"]["status"], "ok")
+        self.assertIsNone(body["data"]["code"])
+
+    @patch("api.routes.github_app.handle_github_app_webhook")
+    def test_webhook_returns_persistence_failure_without_report_identifier(
+        self, handle_github_app_webhook
+    ) -> None:
+        payload = b'{"action":"opened"}'
+        signature = (
+            "sha256="
+            + hmac.new(
+                b"webhook-secret",
+                payload,
+                hashlib.sha256,
+            ).hexdigest()
+        )
+        handle_github_app_webhook.return_value = type(
+            "Result",
+            (),
+            {
+                "event": "pull_request",
+                "action": "opened",
+                "handled": True,
+                "automatic_analysis_triggered": False,
+                "check_run_id": None,
+                "report_id": None,
+                "report_url": None,
+                "note": "Report persistence failed",
+                "status": "failed",
+                "code": "report_persistence_failed",
+            },
+        )()
+
+        response = self.client.post(
+            "/api/v1/github/app/webhook",
+            headers={
+                "X-GitHub-Event": "pull_request",
+                "X-Hub-Signature-256": signature,
+                "Content-Type": "application/json",
+            },
+            content=payload,
+        )
+
+        self.assertEqual(response.status_code, 200)
+        body = response.json()
+        self.assertFalse(body["data"]["automatic_analysis_triggered"])
+        self.assertIsNone(body["data"]["check_run_id"])
+        self.assertIsNone(body["data"]["report_id"])
+        self.assertIsNone(body["data"]["report_url"])
+        self.assertEqual(body["data"]["status"], "failed")
+        self.assertEqual(body["data"]["code"], "report_persistence_failed")
 
     @patch("api.routes.github_app.handle_github_app_webhook")
     def test_webhook_acknowledges_project_scope_error(

--- a/tests/test_cli/test_analyze.py
+++ b/tests/test_cli/test_analyze.py
@@ -662,6 +662,16 @@ class AnalyzeCliTests(unittest.TestCase):
             payload["data"]["persisted_report"]["audit"]["source_interface"], "cli"
         )
         self.assertEqual(
+            payload["data"]["persisted_report"]["audit"]["actor"], "cli_local_user"
+        )
+        self.assertEqual(
+            payload["data"]["persisted_report"]["audit"]["persisted_at"],
+            payload["data"]["persisted_report"]["created_at"],
+        )
+        self.assertEqual(
+            payload["data"]["persisted_report"]["audit"]["redaction_status"], "none"
+        )
+        self.assertEqual(
             payload["data"]["persisted_report"]["audit"]["trigger_type"], "cli_command"
         )
         self.assertEqual(payload["data"]["persisted_report"]["id"], 1)
@@ -2255,6 +2265,55 @@ class AnalyzeCliTests(unittest.TestCase):
         self.assertEqual(payload["error"]["code"], "analysis_failed")
         self.assertEqual(payload["error"]["message"], "Analysis failed.")
         self.assertEqual(payload["error"]["details"]["reason"], "boom")
+
+    def test_analyze_command_reports_persistence_failures_without_success(
+        self,
+    ) -> None:
+        project_service_module.create_project(
+            project_key="payments",
+            display_name="Payments",
+        )
+        artifact_path = Path(self.tempdir.name) / "plan.json"
+        artifact_path.write_text('{"resource_changes": []}', encoding="utf-8")
+        stdout = io.StringIO()
+        stderr = io.StringIO()
+
+        with (
+            patch(
+                "cli.analyze.analyze_uploaded_files",
+                side_effect=analysis_service_module.AnalysisPersistenceError(
+                    "database is read-only"
+                ),
+            ),
+            patch(
+                "sys.argv",
+                [
+                    "deploywhisper",
+                    "analyze",
+                    "--project",
+                    "payments",
+                    str(artifact_path),
+                ],
+            ),
+            redirect_stdout(stdout),
+            redirect_stderr(stderr),
+        ):
+            with self.assertRaises(SystemExit) as ctx:
+                main()
+
+        self.assertEqual(ctx.exception.code, 1)
+        self.assertEqual(stdout.getvalue(), "")
+        payload = json.loads(stderr.getvalue())
+        self.assertEqual(payload["error"]["code"], "report_persistence_failed")
+        self.assertEqual(
+            payload["error"]["message"],
+            "Report persistence failed; final analysis success was not returned.",
+        )
+        self.assertEqual(
+            payload["error"]["details"]["reason"],
+            analysis_service_module.AnalysisPersistenceError.public_reason,
+        )
+        self.assertNotIn("database is read-only", stderr.getvalue())
 
     def test_analyze_command_rejects_payloads_over_limit_before_reading_all_bytes(
         self,

--- a/tests/test_services/test_github_app_service.py
+++ b/tests/test_services/test_github_app_service.py
@@ -164,6 +164,7 @@ class GitHubAppServiceTests(unittest.TestCase):
                     "number": 3,
                     "head": {"sha": "abc123"},
                 },
+                "sender": {"login": "octocat"},
             },
         )
 
@@ -186,6 +187,10 @@ class GitHubAppServiceTests(unittest.TestCase):
         self.assertEqual(
             analyze_uploaded_files.call_args.kwargs["project_key"],
             "deploywhisper-deploywhisper",
+        )
+        self.assertEqual(
+            analyze_uploaded_files.call_args.kwargs["audit_context"]["actor"],
+            "github:octocat",
         )
 
     @patch("integrations.github.app_service._create_check_run")
@@ -449,6 +454,105 @@ class GitHubAppServiceTests(unittest.TestCase):
             )
 
         create_check_run.assert_not_called()
+
+    @patch("integrations.github.app_service._create_check_run")
+    @patch("integrations.github.app_service.analyze_uploaded_files")
+    @patch("integrations.github.app_service._load_pull_request_artifacts")
+    @patch("integrations.github.app_service._generate_installation_access_token")
+    def test_handle_github_app_webhook_reports_persistence_failure(
+        self,
+        generate_installation_access_token,
+        load_pull_request_artifacts,
+        analyze_uploaded_files,
+        create_check_run,
+    ) -> None:
+        generate_installation_access_token.return_value = "installation-token"
+        load_pull_request_artifacts.return_value = [("plan.tf", b'resource "x" "y" {}')]
+        analyze_uploaded_files.side_effect = app_service.AnalysisPersistenceError(
+            "database is read-only"
+        )
+        create_check_run.return_value = 998
+
+        result = app_service.handle_github_app_webhook(
+            event_name="pull_request",
+            payload={
+                "action": "opened",
+                "number": 3,
+                "installation": {"id": 42},
+                "repository": {
+                    "name": "deploywhisper",
+                    "owner": {"login": "deploywhisper"},
+                },
+                "pull_request": {
+                    "number": 3,
+                    "head": {"sha": "abc123"},
+                },
+            },
+        )
+
+        self.assertTrue(result.handled)
+        self.assertFalse(result.automatic_analysis_triggered)
+        self.assertIsNone(result.report_id)
+        self.assertEqual(result.check_run_id, 998)
+        self.assertIn("Report persistence failed", result.note)
+        self.assertIn(app_service.AnalysisPersistenceError.public_reason, result.note)
+        self.assertNotIn("database is read-only", result.note)
+        self.assertEqual(result.status, "failed")
+        self.assertEqual(result.code, "report_persistence_failed")
+        self.assertEqual(create_check_run.call_args.kwargs["conclusion"], "failure")
+        self.assertNotIn(
+            "database is read-only",
+            create_check_run.call_args.kwargs["summary"],
+        )
+
+    @patch("integrations.github.app_service._create_check_run")
+    @patch("integrations.github.app_service.analyze_uploaded_files")
+    @patch("integrations.github.app_service._load_pull_request_artifacts")
+    @patch("integrations.github.app_service._generate_installation_access_token")
+    def test_handle_github_app_webhook_preserves_persistence_failure_when_check_run_fails(
+        self,
+        generate_installation_access_token,
+        load_pull_request_artifacts,
+        analyze_uploaded_files,
+        create_check_run,
+    ) -> None:
+        generate_installation_access_token.return_value = "installation-token"
+        load_pull_request_artifacts.return_value = [("plan.tf", b'resource "x" "y" {}')]
+        analyze_uploaded_files.side_effect = app_service.AnalysisPersistenceError(
+            "database is read-only"
+        )
+        create_check_run.side_effect = app_service.GitHubAppRequestError(
+            "github upstream failed"
+        )
+
+        result = app_service.handle_github_app_webhook(
+            event_name="pull_request",
+            payload={
+                "action": "opened",
+                "number": 3,
+                "installation": {"id": 42},
+                "repository": {
+                    "name": "deploywhisper",
+                    "owner": {"login": "deploywhisper"},
+                },
+                "pull_request": {
+                    "number": 3,
+                    "head": {"sha": "abc123"},
+                },
+            },
+        )
+
+        self.assertTrue(result.handled)
+        self.assertFalse(result.automatic_analysis_triggered)
+        self.assertIsNone(result.report_id)
+        self.assertIsNone(result.check_run_id)
+        self.assertEqual(result.status, "failed")
+        self.assertEqual(result.code, "report_persistence_failed")
+        self.assertIn("Report persistence failed", result.note)
+        self.assertIn(app_service.AnalysisPersistenceError.public_reason, result.note)
+        self.assertIn("Failure check run could not be created.", result.note)
+        self.assertNotIn("database is read-only", result.note)
+        self.assertNotIn("github upstream failed", result.note)
 
     @patch("integrations.github.app_service._create_check_run")
     @patch("integrations.github.app_service.analyze_uploaded_files")

--- a/tests/test_services/test_report_service.py
+++ b/tests/test_services/test_report_service.py
@@ -3527,7 +3527,7 @@ class ReportServiceTests(unittest.TestCase):
                 evidence_items=evidence_items,
             )
 
-    def _persist_shareable_report(self) -> dict:
+    def _persist_shareable_report(self, audit_actor: str | None = None) -> dict:
         parse_batch = ParseBatchResult(
             files=[
                 ParsedFileResult(
@@ -3608,8 +3608,14 @@ class ReportServiceTests(unittest.TestCase):
             narrative,
             findings=findings,
             evidence_items=evidence_items,
-            audit_context={"source_interface": "api"},
+            audit_context={
+                "source_interface": "api",
+                **({"actor": audit_actor} if audit_actor is not None else {}),
+            },
         )
+
+    def _persist_shareable_report_with_audit_actor(self, audit_actor: str) -> dict:
+        return self._persist_shareable_report(audit_actor=audit_actor)
 
     def _persist_comparison_report(
         self,
@@ -3823,14 +3829,32 @@ class ReportServiceTests(unittest.TestCase):
                 "source_interface": "api",
                 "trigger_type": "session",
                 "trigger_id": "sess-123",
+                "actor": "reviewer@example.com",
             },
         )
         self.assertIn("id", persisted)
         self.assertEqual(persisted["audit"]["source_interface"], "api")
         self.assertEqual(persisted["audit"]["trigger_type"], "session")
         self.assertEqual(persisted["audit"]["trigger_id"], "sess-123")
+        self.assertEqual(persisted["audit"]["actor"], "reviewer@example.com")
         self.assertEqual(persisted["audit"]["files_analyzed"], ["plan.json"])
         self.assertEqual(persisted["audit"]["llm_provider"], "ollama")
+        self.assertEqual(persisted["audit"]["persisted_at"], persisted["created_at"])
+        self.assertEqual(
+            persisted["audit"]["delivery"],
+            {
+                "surface": "api",
+                "trigger_type": "session",
+                "trigger_id": "sess-123",
+                "report_id": persisted["id"],
+                "status": "persisted",
+            },
+        )
+        self.assertEqual(persisted["audit"]["redaction_status"], "none")
+        self.assertEqual(
+            persisted["submission_manifest"]["provenance"]["actor"],
+            "reviewer@example.com",
+        )
         self.assertEqual(persisted["assessment_source"], "heuristic-only")
         self.assertEqual(persisted["narrative_source"], "llm")
         self.assertEqual(persisted["report_schema_version"], "v2")
@@ -3883,6 +3907,9 @@ class ReportServiceTests(unittest.TestCase):
         self.assertEqual(fetched["severity"], "high")
         self.assertEqual(fetched["recommendation"], "no-go")
         self.assertEqual(fetched["audit"]["source_interface"], "api")
+        self.assertEqual(fetched["audit"]["actor"], "reviewer@example.com")
+        self.assertEqual(fetched["audit"]["persisted_at"], fetched["created_at"])
+        self.assertEqual(fetched["audit"]["redaction_status"], "none")
         self.assertEqual(fetched["audit"]["files_analyzed"], ["plan.json"])
         self.assertIn(
             "Deterministic severe risk remains", fetched["narrative_explanation"]
@@ -3899,6 +3926,7 @@ class ReportServiceTests(unittest.TestCase):
             fetched["rollback_plan"]["steps"][0]["title"],
             "Revert aws_security_group.main",
         )
+
         self.assertEqual(
             fetched["context_completeness"]["parser_success_by_tool"],
             {"terraform": 1.0},
@@ -3965,6 +3993,159 @@ class ReportServiceTests(unittest.TestCase):
         self.assertEqual(
             history[0]["contributors"][0]["metadata"]["redacted_fields"],
             ["ingress.0.description"],
+        )
+
+    def test_persist_analysis_report_cleans_up_committed_row_after_artifact_failure(
+        self,
+    ) -> None:
+        parse_batch = ParseBatchResult(
+            files=[
+                ParsedFileResult(
+                    file_name="plan.json",
+                    tool="terraform",
+                    status="parsed",
+                    changes=[
+                        UnifiedChange(
+                            source_file="plan.json",
+                            tool="terraform",
+                            resource_id="aws_instance.main",
+                            action="modify",
+                            summary="Terraform changed an instance.",
+                        )
+                    ],
+                )
+            ]
+        )
+        assessment = RiskAssessment(
+            score=42,
+            severity="medium",
+            recommendation="caution",
+            top_risk="Terraform changed an instance.",
+            contributors=[],
+            interaction_risks=[],
+            partial_context=False,
+            warnings=[],
+        )
+        narrative = NarrativeResult(
+            opening_sentence="CAUTION: review the instance update.",
+            explanation="The deployment should be reviewed.",
+            guidance=[],
+            degraded=False,
+            warnings=[],
+        )
+
+        with (
+            patch(
+                "services.report_service.save_report_artifacts",
+                side_effect=RuntimeError("snapshot disk full"),
+            ),
+            self.assertRaisesRegex(RuntimeError, "snapshot disk full"),
+        ):
+            report_service_module.persist_analysis_report(
+                parse_batch,
+                assessment,
+                narrative,
+                artifact_snapshots={"plan.json": b'{"resource_changes": []}'},
+            )
+
+        with sqlite3.connect(self.db_path) as connection:
+            count = connection.execute(
+                "SELECT COUNT(*) FROM analysis_reports"
+            ).fetchone()[0]
+        self.assertEqual(count, 0)
+
+    def test_persist_analysis_report_cleans_up_row_when_artifact_cleanup_fails(
+        self,
+    ) -> None:
+        parse_batch = ParseBatchResult(
+            files=[
+                ParsedFileResult(
+                    file_name="plan.json",
+                    tool="terraform",
+                    status="parsed",
+                    changes=[
+                        UnifiedChange(
+                            source_file="plan.json",
+                            tool="terraform",
+                            resource_id="aws_instance.main",
+                            action="modify",
+                            summary="Terraform changed an instance.",
+                        )
+                    ],
+                )
+            ]
+        )
+        assessment = RiskAssessment(
+            score=42,
+            severity="medium",
+            recommendation="caution",
+            top_risk="Terraform changed an instance.",
+            contributors=[],
+            interaction_risks=[],
+            partial_context=False,
+            warnings=[],
+        )
+        narrative = NarrativeResult(
+            opening_sentence="CAUTION: review the instance update.",
+            explanation="The deployment should be reviewed.",
+            guidance=[],
+            degraded=False,
+            warnings=[],
+        )
+
+        with (
+            patch(
+                "services.report_service.save_report_artifacts",
+                side_effect=RuntimeError("snapshot disk full"),
+            ),
+            patch(
+                "services.report_service.delete_report_artifacts",
+                side_effect=RuntimeError("cleanup disk full"),
+            ),
+            self.assertRaisesRegex(RuntimeError, "snapshot disk full"),
+        ):
+            report_service_module.persist_analysis_report(
+                parse_batch,
+                assessment,
+                narrative,
+                artifact_snapshots={"plan.json": b'{"resource_changes": []}'},
+            )
+
+        with sqlite3.connect(self.db_path) as connection:
+            count = connection.execute(
+                "SELECT COUNT(*) FROM analysis_reports"
+            ).fetchone()[0]
+        self.assertEqual(count, 0)
+
+    def test_persist_analysis_report_normalizes_actor_metadata(self) -> None:
+        report = self._persist_shareable_report_with_audit_actor(
+            " reviewer@example.com\nInjected: yes\t" + ("x" * 200)
+        )
+
+        self.assertNotIn("\n", report["audit"]["actor"])
+        self.assertNotIn("\t", report["audit"]["actor"])
+        self.assertTrue(report["audit"]["actor"].startswith("reviewer@example.com "))
+        self.assertLessEqual(len(report["audit"]["actor"]), 120)
+
+    def test_fetch_report_recovers_actor_from_submission_manifest_fallback(
+        self,
+    ) -> None:
+        report = self._persist_shareable_report_with_audit_actor("reviewer@example.com")
+        with sqlite3.connect(self.db_path) as connection:
+            connection.execute(
+                "UPDATE analysis_reports SET submission_manifest_json = ? WHERE id = ?",
+                ("{not-valid-json", report["id"]),
+            )
+
+        fetched = report_service_module.fetch_analysis_report(report["id"])
+
+        self.assertIsNotNone(fetched)
+        assert fetched is not None
+        self.assertEqual(fetched["audit"]["actor"], "reviewer@example.com")
+        self.assertTrue(fetched["submission_manifest_fallback"])
+        self.assertEqual(
+            fetched["submission_manifest_fallback"][0]["actor"],
+            "reviewer@example.com",
         )
 
     def test_persist_analysis_report_applies_context_uncertainty_downgrade(
@@ -5287,6 +5468,60 @@ class ReportServiceTests(unittest.TestCase):
         self.assertEqual(fallback_by_name["broken.tf"]["status"], "failed")
         self.assertEqual(fallback_by_name[".env"]["status"], "sensitive")
         self.assertEqual(fallback_by_name["notes.txt"]["status"], "excluded")
+        self.assertEqual(fetched["audit"]["redaction_status"], "sensitive_blocked")
+        self.assertEqual(
+            fetched["audit"]["redaction"],
+            {
+                "filenames_redacted": False,
+                "sensitive_content_excluded": True,
+            },
+        )
+
+    def test_fetch_report_marks_filename_redacted_manifest_as_redacted(self) -> None:
+        report = self._persist_shareable_report()
+        manifest = dict(report["submission_manifest"])
+        manifest["redaction"] = {
+            "filenames_redacted": True,
+            "sensitive_content_excluded": False,
+        }
+        manifest["items"] = [
+            {**item, "redaction_status": "none"} for item in manifest["items"]
+        ]
+        with sqlite3.connect(self.db_path) as connection:
+            connection.execute(
+                "UPDATE analysis_reports SET submission_manifest_json = ? WHERE id = ?",
+                (json.dumps(manifest), report["id"]),
+            )
+
+        fetched = report_service_module.fetch_analysis_report(report["id"])
+
+        self.assertIsNotNone(fetched)
+        assert fetched is not None
+        self.assertEqual(fetched["audit"]["redaction_status"], "redacted")
+        self.assertEqual(
+            fetched["audit"]["redaction"],
+            {
+                "filenames_redacted": True,
+                "sensitive_content_excluded": False,
+            },
+        )
+
+    def test_fetch_report_marks_empty_legacy_manifest_redaction_unknown(self) -> None:
+        report = self._persist_shareable_report()
+        with sqlite3.connect(self.db_path) as connection:
+            connection.execute(
+                "UPDATE analysis_reports "
+                "SET submission_manifest_json = ?, submission_manifest_fallback_json = ? "
+                "WHERE id = ?",
+                ("{}", "[]", report["id"]),
+            )
+
+        fetched = report_service_module.fetch_analysis_report(report["id"])
+
+        self.assertIsNotNone(fetched)
+        assert fetched is not None
+        self.assertEqual(fetched["audit"]["redaction_status"], "unknown")
+        self.assertEqual(fetched["audit"]["redaction"], {})
 
     def test_fetch_report_degrades_on_wrong_shape_submission_manifest_json(
         self,

--- a/tests/test_ui/test_upload_panel.py
+++ b/tests/test_ui/test_upload_panel.py
@@ -7,6 +7,8 @@ from unittest.mock import patch
 
 from ui.components.upload_panel import (
     build_feedback_rerender_handler,
+    format_analysis_failure,
+    persisted_report_reference,
     format_submission_manifest_fallback_summary,
     format_submission_manifest_partial_notice,
     format_submission_manifest_summary,
@@ -16,6 +18,7 @@ from ui.components.upload_panel import (
     uploads_allowed,
     run_uploaded_analysis,
 )
+from services.analysis_service import AnalysisPersistenceError
 from parsers.base import ParseBatchResult, ParsedFileResult, UnifiedChange
 from ui.components.change_table import (
     format_change_metadata_lines,
@@ -90,6 +93,7 @@ class UploadPanelTests(unittest.TestCase):
             audit_context={
                 "source_interface": "ui",
                 "trigger_type": "dashboard_upload",
+                "actor": "ui_local_user",
             },
         )
 
@@ -107,6 +111,32 @@ class UploadPanelTests(unittest.TestCase):
             getattr(exc_info.exception, "code", ""), "missing_project_scope"
         )
         build_parse_batch.assert_not_called()
+
+    def test_format_analysis_failure_surfaces_persistence_error_actionably(
+        self,
+    ) -> None:
+        title, message, notification = format_analysis_failure(
+            AnalysisPersistenceError("database is read-only")
+        )
+
+        self.assertEqual(title, "Report persistence failed")
+        self.assertEqual(message, AnalysisPersistenceError.public_reason)
+        self.assertIn("report was not saved", notification)
+        self.assertIn("persistence configuration", notification)
+        self.assertNotIn("database is read-only", message)
+        self.assertNotIn("database is read-only", notification)
+        self.assertNotIn("local storage", notification)
+
+    def test_persisted_report_reference_prefers_saved_report_id(self) -> None:
+        self.assertEqual(
+            persisted_report_reference({"id": 42}),
+            ("Saved report #42", "/reports/42"),
+        )
+        self.assertEqual(
+            persisted_report_reference({"audit": {"delivery": {"report_id": "43"}}}),
+            ("Saved report #43", "/reports/43"),
+        )
+        self.assertIsNone(persisted_report_reference({"id": "not-a-number"}))
 
     def test_resolve_initial_project_selection_requires_saved_choice(self) -> None:
         project_id, project_key = resolve_initial_project_selection(

--- a/ui/components/upload_panel.py
+++ b/ui/components/upload_panel.py
@@ -10,7 +10,7 @@ from nicegui import events, run, ui
 from analysis.blast_radius import BlastRadiusResult
 from analysis.rollback_planner import RollbackPlan
 from parsers.registry import detect_tool_type
-from services.analysis_service import analyze_uploaded_files
+from services.analysis_service import AnalysisPersistenceError, analyze_uploaded_files
 from services.intake_service import (
     MAX_TOTAL_UPLOAD_BYTES,
     build_pending_analysis,
@@ -117,8 +117,36 @@ def run_uploaded_analysis(
         audit_context={
             "source_interface": "ui",
             "trigger_type": "dashboard_upload",
+            "actor": "ui_local_user",
         },
     )
+
+
+def format_analysis_failure(exc: Exception) -> tuple[str, str, str]:
+    if isinstance(exc, AnalysisPersistenceError):
+        return (
+            "Report persistence failed",
+            exc.public_reason,
+            "Analysis completed, but the report was not saved. Retry the analysis; if it repeats, review local application logs and persistence configuration.",
+        )
+    return (
+        "Analysis failed",
+        str(exc),
+        "Analysis failed. Review the dashboard error card for details.",
+    )
+
+
+def persisted_report_reference(report: dict[str, Any]) -> tuple[str, str] | None:
+    report_id = report.get("id") or (report.get("audit", {}).get("delivery") or {}).get(
+        "report_id"
+    )
+    if report_id is None:
+        return None
+    try:
+        normalized_report_id = int(report_id)
+    except (TypeError, ValueError):
+        return None
+    return f"Saved report #{normalized_report_id}", f"/reports/{normalized_report_id}"
 
 
 def resolve_initial_project_selection(*, has_saved_selection: bool, active_project):
@@ -413,6 +441,12 @@ def build_upload_panel(
                         "Narrative unavailable. Review the deterministic findings and evidence below."
                     ).classes("text-sm dw-warning-text leading-6")
                 ui.label(report["parse_summary"]).classes("text-xs dw-muted")
+                report_reference = persisted_report_reference(report)
+                if report_reference is not None:
+                    reference_label, reference_target = report_reference
+                    ui.link(reference_label, reference_target).classes(
+                        "text-xs dw-link"
+                    )
                 manifest = report.get("submission_manifest") or {}
                 if manifest.get("items"):
                     ui.label(format_submission_manifest_summary(manifest)).classes(
@@ -662,15 +696,16 @@ def build_upload_panel(
             if on_analysis_complete:
                 on_analysis_complete()
         except Exception as exc:  # noqa: BLE001
+            failure_title, failure_message, notification = format_analysis_failure(exc)
             result_mount.clear()
             with result_mount:
                 with ui.card().classes("w-full dw-panel shadow-none p-5"):
-                    ui.label("Analysis failed").classes(
+                    ui.label(failure_title).classes(
                         "text-base font-semibold dw-danger-text"
                     )
-                    ui.label(str(exc)).classes("text-sm dw-muted")
+                    ui.label(failure_message).classes("text-sm dw-muted")
             ui.notify(
-                "Analysis failed. Review the dashboard error card for details.",
+                notification,
                 color="negative",
             )
         finally:


### PR DESCRIPTION
Story 2.9 requires every analysis surface to return success only after the report and audit metadata are durably persisted. This wires API, CLI, UI, and GitHub App paths through explicit audit context, exposes safe persistence-failure states, records schema v2 audit metadata, and adds regression coverage for cleanup and failure behavior.

Constraint: DeployWhisper must preserve local-first advisory behavior while making persistence failures explicit.
Constraint: BMad implementation artifacts are git-ignored except tracked sprint status.
Rejected: Treat persistence failures as generic analysis failures | that would imply analysis success without a durable report.
Rejected: Leave partial report rows after artifact serialization failures | that would create misleading audit records.
Confidence: high
Scope-risk: moderate
Directive: Do not add new success paths for analysis without preserving the persisted-report-before-success contract.
Tested: git diff --check; ./.venv/bin/python -m unittest discover -q; APP_PORT=18080 npm run test:ui-review
Not-tested: Manual GitHub App webhook delivery against the live GitHub API

## What does this PR do?

<!-- Brief description of changes -->

## Type of change
- [ ] Feature (new functionality)
- [ ] Bugfix (non-breaking fix)
- [ ] Release preparation
- [ ] Hotfix (critical production fix)
- [ ] Docs / refactor / chore

## Checklist
- [ ] I have followed the branch naming convention
- [ ] Tests pass locally (`pytest tests/ -v`)
- [ ] Linting passes (`ruff check .`)
- [ ] Docker build succeeds
- [ ] I have updated docs if needed
- [ ] No secrets or .env values committed

## Related issue
Closes #