### PR TITLE
Orient reviewers with verdict-first report context

### DIFF
--- a/_bmad-output/implementation-artifacts/3-1-verdict-first-report-header.md
+++ b/_bmad-output/implementation-artifacts/3-1-verdict-first-report-header.md
@@ -1,0 +1,133 @@
+# Story 3.1: Verdict-First Report Header
+
+Status: done
+
+<!-- Generated from updated PRD/architecture/epics plus implementation-readiness-report-2026-05-01.md. -->
+
+## Story
+
+As a reviewer,
+I want the verdict, Evidence Law status, confidence, and top risk visible immediately,
+So that I can orient quickly before drilling into detail.
+
+## Acceptance Criteria
+
+1. Given an analysis report is displayed, When the result page loads, Then verdict, advisory posture, Evidence Law status, confidence, top risk, and next action are visible above the fold. And the copy avoids implying automatic approval or blocking.
+
+### Requirement Traceability
+
+- Primary PRD requirements: Epic 3 coverage: REV-01..10, HIS-03, RSK-04..06, RSK-09..10, NFR-XAI-01..05, UX-DR1..10.
+- Supporting PRD / NFR / differentiation requirements: See `_bmad-output/planning-artifacts/prd.md`, `_bmad-output/planning-artifacts/architecture.md`, and `_bmad-output/planning-artifacts/implementation-readiness-report-2026-05-01.md`.
+- Coverage intent: Baseline + Delta.
+- Story alignment note: This story was created from the updated Epic 3 plan after the 2026-05-01 readiness rerun. The readiness report verified 187/187 PRD functional requirement IDs in the epics artifact, 38 NFR IDs present, and no critical or major readiness defects.
+
+## Tasks / Subtasks
+
+- [x] Implement and verify acceptance criterion 1. (AC: 1)
+- [x] Reuse existing services, repositories, schemas, and UI/CLI/API helpers before adding new abstractions. (AC: all)
+- [x] Add or update deterministic regression coverage for the changed behavior. (AC: all)
+- [x] Update relevant docs or examples if the story changes user-visible, operator, API, CLI, integration, or contribution behavior. (AC: all)
+- [x] Run required validation and record commands/results in the Dev Agent Record. (AC: all)
+
+### Review Findings
+
+- [x] [Review][Patch] Compute Evidence Law status from linked deterministic evidence, not only finding booleans [ui/formatters/report_header.py:32]
+
+## Dev Notes
+
+### Epic Context
+
+- Epic: 3. Report and Review Experience
+- Epic goal: Make the report experience fast, inspectable, and honest.
+- Epic coverage: REV-01..10, HIS-03, RSK-04..06, RSK-09..10, NFR-XAI-01..05, UX-DR1..10
+
+### Architecture and Product Guardrails
+
+- Preserve DeployWhisper's local-first raw artifact boundary: raw IaC, scanner artifacts, incident exports, and sensitive context stay in the user's infrastructure by default.
+- Preserve the advisory-first core. Optional adapters may interpret report outputs, but canonical report semantics remain advisory unless explicit story scope says otherwise.
+- Reuse the shared analysis core and service layer before adapting UI, API, CLI, GitHub, or future workflow surfaces.
+- Keep Evidence Law behavior intact: no high or critical finding without deterministic evidence.
+- Keep project/workspace scope explicit for reports, incidents, topology, outcomes, feedback, scanner imports, and connector-related data.
+- Do not introduce new dependencies unless the active story explicitly requires and justifies them.
+
+### Source Tree Guidance
+
+- API routes belong under `api/routes/` and should use existing `ApiRoute` / `ApiError` envelope patterns.
+- Shared orchestration belongs in `services/`; parsers normalize input, analysis modules score/derive risk, and surfaces adapt outputs.
+- UI work belongs under `ui/routes/` and `ui/components/`, following the existing NiceGUI composition style.
+- CLI behavior belongs under `cli/` and must call the same service-layer paths as UI/API flows.
+- Persistence work belongs under `models/` with Alembic migrations when schema changes are required.
+- Documentation required by a story should be updated in the same workstream.
+
+### Testing Requirements
+
+- Use standard-library `unittest` in the existing `tests/test_*` layout.
+- Add focused regression tests for the layer changed by the story before broad refactors.
+- For Python changes, run `./.venv/bin/ruff check .`, `./.venv/bin/ruff format --check .`, and `./.venv/bin/python -m unittest discover -q` before closing implementation.
+- Use `bash scripts/ci-local.sh` for broader or cross-layer changes.
+
+### Project Structure Notes
+
+- Follow the current repository shape documented in `_bmad-output/project-context.md` and `AGENTS.md`.
+- If implementation reveals a conflict between this story and the current code baseline, keep the smallest compatible change and update the story notes rather than silently drifting from the PRD.
+
+### References
+
+- `_bmad-output/planning-artifacts/epics.md` - source Epic 3 / Story 3.1 definition.
+- `_bmad-output/planning-artifacts/prd.md` - functional and non-functional requirements.
+- `_bmad-output/planning-artifacts/architecture.md` - target architecture, boundaries, and guardrails.
+- `_bmad-output/planning-artifacts/ux-design-specification.md` - UX expectations for user-facing stories.
+- `_bmad-output/planning-artifacts/implementation-readiness-report-2026-05-01.md` - readiness verdict and residual story-format concern.
+- `_bmad-output/project-context.md` - repository-specific implementation rules.
+
+## Dev Agent Record
+
+### Agent Model Used
+
+GPT-5.4
+
+### Debug Log References
+
+- Created feature branch `feature/3-1-verdict-first-report-header` from `develop`.
+- Red-phase focused UI route test initially failed because the report detail header did not explicitly render the verdict-first signals by name.
+- Implemented shared report header signal helpers and rendered them in both saved report detail headers and the dashboard verdict card.
+- Red-phase review-finding tests failed for severe reports without linked deterministic evidence, then passed after Evidence Law status was derived from linked evidence items.
+
+### Completion Notes List
+
+- Added verdict-first header signals for verdict, advisory posture, Evidence Law status, confidence, top risk, and next action above the detailed report sections.
+- Kept copy advisory-first: the UI states that the verdict is not an approval or automatic block and frames the next action as a human review step.
+- Added deterministic formatter coverage for Evidence Law status and next-action copy, route rendering coverage for saved report detail, and Playwright coverage for the dashboard verdict card.
+- Fixed the review finding by requiring severe findings to reference deterministic evidence items before the header reports Evidence Law as satisfied, and by flagging severe reports without visible severe findings for review.
+- No separate documentation update was required; the story changed user-visible report copy only, and the copy is covered by UI tests.
+- Validation results:
+  - `./.venv/bin/python -m unittest tests.test_ui.test_history_page.HistoryPageRenderingTests.test_history_detail_route_renders_verdict_first_header -q` - red-phase failed before implementation, then passed after implementation.
+  - `./.venv/bin/python -m unittest tests.test_ui.test_verdict_card tests.test_ui.test_history_page.HistoryPageRenderingTests.test_history_detail_route_renders_verdict_first_header -q` - passed, 5 tests.
+  - `./.venv/bin/python -m unittest tests.test_ui.test_verdict_card -q` - red-phase failed for the review finding before the fix, then passed after the fix.
+  - `./.venv/bin/python -m unittest tests.test_ui.test_verdict_card tests.test_ui.test_history_page.HistoryPageRenderingTests.test_history_detail_route_renders_verdict_first_header -q` - passed, 7 tests.
+  - `APP_PORT=18080 npm run test:ui-review` - passed, 1 Playwright test.
+  - `./.venv/bin/ruff check .` - passed.
+  - `./.venv/bin/ruff format --check .` - passed after formatting `ui/formatters/report_header.py`.
+  - `git diff --check` - passed.
+  - `./.venv/bin/python -m pip check` - passed, no broken requirements.
+  - `./.venv/bin/bandit -r api/ analysis/ services/ parsers/ llm/ models/ cli/ ui/ evidence/ --severity-level high --confidence-level high -x tests/` - passed, no high issues.
+  - `./.venv/bin/python -m unittest discover -q` - passed, 354 tests, 1 skipped.
+
+### File List
+
+- `_bmad-output/implementation-artifacts/3-1-verdict-first-report-header.md`
+- `_bmad-output/implementation-artifacts/sprint-status.yaml`
+- `tests/e2e/report_review.keyboard.spec.js`
+- `tests/test_ui/test_history_page.py`
+- `tests/test_ui/test_verdict_card.py`
+- `ui/components/report_detail_page.py`
+- `ui/components/verdict_card.py`
+- `ui/formatters/report_header.py`
+
+## Change Log
+
+- 2026-05-01: Story created/aligned from updated PRD, architecture, epics, sprint status, and readiness report.
+- 2026-05-13: Implemented verdict-first report header signals and moved story to review.
+- 2026-05-13: Code review found one Evidence Law status patch item; story moved back to in-progress.
+- 2026-05-13: Fixed Evidence Law linked-evidence review finding and moved story back to review.
+- 2026-05-13: Re-ran BMad code review cleanly and marked story done.

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -71,7 +71,7 @@ development_status:
   epic-2-retrospective: optional
 
   epic-3: in-progress
-  3-1-verdict-first-report-header: ready-for-dev
+  3-1-verdict-first-report-header: done
   3-2-findings-table-with-evidence-badges: ready-for-dev
   3-3-evidence-inspector-panel: ready-for-dev
   3-4-confidence-ledger-and-why-not-lower-higher: ready-for-dev

--- a/tests/e2e/report_review.keyboard.spec.js
+++ b/tests/e2e/report_review.keyboard.spec.js
@@ -70,6 +70,10 @@ test.describe("review keyboard flow", () => {
   }) => {
     await page.goto("/", { waitUntil: "networkidle" });
     await expect(page.getByText("5-second verdict")).toBeVisible();
+    await expect(page.getByText("Advisory posture").first()).toBeVisible();
+    await expect(page.getByText("Evidence Law").first()).toBeVisible();
+    await expect(page.getByText("Next action").first()).toBeVisible();
+    await expect(page.getByText("Review linked evidence").first()).toBeVisible();
     await page.waitForFunction(() => window.dwReviewAccessibilityInstalled === true);
     await expect(page.getByText("Module: module.network").first()).toBeVisible();
     await expect(

--- a/tests/test_ui/test_history_page.py
+++ b/tests/test_ui/test_history_page.py
@@ -528,6 +528,25 @@ class HistoryPageRenderingTests(unittest.TestCase):
         self.assertIn("LOW CONFIDENCE", response.text)
         self.assertIn('"title":"Confidence 0.52"', response.text)
 
+    def test_history_detail_route_renders_verdict_first_header(self) -> None:
+        self._persist_report()
+
+        response = self.client.get("/history/1")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("Verdict", response.text)
+        self.assertIn("NO-GO · CRITICAL RISK", response.text)
+        self.assertIn("Advisory posture", response.text)
+        self.assertIn("Advisory only", response.text)
+        self.assertIn("Evidence Law", response.text)
+        self.assertIn("Satisfied", response.text)
+        self.assertIn("Confidence", response.text)
+        self.assertIn("High (1.00)", response.text)
+        self.assertIn("Top risk", response.text)
+        self.assertIn("Security group exposure risk", response.text)
+        self.assertIn("Next action", response.text)
+        self.assertIn("Review linked evidence", response.text)
+
     def test_history_detail_route_shows_topology_freshness_badge(self) -> None:
         self._persist_report(
             context_completeness={

--- a/tests/test_ui/test_verdict_card.py
+++ b/tests/test_ui/test_verdict_card.py
@@ -5,6 +5,12 @@ from __future__ import annotations
 import unittest
 
 from ui.components.verdict_card import _has_limited_context, _primary_confidence
+from ui.formatters.report_header import (
+    evidence_law_status,
+    next_action_text,
+    report_confidence_text,
+    report_verdict_text,
+)
 
 
 class VerdictCardHelperTests(unittest.TestCase):
@@ -26,6 +32,86 @@ class VerdictCardHelperTests(unittest.TestCase):
                 }
             )
         )
+
+    def test_report_header_signals_use_advisory_copy(self) -> None:
+        report = {
+            "recommendation": "no-go",
+            "severity": "critical",
+            "confidence": 0.91,
+            "findings": [
+                {
+                    "severity": "critical",
+                    "deterministic": True,
+                    "evidence_refs": ["ev-001"],
+                }
+            ],
+            "evidence_items": [
+                {
+                    "evidence_id": "ev-001",
+                    "deterministic": True,
+                    "determinism_level": "deterministic",
+                }
+            ],
+            "warnings": [],
+        }
+
+        status, detail = evidence_law_status(report)
+
+        self.assertEqual(report_verdict_text(report), "NO-GO · CRITICAL RISK")
+        self.assertEqual(report_confidence_text(report), "High (0.91)")
+        self.assertEqual(status, "Satisfied")
+        self.assertIn("deterministic evidence", detail)
+        self.assertIn("Review linked evidence", next_action_text(report, status))
+
+    def test_report_header_signals_flag_unsupported_severe_claims(self) -> None:
+        report = {
+            "recommendation": "no-go",
+            "severity": "critical",
+            "findings": [{"severity": "critical", "deterministic": False}],
+            "warnings": [],
+        }
+
+        status, detail = evidence_law_status(report)
+
+        self.assertEqual(status, "Needs review")
+        self.assertIn("lacks linked deterministic evidence", detail)
+        self.assertIn("before treating severe claims", next_action_text(report, status))
+
+    def test_report_header_signals_do_not_satisfy_severe_report_without_severe_finding(
+        self,
+    ) -> None:
+        report = {
+            "recommendation": "no-go",
+            "severity": "critical",
+            "findings": [{"severity": "medium", "deterministic": True}],
+            "evidence_items": [],
+            "warnings": [],
+        }
+
+        status, detail = evidence_law_status(report)
+
+        self.assertEqual(status, "Needs review")
+        self.assertIn("report is severe", detail)
+
+    def test_report_header_signals_require_linked_deterministic_evidence(self) -> None:
+        report = {
+            "recommendation": "no-go",
+            "severity": "critical",
+            "findings": [
+                {
+                    "severity": "critical",
+                    "deterministic": True,
+                    "evidence_refs": ["missing-evidence"],
+                }
+            ],
+            "evidence_items": [],
+            "warnings": [],
+        }
+
+        status, detail = evidence_law_status(report)
+
+        self.assertEqual(status, "Needs review")
+        self.assertIn("lacks linked deterministic evidence", detail)
 
 
 if __name__ == "__main__":

--- a/ui/components/report_detail_page.py
+++ b/ui/components/report_detail_page.py
@@ -24,11 +24,20 @@ from ui.components.findings_table import render_findings_table
 from ui.components.review_accessibility import decorate_review_section
 from ui.components.rollback_plan import render_rollback_plan
 from ui.components.topology_freshness_banner import render_topology_freshness_banner
-from ui.formatters.confidence import coerce_confidence, render_confidence_badge
+from ui.formatters.confidence import (
+    coerce_confidence,
+    render_confidence_badge,
+)
 from ui.formatters.datetime import format_history_timestamp
 from ui.formatters.narrative import (
     extract_llm_notice,
     extract_submission_manifest_notice,
+)
+from ui.formatters.report_header import (
+    evidence_law_status,
+    next_action_text,
+    report_confidence_text,
+    report_verdict_text,
 )
 from ui.formatters.recommendations import render_recommendation_label
 from ui.formatters.risk_labels import render_risk_badge
@@ -77,6 +86,16 @@ def _detail_stat(label: str, value: str, detail: str) -> None:
                 "text-[11px] font-semibold uppercase tracking-[0.08em] dw-muted"
             )
             ui.label(value).classes("text-lg font-semibold dw-text")
+            ui.label(detail).classes("text-xs dw-muted leading-5")
+
+
+def _header_signal(label: str, value: str, detail: str) -> None:
+    with ui.element("div").classes("dw-panel-soft min-w-[180px] flex-1 p-3"):
+        with ui.column().classes("gap-1"):
+            ui.label(label).classes(
+                "text-[11px] font-semibold uppercase tracking-[0.08em] dw-muted"
+            )
+            ui.label(value).classes("text-base font-semibold dw-text leading-5")
             ui.label(detail).classes("text-xs dw-muted leading-5")
 
 
@@ -585,6 +604,7 @@ def render_report_detail_page(
     context = report.get("context_completeness") or {}
     blast_radius = report.get("blast_radius") or {}
     rollback_plan = report.get("rollback_plan") or {}
+    evidence_status, evidence_detail = evidence_law_status(report)
 
     with ui.card().classes("w-full dw-panel shadow-none p-6") as header_card:
         decorate_review_section(header_card, section="verdict", label="Report header")
@@ -616,25 +636,35 @@ def render_report_detail_page(
                     )
                     ui.label("Risk score").classes("dw-verdict-score-label")
             with ui.row().classes("w-full gap-3 flex-wrap"):
-                _detail_stat(
-                    "Severity",
-                    str(report["severity"]).upper(),
-                    "Highest persisted risk level for this report.",
+                _header_signal(
+                    "Verdict",
+                    report_verdict_text(report),
+                    "Advisory deployment-risk orientation, not an approval or block.",
                 )
-                _detail_stat(
-                    "Recommendation",
-                    str(report["recommendation"]).upper(),
-                    "Advisory release recommendation captured with the report.",
+                _header_signal(
+                    "Advisory posture",
+                    "Advisory only",
+                    "Human release review remains responsible for the decision.",
                 )
-                _detail_stat(
-                    "Created",
-                    format_history_timestamp(report["created_at"]),
-                    "Timestamp of the persisted report.",
+                _header_signal(
+                    "Evidence Law",
+                    evidence_status,
+                    evidence_detail,
                 )
-                _detail_stat(
-                    "Schema",
-                    str(report.get("report_schema_version") or "unknown").upper(),
-                    "Persisted report payload contract version.",
+                _header_signal(
+                    "Confidence",
+                    report_confidence_text(report),
+                    "Overall report confidence captured with the verdict.",
+                )
+                _header_signal(
+                    "Top risk",
+                    str(report.get("top_risk") or "No top risk recorded."),
+                    "Primary risk to inspect before drilling into evidence.",
+                )
+                _header_signal(
+                    "Next action",
+                    next_action_text(report, evidence_status),
+                    "Suggested human review step before release action.",
                 )
 
     _render_summary_and_advisory(report)

--- a/ui/components/verdict_card.py
+++ b/ui/components/verdict_card.py
@@ -7,6 +7,12 @@ from nicegui import ui
 from ui.formatters.confidence import coerce_confidence, render_confidence_badge
 from ui.formatters.context_completeness import render_context_completeness_badge
 from ui.formatters.narrative import extract_llm_notice
+from ui.formatters.report_header import (
+    evidence_law_status,
+    next_action_text,
+    report_confidence_text,
+    report_verdict_text,
+)
 from ui.formatters.recommendations import render_recommendation_label
 from ui.formatters.risk_labels import render_risk_badge
 from ui.components.topology_freshness_banner import render_topology_freshness_banner
@@ -41,11 +47,22 @@ def _context_warning_text(context: dict) -> str:
     )
 
 
+def _verdict_signal(label: str, value: str, detail: str) -> None:
+    with ui.element("div").classes("dw-panel-soft min-w-[170px] flex-1 p-3"):
+        with ui.column().classes("gap-1"):
+            ui.label(label).classes(
+                "text-[11px] font-semibold uppercase tracking-[0.08em] dw-muted"
+            )
+            ui.label(value).classes("text-sm font-semibold dw-text leading-5")
+            ui.label(detail).classes("text-xs dw-muted leading-5")
+
+
 def render_verdict_card(report: dict) -> None:
     """Render the above-the-fold verdict card for the current report."""
     register_review_accessibility()
     context = report.get("context_completeness") or {}
     confidence = _primary_confidence(report)
+    evidence_status, evidence_detail = evidence_law_status(report)
     llm_notice = extract_llm_notice(
         report.get("warnings", []), report.get("narrative_failure_notice")
     )
@@ -79,6 +96,33 @@ def render_verdict_card(report: dict) -> None:
                     else:
                         ui.label("CONFIDENCE UNAVAILABLE").classes("text-xs dw-muted")
                     render_context_completeness_badge(context)
+
+        with ui.row().classes("w-full gap-3 flex-wrap mt-3"):
+            _verdict_signal(
+                "Verdict",
+                report_verdict_text(report),
+                "Advisory orientation, not an approval or automatic block.",
+            )
+            _verdict_signal(
+                "Advisory posture",
+                "Advisory only",
+                "Human release review remains responsible for the decision.",
+            )
+            _verdict_signal(
+                "Evidence Law",
+                evidence_status,
+                evidence_detail,
+            )
+            _verdict_signal(
+                "Confidence",
+                report_confidence_text(report),
+                "Overall report confidence captured with the verdict.",
+            )
+            _verdict_signal(
+                "Next action",
+                next_action_text(report, evidence_status),
+                "Suggested human review step before release action.",
+            )
 
         if llm_notice:
             ui.label("Narrative note: " + llm_notice).classes(

--- a/ui/formatters/report_header.py
+++ b/ui/formatters/report_header.py
@@ -1,0 +1,112 @@
+"""Verdict-first report header signal helpers."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from ui.formatters.confidence import coerce_confidence, confidence_bucket
+
+
+def report_verdict_text(report: dict[str, Any]) -> str:
+    recommendation = str(report.get("recommendation") or "review").upper()
+    severity = str(report.get("severity") or "unknown").upper()
+    return f"{recommendation} · {severity} RISK"
+
+
+def report_confidence_text(report: dict[str, Any]) -> str:
+    confidence = coerce_confidence(report.get("confidence"))
+    if confidence is None:
+        return "Unavailable"
+    return f"{confidence_bucket(confidence).title()} ({confidence:.2f})"
+
+
+def severe_findings(report: dict[str, Any]) -> list[dict[str, Any]]:
+    return [
+        finding
+        for finding in report.get("findings", [])
+        if isinstance(finding, dict)
+        and str(finding.get("severity") or "").lower() in {"high", "critical"}
+    ]
+
+
+def _is_severe_report(report: dict[str, Any]) -> bool:
+    return str(report.get("severity") or "").lower() in {"high", "critical"}
+
+
+def _is_deterministic_evidence(evidence: dict[str, Any]) -> bool:
+    determinism_level = str(
+        evidence.get("determinism_level") or "deterministic"
+    ).lower()
+    return (
+        evidence.get("deterministic") is True and determinism_level == "deterministic"
+    )
+
+
+def _has_linked_deterministic_evidence(
+    finding: dict[str, Any],
+    evidence_by_id: dict[str, dict[str, Any]],
+) -> bool:
+    evidence_refs = [
+        str(evidence_ref)
+        for evidence_ref in finding.get("evidence_refs", [])
+        if evidence_ref
+    ]
+    if not evidence_refs:
+        return False
+    return any(
+        _is_deterministic_evidence(evidence_by_id[evidence_ref])
+        for evidence_ref in evidence_refs
+        if evidence_ref in evidence_by_id
+    )
+
+
+def evidence_law_status(report: dict[str, Any]) -> tuple[str, str]:
+    warnings = [
+        str(warning)
+        for warning in report.get("warnings", [])
+        if "Evidence Law" in str(warning)
+    ]
+    if warnings:
+        return (
+            "Reconciled",
+            "Evidence Law adjusted unsupported or inconsistent severe claims.",
+        )
+    severe = severe_findings(report)
+    if not severe:
+        if _is_severe_report(report):
+            return (
+                "Needs review",
+                "The report is severe, but no high or critical finding is visible for Evidence Law verification.",
+            )
+        return (
+            "Satisfied",
+            "No high or critical finding requires deterministic evidence.",
+        )
+    evidence_by_id = {
+        str(evidence.get("evidence_id")): evidence
+        for evidence in report.get("evidence_items", [])
+        if isinstance(evidence, dict) and evidence.get("evidence_id")
+    }
+    if all(
+        _has_linked_deterministic_evidence(finding, evidence_by_id)
+        for finding in severe
+    ):
+        return (
+            "Satisfied",
+            "High and critical findings are backed by deterministic evidence.",
+        )
+    return (
+        "Needs review",
+        "A severe finding lacks linked deterministic evidence support.",
+    )
+
+
+def next_action_text(report: dict[str, Any], evidence_status: str) -> str:
+    if evidence_status == "Needs review":
+        return "Review linked evidence before treating severe claims as release risk."
+    recommendation = str(report.get("recommendation") or "").lower()
+    if recommendation == "no-go":
+        return "Review linked evidence and rollback readiness before release."
+    if recommendation == "caution":
+        return "Review linked evidence and resolve open context before release."
+    return "Continue normal release review; this advisory is not an approval."


### PR DESCRIPTION
The report and review surfaces now put the verdict, advisory posture, Evidence Law status, confidence, top risk, and next action into the first scan path. The shared formatter keeps the dashboard card and saved report detail page aligned while preserving the advisory-only product posture.

Constraint: Evidence Law status must come from linked deterministic evidence for severe findings, not finding booleans alone
Constraint: Story 3.1 required browser-side validation for changed UI report surfaces
Rejected: Keep the signal formatting local to each component | duplicated Evidence Law and next-action semantics across UI surfaces
Confidence: high
Scope-risk: moderate
Directive: Do not mark severe Evidence Law status as satisfied unless the severe finding links to deterministic evidence items
Tested: ./.venv/bin/python -m unittest tests.test_ui.test_verdict_card tests.test_ui.test_history_page.HistoryPageRenderingTests.test_history_detail_route_renders_verdict_first_header -q
Tested: APP_PORT=18080 npm run test:ui-review
Tested: ./.venv/bin/ruff check .
Tested: ./.venv/bin/ruff format --check .
Tested: ./.venv/bin/python -m pip check
Tested: ./.venv/bin/bandit -r api/ analysis/ services/ parsers/ llm/ models/ cli/ ui/ evidence/ --severity-level high --confidence-level high -x tests/
Tested: ./.venv/bin/python -m unittest discover -q
Not-tested: VoiceOver-specific review flow; copy and keyboard-visible browser flow covered by Playwright

## What does this PR do?

<!-- Brief description of changes -->

## Type of change
- [ ] Feature (new functionality)
- [ ] Bugfix (non-breaking fix)
- [ ] Release preparation
- [ ] Hotfix (critical production fix)
- [ ] Docs / refactor / chore

## Checklist
- [ ] I have followed the branch naming convention
- [ ] Tests pass locally (`pytest tests/ -v`)
- [ ] Linting passes (`ruff check .`)
- [ ] Docker build succeeds
- [ ] I have updated docs if needed
- [ ] No secrets or .env values committed

## Related issue
Closes #