### PR TITLE
Make findings rows scan-safe for reviewers

### DIFF
--- a/_bmad-output/implementation-artifacts/3-2-findings-table-with-evidence-badges.md
+++ b/_bmad-output/implementation-artifacts/3-2-findings-table-with-evidence-badges.md
@@ -1,0 +1,131 @@
+# Story 3.2: Findings Table With Evidence Badges
+
+Status: done
+
+<!-- Generated from updated PRD/architecture/epics plus implementation-readiness-report-2026-05-01.md. -->
+
+## Story
+
+As a reviewer,
+I want a findings table with severity, determinism, confidence, and evidence counts,
+So that I can scan risk quickly and choose what to inspect.
+
+## Acceptance Criteria
+
+1. Given findings exist, When the findings table renders, Then each row shows severity, category, confidence, deterministic/derived/external labels, and evidence count. And high/critical rows visibly satisfy or fail Evidence Law status.
+
+### Requirement Traceability
+
+- Primary PRD requirements: Epic 3 coverage: REV-01..10, HIS-03, RSK-04..06, RSK-09..10, NFR-XAI-01..05, UX-DR1..10.
+- Supporting PRD / NFR / differentiation requirements: See `_bmad-output/planning-artifacts/prd.md`, `_bmad-output/planning-artifacts/architecture.md`, and `_bmad-output/planning-artifacts/implementation-readiness-report-2026-05-01.md`.
+- Coverage intent: Baseline + Delta.
+- Story alignment note: This story was created from the updated Epic 3 plan after the 2026-05-01 readiness rerun. The readiness report verified 187/187 PRD functional requirement IDs in the epics artifact, 38 NFR IDs present, and no critical or major readiness defects.
+
+## Tasks / Subtasks
+
+- [x] Implement and verify acceptance criterion 1. (AC: 1)
+- [x] Reuse existing services, repositories, schemas, and UI/CLI/API helpers before adding new abstractions. (AC: all)
+- [x] Add or update deterministic regression coverage for the changed behavior. (AC: all)
+- [x] Update relevant docs or examples if the story changes user-visible, operator, API, CLI, integration, or contribution behavior. (AC: all)
+- [x] Run required validation and record commands/results in the Dev Agent Record. (AC: all)
+
+### Review Findings
+
+- [x] [Review][Patch] Give row evidence badges enough table width to remain readable [ui/components/findings_table.py:413]
+
+## Dev Notes
+
+### Epic Context
+
+- Epic: 3. Report and Review Experience
+- Epic goal: Make the report experience fast, inspectable, and honest.
+- Epic coverage: REV-01..10, HIS-03, RSK-04..06, RSK-09..10, NFR-XAI-01..05, UX-DR1..10
+
+### Architecture and Product Guardrails
+
+- Preserve DeployWhisper's local-first raw artifact boundary: raw IaC, scanner artifacts, incident exports, and sensitive context stay in the user's infrastructure by default.
+- Preserve the advisory-first core. Optional adapters may interpret report outputs, but canonical report semantics remain advisory unless explicit story scope says otherwise.
+- Reuse the shared analysis core and service layer before adapting UI, API, CLI, GitHub, or future workflow surfaces.
+- Keep Evidence Law behavior intact: no high or critical finding without deterministic evidence.
+- Keep project/workspace scope explicit for reports, incidents, topology, outcomes, feedback, scanner imports, and connector-related data.
+- Do not introduce new dependencies unless the active story explicitly requires and justifies them.
+
+### Source Tree Guidance
+
+- API routes belong under `api/routes/` and should use existing `ApiRoute` / `ApiError` envelope patterns.
+- Shared orchestration belongs in `services/`; parsers normalize input, analysis modules score/derive risk, and surfaces adapt outputs.
+- UI work belongs under `ui/routes/` and `ui/components/`, following the existing NiceGUI composition style.
+- CLI behavior belongs under `cli/` and must call the same service-layer paths as UI/API flows.
+- Persistence work belongs under `models/` with Alembic migrations when schema changes are required.
+- Documentation required by a story should be updated in the same workstream.
+
+### Testing Requirements
+
+- Use standard-library `unittest` in the existing `tests/test_*` layout.
+- Add focused regression tests for the layer changed by the story before broad refactors.
+- For Python changes, run `./.venv/bin/ruff check .`, `./.venv/bin/ruff format --check .`, and `./.venv/bin/python -m unittest discover -q` before closing implementation.
+- Use `bash scripts/ci-local.sh` for broader or cross-layer changes.
+
+### Project Structure Notes
+
+- Follow the current repository shape documented in `_bmad-output/project-context.md` and `AGENTS.md`.
+- If implementation reveals a conflict between this story and the current code baseline, keep the smallest compatible change and update the story notes rather than silently drifting from the PRD.
+
+### References
+
+- `_bmad-output/planning-artifacts/epics.md` - source Epic 3 / Story 3.2 definition.
+- `_bmad-output/planning-artifacts/prd.md` - functional and non-functional requirements.
+- `_bmad-output/planning-artifacts/architecture.md` - target architecture, boundaries, and guardrails.
+- `_bmad-output/planning-artifacts/ux-design-specification.md` - UX expectations for user-facing stories.
+- `_bmad-output/planning-artifacts/implementation-readiness-report-2026-05-01.md` - readiness verdict and residual story-format concern.
+- `_bmad-output/project-context.md` - repository-specific implementation rules.
+
+## Dev Agent Record
+
+### Agent Model Used
+
+GPT-5.4
+
+### Debug Log References
+
+- Created feature branch `feature/3-2-findings-table-with-evidence-badges` from `develop`.
+- Red-phase focused UI tests failed because the findings row did not expose category, row-level evidence labels, evidence count text, or Evidence Law row status.
+- Implemented compact row signal helpers in the existing findings table component and reused them for rendering and deterministic tests.
+- Resolved review layout finding by widening the findings table evidence column and locking the CSS contract with a regression assertion.
+
+### Completion Notes List
+
+- Added findings-row scan signals for category, evidence count text, deterministic/derived/external labels, and Evidence Law satisfied/needs-evidence/not-required status.
+- Kept the change inside the existing NiceGUI findings table and evidence inspector path; no new service or persistence contract was introduced.
+- Added helper-level, rendered component, and Playwright review-flow coverage for the new row signals.
+- Fixed the review finding by giving row evidence badges a wider desktop grid track while preserving the existing responsive one- and two-column mobile layouts.
+- No separate documentation update was required; this story changes user-visible table copy covered by UI tests.
+- Validation results:
+  - `./.venv/bin/python -m unittest tests.test_ui.test_findings_table tests.test_ui.test_findings_table_rendering -q` - red-phase failed before implementation, then passed after implementation.
+  - `./.venv/bin/python -m unittest tests.test_ui.test_findings_table tests.test_ui.test_findings_table_rendering -q` - passed after review fix, 8 tests.
+  - `./.venv/bin/python -m unittest tests.test_ui.test_findings_table tests.test_ui.test_findings_table_rendering tests.test_ui.test_app_shell tests.test_ui.test_history_page.HistoryPageRenderingTests.test_history_detail_route_renders_dedicated_report_page -q` - passed, 22 tests.
+  - `APP_PORT=18080 npm run test:ui-review` - passed, 1 Playwright test.
+  - `./.venv/bin/ruff check .` - passed.
+  - `./.venv/bin/ruff format --check .` - passed after formatting `ui/components/findings_table.py` and `tests/test_ui/test_findings_table_rendering.py`.
+  - `git diff --check` - passed.
+  - `./.venv/bin/python -m pip check` - passed, no broken requirements.
+  - `./.venv/bin/bandit -r api/ analysis/ services/ parsers/ llm/ models/ cli/ ui/ evidence/ --severity-level high --confidence-level high -x tests/` - passed, no high issues.
+  - `./.venv/bin/python -m unittest discover -q` - passed, 357 tests, 1 skipped.
+
+### File List
+
+- `_bmad-output/implementation-artifacts/3-2-findings-table-with-evidence-badges.md`
+- `_bmad-output/implementation-artifacts/sprint-status.yaml`
+- `tests/e2e/report_review.keyboard.spec.js`
+- `tests/test_ui/test_findings_table.py`
+- `tests/test_ui/test_findings_table_rendering.py`
+- `ui/components/findings_table.py`
+- `ui/theme.py`
+
+## Change Log
+
+- 2026-05-01: Story created/aligned from updated PRD, architecture, epics, sprint status, and readiness report.
+- 2026-05-13: Implemented findings table evidence badges and moved story to review.
+- 2026-05-13: Code review found one findings-table layout patch item; story moved back to in-progress.
+- 2026-05-13: Fixed findings-table layout review item and moved story back to review.
+- 2026-05-13: Re-ran BMad code review cleanly and marked story done.

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -72,7 +72,7 @@ development_status:
 
   epic-3: in-progress
   3-1-verdict-first-report-header: done
-  3-2-findings-table-with-evidence-badges: ready-for-dev
+  3-2-findings-table-with-evidence-badges: done
   3-3-evidence-inspector-panel: ready-for-dev
   3-4-confidence-ledger-and-why-not-lower-higher: ready-for-dev
   3-5-context-completeness-and-todo-panel: ready-for-dev

--- a/tests/e2e/report_review.keyboard.spec.js
+++ b/tests/e2e/report_review.keyboard.spec.js
@@ -74,6 +74,10 @@ test.describe("review keyboard flow", () => {
     await expect(page.getByText("Evidence Law").first()).toBeVisible();
     await expect(page.getByText("Next action").first()).toBeVisible();
     await expect(page.getByText("Review linked evidence").first()).toBeVisible();
+    await expect(page.getByText("networking/ingress").first()).toBeVisible();
+    await expect(page.getByText("1 evidence item").first()).toBeVisible();
+    await expect(page.getByText("Evidence Law satisfied").first()).toBeVisible();
+    await expect(page.getByText("External").first()).toBeVisible();
     await page.waitForFunction(() => window.dwReviewAccessibilityInstalled === true);
     await expect(page.getByText("Module: module.network").first()).toBeVisible();
     await expect(

--- a/tests/test_ui/test_findings_table.py
+++ b/tests/test_ui/test_findings_table.py
@@ -4,7 +4,10 @@ from __future__ import annotations
 
 import unittest
 
-from ui.components.findings_table import describe_evidence_item
+from ui.components.findings_table import (
+    describe_evidence_item,
+    finding_row_signals,
+)
 
 
 class FindingsTableEvidenceInspectorTests(unittest.TestCase):
@@ -99,6 +102,65 @@ class FindingsTableEvidenceInspectorTests(unittest.TestCase):
         self.assertEqual(topology_descriptor["source_system"], "payments")
         self.assertEqual(incident_descriptor["source_icon"], "history")
         self.assertEqual(incident_descriptor["source_system"], "checkout")
+
+    def test_finding_row_signals_include_category_evidence_badges_and_law_status(
+        self,
+    ) -> None:
+        signals = finding_row_signals(
+            {
+                "finding_id": "finding-001",
+                "severity": "critical",
+                "category": "networking/ingress",
+                "deterministic": True,
+                "evidence_refs": ["ev-001", "ev-002"],
+            },
+            [
+                {
+                    "evidence_id": "ev-001",
+                    "source_type": "artifact",
+                    "deterministic": True,
+                    "determinism_level": "deterministic",
+                },
+                {
+                    "evidence_id": "ev-002",
+                    "source_type": "topology",
+                    "deterministic": True,
+                    "determinism_level": "deterministic",
+                },
+            ],
+        )
+
+        self.assertEqual(signals["category"], "networking/ingress")
+        self.assertEqual(signals["evidence_count_label"], "2 evidence items")
+        self.assertEqual(signals["evidence_law_label"], "Evidence Law satisfied")
+        self.assertIn("Deterministic", signals["evidence_badges"])
+        self.assertIn("External", signals["evidence_badges"])
+
+    def test_finding_row_signals_flag_severe_findings_without_deterministic_evidence(
+        self,
+    ) -> None:
+        signals = finding_row_signals(
+            {
+                "finding_id": "finding-002",
+                "severity": "high",
+                "category": "",
+                "deterministic": False,
+                "evidence_refs": ["ev-heuristic"],
+            },
+            [
+                {
+                    "evidence_id": "ev-heuristic",
+                    "source_type": "heuristic",
+                    "deterministic": False,
+                    "determinism_level": "heuristic",
+                },
+            ],
+        )
+
+        self.assertEqual(signals["category"], "uncategorized")
+        self.assertEqual(signals["evidence_count_label"], "1 evidence item")
+        self.assertEqual(signals["evidence_law_label"], "Evidence Law needs evidence")
+        self.assertIn("Derived", signals["evidence_badges"])
 
 
 if __name__ == "__main__":

--- a/tests/test_ui/test_findings_table_rendering.py
+++ b/tests/test_ui/test_findings_table_rendering.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import unittest
+from pathlib import Path
 
 import app as app_module
 from fastapi.testclient import TestClient
@@ -20,6 +21,7 @@ def findings_table_render_test_page() -> None:
                 "title": "CRITICAL: aws_security_group.main",
                 "description": "Security group exposure risk",
                 "severity": "critical",
+                "category": "networking/ingress",
                 "confidence": 1.0,
                 "deterministic": True,
                 "evidence_refs": ["ev-001", "ev-002"],
@@ -33,6 +35,7 @@ def findings_table_render_test_page() -> None:
                 "summary": "Terraform changed a security group.",
                 "severity_hint": "high",
                 "deterministic": True,
+                "determinism_level": "deterministic",
                 "confidence": 1.0,
             },
             {
@@ -42,6 +45,7 @@ def findings_table_render_test_page() -> None:
                 "summary": "Topology maps the gateway to the payments service.",
                 "severity_hint": "medium",
                 "deterministic": True,
+                "determinism_level": "deterministic",
                 "confidence": 0.9,
             },
         ],
@@ -74,6 +78,18 @@ class FindingsTableRenderingTests(unittest.TestCase):
         self.assertIn("SYSTEM: payments", response.text)
         self.assertIn("Artifact", response.text)
         self.assertIn("Topology", response.text)
+        self.assertIn("networking/ingress", response.text)
+        self.assertIn("2 evidence items", response.text)
+        self.assertIn("External", response.text)
+        self.assertIn("Evidence Law satisfied", response.text)
+
+    def test_findings_grid_keeps_evidence_badges_readable(self) -> None:
+        theme_css = Path("ui/theme.py").read_text(encoding="utf-8")
+
+        self.assertIn(
+            ".dw-findings-col-evidence {\n  width: min(240px, 100%);", theme_css
+        )
+        self.assertIn("minmax(220px, 0.7fr)", theme_css)
 
 
 if __name__ == "__main__":

--- a/ui/components/findings_table.py
+++ b/ui/components/findings_table.py
@@ -25,6 +25,8 @@ SOURCE_TYPE_META = {
     "heuristic": {"icon": "rule", "label": "Heuristic"},
     "skill": {"icon": "psychology", "label": "Skill"},
 }
+EXTERNAL_SOURCE_TYPES = {"topology", "incident", "history", "scanner", "external"}
+SEVERE_LEVELS = {"high", "critical"}
 
 
 def _parse_fragment(fragment: str) -> tuple[str, dict[str, list[str]]]:
@@ -152,6 +154,111 @@ def _evidence_for_finding(
     ]
 
 
+def _is_deterministic_evidence(evidence_item: dict[str, Any]) -> bool:
+    determinism_level = str(
+        evidence_item.get("determinism_level") or "deterministic"
+    ).lower()
+    return (
+        evidence_item.get("deterministic") is True
+        and determinism_level == "deterministic"
+    )
+
+
+def _source_type(evidence_item: dict[str, Any]) -> str:
+    return str(evidence_item.get("source_type") or "heuristic").lower()
+
+
+def _evidence_count_label(count: int) -> str:
+    noun = "item" if count == 1 else "items"
+    return f"{count} evidence {noun}"
+
+
+def _evidence_badges(
+    finding: dict[str, Any],
+    matched_evidence: list[dict[str, Any]],
+) -> list[str]:
+    badges: list[str] = []
+    if any(_is_deterministic_evidence(item) for item in matched_evidence) or (
+        not matched_evidence and finding.get("deterministic") is True
+    ):
+        badges.append("Deterministic")
+    if (
+        finding.get("deterministic") is not True
+        or any(not _is_deterministic_evidence(item) for item in matched_evidence)
+        or any(
+            _source_type(item) in {"heuristic", "skill"} for item in matched_evidence
+        )
+    ):
+        badges.append("Derived")
+    if any(_source_type(item) in EXTERNAL_SOURCE_TYPES for item in matched_evidence):
+        badges.append("External")
+    return badges or ["Derived"]
+
+
+def _evidence_law_label(
+    finding: dict[str, Any],
+    matched_evidence: list[dict[str, Any]],
+) -> str:
+    if str(finding.get("severity") or "").lower() not in SEVERE_LEVELS:
+        return "Evidence Law not required"
+    if any(_is_deterministic_evidence(item) for item in matched_evidence):
+        return "Evidence Law satisfied"
+    return "Evidence Law needs evidence"
+
+
+def finding_row_signals(
+    finding: dict[str, Any],
+    evidence_items: list[dict[str, Any]],
+) -> dict[str, Any]:
+    """Build compact row signals for scanning findings before expanding evidence."""
+    matched_evidence = _evidence_for_finding(finding, evidence_items)
+    category = str(finding.get("category") or "").strip() or "uncategorized"
+    return {
+        "category": category,
+        "evidence_count": len(matched_evidence),
+        "evidence_count_label": _evidence_count_label(len(matched_evidence)),
+        "evidence_badges": _evidence_badges(finding, matched_evidence),
+        "evidence_law_label": _evidence_law_label(finding, matched_evidence),
+    }
+
+
+def _render_row_signal_badge(label: str) -> None:
+    styles = {
+        "Deterministic": (
+            "rgba(83, 194, 107, 0.12)",
+            "#53c26b",
+            "rgba(83, 194, 107, 0.35)",
+        ),
+        "External": (
+            "var(--dw-accent-soft)",
+            "var(--dw-accent)",
+            "var(--dw-accent-line)",
+        ),
+        "Evidence Law satisfied": (
+            "rgba(83, 194, 107, 0.12)",
+            "#53c26b",
+            "rgba(83, 194, 107, 0.35)",
+        ),
+        "Evidence Law needs evidence": (
+            "rgba(207, 63, 63, 0.12)",
+            "#cf3f3f",
+            "rgba(207, 63, 63, 0.35)",
+        ),
+    }
+    background, color, border = styles.get(
+        label,
+        ("rgba(216, 164, 50, 0.12)", "#d8a432", "rgba(216, 164, 50, 0.35)"),
+    )
+    ui.label(label).classes("text-[11px] font-semibold").style(
+        f"background:{background};"
+        f"color:{color};"
+        f"border:1px solid {border};"
+        "border-radius:12px;"
+        "padding:4px 10px;"
+        "line-height:1.1;"
+    )
+
+
 def _tool_from_evidence(
     finding: dict[str, Any], evidence_items: list[dict[str, Any]]
 ) -> str:
@@ -257,6 +364,7 @@ def render_findings_table(
             for index, finding in enumerate(ordered):
                 finding_id = str(finding["finding_id"])
                 matched_evidence = _evidence_for_finding(finding, evidence_items)
+                row_signals = finding_row_signals(finding, evidence_items)
                 tool = _tool_from_evidence(finding, evidence_items)
                 evidence_panel_id = f"evidence-inspector-{finding_id}"
                 row_classes = "w-full dw-findings-row shadow-none dw-findings-row-card"
@@ -292,6 +400,9 @@ def render_findings_table(
                             ui.label(finding["description"]).classes(
                                 "text-xs dw-muted leading-5"
                             )
+                            ui.label(row_signals["category"]).classes(
+                                "text-xs dw-muted"
+                            )
                             if finding.get("uncertainty_note"):
                                 ui.label(finding["uncertainty_note"]).classes(
                                     "text-xs dw-warning-text"
@@ -299,9 +410,16 @@ def render_findings_table(
                         ui.label(tool).classes(
                             "dw-findings-col dw-findings-col-tool text-xs uppercase dw-muted"
                         )
-                        ui.label(str(len(matched_evidence))).classes(
-                            "dw-findings-col dw-findings-col-evidence text-sm font-semibold dw-text"
-                        )
+                        with ui.column().classes(
+                            "dw-findings-col dw-findings-col-evidence items-start gap-1"
+                        ):
+                            ui.label(row_signals["evidence_count_label"]).classes(
+                                "text-sm font-semibold dw-text normal-case"
+                            )
+                            with ui.row().classes("gap-1 flex-wrap"):
+                                for badge in row_signals["evidence_badges"]:
+                                    _render_row_signal_badge(badge)
+                            _render_row_signal_badge(row_signals["evidence_law_label"])
                         with ui.column().classes(
                             "dw-findings-col dw-findings-col-confidence items-start gap-1"
                         ):

--- a/ui/theme.py
+++ b/ui/theme.py
@@ -738,7 +738,7 @@ html[data-dw-theme="light"] .dw-dashboard-headline .dw-gradient {
 }
 
 .dw-findings-col-evidence {
-  width: 84px;
+  width: min(240px, 100%);
 }
 
 .dw-findings-col-confidence {
@@ -751,7 +751,7 @@ html[data-dw-theme="light"] .dw-dashboard-headline .dw-gradient {
 
 .dw-findings-grid {
   display: grid;
-  grid-template-columns: 140px minmax(0, 1fr) 88px 88px 150px 116px;
+  grid-template-columns: 140px minmax(0, 1fr) 88px minmax(220px, 0.7fr) 150px 116px;
   gap: 12px;
   align-items: start;
 }


### PR DESCRIPTION
Story 3.2 adds row-level signals to the existing findings table so reviewers can scan severity, category, confidence, evidence count, evidence provenance, and Evidence Law status without opening every inspector panel. The implementation stays inside the existing NiceGUI report surface and locks the reviewed layout fix with focused UI and browser coverage.

Constraint: Preserve the existing local-first advisory report flow and shared findings table component

Rejected: Introduce a new report table abstraction | unnecessary for the narrow row-signal behavior

Confidence: high

Scope-risk: narrow

Directive: Keep severe finding row status aligned with deterministic linked evidence; do not weaken Evidence Law wording without matching tests

Tested: ./.venv/bin/python -m unittest discover -q; APP_PORT=18080 npm run test:ui-review; ./.venv/bin/ruff check .; ./.venv/bin/ruff format --check .; git diff --check; ./.venv/bin/python -m pip check; ./.venv/bin/bandit -r api/ analysis/ services/ parsers/ llm/ models/ cli/ ui/ evidence/ --severity-level high --confidence-level high -x tests/

Not-tested: VoiceOver-specific UI review lane

## What does this PR do?

<!-- Brief description of changes -->

## Type of change
- [ ] Feature (new functionality)
- [ ] Bugfix (non-breaking fix)
- [ ] Release preparation
- [ ] Hotfix (critical production fix)
- [ ] Docs / refactor / chore

## Checklist
- [ ] I have followed the branch naming convention
- [ ] Tests pass locally (`pytest tests/ -v`)
- [ ] Linting passes (`ruff check .`)
- [ ] Docker build succeeds
- [ ] I have updated docs if needed
- [ ] No secrets or .env values committed

## Related issue
Closes #