### PR TITLE
Explain confidence boundaries in shared reports

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ What users can use today:
 - **Multi-tool analysis**: analyze Terraform, Kubernetes, Ansible, Jenkins, and CloudFormation inputs through one shared pipeline instead of reviewing every tool in isolation.
 - **LLM-assisted narrative**: connect deterministic scoring with plain-English deployment guidance using Ollama, OpenAI, Anthropic, Gemini, OpenRouter, Groq, or xAI provider settings.
 - **Local-first safety posture**: keep raw IaC processing local, avoid storing provider API keys in the database, exclude sensitive files from unsafe handling, and keep every verdict advisory rather than automatically blocking a release.
-- **Evidence-backed confidence**: trace the report back to findings, resource-level contributors, uploaded artifact references, parser coverage, topology freshness, and warning signals when context is limited.
+- **Evidence-backed confidence**: trace the report back to findings, resource-level contributors, uploaded artifact references, confidence factors, why-not-lower/higher reasoning, parser coverage, topology freshness, and warning signals when context is limited.
 - **Blast-radius and rollback context**: use service-topology input to explain likely downstream impact and generate rollback steps with complexity scoring.
 - **Analysis history**: review saved reports later, filter previous analyses, inspect audit metadata, and compare repeated scans of the same artifact set.
 - **Provider and admin settings UI**: configure LLM provider metadata, upload topology context, manage custom AI Skills, and see provider readiness before running analysis.

--- a/_bmad-output/implementation-artifacts/3-4-confidence-ledger-and-why-not-lower-higher.md
+++ b/_bmad-output/implementation-artifacts/3-4-confidence-ledger-and-why-not-lower-higher.md
@@ -1,0 +1,167 @@
+# Story 3.4: Confidence Ledger and Why-Not-Lower/Higher
+
+Status: done
+
+<!-- Generated from updated PRD/architecture/epics plus implementation-readiness-report-2026-05-01.md. -->
+
+## Story
+
+As a reviewer,
+I want to know why the verdict is not lower or higher,
+So that severity reasoning is explainable.
+
+## Acceptance Criteria
+
+1. Given a verdict is produced, When the reviewer opens reasoning details, Then the report shows contributors, confidence factors, why-not-lower, why-not-higher, and uncertainty drivers. And explanations remain grounded in evidence and context.
+
+### Requirement Traceability
+
+- Primary PRD requirements: Epic 3 coverage: REV-01..10, HIS-03, RSK-04..06, RSK-09..10, NFR-XAI-01..05, UX-DR1..10.
+- Supporting PRD / NFR / differentiation requirements: See `_bmad-output/planning-artifacts/prd.md`, `_bmad-output/planning-artifacts/architecture.md`, and `_bmad-output/planning-artifacts/implementation-readiness-report-2026-05-01.md`.
+- Coverage intent: Baseline + Delta.
+- Story alignment note: This story was created from the updated Epic 3 plan after the 2026-05-01 readiness rerun. The readiness report verified 187/187 PRD functional requirement IDs in the epics artifact, 38 NFR IDs present, and no critical or major readiness defects.
+
+## Tasks / Subtasks
+
+- [x] Implement and verify acceptance criterion 1. (AC: 1)
+- [x] Reuse existing services, repositories, schemas, and UI/CLI/API helpers before adding new abstractions. (AC: all)
+- [x] Add or update deterministic regression coverage for the changed behavior. (AC: all)
+- [x] Update relevant docs or examples if the story changes user-visible, operator, API, CLI, integration, or contribution behavior. (AC: all)
+- [x] Run required validation and record commands/results in the Dev Agent Record. (AC: all)
+
+### Review Findings
+
+- [x] [Review][Decision] Decide whether confidence-ledger reasoning must move into the shared report model — moved ledger derivation into `services/confidence_ledger.py`, attached the derived payload in `services/report_service.py`, and exposed it through API schemas so UI/API/shared report surfaces use one shared model.
+- [x] [Review][Patch] Make contributor contribution parsing tolerant of legacy or malformed report payloads [`services/confidence_ledger.py`]
+- [x] [Review][Patch] Ensure displayed contributors include the contributor used by why-not-lower reasoning [`services/confidence_ledger.py`]
+- [x] [Review][Patch] Ground why-not-higher in report-specific evidence/context, not only generic threshold language [`services/confidence_ledger.py`]
+- [x] [Review][Patch] Add confidence-ledger coverage to the shared `/reports/{id}` report view or redirect saved-report review to a surface that includes the ledger [`app.py`]
+- [x] [Review][Patch] Fix why-not-higher threshold explanations so they cannot claim a score is below the next severity threshold when it is not, and align the low-to-medium boundary with canonical report-service severity floors. [`services/confidence_ledger.py:281`]
+- [x] [Review][Patch] Avoid deriving Evidence Law failure text for list/summary serializations that intentionally omit evidence rows; ledger evidence-status wording must distinguish omitted detail from missing deterministic evidence. [`services/report_service.py:2630`]
+- [x] [Review][Patch] Normalize or regenerate malformed/partial confidence-ledger list sections before rendering or redacting so a string payload cannot become one bullet per character and empty cards get sane fallback content. [`ui/components/confidence_ledger.py:25`]
+- [x] [Review][Patch] Filter uncertainty drivers so non-uncertainty administrative warnings do not appear as context/evidence uncertainty drivers. [`services/confidence_ledger.py:337`]
+- [x] [Review][Patch] Complete the required VoiceOver review validation or resolve the web-server startup blocker with recorded evidence. [`tests/e2e/report_review.keyboard.spec.js:3`]
+- [x] [Review][Patch] Tolerate legacy or malformed contributor contribution values in the report-detail operational narrative before the confidence ledger renders. [`ui/components/report_detail_page.py:154`]
+- [x] [Review][Patch] Add exact command/result validation evidence to the Dev Agent Record for the Story 3.4 closure checks. [`_bmad-output/implementation-artifacts/3-4-confidence-ledger-and-why-not-lower-higher.md:98`]
+- [x] [Review][Patch] Add API route/integration coverage proving serialized analysis responses include all five confidence-ledger sections. [`tests/test_api/test_analyses.py`]
+
+## Dev Notes
+
+### Epic Context
+
+- Epic: 3. Report and Review Experience
+- Epic goal: Make the report experience fast, inspectable, and honest.
+- Epic coverage: REV-01..10, HIS-03, RSK-04..06, RSK-09..10, NFR-XAI-01..05, UX-DR1..10
+
+### Architecture and Product Guardrails
+
+- Preserve DeployWhisper's local-first raw artifact boundary: raw IaC, scanner artifacts, incident exports, and sensitive context stay in the user's infrastructure by default.
+- Preserve the advisory-first core. Optional adapters may interpret report outputs, but canonical report semantics remain advisory unless explicit story scope says otherwise.
+- Reuse the shared analysis core and service layer before adapting UI, API, CLI, GitHub, or future workflow surfaces.
+- Keep Evidence Law behavior intact: no high or critical finding without deterministic evidence.
+- Keep project/workspace scope explicit for reports, incidents, topology, outcomes, feedback, scanner imports, and connector-related data.
+- Do not introduce new dependencies unless the active story explicitly requires and justifies them.
+
+### Source Tree Guidance
+
+- API routes belong under `api/routes/` and should use existing `ApiRoute` / `ApiError` envelope patterns.
+- Shared orchestration belongs in `services/`; parsers normalize input, analysis modules score/derive risk, and surfaces adapt outputs.
+- UI work belongs under `ui/routes/` and `ui/components/`, following the existing NiceGUI composition style.
+- CLI behavior belongs under `cli/` and must call the same service-layer paths as UI/API flows.
+- Persistence work belongs under `models/` with Alembic migrations when schema changes are required.
+- Documentation required by a story should be updated in the same workstream.
+
+### Testing Requirements
+
+- Use standard-library `unittest` in the existing `tests/test_*` layout.
+- Add focused regression tests for the layer changed by the story before broad refactors.
+- For Python changes, run `./.venv/bin/ruff check .`, `./.venv/bin/ruff format --check .`, and `./.venv/bin/python -m unittest discover -q` before closing implementation.
+- Use `bash scripts/ci-local.sh` for broader or cross-layer changes.
+
+### Project Structure Notes
+
+- Follow the current repository shape documented in `_bmad-output/project-context.md` and `AGENTS.md`.
+- If implementation reveals a conflict between this story and the current code baseline, keep the smallest compatible change and update the story notes rather than silently drifting from the PRD.
+
+### References
+
+- `_bmad-output/planning-artifacts/epics.md` - source Epic 3 / Story 3.4 definition.
+- `_bmad-output/planning-artifacts/prd.md` - functional and non-functional requirements.
+- `_bmad-output/planning-artifacts/architecture.md` - target architecture, boundaries, and guardrails.
+- `_bmad-output/planning-artifacts/ux-design-specification.md` - UX expectations for user-facing stories.
+- `_bmad-output/planning-artifacts/implementation-readiness-report-2026-05-01.md` - readiness verdict and residual story-format concern.
+- `_bmad-output/project-context.md` - repository-specific implementation rules.
+
+## Dev Agent Record
+
+### Agent Model Used
+
+GPT-5.4
+
+### Debug Log References
+
+- Red phase: focused history-page tests first failed because `ui.components.confidence_ledger` did not exist.
+- Green phase: focused ledger helper/detail-route tests passed after adding the renderer and aligning route assertions with existing confidence clamping for insufficient context.
+- UI validation: keyboard review flow passed on the seeded Playwright report surface with the new confidence-ledger section in tab order.
+- VoiceOver validation was attempted with `APP_PORT=18080`, `APP_PORT=18081`, and `APP_PORT=18083`; the sandboxed seeded web server exited before Playwright test execution because NiceGUI startup attempted system semaphore access denied by the sandbox. The seeded-server startup blocker was resolved for the browser lane by disabling NiceGUI's process-pool setup in the E2E server and rerunning outside the sandbox.
+- VoiceOver validation rerun outside the sandbox reached the test body, but Guidepup failed with `VoiceOver not supported`; `defaults read com.apple.VoiceOver4/default SCREnableAppleScript` returned `1`, while `/private/var/db/Accessibility/.VoiceOverAppleScriptEnabled` was absent. The required WebKit keyboard review lane passed outside the sandbox.
+- Review fix validation: focused API/UI/service ledger tests passed, broader affected API/UI/service/CLI suite passed, full unittest discovery passed, whole-repo Ruff lint/format passed, WebKit Playwright review lane passed, high/high Bandit passed, dependency audit passed, and `git diff --check` passed.
+- Final review follow-up validation commands/results:
+  - `./.venv/bin/ruff check api/schemas.py app.py ui/components/report_detail_page.py tests/test_api/test_schemas.py tests/test_api/test_analyses.py tests/test_ui/test_history_page.py` - passed.
+  - `./.venv/bin/ruff check .` - passed.
+  - `./.venv/bin/ruff format --check .` - passed (`271 files already formatted`).
+  - `git diff --check` - passed.
+  - `./.venv/bin/python -m unittest tests.test_api.test_schemas.ApiSchemaTests.test_persisted_report_exposes_confidence_ledger tests.test_api.test_schemas.ApiSchemaTests.test_persisted_report_normalizes_legacy_confidence_ledger tests.test_api.test_analyses.AnalysesApiTests.test_create_analysis_preserves_real_pipeline_metadata_in_persisted_contributors tests.test_ui.test_history_page.HistoryPageHelpersTests.test_confidence_ledger_normalizes_malformed_ledger_sections tests.test_ui.test_history_page.HistoryPageRenderingTests.test_history_detail_route_renders_confidence_ledger tests.test_ui.test_history_page.HistoryPageRenderingTests.test_history_detail_route_tolerates_legacy_contributor_values -q` - initially failed on a missing confidence fixture and legacy contributor metadata assumptions; passed after fixes (`Ran 6 tests ... OK`).
+  - `./.venv/bin/python -m unittest tests.test_api.test_schemas tests.test_api.test_analyses tests.test_services.test_report_service tests.test_ui.test_history_page -q` - passed (`Ran 212 tests in 46.030s`, `OK`).
+  - `./.venv/bin/python -m unittest discover -q` - passed (`Ran 399 tests in 42.251s`, `OK (skipped=1)`).
+  - `./.venv/bin/bandit -r app.py api services ui tests/e2e/seeded_server.py --severity-level high --confidence-level high -q` - passed.
+  - `./.venv/bin/python -m pip_audit -r requirements.txt` - passed (`No known vulnerabilities found`).
+  - `bash scripts/ci-local.sh` - passed; local CI completed Ruff, format, dependency check, Bandit, compile, parser scenarios, and unittest discovery (`Ran 399 tests in 41.468s`, `OK (skipped=1)`).
+  - `APP_PORT=18090 npm run test:ui-review` - passed (`3 passed (14.8s)`).
+- Local VoiceOver validation is not applicable for this project environment per project directive; do not run `npm run test:ui-review:voiceover` locally unless explicitly requested.
+- BMad code review rerun: clean review; Blind Hunter, Edge Case Hunter, and Acceptance Auditor passes found no new actionable findings.
+
+### Completion Notes List
+
+- Added shared confidence-ledger derivation in `services/confidence_ledger.py` and attached it to persisted report serialization so UI, API, CLI-shaped persisted payloads, and public report views consume the same derived model.
+- Made contributor parsing tolerant of legacy string, decimal-string, and malformed values; sorted displayed contributors by parsed contribution so why-not-lower reasoning cannot cite a hidden contributor.
+- Grounded why-not-higher in report-specific score threshold, strongest finding, top contributor, confidence, context, and Evidence Law status.
+- Rendered the ledger on immediate upload results, persisted history detail pages, and shared `/reports/{id}` HTML reports.
+- Added deterministic unit coverage for shared ledger derivation, persisted report serialization/redaction, API schema exposure, public report rendering, and persisted history detail rendering.
+- Added Playwright keyboard/review coverage for the new ledger section and updated README feature copy.
+- Security scan note: targeted high-severity/high-confidence Bandit passes, and the dependency audit reports no known vulnerabilities after the prior NiceGUI security upgrade.
+- Re-run code review note: BMad review found five unresolved patch findings, so the story was returned to in-progress for follow-up.
+- Follow-up review fixes: aligned confidence-ledger thresholds with canonical severity floors, prevented false below-threshold why-not-higher copy, distinguished omitted summary evidence from missing deterministic evidence, normalized malformed ledger sections before render/redaction, filtered administrative warnings out of uncertainty drivers, and resolved the E2E seeded-server startup blocker with recorded VoiceOver environment evidence.
+- Final review follow-up fixes: hardened report-detail operational narrative rendering for legacy contributor values and missing contributor metadata, normalized legacy schema confidence-ledger payloads, regenerated public report fallback ledgers, and added API route assertions proving assessment, persisted-report, and detail responses include all five ledger sections.
+
+### File List
+
+- `README.md`
+- `_bmad-output/implementation-artifacts/3-4-confidence-ledger-and-why-not-lower-higher.md`
+- `_bmad-output/implementation-artifacts/sprint-status.yaml`
+- `api/schemas.py`
+- `app.py`
+- `services/confidence_ledger.py`
+- `services/report_service.py`
+- `tests/e2e/report_review.keyboard.spec.js`
+- `tests/e2e/seeded_server.py`
+- `tests/test_api/test_analyses.py`
+- `tests/test_api/test_schemas.py`
+- `tests/test_services/test_report_service.py`
+- `tests/test_ui/test_history_page.py`
+- `ui/components/confidence_ledger.py`
+- `ui/components/report_detail_page.py`
+- `ui/components/upload_panel.py`
+- `ui/formatters/confidence.py`
+- `ui/formatters/report_header.py`
+
+## Change Log
+
+- 2026-05-01: Story created/aligned from updated PRD, architecture, epics, sprint status, and readiness report.
+- 2026-05-19: Implemented confidence ledger reasoning details on report UI surfaces with unit, browser, lint, and regression validation.
+- 2026-05-19: Fixed all Story 3.4 code-review findings by moving ledger derivation to the shared service/report model, hardening legacy contributor handling, grounding why-not-higher, exposing the ledger through schemas, and adding shared `/reports/{id}` coverage.
+- 2026-05-19: Re-ran BMad code review; five patch findings remain open and Story 3.4 returned to in-progress.
+- 2026-05-19: Fixed the remaining Story 3.4 review findings, reran focused/full validation, and returned Story 3.4 to review with VoiceOver environment limitations recorded.
+- 2026-05-19: Re-ran BMad code review; three patch findings remain open and Story 3.4 returned to in-progress.
+- 2026-05-19: Fixed the final Story 3.4 review findings, recorded exact validation evidence, and returned Story 3.4 to review; local VoiceOver validation is explicitly not applicable for this project environment.
+- 2026-05-19: Re-ran BMad code review; clean review with no new actionable findings, and Story 3.4 moved to done.

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -74,7 +74,7 @@ development_status:
   3-1-verdict-first-report-header: done
   3-2-findings-table-with-evidence-badges: done
   3-3-evidence-inspector-panel: done
-  3-4-confidence-ledger-and-why-not-lower-higher: ready-for-dev
+  3-4-confidence-ledger-and-why-not-lower-higher: done
   3-5-context-completeness-and-todo-panel: ready-for-dev
   3-6-report-diff-after-rerun: ready-for-dev
   3-7-keyboard-and-accessibility-review-pass: ready-for-dev

--- a/api/schemas.py
+++ b/api/schemas.py
@@ -6,7 +6,9 @@ from typing import Any, Literal
 
 from config import settings
 from evidence.models import FindingEvidenceClassification
-from pydantic import BaseModel, Field, computed_field
+from pydantic import BaseModel, Field, computed_field, model_validator
+
+from services.confidence_ledger import normalize_confidence_ledger_payload
 
 
 class MetaPayload(BaseModel):
@@ -309,6 +311,34 @@ class ProjectData(BaseModel):
     updated_at: str = Field(..., description="Last update timestamp")
 
 
+class ConfidenceLedgerData(BaseModel):
+    contributors: list[str] = Field(
+        default_factory=list,
+        description="Reviewer-facing contributor lines backing the verdict",
+    )
+    confidence_factors: list[str] = Field(
+        default_factory=list,
+        description="Confidence signals used to interpret the verdict",
+    )
+    why_not_lower: list[str] = Field(
+        default_factory=list,
+        description="Evidence-backed reasons the verdict is not lower",
+    )
+    why_not_higher: list[str] = Field(
+        default_factory=list,
+        description="Evidence-backed reasons the verdict is not higher",
+    )
+    uncertainty_drivers: list[str] = Field(
+        default_factory=list,
+        description="Context and evidence limitations affecting certainty",
+    )
+
+    @model_validator(mode="before")
+    @classmethod
+    def normalize_legacy_payload(cls, data: Any) -> dict[str, list[str]]:
+        return normalize_confidence_ledger_payload(data)
+
+
 class PersistedReportData(BaseModel):
     id: int
     project: ProjectData = Field(..., description="Owning project/workspace")
@@ -363,6 +393,10 @@ class PersistedReportData(BaseModel):
     findings: list["FindingData"] = Field(default_factory=list)
     evidence_items: list["EvidenceItemData"] = Field(default_factory=list)
     contributors: list["RiskContributorData"] = Field(default_factory=list)
+    confidence_ledger: ConfidenceLedgerData = Field(
+        default_factory=ConfidenceLedgerData,
+        description="Shared confidence ledger and why-not boundary explanations",
+    )
     dashboard_display_duration_seconds: int | None = Field(default=None)
     dashboard_remaining_seconds: int | None = Field(default=None)
     submission_manifest: SubmissionManifestData | None = Field(
@@ -824,6 +858,10 @@ class AssessmentData(BaseModel):
     )
     contributors: list[RiskContributorData] = Field(
         default_factory=list, description="Score contributors"
+    )
+    confidence_ledger: ConfidenceLedgerData = Field(
+        default_factory=ConfidenceLedgerData,
+        description="Shared confidence ledger and why-not boundary explanations",
     )
     interaction_risks: list[InteractionRiskData] = Field(
         default_factory=list, description="Cross-tool interaction findings"
@@ -1291,6 +1329,9 @@ def build_analysis_run_data(
                 _copy_model(contributor, RiskContributorData)
                 for contributor in assessment.contributors
             ],
+            confidence_ledger=ConfidenceLedgerData.model_validate(
+                persisted_report.get("confidence_ledger", {})
+            ),
             interaction_risks=[
                 _copy_model(interaction_risk, InteractionRiskData)
                 for interaction_risk in assessment.interaction_risks

--- a/app.py
+++ b/app.py
@@ -38,6 +38,10 @@ from logging_config import configure_logging
 from models.database import init_db
 from services.artifact_snapshot_service import load_report_artifact
 from services.backtesting_service import run_due_weekly_backtests
+from services.confidence_ledger import (
+    build_confidence_ledger,
+    normalize_confidence_ledger_payload,
+)
 from services.report_service import (
     fetch_analysis_report,
     fetch_shared_analysis_report,
@@ -312,6 +316,58 @@ def _shared_report_severity_change_list(items: list[dict]) -> str:
     return f"<ul class='diff-list'>{''.join(rows)}</ul>"
 
 
+def _shared_report_ledger_list(items: list[str], empty_message: str) -> str:
+    if not items:
+        return f"<p class='empty'>{escape(empty_message)}</p>"
+    return "<ul>" + "".join(f"<li>{escape(str(item))}</li>" for item in items) + "</ul>"
+
+
+def _shared_report_confidence_ledger_html(report: dict) -> str:
+    ledger = normalize_confidence_ledger_payload(
+        report.get("confidence_ledger") or {},
+        fallback_ledger=build_confidence_ledger(report),
+    )
+    sections = [
+        (
+            "Contributors",
+            ledger.get("contributors") or [],
+            "No resource-level contributors were recorded.",
+        ),
+        (
+            "Confidence factors",
+            ledger.get("confidence_factors") or [],
+            "No confidence factors were recorded.",
+        ),
+        (
+            "Why not lower",
+            ledger.get("why_not_lower") or [],
+            "No why-not-lower reasoning was recorded.",
+        ),
+        (
+            "Why not higher",
+            ledger.get("why_not_higher") or [],
+            "No why-not-higher reasoning was recorded.",
+        ),
+        (
+            "Uncertainty drivers",
+            ledger.get("uncertainty_drivers") or [],
+            "No uncertainty drivers were recorded.",
+        ),
+    ]
+    cards = "".join(
+        "<div class='ledger-card'>"
+        f"<h3>{escape(title)}</h3>"
+        f"{_shared_report_ledger_list([str(item) for item in items], empty_message)}"
+        "</div>"
+        for title, items, empty_message in sections
+    )
+    return (
+        "<section class='panel'><h2>Confidence ledger</h2>"
+        "<p class='empty'>Reasoning details derived from the shared report payload.</p>"
+        f"<div class='ledger-grid'>{cards}</div></section>"
+    )
+
+
 def _shared_report_comparison_html(
     report: dict,
     comparison: dict | None,
@@ -489,6 +545,9 @@ def _shared_report_html(
         ".freshness.unknown{background:rgba(69,81,99,0.06);border:1px solid rgba(69,81,99,0.18);}"
         ".freshness-row{display:flex;align-items:flex-start;justify-content:space-between;gap:12px;flex-wrap:wrap;}"
         ".freshness-meta{display:flex;align-items:center;gap:8px;flex-wrap:wrap;}"
+        ".ledger-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(260px,1fr));gap:16px;margin-top:16px;}"
+        ".ledger-card{background:#fbf8f2;border-radius:16px;padding:18px;}"
+        ".ledger-card h3{margin:0 0 8px;font-size:15px;}"
         "code{display:inline-block;margin-top:6px;padding:4px 6px;border-radius:8px;background:#f1ede5;color:#455163;word-break:break-all;}"
         "a{color:#d96b3d;text-decoration:none;}"
         "</style></head><body><main>"
@@ -515,6 +574,7 @@ def _shared_report_html(
         "</div>"
         f"{_shared_report_comparison_html(report, comparison, show_comparison=show_comparison)}"
         "</section>"
+        f"{_shared_report_confidence_ledger_html(report)}"
         "<section class='panel'><div class='grid'>"
         f"<div><strong>Created</strong><p>{escape(str(report.get('created_at') or ''))}</p></div>"
         f"<div><strong>Share URL</strong><p><a href='{escape(str(share.get('share_url') or ''))}'>{escape(str(share.get('share_url') or ''))}</a></p></div>"

--- a/services/confidence_ledger.py
+++ b/services/confidence_ledger.py
@@ -1,0 +1,452 @@
+"""Shared confidence-ledger derivation for persisted reports."""
+
+from __future__ import annotations
+
+import math
+from typing import Any
+
+SEVERITY_ORDER = {"low": 1, "medium": 2, "high": 3, "critical": 4}
+SEVERITY_THRESHOLDS = {
+    "low": ("medium", 42),
+    "medium": ("high", 70),
+    "high": ("critical", 90),
+}
+LEDGER_KEYS = (
+    "contributors",
+    "confidence_factors",
+    "why_not_lower",
+    "why_not_higher",
+    "uncertainty_drivers",
+)
+
+
+def coerce_confidence(value: object) -> float | None:
+    """Return a bounded confidence value or None when the value is unusable."""
+    if value is None:
+        return None
+    try:
+        confidence = float(value)
+    except (TypeError, ValueError):
+        return None
+    if not math.isfinite(confidence) or confidence < 0.0 or confidence > 1.0:
+        return None
+    return confidence
+
+
+def confidence_bucket(confidence: float) -> str:
+    """Map a confidence score to the report's reviewer-facing bucket."""
+    if confidence >= 0.85:
+        return "high"
+    if confidence >= 0.60:
+        return "medium"
+    return "low"
+
+
+def confidence_label(value: object) -> str:
+    """Format confidence for report surfaces."""
+    confidence = coerce_confidence(value)
+    if confidence is None:
+        return "Unavailable"
+    return f"{confidence_bucket(confidence).title()} ({confidence:.2f})"
+
+
+def _numeric_value(value: object) -> float | None:
+    if value is None:
+        return None
+    try:
+        number = float(value)
+    except (TypeError, ValueError):
+        return None
+    if not math.isfinite(number):
+        return None
+    return number
+
+
+def _format_number(value: object) -> str:
+    number = _numeric_value(value)
+    if number is None:
+        return "unknown"
+    if number.is_integer():
+        return str(int(number))
+    return f"{number:.2f}".rstrip("0").rstrip(".")
+
+
+def _contribution_sort_key(contributor: dict[str, Any]) -> tuple[float, str]:
+    contribution = _numeric_value(contributor.get("contribution"))
+    return (
+        contribution if contribution is not None else float("-inf"),
+        str(contributor.get("resource_id") or ""),
+    )
+
+
+def _sorted_contributors(
+    contributors: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    return sorted(contributors, key=_contribution_sort_key, reverse=True)
+
+
+def _primary_finding(findings: list[dict[str, Any]]) -> dict[str, Any] | None:
+    if not findings:
+        return None
+    return max(
+        findings,
+        key=lambda finding: (
+            SEVERITY_ORDER.get(str(finding.get("severity") or "").lower(), 0),
+            coerce_confidence(finding.get("confidence")) or 0.0,
+            str(finding.get("title") or ""),
+        ),
+    )
+
+
+def _contributor_line(contributor: dict[str, Any]) -> str:
+    resource_id = str(contributor.get("resource_id") or "unknown resource")
+    severity = str(contributor.get("severity") or "unknown").upper()
+    contribution = _format_number(contributor.get("contribution"))
+    source_file = str(contributor.get("source_file") or "unknown source")
+    return f"{resource_id} · {severity} · contribution {contribution} · {source_file}"
+
+
+def severe_findings(report: dict[str, Any]) -> list[dict[str, Any]]:
+    """Return severe findings visible in the serialized report."""
+    return [
+        finding
+        for finding in report.get("findings", [])
+        if isinstance(finding, dict)
+        and str(finding.get("severity") or "").lower() in {"high", "critical"}
+    ]
+
+
+def _is_severe_report(report: dict[str, Any]) -> bool:
+    return str(report.get("severity") or "").lower() in {"high", "critical"}
+
+
+def _is_deterministic_evidence(evidence: dict[str, Any]) -> bool:
+    determinism_level = str(
+        evidence.get("determinism_level") or "deterministic"
+    ).lower()
+    return (
+        evidence.get("deterministic") is True and determinism_level == "deterministic"
+    )
+
+
+def _has_linked_deterministic_evidence(
+    finding: dict[str, Any],
+    evidence_by_id: dict[str, dict[str, Any]],
+) -> bool:
+    evidence_refs = [
+        str(evidence_ref)
+        for evidence_ref in finding.get("evidence_refs", [])
+        if evidence_ref
+    ]
+    if not evidence_refs:
+        return False
+    return any(
+        _is_deterministic_evidence(evidence_by_id[evidence_ref])
+        for evidence_ref in evidence_refs
+        if evidence_ref in evidence_by_id
+    )
+
+
+def evidence_law_status(
+    report: dict[str, Any],
+    *,
+    evidence_detail_available: bool = True,
+) -> tuple[str, str]:
+    """Return the Evidence Law status for serialized report payloads."""
+    warnings = [
+        str(warning)
+        for warning in report.get("warnings", [])
+        if "Evidence Law" in str(warning)
+    ]
+    if warnings:
+        return (
+            "Reconciled",
+            "Evidence Law adjusted unsupported or inconsistent severe claims.",
+        )
+    severe = severe_findings(report)
+    if not severe:
+        if _is_severe_report(report):
+            return (
+                "Needs review",
+                "The report is severe, but no high or critical finding is visible for Evidence Law verification.",
+            )
+        return (
+            "Satisfied",
+            "No high or critical finding requires deterministic evidence.",
+        )
+    if not evidence_detail_available:
+        return (
+            "Detail omitted",
+            "Evidence rows are not included in this summary view; open the report to inspect deterministic evidence.",
+        )
+    evidence_by_id = {
+        str(evidence.get("evidence_id")): evidence
+        for evidence in report.get("evidence_items", [])
+        if isinstance(evidence, dict) and evidence.get("evidence_id")
+    }
+    if all(
+        _has_linked_deterministic_evidence(finding, evidence_by_id)
+        for finding in severe
+    ):
+        return (
+            "Satisfied",
+            "High and critical findings are backed by deterministic evidence.",
+        )
+    return (
+        "Needs review",
+        "A severe finding lacks linked deterministic evidence support.",
+    )
+
+
+def _context_score(context: dict[str, Any]) -> float | None:
+    score = _numeric_value(context.get("context_score"))
+    if score is None or score < 0.0 or score > 1.0:
+        return None
+    return score
+
+
+def _finding_confidence_factor(findings: list[dict[str, Any]]) -> str | None:
+    confidences = [
+        confidence
+        for finding in findings
+        if (confidence := coerce_confidence(finding.get("confidence"))) is not None
+    ]
+    if not confidences:
+        return None
+    deterministic_count = sum(1 for finding in findings if finding.get("deterministic"))
+    return (
+        f"Finding confidence range is {min(confidences):.2f}-{max(confidences):.2f}; "
+        f"{deterministic_count} deterministic findings are linked to the verdict."
+    )
+
+
+def _confidence_factors(
+    report: dict[str, Any],
+    *,
+    evidence_detail_available: bool,
+) -> list[str]:
+    context = report.get("context_completeness") or {}
+    findings = [item for item in report.get("findings", []) if isinstance(item, dict)]
+    evidence_status, evidence_detail = evidence_law_status(
+        report,
+        evidence_detail_available=evidence_detail_available,
+    )
+    factors = [f"Report confidence is {confidence_label(report.get('confidence'))}."]
+    score = _context_score(context)
+    context_level = str(context.get("confidence_level") or "").strip().lower()
+    if score is not None or context_level:
+        if score is None:
+            factors.append(f"Context confidence is {context_level or 'unknown'}.")
+        else:
+            factors.append(
+                f"Context confidence is {context_level or 'unknown'} with score {score:.2f}."
+            )
+    factors.append(f"Evidence Law: {evidence_status} - {evidence_detail}")
+    finding_factor = _finding_confidence_factor(findings)
+    if finding_factor:
+        factors.append(finding_factor)
+    if report.get("narrative_available", True):
+        factors.append("Narrative is available and secondary to deterministic scoring.")
+    else:
+        factors.append("Narrative is degraded; deterministic scoring remains primary.")
+    return factors
+
+
+def _why_not_lower(
+    report: dict[str, Any],
+    contributors: list[dict[str, Any]],
+    findings: list[dict[str, Any]],
+) -> list[str]:
+    severity = str(report.get("severity") or "unknown").lower()
+    score = _numeric_value(report.get("risk_score"))
+    primary_contributor = contributors[0] if contributors else None
+    primary_finding = _primary_finding(findings)
+    reasons: list[str] = []
+    if primary_contributor is not None:
+        reasons.append(
+            "Severity stays elevated because "
+            f"{primary_contributor.get('resource_id') or 'the top contributor'} "
+            f"contributes {_format_number(primary_contributor.get('contribution'))} "
+            f"risk points from {primary_contributor.get('source_file') or 'recorded evidence'}."
+        )
+    if primary_finding is not None:
+        reasons.append(
+            "The top finding remains "
+            f"{str(primary_finding.get('severity') or severity).upper()} with "
+            f"{confidence_label(primary_finding.get('confidence'))} finding confidence."
+        )
+    if score is not None:
+        reasons.append(
+            f"The risk score is {_format_number(score)}, which supports the {severity.upper()} verdict."
+        )
+    if not reasons:
+        reasons.append(
+            "The verdict is not lower because the persisted report still records material deployment risk."
+        )
+    return reasons
+
+
+def _why_not_higher(
+    report: dict[str, Any],
+    contributors: list[dict[str, Any]],
+    findings: list[dict[str, Any]],
+    *,
+    evidence_detail_available: bool,
+) -> list[str]:
+    severity = str(report.get("severity") or "unknown").lower()
+    confidence = coerce_confidence(report.get("confidence"))
+    context = report.get("context_completeness") or {}
+    score = _numeric_value(report.get("risk_score"))
+    primary_contributor = contributors[0] if contributors else None
+    primary_finding = _primary_finding(findings)
+    reasons: list[str] = []
+    if severity == "critical":
+        reasons.append("The verdict is already at the highest severity level.")
+    else:
+        next_severity, threshold = SEVERITY_THRESHOLDS.get(severity, ("the next", None))
+        if score is not None and threshold is not None:
+            if score < threshold:
+                reasons.append(
+                    "The verdict is not higher because "
+                    f"the risk score is {_format_number(score)}, below the {next_severity.upper()} threshold of {threshold}."
+                )
+            else:
+                reasons.append(
+                    "The verdict is not higher because "
+                    f"the persisted {severity.upper()} verdict is not paired with "
+                    f"{next_severity.upper()} finding and evidence context, even though "
+                    f"the risk score is {_format_number(score)}."
+                )
+        else:
+            reasons.append(
+                "The verdict is not higher because persisted scoring did not provide evidence for the next severity boundary."
+            )
+    if primary_finding is not None:
+        reasons.append(
+            "The strongest finding shown is "
+            f"{str(primary_finding.get('severity') or 'unknown').upper()} "
+            f"({primary_finding.get('title') or 'untitled finding'}), "
+            "so the boundary is tied to the recorded finding severity."
+        )
+    if primary_contributor is not None:
+        reasons.append(
+            "The largest recorded contributor is "
+            f"{primary_contributor.get('resource_id') or 'unknown resource'} "
+            f"at {_format_number(primary_contributor.get('contribution'))} risk points, "
+            "not an unbounded escalation signal."
+        )
+    if confidence is not None and confidence < 0.85:
+        reasons.append(
+            f"Report confidence is {confidence_label(confidence)}, so the explanation avoids overstating certainty."
+        )
+    if str(context.get("uncertainty") or "").strip():
+        reasons.append(
+            "Context uncertainty is present, so the report recommends review rather than escalation by assumption."
+        )
+    evidence_status, _ = evidence_law_status(
+        report,
+        evidence_detail_available=evidence_detail_available,
+    )
+    if evidence_status in {"Needs review", "Reconciled"}:
+        reasons.append(
+            "Evidence Law does not provide support for a stronger severity claim."
+        )
+    return reasons
+
+
+def _is_uncertainty_warning(warning: str) -> bool:
+    warning_text = warning.lower()
+    if "evidence law" in warning_text:
+        return False
+    if "manifest" in warning_text and "context" not in warning_text:
+        return False
+    uncertainty_keywords = (
+        "uncertainty",
+        "context",
+        "parser",
+        "topology",
+        "confidence metadata",
+        "narrative",
+    )
+    return any(keyword in warning_text for keyword in uncertainty_keywords)
+
+
+def _uncertainty_drivers(report: dict[str, Any]) -> list[str]:
+    context = report.get("context_completeness") or {}
+    findings = [item for item in report.get("findings", []) if isinstance(item, dict)]
+    drivers: list[str] = []
+    uncertainty = str(context.get("uncertainty") or "").strip()
+    if uncertainty:
+        drivers.append(uncertainty)
+    score = _context_score(context)
+    if score is not None and score < 0.7:
+        drivers.append(f"Context completeness score is {score:.2f}.")
+    if bool(context.get("insufficient_context")):
+        drivers.append("Context is marked insufficient for full certainty.")
+    for finding in findings:
+        note = str(finding.get("uncertainty_note") or "").strip()
+        if note and note not in drivers:
+            drivers.append(note)
+    for warning in report.get("warnings", []):
+        warning_text = str(warning or "").strip()
+        if (
+            warning_text
+            and _is_uncertainty_warning(warning_text)
+            and warning_text not in drivers
+        ):
+            drivers.append(warning_text)
+    if not report.get("narrative_available", True):
+        drivers.append("Narrative generation was degraded or unavailable.")
+    return drivers or ["No additional uncertainty drivers were recorded."]
+
+
+def _coerce_ledger_items(value: object) -> list[str]:
+    if isinstance(value, str):
+        text = value.strip()
+        return [text] if text else []
+    if isinstance(value, (list, tuple, set)):
+        return [str(item) for item in value if str(item).strip()]
+    return []
+
+
+def normalize_confidence_ledger_payload(
+    payload: object,
+    *,
+    fallback_ledger: dict[str, list[str]] | None = None,
+) -> dict[str, list[str]]:
+    """Normalize ledger payloads without iterating malformed strings as chars."""
+    fallback = fallback_ledger or {}
+    source = payload if isinstance(payload, dict) else {}
+    normalized: dict[str, list[str]] = {}
+    for key in LEDGER_KEYS:
+        items = _coerce_ledger_items(source.get(key))
+        normalized[key] = items or list(fallback.get(key, []))
+    return normalized
+
+
+def build_confidence_ledger(
+    report: dict[str, Any],
+    *,
+    evidence_detail_available: bool = True,
+) -> dict[str, list[str]]:
+    """Build report reasoning details from persisted evidence and context."""
+    contributors = _sorted_contributors(
+        [item for item in report.get("contributors", []) if isinstance(item, dict)]
+    )
+    findings = [item for item in report.get("findings", []) if isinstance(item, dict)]
+    visible_contributors = contributors[:5]
+    return {
+        "contributors": [_contributor_line(item) for item in visible_contributors],
+        "confidence_factors": _confidence_factors(
+            report,
+            evidence_detail_available=evidence_detail_available,
+        ),
+        "why_not_lower": _why_not_lower(report, visible_contributors, findings),
+        "why_not_higher": _why_not_higher(
+            report,
+            visible_contributors,
+            findings,
+            evidence_detail_available=evidence_detail_available,
+        ),
+        "uncertainty_drivers": _uncertainty_drivers(report),
+    }

--- a/services/report_service.py
+++ b/services/report_service.py
@@ -46,6 +46,11 @@ from services.artifact_snapshot_service import (
     delete_report_artifacts,
     save_report_artifacts,
 )
+from services.confidence_ledger import (
+    LEDGER_KEYS,
+    build_confidence_ledger,
+    normalize_confidence_ledger_payload,
+)
 from services.project_service import (
     build_project_payload,
     build_workspace_payload,
@@ -415,8 +420,27 @@ def _redact_report_file_names(report: dict[str, Any]) -> dict[str, Any]:
             }
             for evidence_item in (report.get("evidence_items") or [])
         ],
+        "confidence_ledger": _redact_confidence_ledger(
+            report.get("confidence_ledger") or {},
+            pairs,
+        ),
     }
     return redacted
+
+
+def _redact_confidence_ledger(
+    ledger: dict[str, Any],
+    pairs: list[tuple[str, str]],
+) -> dict[str, list[str]]:
+    normalized = normalize_confidence_ledger_payload(ledger)
+    return {
+        key: [
+            str(_redact_text_value(item, pairs))
+            for item in normalized[key]
+            if str(item).strip()
+        ]
+        for key in LEDGER_KEYS
+    }
 
 
 def _redact_submission_manifest_file_names(
@@ -2652,7 +2676,7 @@ def _serialize_report(report, *, include_evidence: bool = True) -> dict:
         failure_notice=narrative_failure_notice,
         narrative_available=narrative_available,
     )
-    return {
+    payload = {
         "id": report.id,
         "project": build_project_payload(
             {
@@ -2753,6 +2777,11 @@ def _serialize_report(report, *, include_evidence: bool = True) -> dict:
         ),
         "audit": audit,
     }
+    payload["confidence_ledger"] = build_confidence_ledger(
+        payload,
+        evidence_detail_available=include_evidence,
+    )
+    return payload
 
 
 def persist_analysis_report(

--- a/tests/e2e/report_review.keyboard.spec.js
+++ b/tests/e2e/report_review.keyboard.spec.js
@@ -2,6 +2,7 @@ const { test, expect } = require("@playwright/test");
 
 const REVIEW_ORDER = [
   "verdict",
+  "confidence-ledger",
   "findings",
   "evidence",
   "context",
@@ -113,6 +114,10 @@ test.describe("review keyboard flow", () => {
     await expect(page.getByText("Evidence Law").first()).toBeVisible();
     await expect(page.getByText("Next action").first()).toBeVisible();
     await expect(page.getByText("Review linked evidence").first()).toBeVisible();
+    await expect(page.getByText("Confidence ledger").first()).toBeVisible();
+    await expect(page.getByText("Why not lower").first()).toBeVisible();
+    await expect(page.getByText("Why not higher").first()).toBeVisible();
+    await expect(page.getByText("Uncertainty drivers").first()).toBeVisible();
     await expect(page.getByText("networking/ingress").first()).toBeVisible();
     await expect(page.getByText("1 evidence item").first()).toBeVisible();
     await expect(page.getByText("3 evidence items").first()).toBeVisible();
@@ -280,6 +285,12 @@ test.describe("review keyboard flow", () => {
     await page.waitForFunction(() => window.dwReviewAccessibilityInstalled === true);
 
     await page.locator('[data-dw-review-section="verdict"]').focus();
+    const confidenceLedgerSection = await tabUntilSection(
+      page,
+      "confidence-ledger",
+      8
+    );
+    expect(confidenceLedgerSection).toBe("confidence-ledger");
     const findingsSection = await tabUntilSection(page, "findings", 8);
     expect(findingsSection).toBe("findings");
 
@@ -312,7 +323,7 @@ test.describe("review keyboard flow", () => {
       expandedBeforeInspectorKeys
     );
 
-    const seen = ["verdict", "findings", "evidence"];
+    const seen = ["verdict", "confidence-ledger", "findings", "evidence"];
     for (let step = 0; step < 40; step += 1) {
       await page.keyboard.press("Tab");
       const target = await activeReviewTarget(page);
@@ -343,6 +354,12 @@ test.describe("review keyboard flow", () => {
       page.getByText("Unsupported plan fields: plan.planned_values").first()
     ).toBeVisible();
     await expect(page.locator('[data-dw-modal-root="1"]')).toHaveCount(0);
+    await expect(
+      page.locator('[data-dw-review-section="confidence-ledger"]')
+    ).toBeVisible();
+    await expect(page.getByText("Confidence ledger").first()).toBeVisible();
+    await expect(page.getByText("Why not lower").first()).toBeVisible();
+    await expect(page.getByText("Why not higher").first()).toBeVisible();
     await expect(page.locator('[data-dw-review-section="findings"]')).toBeVisible();
     await expect(page.locator('[data-dw-review-section="context"]')).toBeVisible();
     await expect(

--- a/tests/e2e/seeded_server.py
+++ b/tests/e2e/seeded_server.py
@@ -9,6 +9,7 @@ import json
 from importlib import import_module, reload
 from pathlib import Path
 
+import nicegui.nicegui as nicegui_runtime
 import nicegui.run as nicegui_run
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -30,6 +31,7 @@ def _safe_nicegui_setup() -> None:
 
 
 nicegui_run.setup = _safe_nicegui_setup
+nicegui_runtime.run.setup = _safe_nicegui_setup
 
 
 def _load_runtime_modules() -> tuple[object, object, object, object, object]:

--- a/tests/test_api/test_analyses.py
+++ b/tests/test_api/test_analyses.py
@@ -957,6 +957,15 @@ class AnalysesApiTests(unittest.TestCase):
 
         self.assertEqual(response.status_code, 200)
         payload = response.json()
+        for ledger in (
+            payload["data"]["assessment"]["confidence_ledger"],
+            payload["data"]["persisted_report"]["confidence_ledger"],
+        ):
+            self.assertGreater(len(ledger["contributors"]), 0)
+            self.assertGreater(len(ledger["confidence_factors"]), 0)
+            self.assertGreater(len(ledger["why_not_lower"]), 0)
+            self.assertGreater(len(ledger["why_not_higher"]), 0)
+            self.assertGreater(len(ledger["uncertainty_drivers"]), 0)
         contributors = {
             contributor["resource_id"]: contributor
             for contributor in payload["data"]["persisted_report"]["contributors"]
@@ -979,6 +988,12 @@ class AnalysesApiTests(unittest.TestCase):
             params={"project_key": "payments"},
         )
         self.assertEqual(detail.status_code, 200)
+        detail_ledger = detail.json()["data"]["confidence_ledger"]
+        self.assertGreater(len(detail_ledger["contributors"]), 0)
+        self.assertGreater(len(detail_ledger["confidence_factors"]), 0)
+        self.assertGreater(len(detail_ledger["why_not_lower"]), 0)
+        self.assertGreater(len(detail_ledger["why_not_higher"]), 0)
+        self.assertGreater(len(detail_ledger["uncertainty_drivers"]), 0)
         detail_contributors = {
             contributor["resource_id"]: contributor
             for contributor in detail.json()["data"]["contributors"]

--- a/tests/test_api/test_schemas.py
+++ b/tests/test_api/test_schemas.py
@@ -44,6 +44,40 @@ class ApiSchemaTests(unittest.TestCase):
 
         self.assertEqual(report.confidence, 0.52)
 
+    def test_persisted_report_exposes_confidence_ledger(self) -> None:
+        payload = self._persisted_report_payload()
+        payload["confidence"] = 0.72
+        payload["confidence_ledger"] = {
+            "contributors": ["aws_security_group.main"],
+            "confidence_factors": ["Report confidence is Medium (0.72)."],
+            "why_not_lower": ["Severity stays elevated."],
+            "why_not_higher": ["The risk score is below the next threshold."],
+            "uncertainty_drivers": ["No additional uncertainty drivers were recorded."],
+        }
+
+        report = PersistedReportData.model_validate(payload)
+
+        self.assertEqual(
+            report.confidence_ledger.why_not_higher,
+            ["The risk score is below the next threshold."],
+        )
+
+    def test_persisted_report_normalizes_legacy_confidence_ledger(self) -> None:
+        payload = self._persisted_report_payload()
+        payload["confidence"] = 0.72
+        payload["confidence_ledger"] = {
+            "contributors": "single contributor",
+            "why_not_higher": "single higher reason",
+        }
+
+        report = PersistedReportData.model_validate(payload)
+
+        self.assertEqual(report.confidence_ledger.contributors, ["single contributor"])
+        self.assertEqual(
+            report.confidence_ledger.why_not_higher, ["single higher reason"]
+        )
+        self.assertEqual(report.confidence_ledger.why_not_lower, [])
+
     def test_persisted_report_requires_explicit_narrative_degraded(self) -> None:
         payload = self._persisted_report_payload()
         payload["confidence"] = 0.52

--- a/tests/test_services/test_report_service.py
+++ b/tests/test_services/test_report_service.py
@@ -4546,11 +4546,86 @@ class ReportServiceTests(unittest.TestCase):
         )
         self.assertEqual(shared_report["audit"]["files_analyzed"], ["Artifact 1"])
         self.assertEqual(shared_report["contributors"][0]["source_file"], "Artifact 1")
+        self.assertIn("confidence_ledger", shared_report)
+        self.assertIn(
+            "Artifact 1", shared_report["confidence_ledger"]["contributors"][0]
+        )
+        self.assertNotIn(
+            "prod/network/plan.json",
+            " ".join(shared_report["confidence_ledger"]["contributors"]),
+        )
         self.assertIn("Artifact 1", shared_report["evidence_items"][0]["source_ref"])
         self.assertNotIn(
             "prod/network/plan.json",
             shared_report["evidence_items"][0]["source_ref"],
         )
+
+    def test_fetch_analysis_report_builds_confidence_ledger_from_legacy_contributors(
+        self,
+    ) -> None:
+        report = self._persist_shareable_report()
+        legacy_contributors = [
+            {
+                "evidence_id": "ev-low",
+                "source_file": "low.json",
+                "tool": "terraform",
+                "resource_id": "hidden.low",
+                "action": "modify",
+                "contribution": "2.5",
+                "summary": "Lower contributor.",
+                "severity": "medium",
+            },
+            {
+                "evidence_id": "ev-top",
+                "source_file": "top.json",
+                "tool": "terraform",
+                "resource_id": "visible.top",
+                "action": "modify",
+                "contribution": "20.5",
+                "summary": "Top contributor.",
+                "severity": "high",
+            },
+            {
+                "evidence_id": "ev-invalid",
+                "source_file": "legacy.json",
+                "tool": "terraform",
+                "resource_id": "invalid.legacy",
+                "action": "modify",
+                "contribution": "unknown",
+                "summary": "Malformed legacy contributor.",
+                "severity": "low",
+            },
+        ]
+        with database_module.SessionLocal() as session:
+            stored = session.get(tables_module.AnalysisReport, report["id"])
+            assert stored is not None
+            stored.contributors_json = json.dumps(legacy_contributors)
+            session.commit()
+
+        fetched = report_service_module.fetch_analysis_report(report["id"])
+
+        self.assertIsNotNone(fetched)
+        assert fetched is not None
+        ledger = fetched["confidence_ledger"]
+        self.assertEqual(
+            ledger["contributors"][0],
+            "visible.top · HIGH · contribution 20.5 · top.json",
+        )
+        self.assertIn(
+            "invalid.legacy · LOW · contribution unknown · legacy.json",
+            ledger["contributors"],
+        )
+        self.assertIn("visible.top", ledger["why_not_lower"][0])
+        self.assertTrue(any("visible.top" in item for item in ledger["why_not_higher"]))
+
+    def test_history_summary_ledger_marks_evidence_detail_omitted(self) -> None:
+        self._persist_shareable_report()
+
+        history = report_service_module.fetch_filtered_analysis_history()
+
+        self.assertEqual(len(history), 1)
+        factors = " ".join(history[0]["confidence_ledger"]["confidence_factors"])
+        self.assertNotIn("lacks linked deterministic evidence", factors)
 
     def test_share_report_link_normalizes_unspecified_app_host(self) -> None:
         for raw_host in ("", "   ", "0.0.0.0", "::", " :: ", "[::]"):

--- a/tests/test_ui/test_history_page.py
+++ b/tests/test_ui/test_history_page.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import os
 import tempfile
 import unittest
@@ -24,6 +25,10 @@ from evidence.models import EvidenceItem, Finding
 from fastapi.testclient import TestClient
 from llm.narrator import NarrativeResult
 from parsers.base import ParseBatchResult, ParsedFileResult, UnifiedChange
+from services.confidence_ledger import (
+    build_confidence_ledger,
+    normalize_confidence_ledger_payload,
+)
 from ui.formatters.datetime import format_history_timestamp
 from ui.formatters.recommendations import recommendation_classes, recommendation_text
 from ui.routes.history import page_selection_state
@@ -631,6 +636,275 @@ class HistoryPageHelpersTests(unittest.TestCase):
         self.assertIn("linked evidence metadata", verify_before_deploy)
         self.assertNotIn("Unknown redaction summary", verify_before_deploy)
 
+    def test_confidence_ledger_builds_grounded_reasoning_sections(self) -> None:
+        ledger = build_confidence_ledger(
+            {
+                "risk_score": 76,
+                "severity": "high",
+                "recommendation": "caution",
+                "confidence": 0.72,
+                "top_risk": "Security group exposure risk",
+                "warnings": ["Narrative degraded: provider unavailable."],
+                "narrative_available": False,
+                "contributors": [
+                    {
+                        "resource_id": "aws_security_group.main",
+                        "source_file": "plan.json",
+                        "normalized_action": "modify",
+                        "resource_category": "networking",
+                        "severity": "high",
+                        "contribution": 20,
+                        "reasoning": "Ingress is exposed to the internet.",
+                    }
+                ],
+                "findings": [
+                    {
+                        "title": "HIGH: aws_security_group.main",
+                        "severity": "high",
+                        "confidence": 0.68,
+                        "deterministic": True,
+                        "uncertainty_note": "Parser coverage is partial.",
+                    }
+                ],
+                "context_completeness": {
+                    "context_score": 0.64,
+                    "confidence_level": "low",
+                    "uncertainty": "Uncertainty: topology context is stale.",
+                },
+            }
+        )
+
+        self.assertEqual(
+            ledger["contributors"][0],
+            "aws_security_group.main · HIGH · contribution 20 · plan.json",
+        )
+        self.assertIn(
+            "Report confidence is Medium (0.72).", ledger["confidence_factors"]
+        )
+        self.assertIn(
+            "Context confidence is low with score 0.64.",
+            ledger["confidence_factors"],
+        )
+        self.assertTrue(
+            any("Severity stays elevated" in item for item in ledger["why_not_lower"])
+        )
+        self.assertTrue(
+            any("not higher" in item.lower() for item in ledger["why_not_higher"])
+        )
+        self.assertIn(
+            "Uncertainty: topology context is stale.", ledger["uncertainty_drivers"]
+        )
+        self.assertIn("Parser coverage is partial.", ledger["uncertainty_drivers"])
+
+    def test_confidence_ledger_tolerates_legacy_contributor_payloads(
+        self,
+    ) -> None:
+        ledger = build_confidence_ledger(
+            {
+                "risk_score": 76,
+                "severity": "high",
+                "confidence": 0.72,
+                "contributors": [
+                    {
+                        "resource_id": "hidden.low",
+                        "source_file": "low.json",
+                        "severity": "medium",
+                        "contribution": "2.5",
+                    },
+                    {
+                        "resource_id": "visible.top",
+                        "source_file": "top.json",
+                        "severity": "high",
+                        "contribution": "20.5",
+                    },
+                    {
+                        "resource_id": "invalid.legacy",
+                        "source_file": "legacy.json",
+                        "severity": "low",
+                        "contribution": "unknown",
+                    },
+                ],
+                "findings": [
+                    {
+                        "title": "HIGH: visible.top",
+                        "severity": "high",
+                        "confidence": 0.68,
+                        "deterministic": True,
+                    }
+                ],
+                "context_completeness": {
+                    "context_score": 0.72,
+                    "confidence_level": "medium",
+                },
+            }
+        )
+
+        self.assertEqual(
+            ledger["contributors"][0],
+            "visible.top · HIGH · contribution 20.5 · top.json",
+        )
+        self.assertIn(
+            "invalid.legacy · LOW · contribution unknown · legacy.json",
+            ledger["contributors"],
+        )
+        self.assertIn("visible.top", ledger["why_not_lower"][0])
+        self.assertTrue(
+            any(
+                "below the CRITICAL threshold of 90" in item
+                for item in ledger["why_not_higher"]
+            )
+        )
+        self.assertTrue(any("visible.top" in item for item in ledger["why_not_higher"]))
+
+    def test_confidence_ledger_uses_canonical_thresholds_without_false_below_claims(
+        self,
+    ) -> None:
+        low_ledger = build_confidence_ledger(
+            {
+                "risk_score": 41,
+                "severity": "low",
+                "confidence": 0.72,
+                "contributors": [],
+                "findings": [],
+                "context_completeness": {},
+            }
+        )
+        medium_ledger = build_confidence_ledger(
+            {
+                "risk_score": 70,
+                "severity": "medium",
+                "confidence": 0.72,
+                "contributors": [],
+                "findings": [
+                    {
+                        "title": "MEDIUM: change",
+                        "severity": "medium",
+                        "confidence": 0.72,
+                        "deterministic": True,
+                    }
+                ],
+                "context_completeness": {},
+            }
+        )
+
+        self.assertTrue(
+            any(
+                "below the MEDIUM threshold of 42" in item
+                for item in low_ledger["why_not_higher"]
+            )
+        )
+        self.assertFalse(
+            any(
+                "below the HIGH threshold" in item
+                for item in medium_ledger["why_not_higher"]
+            )
+        )
+        self.assertTrue(
+            any(
+                "persisted MEDIUM verdict" in item
+                for item in medium_ledger["why_not_higher"]
+            )
+        )
+
+    def test_confidence_ledger_filters_administrative_warnings_from_uncertainty(
+        self,
+    ) -> None:
+        ledger = build_confidence_ledger(
+            {
+                "risk_score": 76,
+                "severity": "high",
+                "confidence": 0.72,
+                "warnings": [
+                    "Evidence Law reconciled report score to match severity metadata.",
+                    "Submission manifest metadata was inferred from available analysis artifacts.",
+                    "Context completeness metadata was unavailable because persisted JSON was malformed.",
+                ],
+                "contributors": [],
+                "findings": [],
+                "context_completeness": {},
+            }
+        )
+
+        uncertainty = " ".join(ledger["uncertainty_drivers"])
+        self.assertNotIn("Evidence Law reconciled", uncertainty)
+        self.assertNotIn("Submission manifest metadata", uncertainty)
+        self.assertIn("Context completeness metadata", uncertainty)
+
+    def test_confidence_ledger_marks_evidence_detail_omitted_for_summary_payloads(
+        self,
+    ) -> None:
+        ledger = build_confidence_ledger(
+            {
+                "risk_score": 76,
+                "severity": "high",
+                "confidence": 0.72,
+                "contributors": [],
+                "findings": [
+                    {
+                        "title": "HIGH: change",
+                        "severity": "high",
+                        "confidence": 0.72,
+                        "deterministic": True,
+                        "evidence_refs": ["ev-001"],
+                    }
+                ],
+                "context_completeness": {},
+            },
+            evidence_detail_available=False,
+        )
+
+        factors = " ".join(ledger["confidence_factors"])
+        why_not_higher = " ".join(ledger["why_not_higher"])
+        self.assertIn("Evidence Law: Detail omitted", factors)
+        self.assertNotIn("lacks linked deterministic evidence", factors)
+        self.assertNotIn("Evidence Law does not provide support", why_not_higher)
+
+    def test_confidence_ledger_normalizes_malformed_ledger_sections(self) -> None:
+        fallback = {
+            "contributors": ["fallback contributor"],
+            "confidence_factors": ["fallback confidence"],
+            "why_not_lower": ["fallback lower"],
+            "why_not_higher": ["fallback higher"],
+            "uncertainty_drivers": ["fallback uncertainty"],
+        }
+
+        ledger = normalize_confidence_ledger_payload(
+            {
+                "contributors": "single contributor",
+                "confidence_factors": [],
+                "why_not_higher": "single why-not-higher reason",
+            },
+            fallback_ledger=fallback,
+        )
+        html = app_module._shared_report_confidence_ledger_html(
+            {"confidence_ledger": {"why_not_higher": "single reason"}}
+        )
+        fallback_html = app_module._shared_report_confidence_ledger_html(
+            {
+                "risk_score": 76,
+                "severity": "high",
+                "confidence": 0.72,
+                "contributors": [
+                    {
+                        "resource_id": "fallback.top",
+                        "source_file": "plan.json",
+                        "severity": "high",
+                        "contribution": 20,
+                    }
+                ],
+                "findings": [],
+                "context_completeness": {},
+            }
+        )
+
+        self.assertEqual(ledger["contributors"], ["single contributor"])
+        self.assertEqual(ledger["confidence_factors"], ["fallback confidence"])
+        self.assertEqual(ledger["why_not_lower"], ["fallback lower"])
+        self.assertEqual(ledger["why_not_higher"], ["single why-not-higher reason"])
+        self.assertIn("<li>single reason</li>", html)
+        self.assertNotIn("<li>s</li>", html)
+        self.assertIn("fallback.top", fallback_html)
+
     def test_history_row_confidence_does_not_fallback_to_finding_confidence(
         self,
     ) -> None:
@@ -1133,6 +1407,67 @@ class HistoryPageRenderingTests(unittest.TestCase):
         self.assertIn("Next action", response.text)
         self.assertIn("Review linked evidence", response.text)
 
+    def test_history_detail_route_renders_confidence_ledger(self) -> None:
+        self._persist_report(
+            assessment_confidence=0.72,
+            finding_confidence=0.68,
+            context_completeness={
+                "topology_freshness_days": 45,
+                "topology_last_imported_at": "2026-04-18T11:22:33Z",
+                "incident_index_size": 7,
+                "parser_success_rate": 0.8,
+                "parser_success_by_tool": {"terraform": 0.8},
+                "context_score": 0.64,
+                "confidence_level": "low",
+                "uncertainty": "Uncertainty: topology context is stale.",
+            },
+        )
+
+        response = self.client.get("/history/1")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("Confidence ledger", response.text)
+        self.assertIn("Why not lower", response.text)
+        self.assertIn("Why not higher", response.text)
+        self.assertIn("Uncertainty drivers", response.text)
+        self.assertIn("Report confidence is Medium (0.64).", response.text)
+        self.assertIn(
+            "Context confidence is low with score 0.64.",
+            response.text,
+        )
+        self.assertIn("aws_security_group.main", response.text)
+        self.assertIn("Uncertainty: topology context is stale.", response.text)
+
+    def test_history_detail_route_tolerates_legacy_contributor_values(self) -> None:
+        report = self._persist_report()
+        with database_module.SessionLocal() as session:
+            stored = session.get(tables_module.AnalysisReport, report["id"])
+            assert stored is not None
+            stored.contributors_json = json.dumps(
+                [
+                    {
+                        "resource_id": "legacy.invalid",
+                        "source_file": "legacy.json",
+                        "severity": "low",
+                        "contribution": "unknown",
+                    },
+                    {
+                        "resource_id": "legacy.decimal",
+                        "source_file": "top.json",
+                        "severity": "high",
+                        "contribution": "20.5",
+                    },
+                ]
+            )
+            session.commit()
+
+        response = self.client.get("/history/1")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("legacy.decimal", response.text)
+        self.assertIn("Confidence ledger", response.text)
+        self.assertIn("Why not lower", response.text)
+
     def test_history_detail_route_shows_topology_freshness_badge(self) -> None:
         self._persist_report(
             context_completeness={
@@ -1162,6 +1497,10 @@ class HistoryPageRenderingTests(unittest.TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertIn("Shared DeployWhisper report", response.text)
         self.assertIn("Analysis report", response.text)
+        self.assertIn("Confidence ledger", response.text)
+        self.assertIn("Why not lower", response.text)
+        self.assertIn("Why not higher", response.text)
+        self.assertIn("aws_security_group.main", response.text)
         self.assertNotIn("Delete selected", response.text)
 
     def test_public_report_route_shows_topology_freshness_without_internal_settings_link(

--- a/ui/components/confidence_ledger.py
+++ b/ui/components/confidence_ledger.py
@@ -1,0 +1,77 @@
+"""Confidence-ledger rendering for report reasoning details."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from nicegui import ui
+
+from services.confidence_ledger import (
+    build_confidence_ledger,
+    normalize_confidence_ledger_payload,
+)
+from ui.components.review_accessibility import decorate_review_section
+
+
+def _render_list(title: str, items: list[str]) -> None:
+    with ui.card().classes("dw-panel-soft shadow-none min-w-[240px] flex-1"):
+        with ui.column().classes("gap-2 p-4"):
+            ui.label(title).classes(
+                "text-[11px] font-semibold uppercase tracking-[0.08em] dw-muted"
+            )
+            for item in items:
+                ui.label(item).classes("text-sm dw-text leading-6")
+
+
+def _ledger_payload(report: dict[str, Any]) -> dict[str, list[str]]:
+    payload = report.get("confidence_ledger")
+    if isinstance(payload, dict):
+        return normalize_confidence_ledger_payload(
+            payload,
+            fallback_ledger=build_confidence_ledger(report),
+        )
+    return build_confidence_ledger(report)
+
+
+def render_confidence_ledger(report: dict[str, Any]) -> None:
+    """Render confidence factors and why-not-lower/higher reasoning."""
+    ledger = _ledger_payload(report)
+    with ui.card().classes("w-full dw-panel shadow-none p-5") as ledger_card:
+        decorate_review_section(
+            ledger_card,
+            section="confidence-ledger",
+            label="Confidence ledger",
+        )
+        with ui.column().classes("gap-4"):
+            with ui.column().classes("gap-1"):
+                ui.label("Confidence ledger").classes("text-lg font-medium dw-text")
+                ui.label(
+                    "Reasoning details that explain the verdict using persisted evidence, contributors, confidence, and context quality."
+                ).classes("text-sm dw-muted leading-6")
+            with ui.row().classes("w-full gap-3 flex-wrap"):
+                _render_list(
+                    "Contributors",
+                    ledger["contributors"]
+                    or ["No resource-level contributors were recorded."],
+                )
+                _render_list(
+                    "Confidence factors",
+                    ledger["confidence_factors"]
+                    or ["No confidence factors were recorded."],
+                )
+            with ui.row().classes("w-full gap-3 flex-wrap"):
+                _render_list(
+                    "Why not lower",
+                    ledger["why_not_lower"]
+                    or ["No why-not-lower reasoning was recorded."],
+                )
+                _render_list(
+                    "Why not higher",
+                    ledger["why_not_higher"]
+                    or ["No why-not-higher reasoning was recorded."],
+                )
+                _render_list(
+                    "Uncertainty drivers",
+                    ledger["uncertainty_drivers"]
+                    or ["No uncertainty drivers were recorded."],
+                )

--- a/ui/components/report_detail_page.py
+++ b/ui/components/report_detail_page.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
+import math
 from typing import Any
 from urllib.parse import urlencode
 
@@ -18,6 +19,7 @@ from services.feedback_service import (
 )
 from ui.components.blast_radius_graph import render_blast_radius_panel
 from ui.components.change_table import format_change_metadata_lines
+from ui.components.confidence_ledger import render_confidence_ledger
 from ui.components.context_completeness_panel import (
     render_context_completeness_panel,
 )
@@ -161,10 +163,20 @@ def _primary_contributor(report: dict[str, Any]) -> dict[str, Any] | None:
     return max(
         contributors,
         key=lambda contributor: (
-            int(contributor.get("contribution") or 0),
+            _numeric_sort_value(contributor.get("contribution")),
             str(contributor.get("resource_id") or ""),
         ),
     )
+
+
+def _numeric_sort_value(value: object) -> float:
+    try:
+        number = float(value)
+    except (TypeError, ValueError):
+        return float("-inf")
+    if not math.isfinite(number):
+        return float("-inf")
+    return number
 
 
 def _primary_finding(report: dict[str, Any]) -> dict[str, Any] | None:
@@ -178,7 +190,7 @@ def _primary_finding(report: dict[str, Any]) -> dict[str, Any] | None:
         findings,
         key=lambda finding: (
             severity_order.get(str(finding.get("severity") or "").lower(), 0),
-            float(finding.get("confidence") or 0.0),
+            coerce_confidence(finding.get("confidence")) or 0.0,
             str(finding.get("title") or ""),
         ),
     )
@@ -446,16 +458,24 @@ def _render_resource_breakdown(report: dict[str, Any]) -> None:
                         "w-full items-start justify-between gap-3 p-4 flex-wrap"
                     ):
                         with ui.column().classes("min-w-0 flex-1 gap-1"):
-                            ui.label(contributor["resource_id"]).classes(
-                                "text-sm font-semibold dw-text"
-                            )
                             ui.label(
-                                f"{contributor['resource_category']} · {contributor['normalized_action']} · "
-                                f"{contributor['environment']} · scope {contributor['downstream_scope']}"
+                                str(
+                                    contributor.get("resource_id") or "unknown resource"
+                                )
+                            ).classes("text-sm font-semibold dw-text")
+                            ui.label(
+                                f"{contributor.get('resource_category') or 'unknown category'} · "
+                                f"{contributor.get('normalized_action') or contributor.get('action') or 'unknown action'} · "
+                                f"{contributor.get('environment') or 'unknown environment'} · "
+                                f"scope {contributor.get('downstream_scope') or 'unknown'}"
                             ).classes("text-xs dw-muted")
-                            ui.label(contributor["reasoning"]).classes(
-                                "text-sm dw-muted leading-6"
-                            )
+                            ui.label(
+                                str(
+                                    contributor.get("reasoning")
+                                    or contributor.get("summary")
+                                    or "No contributor reasoning was recorded."
+                                )
+                            ).classes("text-sm dw-muted leading-6")
                             for metadata_line in format_change_metadata_lines(
                                 contributor.get("metadata") or {}
                             ):
@@ -466,7 +486,7 @@ def _render_resource_breakdown(report: dict[str, Any]) -> None:
                                 ui.label(security_flag).classes(
                                     "text-xs dw-danger-text"
                                 )
-                        render_risk_badge(contributor["severity"])
+                        render_risk_badge(str(contributor.get("severity") or "unknown"))
 
 
 def _render_audit_metadata(report: dict[str, Any]) -> None:
@@ -795,6 +815,7 @@ def render_report_detail_page(
 
     _render_summary_and_advisory(report)
     _render_operational_narrative(report)
+    render_confidence_ledger(report)
     render_findings_table(
         findings,
         evidence_items,

--- a/ui/components/upload_panel.py
+++ b/ui/components/upload_panel.py
@@ -37,6 +37,7 @@ from ui.components.change_table import (
     format_change_metadata_lines,
     render_change_table,
 )
+from ui.components.confidence_ledger import render_confidence_ledger
 from ui.components.report_detail_page import (
     format_submission_manifest_fallback_summary,
     format_submission_manifest_partial_notice,
@@ -492,6 +493,7 @@ def build_upload_panel(
                     )
                 context = report.get("context_completeness") or {}
                 render_topology_freshness_banner(context)
+                render_confidence_ledger(report)
                 if parse_batch is not None:
                     render_change_table(parse_batch)
                 findings = report.get("findings", [])

--- a/ui/formatters/confidence.py
+++ b/ui/formatters/confidence.py
@@ -2,29 +2,11 @@
 
 from __future__ import annotations
 
-import math
-
 from nicegui import ui
-
-
-def coerce_confidence(value: object) -> float | None:
-    if value is None:
-        return None
-    try:
-        confidence = float(value)
-    except (TypeError, ValueError):
-        return None
-    if not math.isfinite(confidence) or confidence < 0.0 or confidence > 1.0:
-        return None
-    return confidence
-
-
-def confidence_bucket(confidence: float) -> str:
-    if confidence >= 0.85:
-        return "high"
-    if confidence >= 0.60:
-        return "medium"
-    return "low"
+from services.confidence_ledger import (
+    confidence_bucket as confidence_bucket,
+    coerce_confidence as coerce_confidence,
+)
 
 
 def _confidence_style(bucket: str) -> str:

--- a/ui/formatters/report_header.py
+++ b/ui/formatters/report_header.py
@@ -4,6 +4,10 @@ from __future__ import annotations
 
 from typing import Any
 
+from services.confidence_ledger import (
+    evidence_law_status as evidence_law_status,
+    severe_findings as severe_findings,
+)
 from ui.formatters.confidence import coerce_confidence, confidence_bucket
 
 
@@ -18,87 +22,6 @@ def report_confidence_text(report: dict[str, Any]) -> str:
     if confidence is None:
         return "Unavailable"
     return f"{confidence_bucket(confidence).title()} ({confidence:.2f})"
-
-
-def severe_findings(report: dict[str, Any]) -> list[dict[str, Any]]:
-    return [
-        finding
-        for finding in report.get("findings", [])
-        if isinstance(finding, dict)
-        and str(finding.get("severity") or "").lower() in {"high", "critical"}
-    ]
-
-
-def _is_severe_report(report: dict[str, Any]) -> bool:
-    return str(report.get("severity") or "").lower() in {"high", "critical"}
-
-
-def _is_deterministic_evidence(evidence: dict[str, Any]) -> bool:
-    determinism_level = str(
-        evidence.get("determinism_level") or "deterministic"
-    ).lower()
-    return (
-        evidence.get("deterministic") is True and determinism_level == "deterministic"
-    )
-
-
-def _has_linked_deterministic_evidence(
-    finding: dict[str, Any],
-    evidence_by_id: dict[str, dict[str, Any]],
-) -> bool:
-    evidence_refs = [
-        str(evidence_ref)
-        for evidence_ref in finding.get("evidence_refs", [])
-        if evidence_ref
-    ]
-    if not evidence_refs:
-        return False
-    return any(
-        _is_deterministic_evidence(evidence_by_id[evidence_ref])
-        for evidence_ref in evidence_refs
-        if evidence_ref in evidence_by_id
-    )
-
-
-def evidence_law_status(report: dict[str, Any]) -> tuple[str, str]:
-    warnings = [
-        str(warning)
-        for warning in report.get("warnings", [])
-        if "Evidence Law" in str(warning)
-    ]
-    if warnings:
-        return (
-            "Reconciled",
-            "Evidence Law adjusted unsupported or inconsistent severe claims.",
-        )
-    severe = severe_findings(report)
-    if not severe:
-        if _is_severe_report(report):
-            return (
-                "Needs review",
-                "The report is severe, but no high or critical finding is visible for Evidence Law verification.",
-            )
-        return (
-            "Satisfied",
-            "No high or critical finding requires deterministic evidence.",
-        )
-    evidence_by_id = {
-        str(evidence.get("evidence_id")): evidence
-        for evidence in report.get("evidence_items", [])
-        if isinstance(evidence, dict) and evidence.get("evidence_id")
-    }
-    if all(
-        _has_linked_deterministic_evidence(finding, evidence_by_id)
-        for finding in severe
-    ):
-        return (
-            "Satisfied",
-            "High and critical findings are backed by deterministic evidence.",
-        )
-    return (
-        "Needs review",
-        "A severe finding lacks linked deterministic evidence support.",
-    )
 
 
 def next_action_text(report: dict[str, Any], evidence_status: str) -> str:


### PR DESCRIPTION
Story 3.4 needed one shared confidence ledger so reviewers can see why a verdict is not lower or higher across UI, API, persisted history, and shared report surfaces. The implementation derives the ledger from persisted report evidence/context once in the service layer, normalizes legacy payloads at boundaries, and renders the same five sections consistently.

Constraint: Preserve local-first, advisory-only report semantics and Evidence Law behavior
Constraint: Keep UI, API, CLI-shaped persisted payloads, and shared report views on the shared report model
Rejected: Render ledger reasoning only in the NiceGUI detail page | would leave API and shared reports without the acceptance-criteria explanation
Rejected: Trust persisted legacy ledger payloads as-is | malformed strings could render one character per bullet or omit fallback reasoning
Confidence: high
Scope-risk: moderate
Directive: Keep future verdict explanation fields derived in services/confidence_ledger.py before adapting them in UI or API layers
Tested: ./.venv/bin/ruff check .
Tested: ./.venv/bin/ruff format --check .
Tested: git diff --check
Tested: ./.venv/bin/python -m unittest discover -q
Tested: bash scripts/ci-local.sh
Tested: ./.venv/bin/python -m pip_audit -r requirements.txt
Tested: APP_PORT=18090 npm run test:ui-review
Not-tested: Local VoiceOver lane per project directive that it is not applicable unless explicitly requested

## What does this PR do?

<!-- Brief description of changes -->

## Type of change
- [ ] Feature (new functionality)
- [ ] Bugfix (non-breaking fix)
- [ ] Release preparation
- [ ] Hotfix (critical production fix)
- [ ] Docs / refactor / chore

## Checklist
- [ ] I have followed the branch naming convention
- [ ] Tests pass locally (`pytest tests/ -v`)
- [ ] Linting passes (`ruff check .`)
- [ ] Docker build succeeds
- [ ] I have updated docs if needed
- [ ] No secrets or .env values committed

## Related issue
Closes #