### PR TITLE
Make report rerun diffs review-complete

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ What users can use today:
 - **Local-first safety posture**: keep raw IaC processing local, avoid storing provider API keys in the database, exclude sensitive files from unsafe handling, and keep every verdict advisory rather than automatically blocking a release.
 - **Evidence-backed confidence**: trace the report back to findings, resource-level contributors, uploaded artifact references, confidence factors, why-not-lower/higher reasoning, parser coverage, topology freshness, context TODOs, and warning signals when context is limited.
 - **Blast-radius and rollback context**: use service-topology input to explain likely downstream impact and generate rollback steps with complexity scoring.
-- **Analysis history**: review saved reports later, filter previous analyses, inspect audit metadata, and compare repeated scans of the same artifact set.
+- **Analysis history**: review saved reports later, filter previous analyses, inspect audit metadata, and compare repeated scans of the same artifact set with new, resolved, persistent, severity-changed, and context-changed findings.
 - **Provider and admin settings UI**: configure LLM provider metadata, upload topology context, manage custom AI Skills, and see provider readiness before running analysis.
 - **REST API and CLI access**: run the same analysis pipeline from `/api/v1` endpoints or the headless CLI for local automation and CI workflows.
 - **Shareable reports**: create read-only report links, optionally protect sensitive shared reports with a password, redact filenames, and compare shared reruns when previous scans exist.
@@ -634,9 +634,10 @@ Shared report links now resolve to `/reports/{id}` read-only pages. For sensitiv
 reports, configure password protection and opt-in file-name redaction via
 `POST /api/v1/analyses/{id}/share` with the `X-DeployWhisper-Share-Token`
 header. Set `DEPLOYWHISPER_SHARE_TOKEN` before exposing that management API.
-When a prior scan exists for the same analyzed artifact set, the shared report
-page also exposes a `Compare with previous` view with risk-score, findings, and
-evidence deltas.
+When a prior comparable report exists in the same project, workspace, and
+workflow context, the shared report page also exposes a `Compare with previous`
+view with risk-score, new, resolved, persistent, severity-changed,
+context-changed, and evidence deltas.
 
 ### GitHub App Mode
 

--- a/_bmad-output/implementation-artifacts/3-6-report-diff-after-rerun.md
+++ b/_bmad-output/implementation-artifacts/3-6-report-diff-after-rerun.md
@@ -1,0 +1,244 @@
+# Story 3.6: Report Diff After Rerun
+
+Status: done
+
+<!-- Generated from updated PRD/architecture/epics plus implementation-readiness-report-2026-05-01.md. -->
+
+## Story
+
+As a reviewer,
+I want report diffs after reruns,
+So that I can see which risks are new, resolved, or persistent.
+
+## Acceptance Criteria
+
+1. Given two related reports exist for the same project/workspace and workflow context, When the reviewer opens comparison, Then the diff shows new, resolved, persistent, changed-severity, and changed-context findings. And comparison respects redaction and project scope.
+
+### Requirement Traceability
+
+- Primary PRD requirements: Epic 3 coverage: REV-01..10, HIS-03, RSK-04..06, RSK-09..10, NFR-XAI-01..05, UX-DR1..10.
+- Supporting PRD / NFR / differentiation requirements: See `_bmad-output/planning-artifacts/prd.md`, `_bmad-output/planning-artifacts/architecture.md`, and `_bmad-output/planning-artifacts/implementation-readiness-report-2026-05-01.md`.
+- Coverage intent: Baseline + Delta.
+- Story alignment note: This story was created from the updated Epic 3 plan after the 2026-05-01 readiness rerun. The readiness report verified 187/187 PRD functional requirement IDs in the epics artifact, 38 NFR IDs present, and no critical or major readiness defects.
+
+## Tasks / Subtasks
+
+- [x] Implement and verify acceptance criterion 1. (AC: 1)
+- [x] Reuse existing services, repositories, schemas, and UI/CLI/API helpers before adding new abstractions. (AC: all)
+- [x] Add or update deterministic regression coverage for the changed behavior. (AC: all)
+- [x] Update relevant docs or examples if the story changes user-visible, operator, API, CLI, integration, or contribution behavior. (AC: all)
+- [x] Run required validation and record commands/results in the Dev Agent Record. (AC: all)
+
+### Review Findings
+
+- [x] [Review][Patch] Duplicate title/category findings can be mispaired after description was removed from the finding fingerprint [services/report_service.py:823]
+- [x] [Review][Patch] Guidance reordering can create false changed-context diffs because guidance is compared as an ordered tuple [services/report_service.py:949]
+- [x] [Review][Patch] Comparable-report lookup does not isolate workflow context even though AC1 requires same project/workspace and workflow context [services/report_service.py:1238]
+- [x] [Review][Patch] Duplicate finding pairing accepts same-description matches before evidence identity, hiding added/removed findings [services/report_service.py:1090]
+- [x] [Review][Patch] Singleton fallback pairs findings with no shared description or evidence identity [services/report_service.py:1158]
+- [x] [Review][Patch] Workflow context comparison is case/whitespace sensitive [services/report_service.py:819]
+- [x] [Review][Decision] Workflow scoping ignores trigger_id — AC1 requires comparison within the same workflow context, but the current comparable-report key uses source_interface and trigger_type while ignoring audit.trigger_id. If trigger_id represents a stable workflow instance such as a PR/session, unrelated runs can be diffed together; if it represents a unique CI/job run, requiring equality would suppress valid reruns. Decide whether trigger_id is part of workflow context before patching.
+- [x] [Review][Patch] Title/category drift is still reported as removed plus added instead of persistent plus changed-context [services/report_service.py:857]
+- [x] [Review][Decision] Protected shared-report comparison needs an explicit auth model — Current report unlock uses a report-specific cookie, but compare fetches the previous shared report without carrying prior-report auth. Decide whether unlocking the current comparable report should grant compare access to the prior protected report, or whether the shared compare flow must require a separate compare unlock before patching.
+- [x] [Review][Patch] Reviewer-facing comparison still says removed instead of resolved [ui/routes/history.py:476]
+- [x] [Review][Patch] Greedy evidence-overlap pairing can misclassify duplicate findings [services/report_service.py:1106]
+- [x] [Review][Patch] Auto-compare serializes unreadable off-path reports instead of skipping them [services/report_service.py:1464]
+- [x] [Review][Patch] Visible unreadable reports can still break history page serialization [services/report_service.py:3736]
+- [x] [Review][Patch] Optimal evidence matching can become exponential on dense overlap components [services/report_service.py:1176]
+- [x] [Review][Patch] Reviewer-facing current-side comparison still says added instead of new [ui/routes/history.py:497]
+- [x] [Review][Patch] UI history skips unreadable rows after pagination, which can hide readable reports behind unreadable page rows [services/report_service.py:3811]
+- [x] [Review][Decision] Mixed legacy/current workflow provenance can suppress a valid previous comparison — `_reports_are_comparable` now requires exact source_interface/trigger_type/trigger_id equality. That satisfies strict workflow-context isolation for fully populated reports, but older persisted reports with blank audit context no longer compare with newer reruns that now carry provenance. Decide whether blank legacy workflow fields should act as compatibility wildcards, whether trigger_id strictness should require an explicit provenance version/backfill signal, or whether suppressing legacy comparisons is intentional.
+- [x] [Review][Patch] UI history skip-unreadable pagination materializes all matching rows before slicing [services/report_service.py:3817]
+- [x] [Review][Patch] Large dense-overlap evidence components silently fall back to approximate greedy pairing [services/report_service.py:1235]
+- [x] [Review][Patch] Evidence-overlap scoring collapses repeated evidence identities into a set [services/report_service.py:911]
+- [x] [Review][Patch] Comparison copy still describes artifact-only matching instead of project/workspace/workflow-scoped comparable reports [ui/routes/history.py:454]
+- [x] [Review][Patch] Workflow-context wildcard matching can compare reports from different workflows and can prefer a newer blank-context report over an exact prior match [services/report_service.py:830]
+- [x] [Review][Patch] Skip-unreadable history filtering drops legacy readable reports with null or blank schema versions [models/repositories/analysis_reports.py:599]
+- [x] [Review][Patch] Evidence-only matching can classify a different finding on the same resource as persistent changed-context instead of resolved plus new [services/report_service.py:1370]
+
+## Dev Notes
+
+### Epic Context
+
+- Epic: 3. Report and Review Experience
+- Epic goal: Make the report experience fast, inspectable, and honest.
+- Epic coverage: REV-01..10, HIS-03, RSK-04..06, RSK-09..10, NFR-XAI-01..05, UX-DR1..10
+
+### Architecture and Product Guardrails
+
+- Preserve DeployWhisper's local-first raw artifact boundary: raw IaC, scanner artifacts, incident exports, and sensitive context stay in the user's infrastructure by default.
+- Preserve the advisory-first core. Optional adapters may interpret report outputs, but canonical report semantics remain advisory unless explicit story scope says otherwise.
+- Reuse the shared analysis core and service layer before adapting UI, API, CLI, GitHub, or future workflow surfaces.
+- Keep Evidence Law behavior intact: no high or critical finding without deterministic evidence.
+- Keep project/workspace scope explicit for reports, incidents, topology, outcomes, feedback, scanner imports, and connector-related data.
+- Do not introduce new dependencies unless the active story explicitly requires and justifies them.
+
+### Source Tree Guidance
+
+- API routes belong under `api/routes/` and should use existing `ApiRoute` / `ApiError` envelope patterns.
+- Shared orchestration belongs in `services/`; parsers normalize input, analysis modules score/derive risk, and surfaces adapt outputs.
+- UI work belongs under `ui/routes/` and `ui/components/`, following the existing NiceGUI composition style.
+- CLI behavior belongs under `cli/` and must call the same service-layer paths as UI/API flows.
+- Persistence work belongs under `models/` with Alembic migrations when schema changes are required.
+- Documentation required by a story should be updated in the same workstream.
+
+### Testing Requirements
+
+- Use standard-library `unittest` in the existing `tests/test_*` layout.
+- Add focused regression tests for the layer changed by the story before broad refactors.
+- For Python changes, run `./.venv/bin/ruff check .`, `./.venv/bin/ruff format --check .`, and `./.venv/bin/python -m unittest discover -q` before closing implementation.
+- Use `bash scripts/ci-local.sh` for broader or cross-layer changes.
+
+### Project Structure Notes
+
+- Follow the current repository shape documented in `_bmad-output/project-context.md` and `AGENTS.md`.
+- If implementation reveals a conflict between this story and the current code baseline, keep the smallest compatible change and update the story notes rather than silently drifting from the PRD.
+
+### References
+
+- `_bmad-output/planning-artifacts/epics.md` - source Epic 3 / Story 3.6 definition.
+- `_bmad-output/planning-artifacts/prd.md` - functional and non-functional requirements.
+- `_bmad-output/planning-artifacts/architecture.md` - target architecture, boundaries, and guardrails.
+- `_bmad-output/planning-artifacts/ux-design-specification.md` - UX expectations for user-facing stories.
+- `_bmad-output/planning-artifacts/implementation-readiness-report-2026-05-01.md` - readiness verdict and residual story-format concern.
+- `_bmad-output/project-context.md` - repository-specific implementation rules.
+
+## Dev Agent Record
+
+### Agent Model Used
+
+GPT-5.4
+
+### Debug Log References
+
+- `./.venv/bin/python -m unittest tests.test_services.test_report_service.ReportServiceTests.test_fetch_report_comparison_returns_findings_and_evidence_deltas tests.test_services.test_report_service.ReportServiceTests.test_fetch_report_comparison_is_stable_when_duplicate_finding_order_flips tests.test_ui.test_history_page.HistoryPageRenderingTests.test_public_report_route_shows_compare_button_and_diff_view tests.test_ui.test_history_page.HistoryPageRenderingTests.test_history_detail_route_shows_compare_button_and_diff_view -q` - failed as expected before implementation because persistent/changed-context buckets were missing.
+- `./.venv/bin/python -m unittest tests.test_services.test_report_service.ReportServiceTests.test_fetch_report_comparison_returns_findings_and_evidence_deltas tests.test_services.test_report_service.ReportServiceTests.test_fetch_report_comparison_is_stable_when_duplicate_finding_order_flips tests.test_ui.test_history_page.HistoryPageRenderingTests.test_public_report_route_shows_compare_button_and_diff_view tests.test_ui.test_history_page.HistoryPageRenderingTests.test_history_detail_route_shows_compare_button_and_diff_view -q` - passed, 4 tests.
+- `./.venv/bin/python -m unittest tests.test_services.test_report_service.ReportServiceTests.test_fetch_report_comparison_returns_findings_and_evidence_deltas tests.test_services.test_report_service.ReportServiceTests.test_fetch_report_comparison_preserves_duplicate_findings tests.test_services.test_report_service.ReportServiceTests.test_fetch_report_comparison_is_stable_when_duplicate_finding_order_flips tests.test_services.test_report_service.ReportServiceTests.test_fetch_shared_report_comparison_respects_filename_redaction tests.test_services.test_report_service.ReportServiceTests.test_fetch_shared_report_comparison_redacts_manifest_only_failed_files tests.test_services.test_report_service.ReportServiceTests.test_previous_scan_diffs_do_not_cross_project_boundaries -q` - passed, 6 tests.
+- `./.venv/bin/python -m unittest tests.test_services.test_report_service.ReportServiceTests.test_fetch_report_comparison_does_not_mispair_duplicate_title_category_findings tests.test_services.test_report_service.ReportServiceTests.test_fetch_report_comparison_ignores_guidance_reordering tests.test_services.test_report_service.ReportServiceTests.test_previous_scan_diffs_do_not_cross_workflow_contexts -q` - failed as expected before review fixes, covering all 3 reviewer findings.
+- `./.venv/bin/python -m unittest tests.test_services.test_report_service.ReportServiceTests.test_fetch_report_comparison_does_not_mispair_duplicate_title_category_findings tests.test_services.test_report_service.ReportServiceTests.test_fetch_report_comparison_ignores_guidance_reordering tests.test_services.test_report_service.ReportServiceTests.test_previous_scan_diffs_do_not_cross_workflow_contexts -q` - passed, 3 tests.
+- `./.venv/bin/python -m unittest tests.test_services.test_report_service.ReportServiceTests.test_fetch_report_comparison_returns_findings_and_evidence_deltas tests.test_services.test_report_service.ReportServiceTests.test_fetch_report_comparison_preserves_duplicate_findings tests.test_services.test_report_service.ReportServiceTests.test_fetch_report_comparison_is_stable_when_duplicate_finding_order_flips tests.test_services.test_report_service.ReportServiceTests.test_fetch_report_comparison_does_not_mispair_duplicate_title_category_findings tests.test_services.test_report_service.ReportServiceTests.test_fetch_report_comparison_ignores_guidance_reordering tests.test_services.test_report_service.ReportServiceTests.test_fetch_shared_report_comparison_respects_filename_redaction tests.test_services.test_report_service.ReportServiceTests.test_fetch_shared_report_comparison_redacts_manifest_only_failed_files tests.test_services.test_report_service.ReportServiceTests.test_previous_scan_diffs_do_not_cross_project_boundaries tests.test_services.test_report_service.ReportServiceTests.test_previous_scan_diffs_do_not_cross_workflow_contexts tests.test_services.test_report_service.ReportServiceTests.test_previous_scan_diffs_use_immediately_previous_comparable_report tests.test_services.test_report_service.ReportServiceTests.test_filtered_history_ignores_unreadable_off_page_reports_for_diffs tests.test_services.test_report_service.ReportServiceTests.test_previous_scan_diffs_compute_history_signature_once_per_report -q` - passed, 12 tests.
+- `./.venv/bin/python -m unittest tests.test_services.test_report_service.ReportServiceTests.test_fetch_report_comparison_matches_duplicate_same_description_by_evidence tests.test_services.test_report_service.ReportServiceTests.test_fetch_report_comparison_does_not_pair_singletons_without_identity tests.test_services.test_report_service.ReportServiceTests.test_previous_scan_diffs_normalize_workflow_contexts tests.test_services.test_report_service.ReportServiceTests.test_fetch_report_comparison_does_not_mispair_duplicate_title_category_findings tests.test_services.test_report_service.ReportServiceTests.test_previous_scan_diffs_do_not_cross_workflow_contexts -q` - passed, 5 tests.
+- `./.venv/bin/python -m unittest tests.test_services.test_report_service.ReportServiceTests.test_fetch_report_comparison_returns_findings_and_evidence_deltas tests.test_services.test_report_service.ReportServiceTests.test_fetch_report_comparison_preserves_duplicate_findings tests.test_services.test_report_service.ReportServiceTests.test_fetch_report_comparison_is_stable_when_duplicate_finding_order_flips tests.test_services.test_report_service.ReportServiceTests.test_fetch_report_comparison_does_not_mispair_duplicate_title_category_findings tests.test_services.test_report_service.ReportServiceTests.test_fetch_report_comparison_matches_duplicate_same_description_by_evidence tests.test_services.test_report_service.ReportServiceTests.test_fetch_report_comparison_does_not_pair_singletons_without_identity tests.test_services.test_report_service.ReportServiceTests.test_fetch_report_comparison_ignores_guidance_reordering tests.test_services.test_report_service.ReportServiceTests.test_fetch_shared_report_comparison_respects_filename_redaction tests.test_services.test_report_service.ReportServiceTests.test_fetch_shared_report_comparison_redacts_manifest_only_failed_files tests.test_services.test_report_service.ReportServiceTests.test_previous_scan_diffs_do_not_cross_project_boundaries tests.test_services.test_report_service.ReportServiceTests.test_previous_scan_diffs_do_not_cross_workflow_contexts tests.test_services.test_report_service.ReportServiceTests.test_previous_scan_diffs_normalize_workflow_contexts tests.test_services.test_report_service.ReportServiceTests.test_previous_scan_diffs_use_immediately_previous_comparable_report tests.test_services.test_report_service.ReportServiceTests.test_filtered_history_ignores_unreadable_off_page_reports_for_diffs tests.test_services.test_report_service.ReportServiceTests.test_previous_scan_diffs_compute_history_signature_once_per_report -q` - passed, 15 tests.
+- `./.venv/bin/python -m unittest tests.test_ui.test_history_page.HistoryPageRenderingTests -q` - passed, 22 tests.
+- `./.venv/bin/ruff check .` - passed.
+- `./.venv/bin/ruff format --check .` - passed, 271 files already formatted.
+- `./.venv/bin/python -m unittest discover -q` - passed, 400 tests, 1 skipped.
+- `./.venv/bin/bandit -r app.py services ui tests/e2e/seeded_server.py --severity-level high --confidence-level high -q` - passed with no high-confidence/high-severity findings.
+- `./.venv/bin/python -m pip_audit -r requirements.txt` - passed, no known vulnerabilities found.
+- `APP_PORT=18080 npm run test:ui-review` - failed once after the second review fix because the browser fixture used different evidence identity for its intended persistent finding; updated the fixture, then passed: 3 WebKit browser tests.
+- `bash scripts/ci-local.sh` - passed after final changes: lint/format/dependency checks, Bandit, parser fixtures, and 400 tests with 1 skipped.
+- `git diff --check` - passed.
+- VoiceOver validation intentionally not run per project directive.
+- `./.venv/bin/python -m unittest tests.test_services.test_report_service.ReportServiceTests.test_fetch_report_comparison_pairs_title_category_drift_by_evidence tests.test_services.test_report_service.ReportServiceTests.test_previous_scan_diffs_do_not_cross_trigger_ids tests.test_services.test_report_service.ReportServiceTests.test_previous_scan_diffs_normalize_workflow_contexts tests.test_services.test_report_service.ReportServiceTests.test_fetch_report_comparison_matches_duplicate_same_description_by_evidence tests.test_services.test_report_service.ReportServiceTests.test_fetch_report_comparison_does_not_pair_singletons_without_identity tests.test_services.test_report_service.ReportServiceTests.test_fetch_report_comparison_does_not_mispair_duplicate_title_category_findings tests.test_services.test_report_service.ReportServiceTests.test_previous_scan_diffs_do_not_cross_workflow_contexts -q` - passed, 7 tests.
+- `./.venv/bin/python -m unittest tests.test_services.test_report_service.ReportServiceTests.test_fetch_report_comparison_returns_findings_and_evidence_deltas tests.test_services.test_report_service.ReportServiceTests.test_fetch_report_comparison_preserves_duplicate_findings tests.test_services.test_report_service.ReportServiceTests.test_fetch_report_comparison_is_stable_when_duplicate_finding_order_flips tests.test_services.test_report_service.ReportServiceTests.test_fetch_report_comparison_does_not_mispair_duplicate_title_category_findings tests.test_services.test_report_service.ReportServiceTests.test_fetch_report_comparison_matches_duplicate_same_description_by_evidence tests.test_services.test_report_service.ReportServiceTests.test_fetch_report_comparison_pairs_title_category_drift_by_evidence tests.test_services.test_report_service.ReportServiceTests.test_fetch_report_comparison_does_not_pair_singletons_without_identity tests.test_services.test_report_service.ReportServiceTests.test_fetch_report_comparison_ignores_guidance_reordering tests.test_services.test_report_service.ReportServiceTests.test_fetch_shared_report_comparison_respects_filename_redaction tests.test_services.test_report_service.ReportServiceTests.test_fetch_shared_report_comparison_redacts_manifest_only_failed_files tests.test_services.test_report_service.ReportServiceTests.test_previous_scan_diffs_do_not_cross_project_boundaries tests.test_services.test_report_service.ReportServiceTests.test_previous_scan_diffs_do_not_cross_workflow_contexts tests.test_services.test_report_service.ReportServiceTests.test_previous_scan_diffs_do_not_cross_trigger_ids tests.test_services.test_report_service.ReportServiceTests.test_previous_scan_diffs_normalize_workflow_contexts tests.test_services.test_report_service.ReportServiceTests.test_previous_scan_diffs_use_immediately_previous_comparable_report tests.test_services.test_report_service.ReportServiceTests.test_filtered_history_ignores_unreadable_off_page_reports_for_diffs tests.test_services.test_report_service.ReportServiceTests.test_previous_scan_diffs_compute_history_signature_once_per_report -q` - passed, 17 tests.
+- `./.venv/bin/ruff check .` - passed after final review-rerun fixes.
+- `./.venv/bin/ruff format --check .` - passed after final review-rerun fixes, 271 files already formatted.
+- `./.venv/bin/python -m unittest discover -q` - passed after final review-rerun fixes, 400 tests with 1 skipped.
+- `./.venv/bin/bandit -r app.py services ui tests/e2e/seeded_server.py --severity-level high --confidence-level high -q` - passed after final review-rerun fixes with no high-confidence/high-severity findings.
+- `./.venv/bin/python -m pip_audit -r requirements.txt` - passed after final review-rerun fixes, no known vulnerabilities found.
+- `APP_PORT=18080 npm run test:ui-review` - passed after final review-rerun fixes: 3 WebKit browser tests.
+- `bash scripts/ci-local.sh` - passed after final review-rerun fixes: lint/format/dependency checks, Bandit, parser fixtures, and 400 tests with 1 skipped.
+- `git diff --check` - passed after final review-rerun fixes.
+- VoiceOver validation intentionally not run per project directive after final review-rerun fixes.
+- `./.venv/bin/python -m unittest tests.test_services.test_report_service.ReportServiceTests.test_fetch_report_comparison_uses_optimal_evidence_matching tests.test_services.test_report_service.ReportServiceTests.test_fetch_report_comparison_matches_duplicate_same_description_by_evidence tests.test_services.test_report_service.ReportServiceTests.test_fetch_report_comparison_pairs_title_category_drift_by_evidence tests.test_services.test_report_service.ReportServiceTests.test_fetch_report_comparison_ignores_unreadable_off_path_reports tests.test_services.test_report_service.ReportServiceTests.test_filtered_history_ignores_unreadable_off_page_reports_for_diffs tests.test_ui.test_history_page.HistoryPageRenderingTests.test_public_report_route_shows_compare_button_and_diff_view tests.test_ui.test_history_page.HistoryPageRenderingTests.test_history_detail_route_shows_compare_button_and_diff_view tests.test_ui.test_history_page.HistoryPageRenderingTests.test_public_report_route_blocks_compare_view_when_previous_report_is_protected tests.test_ui.test_history_page.HistoryPageRenderingTests.test_public_report_compare_allows_same_password_protected_reruns -q` - passed, 9 tests.
+- `./.venv/bin/python -m unittest tests.test_services.test_report_service.ReportServiceTests.test_fetch_report_comparison_returns_findings_and_evidence_deltas tests.test_services.test_report_service.ReportServiceTests.test_fetch_report_comparison_preserves_duplicate_findings tests.test_services.test_report_service.ReportServiceTests.test_fetch_report_comparison_is_stable_when_duplicate_finding_order_flips tests.test_services.test_report_service.ReportServiceTests.test_fetch_report_comparison_does_not_mispair_duplicate_title_category_findings tests.test_services.test_report_service.ReportServiceTests.test_fetch_report_comparison_matches_duplicate_same_description_by_evidence tests.test_services.test_report_service.ReportServiceTests.test_fetch_report_comparison_uses_optimal_evidence_matching tests.test_services.test_report_service.ReportServiceTests.test_fetch_report_comparison_pairs_title_category_drift_by_evidence tests.test_services.test_report_service.ReportServiceTests.test_fetch_report_comparison_does_not_pair_singletons_without_identity tests.test_services.test_report_service.ReportServiceTests.test_fetch_report_comparison_ignores_guidance_reordering tests.test_services.test_report_service.ReportServiceTests.test_fetch_shared_report_comparison_respects_filename_redaction tests.test_services.test_report_service.ReportServiceTests.test_fetch_shared_report_comparison_redacts_manifest_only_failed_files tests.test_services.test_report_service.ReportServiceTests.test_previous_scan_diffs_do_not_cross_project_boundaries tests.test_services.test_report_service.ReportServiceTests.test_previous_scan_diffs_do_not_cross_workflow_contexts tests.test_services.test_report_service.ReportServiceTests.test_previous_scan_diffs_do_not_cross_trigger_ids tests.test_services.test_report_service.ReportServiceTests.test_previous_scan_diffs_normalize_workflow_contexts tests.test_services.test_report_service.ReportServiceTests.test_previous_scan_diffs_use_immediately_previous_comparable_report tests.test_services.test_report_service.ReportServiceTests.test_filtered_history_ignores_unreadable_off_page_reports_for_diffs tests.test_services.test_report_service.ReportServiceTests.test_fetch_report_comparison_ignores_unreadable_off_path_reports tests.test_services.test_report_service.ReportServiceTests.test_previous_scan_diffs_compute_history_signature_once_per_report tests.test_ui.test_history_page.HistoryPageRenderingTests -q` - passed, 42 tests.
+- `./.venv/bin/ruff check .` - passed after reviewer finding fixes.
+- `./.venv/bin/ruff format --check .` - passed after reviewer finding fixes, 271 files already formatted.
+- `git diff --check` - passed after reviewer finding fixes.
+- `./.venv/bin/python -m unittest discover -q` - passed after reviewer finding fixes, 401 tests with 1 skipped.
+- `./.venv/bin/bandit -r app.py services ui tests/e2e/seeded_server.py --severity-level high --confidence-level high -q` - passed after reviewer finding fixes with no high-confidence/high-severity findings.
+- `./.venv/bin/python -m pip_audit -r requirements.txt` - passed after reviewer finding fixes, no known vulnerabilities found.
+- `APP_PORT=18080 npm run test:ui-review` - passed after reviewer finding fixes: 3 WebKit browser tests.
+- `bash scripts/ci-local.sh` - passed after reviewer finding fixes: lint/format/dependency checks, Bandit, parser fixtures, and 401 tests with 1 skipped.
+- VoiceOver validation intentionally not run per project directive after reviewer finding fixes.
+- `./.venv/bin/python -m unittest tests.test_services.test_report_service.ReportServiceTests.test_filtered_history_ignores_visible_unreadable_reports tests.test_services.test_report_service.ReportServiceTests.test_fetch_report_comparison_caps_dense_evidence_matching tests.test_ui.test_history_page.HistoryPageRenderingTests.test_public_report_route_shows_compare_button_and_diff_view tests.test_ui.test_history_page.HistoryPageRenderingTests.test_history_detail_route_shows_compare_button_and_diff_view -q` - failed once with an indentation error introduced during the helper extraction, then passed after correction: 4 tests.
+- `./.venv/bin/python -m unittest tests.test_api.test_analyses.AnalysesApiTests.test_list_analyses_rejects_newer_report_schema_versions tests.test_services.test_report_service.ReportServiceTests.test_fetch_report_comparison_ignores_unreadable_off_path_reports tests.test_services.test_report_service.ReportServiceTests.test_filtered_history_ignores_visible_unreadable_reports tests.test_services.test_report_service.ReportServiceTests.test_filtered_history_ignores_unreadable_off_page_reports_for_diffs -q` - passed, 4 tests.
+- Story 3.6 regression slice including API schema strictness, comparison matching, unreadable-history handling, and `HistoryPageRenderingTests` - passed, 45 tests.
+- `./.venv/bin/ruff check .` - passed after latest reviewer finding fixes.
+- `./.venv/bin/ruff format --check .` - passed after latest reviewer finding fixes, 271 files already formatted.
+- `git diff --check` - passed after latest reviewer finding fixes.
+- `./.venv/bin/python -m unittest discover -q` - failed once because the initial visible-row skip also softened the API list schema contract, then passed after narrowing the skip to history/previous-comparable flows: 401 tests with 1 skipped.
+- `./.venv/bin/bandit -r app.py services ui tests/e2e/seeded_server.py --severity-level high --confidence-level high -q` - passed after latest reviewer finding fixes with no high-confidence/high-severity findings.
+- `./.venv/bin/python -m pip_audit -r requirements.txt` - passed after latest reviewer finding fixes, no known vulnerabilities found.
+- `APP_PORT=18080 npm run test:ui-review` - passed after latest reviewer finding fixes: 3 WebKit browser tests.
+- `bash scripts/ci-local.sh` - passed after latest reviewer finding fixes: lint/format/dependency checks, Bandit, parser fixtures, and 401 tests with 1 skipped.
+- VoiceOver validation intentionally not run per project directive after latest reviewer finding fixes.
+- `bmad-code-review` rerun on Story 3.6 working-tree diff - clean review, all review findings remain checked and no new decision/patch/defer findings were added.
+- `./.venv/bin/python -m unittest tests.test_api.test_analyses.AnalysesApiTests.test_list_analyses_rejects_newer_report_schema_versions tests.test_services.test_report_service.ReportServiceTests.test_filtered_history_backfills_after_visible_unreadable_reports tests.test_services.test_report_service.ReportServiceTests.test_filtered_history_ignores_visible_unreadable_reports tests.test_services.test_report_service.ReportServiceTests.test_filtered_history_ignores_unreadable_off_page_reports_for_diffs tests.test_services.test_report_service.ReportServiceTests.test_fetch_report_comparison_ignores_unreadable_off_path_reports -q` - passed after final pagination reviewer fix, 5 tests.
+- Story 3.6 regression slice including API schema strictness, comparison matching, unreadable-history pagination/backfill handling, and `HistoryPageRenderingTests` - passed after final pagination reviewer fix, 46 tests.
+- `./.venv/bin/ruff check .` - passed after final pagination reviewer fix.
+- `./.venv/bin/ruff format --check .` - passed after final pagination reviewer fix, 271 files already formatted.
+- `git diff --check` - passed after final pagination reviewer fix.
+- `./.venv/bin/python -m unittest discover -q` - passed after final pagination reviewer fix, 401 tests with 1 skipped.
+- `./.venv/bin/bandit -r app.py services ui tests/e2e/seeded_server.py --severity-level high --confidence-level high -q` - passed after final pagination reviewer fix with no high-confidence/high-severity findings.
+- `./.venv/bin/python -m pip_audit -r requirements.txt` - passed after final pagination reviewer fix, no known vulnerabilities found. Initial sandbox run failed due DNS/network isolation, then the same command passed with network access.
+- `APP_PORT=18080 npm run test:ui-review` - passed after final pagination reviewer fix: 3 WebKit browser tests.
+- `bash scripts/ci-local.sh` - passed after final pagination reviewer fix: lint/format/dependency checks, Bandit, parser fixtures, and 401 tests with 1 skipped.
+- VoiceOver validation intentionally not run per project directive after final pagination reviewer fix.
+- `./.venv/bin/python -m unittest tests.test_services.test_report_service.ReportServiceTests.test_previous_scan_diffs_match_legacy_blank_workflow_context tests.test_services.test_report_service.ReportServiceTests.test_previous_scan_diffs_do_not_cross_trigger_ids tests.test_services.test_report_service.ReportServiceTests.test_filtered_history_skip_unreadable_keeps_database_pagination tests.test_services.test_report_service.ReportServiceTests.test_filtered_history_backfills_after_visible_unreadable_reports tests.test_services.test_report_service.ReportServiceTests.test_fetch_report_comparison_caps_dense_evidence_matching tests.test_services.test_report_service.ReportServiceTests.test_evidence_identity_counts_preserve_repeated_identities tests.test_ui.test_history_page.HistoryPageRenderingTests.test_public_report_route_shows_compare_button_and_diff_view tests.test_ui.test_history_page.HistoryPageRenderingTests.test_history_detail_route_shows_compare_button_and_diff_view -q` - passed after final reviewer finding fixes, 8 tests.
+- Story 3.6 regression slice including API schema strictness, comparison matching, unreadable-history pagination/backfill handling, dense evidence matching, legacy workflow provenance, and `HistoryPageRenderingTests` - passed after final reviewer finding fixes, 49 tests.
+- `./.venv/bin/ruff check .` - passed after final reviewer finding fixes.
+- `./.venv/bin/ruff format --check .` - passed after final reviewer finding fixes, 271 files already formatted.
+- `git diff --check` - passed after final reviewer finding fixes.
+- `./.venv/bin/python -m unittest discover -q` - passed after final reviewer finding fixes, 401 tests with 1 skipped.
+- `./.venv/bin/bandit -r app.py services ui tests/e2e/seeded_server.py --severity-level high --confidence-level high -q` - passed after final reviewer finding fixes with no high-confidence/high-severity findings.
+- `./.venv/bin/python -m pip_audit -r requirements.txt` - passed after final reviewer finding fixes, no known vulnerabilities found.
+- `APP_PORT=18080 npm run test:ui-review` - passed after final reviewer finding fixes: 3 WebKit browser tests.
+- `bash scripts/ci-local.sh` - passed after final reviewer finding fixes: lint/format/dependency checks, Bandit, parser fixtures, and 401 tests with 1 skipped.
+- VoiceOver validation intentionally not run per project directive after final reviewer finding fixes.
+- `./.venv/bin/python -m unittest tests.test_services.test_report_service.ReportServiceTests.test_fetch_report_comparison_does_not_pair_different_findings_on_same_evidence tests.test_services.test_report_service.ReportServiceTests.test_previous_scan_diffs_prefer_exact_context_over_legacy_blank tests.test_services.test_report_service.ReportServiceTests.test_previous_scan_diffs_do_not_treat_partial_context_as_wildcard tests.test_services.test_report_service.ReportServiceTests.test_filtered_history_includes_legacy_blank_schema_reports tests.test_services.test_report_service.ReportServiceTests.test_fetch_report_comparison_uses_legacy_blank_schema_previous_report -q` - passed after latest reviewer finding fixes, alongside related matching/schema regressions: 8 tests.
+- Story 3.6 regression slice including API schema strictness, comparison matching, unreadable-history handling, legacy blank schema compatibility, and `HistoryPageRenderingTests` - passed after latest reviewer finding fixes, 54 tests.
+- `./.venv/bin/ruff check .` - passed after latest reviewer finding fixes.
+- `./.venv/bin/ruff format --check .` - passed after latest reviewer finding fixes, 271 files already formatted.
+- `git diff --check` - passed after latest reviewer finding fixes.
+- `./.venv/bin/python -m unittest discover -q` - passed after latest reviewer finding fixes, 401 tests with 1 skipped.
+- `./.venv/bin/bandit -r app.py services ui tests/e2e/seeded_server.py --severity-level high --confidence-level high -q` - passed after latest reviewer finding fixes with no high-confidence/high-severity findings.
+- `./.venv/bin/python -m pip_audit -r requirements.txt` - passed after latest reviewer finding fixes, no known vulnerabilities found.
+- `APP_PORT=18080 npm run test:ui-review` - passed after latest reviewer finding fixes: 3 WebKit browser tests.
+- `bash scripts/ci-local.sh` - passed after latest reviewer finding fixes: lint/format/dependency checks, Bandit, parser fixtures, and 401 tests with 1 skipped.
+- VoiceOver validation intentionally not run per project directive after latest reviewer finding fixes.
+
+### Completion Notes List
+
+- Added first-class persistent and changed-context finding buckets to persisted report comparisons while preserving existing new, resolved, severity-changed, and evidence delta outputs.
+- Changed persistent finding matching to tolerate description changes and classify description, evidence, confidence, explanation, guidance, evidence classification, uncertainty, and skill context changes as changed context.
+- Rendered `Persistent findings` and `Changed context` sections in NiceGUI history comparison and shared report HTML, including empty states and shared-report redaction coverage for the new buckets.
+- Updated regression coverage for service comparisons, duplicate finding stability, redaction, history rendering, and browser review flow.
+- Updated README report-history/shared-report documentation for persistent and changed-context diffs.
+- Fixed reviewer findings by pairing duplicate title/category findings with evidence identity when descriptions differ, normalizing guidance ordering before context comparison, and requiring comparable reports to match project, workspace, workflow context, and artifact signature.
+- Fixed second reviewer-rerun findings by making evidence identity the first persistent-finding match, restricting description fallback to descriptions unique in both reports, removing unsafe singleton fallback pairing, and normalizing workflow context case/whitespace.
+- Fixed final review-rerun findings by treating trigger ID as part of the normalized workflow context and pairing title/category drift through evidence identity so it surfaces as changed context instead of removed plus added.
+- Fixed latest reviewer findings by requiring a separate previous-report unlock for protected shared comparisons, using resolved terminology in reviewer-facing comparison copy, replacing greedy evidence-overlap matching with optimal one-to-one pairing, and skipping unreadable off-path report candidates during auto-compare.
+- Fixed latest reviewer-rerun findings by skipping unreadable visible history rows only in UI/history comparison flows, bounding dense evidence matching with deterministic greedy fallback, and using New findings terminology in reviewer-facing current-side comparison copy while preserving API schema strictness.
+- Fixed final pagination reviewer finding by filtering unreadable schema rows before UI history pagination/backfill while preserving default API schema strictness.
+- Fixed final Story 3.6 reviewer findings by adding legacy blank workflow-context compatibility, restoring DB-backed skip-unreadable pagination, surfacing dense-match approximation warnings, preserving repeated evidence identity counts, and updating comparison copy to project/workspace/workflow scoped language.
+- Fixed latest reviewer findings by ranking exact workflow-context matches ahead of blank legacy fallback, preserving blank legacy `v1` schema reports under skip-unreadable filters, and blocking evidence-only pairing when the same resource carries a different finding.
+- Re-ran `bmad-code-review` after the latest fixes; no new findings were raised.
+
+### File List
+
+- `README.md`
+- `_bmad-output/implementation-artifacts/3-6-report-diff-after-rerun.md`
+- `_bmad-output/implementation-artifacts/sprint-status.yaml`
+- `app.py`
+- `models/repositories/analysis_reports.py`
+- `services/report_service.py`
+- `tests/e2e/report_review.keyboard.spec.js`
+- `tests/e2e/seeded_server.py`
+- `tests/test_services/test_report_service.py`
+- `tests/test_ui/test_history_page.py`
+- `ui/routes/history.py`
+
+## Change Log
+
+- 2026-05-01: Story created/aligned from updated PRD, architecture, epics, sprint status, and readiness report.
+- 2026-05-19: Implemented report comparison persistent and changed-context finding buckets across service, history UI, shared report HTML, tests, and README.
+- 2026-05-19: Fixed Story 3.6 code-review findings for duplicate pairing, guidance ordering, and workflow-context comparison isolation.
+- 2026-05-19: Fixed Story 3.6 review-rerun findings for same-description duplicate pairing, singleton no-identity pairing, normalized workflow context, and browser fixture persistence identity.
+- 2026-05-19: Fixed Story 3.6 final review-rerun findings for trigger ID workflow scoping and title/category drift changed-context classification.
+- 2026-05-19: Fixed Story 3.6 reviewer findings for protected shared comparison auth, resolved wording, optimal evidence matching, and unreadable candidate skipping.
+- 2026-05-20: Fixed Story 3.6 review-rerun findings for visible unreadable history rows, bounded dense evidence matching, and new/resolved reviewer vocabulary.
+- 2026-05-20: Fixed Story 3.6 reviewer finding for unreadable schema rows hiding readable reports during UI history pagination.
+- 2026-05-20: Fixed Story 3.6 reviewer findings for legacy workflow provenance, skip-unreadable pagination, dense evidence matching warnings, repeated evidence identity scoring, and scoped comparison copy.
+- 2026-05-20: Fixed Story 3.6 reviewer findings for workflow-context match ranking, legacy blank schema filtering, and evidence-only different-finding pairing.
+- 2026-05-20: Re-ran Story 3.6 code review clean and moved the story to done.

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -1,5 +1,5 @@
 # generated: 2026-05-01
-# last_updated: 2026-05-19
+# last_updated: 2026-05-20
 # project: deploywhisper
 # project_key: NOKEY
 # tracking_system: file-system
@@ -35,7 +35,7 @@
 # - Dev moves story to review, then runs code-review
 
 generated: 2026-05-01
-last_updated: 2026-05-19
+last_updated: 2026-05-20
 project: deploywhisper
 project_key: NOKEY
 tracking_system: file-system
@@ -76,7 +76,7 @@ development_status:
   3-3-evidence-inspector-panel: done
   3-4-confidence-ledger-and-why-not-lower-higher: done
   3-5-context-completeness-and-todo-panel: done
-  3-6-report-diff-after-rerun: ready-for-dev
+  3-6-report-diff-after-rerun: done
   3-7-keyboard-and-accessibility-review-pass: ready-for-dev
   3-8-historical-report-search-and-filtering: ready-for-dev
   epic-3-retrospective: optional

--- a/app.py
+++ b/app.py
@@ -44,6 +44,7 @@ from services.confidence_ledger import (
 )
 from services.report_service import (
     fetch_analysis_report,
+    fetch_previous_comparable_report,
     fetch_shared_analysis_report,
     fetch_shared_report_comparison,
 )
@@ -207,11 +208,29 @@ def skill_manifest_schema_document() -> JSONResponse:
     )
 
 
-def _shared_report_prompt_html(report_id: int, *, invalid_password: bool) -> str:
+def _safe_report_redirect(value: str | None, *, fallback_report_id: int) -> str:
+    target = str(value or "").strip()
+    if target.startswith("/reports/") and not target.startswith("//"):
+        return target
+    return f"/reports/{fallback_report_id}"
+
+
+def _shared_report_prompt_html(
+    report_id: int,
+    *,
+    invalid_password: bool,
+    message: str | None = None,
+    return_to: str | None = None,
+) -> str:
     message = (
         "Incorrect password. Try again."
         if invalid_password
-        else "This shared report requires a password."
+        else message or "This shared report requires a password."
+    )
+    return_to_field = (
+        f"<input type='hidden' name='next' value='{escape(return_to, quote=True)}' />"
+        if return_to
+        else ""
     )
     return (
         "<!doctype html><html><head><meta charset='utf-8'>"
@@ -230,6 +249,7 @@ def _shared_report_prompt_html(report_id: int, *, invalid_password: bool) -> str
         "<h1>Shared DeployWhisper report</h1>"
         f"<p class='{'error' if invalid_password else ''}'>{escape(message)}</p>"
         f"<form method='post' action='/reports/{report_id}/unlock'>"
+        f"{return_to_field}"
         "<label for='password'>Password required</label>"
         "<input id='password' name='password' type='password' autocomplete='current-password' />"
         "<button type='submit'>Open shared report</button>"
@@ -424,12 +444,16 @@ def _shared_report_comparison_html(
         if score_delta < 0
         else "delta-flat"
     )
+    warning_html = "".join(
+        f"<p class='diff-meta'><strong>Comparison warning:</strong> {escape(str(warning))}</p>"
+        for warning in (comparison.get("summary", {}).get("warnings") or [])
+    )
     comparison_section = (
         "<section class='panel' id='report-comparison'>"
         "<div class='comparison-header'>"
         "<div>"
         f"<div class='eyebrow'>Comparison</div><h2>Comparison with report #{int(comparison['previous_report']['id'])}</h2>"
-        "<p>Side-by-side changes against the previous scan of the same analyzed artifacts.</p>"
+        "<p>Side-by-side changes against the previous comparable report in the same project, workspace, and workflow context.</p>"
         "</div>"
         "<div class='delta-card'>"
         "<div class='delta-label'>Risk score delta</div>"
@@ -437,31 +461,36 @@ def _shared_report_comparison_html(
         f"<div class='delta-meta'>{int(comparison['previous_report']['risk_score'])} → {int(comparison['current_report']['risk_score'])}</div>"
         "</div>"
         "</div>"
+        f"{warning_html}"
         "<div class='comparison-grid'>"
         "<section class='comparison-column'>"
         "<h3>Previous report</h3>"
         f"<p class='diff-meta'>Report #{int(comparison['previous_report']['id'])} · {escape(str(comparison['previous_report']['severity']).upper())} · {escape(str(comparison['previous_report']['recommendation']).upper())}</p>"
         "<p class='diff-meta'><strong>Topology freshness</strong></p>"
         f"<p class='diff-meta'>{escape(previous_freshness_age)} <span class='diff-chip'>{escape(previous_freshness_badge)}</span></p>"
-        "<h4>Findings removed</h4>"
-        f"{_shared_report_diff_list(comparison['findings']['removed'], empty_message='No findings were removed.')}"
-        "<h4>Evidence removed</h4>"
-        f"{_shared_report_diff_list(comparison['evidence']['removed'], empty_message='No evidence was removed.', include_severity=False)}"
+        "<h4>Resolved findings</h4>"
+        f"{_shared_report_diff_list(comparison['findings']['removed'], empty_message='No resolved findings were found.')}"
+        "<h4>Evidence resolved</h4>"
+        f"{_shared_report_diff_list(comparison['evidence']['removed'], empty_message='No evidence was resolved.', include_severity=False)}"
         "</section>"
         "<section class='comparison-column'>"
         "<h3>Current report</h3>"
         f"<p class='diff-meta'>Report #{int(comparison['current_report']['id'])} · {escape(str(comparison['current_report']['severity']).upper())} · {escape(str(comparison['current_report']['recommendation']).upper())}</p>"
         "<p class='diff-meta'><strong>Topology freshness</strong></p>"
         f"<p class='diff-meta'>{escape(current_freshness_age)} <span class='diff-chip'>{escape(current_freshness_badge)}</span></p>"
-        "<h4>Findings added</h4>"
-        f"{_shared_report_diff_list(comparison['findings']['added'], empty_message='No findings were added.')}"
+        "<h4>New findings</h4>"
+        f"{_shared_report_diff_list(comparison['findings']['added'], empty_message='No new findings were found.')}"
         "<h4>Evidence added</h4>"
         f"{_shared_report_diff_list(comparison['evidence']['added'], empty_message='No evidence was added.', include_severity=False)}"
         "</section>"
         "</div>"
         "<section class='comparison-severity'>"
+        "<h3>Persistent findings</h3>"
+        f"{_shared_report_diff_list(comparison['findings']['persistent'], empty_message='No findings persisted across both reports.')}"
         "<h3>Severity changes</h3>"
         f"{_shared_report_severity_change_list(comparison['findings']['severity_changed'])}"
+        "<h3>Changed context</h3>"
+        f"{_shared_report_diff_list(comparison['findings']['context_changed'], empty_message='No persistent findings changed evidence or context.')}"
         "</section>"
         "</section>"
     )
@@ -606,6 +635,11 @@ def shared_report_view(
             content=_shared_report_prompt_html(
                 report_id,
                 invalid_password=False,
+                return_to=(
+                    f"/reports/{report_id}?compare=previous#report-comparison"
+                    if compare == "previous"
+                    else None
+                ),
             )
         )
     shared_report = fetch_shared_analysis_report(
@@ -616,9 +650,33 @@ def shared_report_view(
         raise StarletteHTTPException(status_code=404, detail="Report not found")
     comparison = None
     if compare == "previous":
+        previous_report = fetch_previous_comparable_report(report_id)
+        previous_password_required = bool(
+            previous_report and previous_report.get("share_password_hash")
+        )
+        if previous_password_required and not _has_valid_share_cookie(
+            previous_report,
+            request,
+        ):
+            return HTMLResponse(
+                content=_shared_report_prompt_html(
+                    int(previous_report["id"]),
+                    invalid_password=False,
+                    message=(
+                        "The previous shared report requires a password before "
+                        "comparison."
+                    ),
+                    return_to=f"/reports/{report_id}?compare=previous#report-comparison",
+                )
+            )
+        previous_access_granted = previous_report is not None and (
+            not previous_password_required
+            or _has_valid_share_cookie(previous_report, request)
+        )
         comparison = fetch_shared_report_comparison(
             report_id,
             bypass_password=password_required,
+            previous_bypass_password=previous_access_granted,
         )
     return HTMLResponse(
         content=_shared_report_html(
@@ -630,23 +688,34 @@ def shared_report_view(
 
 
 @fastapi_app.post("/reports/{report_id}/unlock", include_in_schema=False)
-def unlock_shared_report(report_id: int, password: str = Form(...)) -> RedirectResponse:
+def unlock_shared_report(
+    report_id: int,
+    password: str = Form(...),
+    next: str | None = Form(None),
+) -> RedirectResponse:
     """Validate a shared-report password and issue an HttpOnly access cookie."""
     shared_report = fetch_shared_analysis_report(report_id, password=password)
     if shared_report is None:
         return HTMLResponse(
-            content=_shared_report_prompt_html(report_id, invalid_password=True),
+            content=_shared_report_prompt_html(
+                report_id,
+                invalid_password=True,
+                return_to=_safe_report_redirect(next, fallback_report_id=report_id),
+            ),
             status_code=401,
         )
     report = fetch_analysis_report(report_id)
     if report is None:
         raise StarletteHTTPException(status_code=404, detail="Report not found")
-    response = RedirectResponse(url=f"/reports/{report_id}", status_code=303)
+    response = RedirectResponse(
+        url=_safe_report_redirect(next, fallback_report_id=report_id),
+        status_code=303,
+    )
     response.set_cookie(
         _share_cookie_name(report_id),
         _share_cookie_value(report),
         httponly=True,
-        path=f"/reports/{report_id}",
+        path="/reports",
         secure=_share_cookie_secure(shared_report),
         samesite="lax",
     )

--- a/models/repositories/analysis_reports.py
+++ b/models/repositories/analysis_reports.py
@@ -6,9 +6,10 @@ import json
 import math
 import re
 from datetime import UTC, datetime, timedelta
+from collections.abc import Sequence
 from typing import Any
 
-from sqlalchemy import func, select
+from sqlalchemy import func, or_, select
 from sqlalchemy.orm import Session, selectinload
 
 from evidence.models import EvidenceItem as EvidenceItemPayload
@@ -570,6 +571,7 @@ def list_analysis_reports(
     severity: str | None = None,
     recommendation: str | None = None,
     search: str | None = None,
+    report_schema_versions: Sequence[str] | None = None,
     limit: int | None = None,
     offset: int | None = None,
     include_evidence: bool = False,
@@ -594,6 +596,16 @@ def list_analysis_reports(
             | AnalysisReport.narrative_opening.ilike(like)
             | AnalysisReport.parse_summary.ilike(like)
         )
+    if report_schema_versions is not None:
+        schema_versions = tuple(report_schema_versions)
+        schema_predicate = AnalysisReport.report_schema_version.in_(schema_versions)
+        if "v1" in schema_versions:
+            schema_predicate = or_(
+                schema_predicate,
+                AnalysisReport.report_schema_version.is_(None),
+                AnalysisReport.report_schema_version == "",
+            )
+        stmt = stmt.where(schema_predicate)
     if offset:
         stmt = stmt.offset(offset)
     if limit is not None:
@@ -610,6 +622,7 @@ def count_analysis_reports(
     severity: str | None = None,
     recommendation: str | None = None,
     search: str | None = None,
+    report_schema_versions: Sequence[str] | None = None,
 ) -> int:
     stmt = select(func.count()).select_from(AnalysisReport)
     if project_id is not None:
@@ -627,6 +640,16 @@ def count_analysis_reports(
             | AnalysisReport.narrative_opening.ilike(like)
             | AnalysisReport.parse_summary.ilike(like)
         )
+    if report_schema_versions is not None:
+        schema_versions = tuple(report_schema_versions)
+        schema_predicate = AnalysisReport.report_schema_version.in_(schema_versions)
+        if "v1" in schema_versions:
+            schema_predicate = or_(
+                schema_predicate,
+                AnalysisReport.report_schema_version.is_(None),
+                AnalysisReport.report_schema_version == "",
+            )
+        stmt = stmt.where(schema_predicate)
     return int(session.execute(stmt).scalar_one())
 
 

--- a/services/report_service.py
+++ b/services/report_service.py
@@ -13,6 +13,7 @@ import re
 import unicodedata
 from datetime import UTC, datetime
 from collections import Counter, defaultdict
+from functools import lru_cache
 from urllib.parse import urlsplit
 from typing import Any
 
@@ -76,6 +77,7 @@ _SUBMISSION_MANIFEST_INFERRED_WARNING = (
 )
 _AMBIGUOUS_ARTIFACT_REPLACEMENT = "Artifact file"
 _NON_VISIBLE_NARRATIVE_CATEGORIES = {"Cc", "Cf", "Mc", "Me", "Mn"}
+_EVIDENCE_MATCHING_EXACT_COMPONENT_LIMIT = 8
 _EXTENSIONLESS_FILE_BASENAMES = {
     "Brewfile",
     "BUILD",
@@ -802,13 +804,74 @@ def _comparison_signatures_match(
 
 def _history_signature(
     report: dict[str, Any],
-) -> tuple[int, int, tuple[ComparisonArtifact, ...]] | None:
+) -> tuple[int, int, tuple[str, str, str], tuple[ComparisonArtifact, ...]] | None:
     artifact_signature = _comparison_artifact_signature(report)
     if not artifact_signature:
         return None
     project_id = int(report.get("project", {}).get("id") or 0)
     workspace_id = int((report.get("workspace") or {}).get("id") or 0)
-    return (project_id, workspace_id, artifact_signature)
+    return (
+        project_id,
+        workspace_id,
+        _comparison_workflow_context(report),
+        artifact_signature,
+    )
+
+
+def _comparison_workflow_context(report: dict[str, Any]) -> tuple[str, str, str]:
+    audit = report.get("audit") or {}
+    return (
+        _normalize_free_text(audit.get("source_interface")),
+        _normalize_free_text(audit.get("trigger_type")),
+        _normalize_free_text(audit.get("trigger_id")),
+    )
+
+
+def _workflow_contexts_match(
+    left: tuple[str, str, str],
+    right: tuple[str, str, str],
+) -> bool:
+    return _workflow_context_match_rank(left, right) > 0
+
+
+def _workflow_context_is_blank(context: tuple[str, str, str]) -> bool:
+    return all(not part for part in context)
+
+
+def _workflow_context_match_rank(
+    previous_context: tuple[str, str, str],
+    current_context: tuple[str, str, str],
+) -> int:
+    if previous_context == current_context:
+        return 2
+    if _workflow_context_is_blank(previous_context) and not _workflow_context_is_blank(
+        current_context
+    ):
+        return 1
+    return 0
+
+
+def _reports_are_comparable(
+    current_report: dict[str, Any],
+    previous_report: dict[str, Any],
+) -> bool:
+    current_signature = _comparison_artifact_signature(current_report)
+    if not current_signature:
+        return False
+    return (
+        int(previous_report.get("project", {}).get("id") or 0)
+        == int(current_report.get("project", {}).get("id") or 0)
+        and int((previous_report.get("workspace") or {}).get("id") or 0)
+        == int((current_report.get("workspace") or {}).get("id") or 0)
+        and _workflow_contexts_match(
+            _comparison_workflow_context(previous_report),
+            _comparison_workflow_context(current_report),
+        )
+        and _comparison_signatures_match(
+            _comparison_artifact_signature(previous_report),
+            current_signature,
+        )
+    )
 
 
 def _normalize_free_text(value: Any) -> str:
@@ -825,7 +888,6 @@ def _finding_fingerprint(finding: dict[str, Any]) -> str:
         [
             _normalize_free_text(finding.get("category")),
             _normalize_finding_text(finding.get("title")),
-            _normalize_finding_text(finding.get("description")),
         ]
     )
 
@@ -849,6 +911,37 @@ def _evidence_fingerprint(evidence_item: dict[str, Any]) -> str:
             _normalize_free_text(evidence_item.get("severity_hint")),
             related_change_ids,
         ]
+    )
+
+
+def _evidence_identity_fingerprint(evidence_item: dict[str, Any]) -> str:
+    related_change_ids = ",".join(
+        sorted(
+            str(change_id)
+            for change_id in evidence_item.get("related_change_ids") or []
+        )
+    )
+    return "|".join(
+        [
+            _normalize_free_text(evidence_item.get("source_type")),
+            _normalize_free_text(evidence_item.get("source_ref")),
+            _normalize_free_text(evidence_item.get("artifact")),
+            _normalize_free_text(evidence_item.get("location")),
+            _normalize_free_text(evidence_item.get("resource")),
+            _normalize_free_text(evidence_item.get("operation")),
+            related_change_ids,
+        ]
+    )
+
+
+def _evidence_identity_counts(evidence_items: list[dict[str, Any]]) -> Counter[str]:
+    return Counter(
+        fingerprint
+        for fingerprint in (
+            _evidence_identity_fingerprint(evidence_item)
+            for evidence_item in evidence_items
+        )
+        if fingerprint.strip("|")
     )
 
 
@@ -879,6 +972,26 @@ def _comparison_finding_summary(
     }
 
 
+def _comparison_persistent_finding_summary(
+    previous_finding: dict[str, Any],
+    current_finding: dict[str, Any],
+    *,
+    previous_evidence_items: list[dict[str, Any]],
+    current_evidence_items: list[dict[str, Any]],
+) -> dict[str, Any]:
+    summary = _comparison_finding_summary(
+        current_finding,
+        evidence_items=current_evidence_items,
+    )
+    return {
+        **summary,
+        "previous_severity": str(previous_finding.get("severity") or "unknown"),
+        "current_severity": str(current_finding.get("severity") or "unknown"),
+        "previous_evidence_count": len(previous_evidence_items),
+        "current_evidence_count": len(current_evidence_items),
+    }
+
+
 def _comparison_evidence_summary(
     evidence_item: dict[str, Any],
     *,
@@ -903,6 +1016,7 @@ def _comparison_finding_sort_key(
     )
     return (
         evidence_key,
+        _normalize_finding_text(finding.get("description")),
         str(finding.get("severity") or "unknown"),
         f"{float(finding.get('confidence') or 0.0):.6f}",
         str(finding.get("explanation") or ""),
@@ -911,6 +1025,446 @@ def _comparison_finding_sort_key(
         str(finding.get("uncertainty_note") or ""),
         str(finding.get("skill_id") or ""),
     )
+
+
+def _normalized_guidance_items(finding: dict[str, Any]) -> tuple[str, ...]:
+    return tuple(
+        sorted(
+            _normalize_free_text(item)
+            for item in (finding.get("guidance") or [])
+            if _normalize_free_text(item)
+        )
+    )
+
+
+def _comparison_finding_context_snapshot(
+    finding: dict[str, Any],
+    evidence_items: list[dict[str, Any]],
+) -> dict[str, Any]:
+    return {
+        "title": _normalize_finding_text(finding.get("title")),
+        "category": _normalize_free_text(finding.get("category")),
+        "evidence": tuple(
+            sorted(
+                _evidence_fingerprint(evidence_item) for evidence_item in evidence_items
+            )
+        ),
+        "description": _normalize_finding_text(finding.get("description")),
+        "confidence": f"{float(finding.get('confidence') or 0.0):.6f}",
+        "explanation": str(finding.get("explanation") or ""),
+        "guidance": _normalized_guidance_items(finding),
+        "evidence_classification": str(finding.get("evidence_classification") or ""),
+        "uncertainty_note": str(finding.get("uncertainty_note") or ""),
+        "skill_id": str(finding.get("skill_id") or ""),
+    }
+
+
+def _comparison_context_change_labels(
+    previous_finding: dict[str, Any],
+    current_finding: dict[str, Any],
+    *,
+    previous_evidence_items: list[dict[str, Any]],
+    current_evidence_items: list[dict[str, Any]],
+) -> list[str]:
+    previous = _comparison_finding_context_snapshot(
+        previous_finding,
+        previous_evidence_items,
+    )
+    current = _comparison_finding_context_snapshot(
+        current_finding,
+        current_evidence_items,
+    )
+    labels = {
+        "title": "Title changed",
+        "category": "Category changed",
+        "evidence": "Evidence changed",
+        "description": "Description changed",
+        "confidence": "Confidence changed",
+        "explanation": "Explanation changed",
+        "guidance": "Guidance changed",
+        "evidence_classification": "Evidence classification changed",
+        "uncertainty_note": "Uncertainty changed",
+        "skill_id": "Skill context changed",
+    }
+    return [label for key, label in labels.items() if previous[key] != current[key]]
+
+
+def _description_match_key(finding: dict[str, Any]) -> str:
+    return _normalize_finding_text(finding.get("description"))
+
+
+def _comparison_evidence_for_finding(
+    evidence_by_finding: dict[str, list[dict[str, Any]]],
+    finding: dict[str, Any],
+) -> list[dict[str, Any]]:
+    return evidence_by_finding.get(str(finding.get("finding_id") or ""), [])
+
+
+def _select_greedy_evidence_candidate_pairs(
+    component_candidates: dict[
+        int,
+        list[
+            tuple[
+                int,
+                tuple[int, int, int],
+                tuple[Any, ...],
+                dict[str, Any],
+                dict[str, Any],
+            ]
+        ],
+    ],
+    previous_positions: tuple[int, ...],
+) -> list[tuple[dict[str, Any], dict[str, Any]]]:
+    candidates = [
+        (
+            score,
+            tie_key,
+            previous_position,
+            current_position,
+            previous_finding,
+            current_finding,
+        )
+        for previous_position in previous_positions
+        for (
+            current_position,
+            score,
+            tie_key,
+            previous_finding,
+            current_finding,
+        ) in component_candidates.get(previous_position, [])
+    ]
+    selected_pairs: list[tuple[dict[str, Any], dict[str, Any]]] = []
+    used_previous: set[int] = set()
+    used_current: set[int] = set()
+    for (
+        score,
+        tie_key,
+        previous_position,
+        current_position,
+        previous_finding,
+        current_finding,
+    ) in sorted(
+        candidates,
+        key=lambda item: (
+            -item[0][0],
+            -item[0][1],
+            -item[0][2],
+            item[1],
+            item[2],
+            item[3],
+        ),
+    ):
+        if previous_position in used_previous or current_position in used_current:
+            continue
+        used_previous.add(previous_position)
+        used_current.add(current_position)
+        selected_pairs.append((previous_finding, current_finding))
+    return selected_pairs
+
+
+def _select_evidence_candidate_pairs(
+    evidence_candidates: list[
+        tuple[int, bool, tuple[Any, ...], dict[str, Any], dict[str, Any]]
+    ],
+    previous_group: list[dict[str, Any]],
+    current_group: list[dict[str, Any]],
+) -> tuple[list[tuple[dict[str, Any], dict[str, Any]]], bool]:
+    previous_index = {
+        id(finding): index for index, finding in enumerate(previous_group)
+    }
+    current_index = {id(finding): index for index, finding in enumerate(current_group)}
+    candidates_by_pair: dict[
+        tuple[int, int],
+        tuple[tuple[int, int, int], tuple[Any, ...], dict[str, Any], dict[str, Any]],
+    ] = {}
+    previous_edges: dict[int, set[int]] = defaultdict(set)
+    current_edges: dict[int, set[int]] = defaultdict(set)
+    approximate_matching_used = False
+    for (
+        overlap,
+        same_description,
+        tie_key,
+        previous_finding,
+        current_finding,
+    ) in evidence_candidates:
+        previous_position = previous_index[id(previous_finding)]
+        current_position = current_index[id(current_finding)]
+        score = (1, overlap, 1 if same_description else 0)
+        pair_key = (previous_position, current_position)
+        existing = candidates_by_pair.get(pair_key)
+        if (
+            existing is None
+            or score > existing[0]
+            or (score == existing[0] and tie_key < existing[1])
+        ):
+            candidates_by_pair[pair_key] = (
+                score,
+                tie_key,
+                previous_finding,
+                current_finding,
+            )
+        previous_edges[previous_position].add(current_position)
+        current_edges[current_position].add(previous_position)
+
+    selected_pairs: list[tuple[dict[str, Any], dict[str, Any]]] = []
+    unseen_previous = set(previous_edges)
+    while unseen_previous:
+        start = min(unseen_previous)
+        stack = [start]
+        component_previous: set[int] = set()
+        component_current: set[int] = set()
+        while stack:
+            previous_position = stack.pop()
+            if previous_position in component_previous:
+                continue
+            component_previous.add(previous_position)
+            unseen_previous.discard(previous_position)
+            for current_position in previous_edges[previous_position]:
+                component_current.add(current_position)
+                for linked_previous in current_edges[current_position]:
+                    if linked_previous not in component_previous:
+                        stack.append(linked_previous)
+
+        previous_positions = tuple(sorted(component_previous))
+        current_positions = tuple(sorted(component_current))
+        component_candidates: dict[
+            int,
+            list[
+                tuple[
+                    int,
+                    tuple[int, int, int],
+                    tuple[Any, ...],
+                    dict[str, Any],
+                    dict[str, Any],
+                ]
+            ],
+        ] = defaultdict(list)
+        for (
+            previous_position,
+            current_position,
+        ), candidate in candidates_by_pair.items():
+            if (
+                previous_position not in component_previous
+                or current_position not in component_current
+            ):
+                continue
+            score, tie_key, previous_finding, current_finding = candidate
+            component_candidates[previous_position].append(
+                (
+                    current_position,
+                    score,
+                    tie_key,
+                    previous_finding,
+                    current_finding,
+                )
+            )
+
+        if (
+            len(previous_positions) > _EVIDENCE_MATCHING_EXACT_COMPONENT_LIMIT
+            or len(current_positions) > _EVIDENCE_MATCHING_EXACT_COMPONENT_LIMIT
+        ):
+            approximate_matching_used = True
+            selected_pairs.extend(
+                _select_greedy_evidence_candidate_pairs(
+                    component_candidates,
+                    previous_positions,
+                )
+            )
+            continue
+
+        current_bits = {
+            current_position: index
+            for index, current_position in enumerate(current_positions)
+        }
+
+        @lru_cache(maxsize=None)
+        def best_matching(
+            previous_offset: int,
+            used_current_mask: int,
+        ) -> tuple[
+            tuple[int, int, int],
+            tuple[tuple[Any, ...], ...],
+            tuple[tuple[int, int], ...],
+        ]:
+            if previous_offset >= len(previous_positions):
+                return (0, 0, 0), (), ()
+            previous_position = previous_positions[previous_offset]
+            best_score, best_ties, best_pairs = best_matching(
+                previous_offset + 1,
+                used_current_mask,
+            )
+            for (
+                current_position,
+                score,
+                tie_key,
+                _previous_finding,
+                _current_finding,
+            ) in component_candidates.get(previous_position, []):
+                current_bit = 1 << current_bits[current_position]
+                if used_current_mask & current_bit:
+                    continue
+                tail_score, tail_ties, tail_pairs = best_matching(
+                    previous_offset + 1,
+                    used_current_mask | current_bit,
+                )
+                candidate_score = tuple(
+                    left + right for left, right in zip(score, tail_score, strict=True)
+                )
+                candidate_ties = (tie_key,) + tail_ties
+                candidate_pairs = ((previous_position, current_position),) + tail_pairs
+                if candidate_score > best_score or (
+                    candidate_score == best_score and candidate_ties < best_ties
+                ):
+                    best_score = candidate_score
+                    best_ties = candidate_ties
+                    best_pairs = candidate_pairs
+            return best_score, best_ties, best_pairs
+
+        _score, _ties, component_pairs = best_matching(0, 0)
+        for pair_key in component_pairs:
+            selected_pairs.append(
+                (
+                    candidates_by_pair[pair_key][2],
+                    candidates_by_pair[pair_key][3],
+                )
+            )
+
+    return selected_pairs, approximate_matching_used
+
+
+def _pair_comparison_findings(
+    previous_group: list[dict[str, Any]],
+    current_group: list[dict[str, Any]],
+    *,
+    previous_evidence_by_finding: dict[str, list[dict[str, Any]]],
+    current_evidence_by_finding: dict[str, list[dict[str, Any]]],
+    allow_description_fallback_across_fingerprints: bool = False,
+) -> tuple[
+    list[tuple[dict[str, Any], dict[str, Any]]],
+    list[dict[str, Any]],
+    list[dict[str, Any]],
+    bool,
+]:
+    previous_unmatched = list(previous_group)
+    current_unmatched = list(current_group)
+    original_previous_description_counts = Counter(
+        _description_match_key(finding)
+        for finding in previous_group
+        if _description_match_key(finding)
+    )
+    original_current_description_counts = Counter(
+        _description_match_key(finding)
+        for finding in current_group
+        if _description_match_key(finding)
+    )
+    pairs: list[tuple[dict[str, Any], dict[str, Any]]] = []
+    approximate_matching_used = False
+
+    def pair(previous_finding: dict[str, Any], current_finding: dict[str, Any]) -> None:
+        previous_unmatched.remove(previous_finding)
+        current_unmatched.remove(current_finding)
+        pairs.append((previous_finding, current_finding))
+
+    evidence_candidates: list[
+        tuple[int, bool, tuple[Any, ...], dict[str, Any], dict[str, Any]]
+    ] = []
+    for previous_finding in previous_unmatched:
+        previous_evidence = _comparison_evidence_for_finding(
+            previous_evidence_by_finding,
+            previous_finding,
+        )
+        previous_identity = _evidence_identity_counts(previous_evidence)
+        if not previous_identity:
+            continue
+        for current_finding in current_unmatched:
+            current_evidence = _comparison_evidence_for_finding(
+                current_evidence_by_finding,
+                current_finding,
+            )
+            same_description = _description_match_key(
+                previous_finding
+            ) == _description_match_key(current_finding)
+            if _finding_fingerprint(previous_finding) != _finding_fingerprint(
+                current_finding
+            ):
+                description_key = _description_match_key(previous_finding)
+                if (
+                    not description_key
+                    or not same_description
+                    or original_previous_description_counts[description_key] != 1
+                    or original_current_description_counts[description_key] != 1
+                ):
+                    continue
+            overlap = sum(
+                (
+                    previous_identity & _evidence_identity_counts(current_evidence)
+                ).values()
+            )
+            if overlap <= 0:
+                continue
+            evidence_candidates.append(
+                (
+                    overlap,
+                    same_description,
+                    (
+                        _comparison_finding_sort_key(
+                            previous_finding,
+                            evidence_items=previous_evidence,
+                        ),
+                        _comparison_finding_sort_key(
+                            current_finding,
+                            evidence_items=current_evidence,
+                        ),
+                    ),
+                    previous_finding,
+                    current_finding,
+                )
+            )
+
+    evidence_pairs, approximate_matching_used = _select_evidence_candidate_pairs(
+        evidence_candidates,
+        previous_unmatched,
+        current_unmatched,
+    )
+    for previous_finding, current_finding in evidence_pairs:
+        if (
+            previous_finding in previous_unmatched
+            and current_finding in current_unmatched
+        ):
+            pair(previous_finding, current_finding)
+
+    previous_by_description: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    current_by_description: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    for previous_finding in previous_unmatched:
+        description_key = _description_match_key(previous_finding)
+        if description_key:
+            previous_by_description[description_key].append(previous_finding)
+    for current_finding in current_unmatched:
+        description_key = _description_match_key(current_finding)
+        if description_key:
+            current_by_description[description_key].append(current_finding)
+
+    for description_key in sorted(
+        set(previous_by_description) & set(current_by_description)
+    ):
+        if (
+            original_previous_description_counts[description_key] != 1
+            or original_current_description_counts[description_key] != 1
+        ):
+            continue
+        previous_matches = previous_by_description[description_key]
+        current_matches = current_by_description[description_key]
+        if len(previous_matches) != 1 or len(current_matches) != 1:
+            continue
+        previous_finding = previous_matches[0]
+        current_finding = current_matches[0]
+        if not allow_description_fallback_across_fingerprints and _finding_fingerprint(
+            previous_finding
+        ) != _finding_fingerprint(current_finding):
+            continue
+        pair(previous_finding, current_finding)
+
+    return pairs, previous_unmatched, current_unmatched, approximate_matching_used
 
 
 def _report_finding_maps(
@@ -989,117 +1543,152 @@ def _build_report_comparison(
     previous_findings, previous_evidence_by_finding = _report_finding_maps(
         previous_report
     )
+    previous_all_findings = [
+        finding for group in previous_findings.values() for finding in group
+    ]
+    current_all_findings = [
+        finding for group in current_findings.values() for finding in group
+    ]
     findings_added: list[dict[str, Any]] = []
     findings_removed: list[dict[str, Any]] = []
+    findings_persistent: list[dict[str, Any]] = []
     severity_changed: list[dict[str, Any]] = []
+    context_changed: list[dict[str, Any]] = []
     evidence_added: list[dict[str, Any]] = []
     evidence_removed: list[dict[str, Any]] = []
 
-    for fingerprint in sorted(set(previous_findings) | set(current_findings)):
-        previous_group = sorted(
-            previous_findings.get(fingerprint, []),
-            key=lambda finding: _comparison_finding_sort_key(
-                finding,
-                evidence_items=previous_evidence_by_finding.get(
-                    str(finding.get("finding_id") or ""),
-                    [],
-                ),
-            ),
-        )
-        current_group = sorted(
-            current_findings.get(fingerprint, []),
-            key=lambda finding: _comparison_finding_sort_key(
-                finding,
-                evidence_items=current_evidence_by_finding.get(
-                    str(finding.get("finding_id") or ""),
-                    [],
-                ),
-            ),
-        )
-        shared_count = min(len(previous_group), len(current_group))
-
-        for current_finding in current_group[shared_count:]:
-            current_evidence = current_evidence_by_finding.get(
-                str(current_finding.get("finding_id") or ""),
+    previous_group = sorted(
+        previous_all_findings,
+        key=lambda finding: _comparison_finding_sort_key(
+            finding,
+            evidence_items=previous_evidence_by_finding.get(
+                str(finding.get("finding_id") or ""),
                 [],
-            )
-            findings_added.append(
-                _comparison_finding_summary(
-                    current_finding,
-                    evidence_items=current_evidence,
-                )
-            )
-            evidence_added.extend(
-                _comparison_evidence_summary(
-                    evidence_item,
-                    finding_title=str(
-                        current_finding.get("title") or "Untitled finding"
-                    ),
-                )
-                for evidence_item in current_evidence
-            )
-        for previous_finding in previous_group[shared_count:]:
-            previous_evidence = previous_evidence_by_finding.get(
-                str(previous_finding.get("finding_id") or ""),
+            ),
+        ),
+    )
+    current_group = sorted(
+        current_all_findings,
+        key=lambda finding: _comparison_finding_sort_key(
+            finding,
+            evidence_items=current_evidence_by_finding.get(
+                str(finding.get("finding_id") or ""),
                 [],
-            )
-            findings_removed.append(
-                _comparison_finding_summary(
-                    previous_finding,
-                    evidence_items=previous_evidence,
-                )
-            )
-            evidence_removed.extend(
-                _comparison_evidence_summary(
-                    evidence_item,
-                    finding_title=str(
-                        previous_finding.get("title") or "Untitled finding"
-                    ),
-                )
-                for evidence_item in previous_evidence
-            )
+            ),
+        ),
+    )
+    (
+        paired_findings,
+        unmatched_previous,
+        unmatched_current,
+        approximate_matching_used,
+    ) = _pair_comparison_findings(
+        previous_group,
+        current_group,
+        previous_evidence_by_finding=previous_evidence_by_finding,
+        current_evidence_by_finding=current_evidence_by_finding,
+    )
 
-        for previous_finding, current_finding in zip(
-            previous_group[:shared_count],
-            current_group[:shared_count],
+    for current_finding in unmatched_current:
+        current_evidence = current_evidence_by_finding.get(
+            str(current_finding.get("finding_id") or ""),
+            [],
+        )
+        findings_added.append(
+            _comparison_finding_summary(
+                current_finding,
+                evidence_items=current_evidence,
+            )
+        )
+        evidence_added.extend(
+            _comparison_evidence_summary(
+                evidence_item,
+                finding_title=str(current_finding.get("title") or "Untitled finding"),
+            )
+            for evidence_item in current_evidence
+        )
+    for previous_finding in unmatched_previous:
+        previous_evidence = previous_evidence_by_finding.get(
+            str(previous_finding.get("finding_id") or ""),
+            [],
+        )
+        findings_removed.append(
+            _comparison_finding_summary(
+                previous_finding,
+                evidence_items=previous_evidence,
+            )
+        )
+        evidence_removed.extend(
+            _comparison_evidence_summary(
+                evidence_item,
+                finding_title=str(previous_finding.get("title") or "Untitled finding"),
+            )
+            for evidence_item in previous_evidence
+        )
+
+    for previous_finding, current_finding in paired_findings:
+        previous_evidence = previous_evidence_by_finding.get(
+            str(previous_finding.get("finding_id") or ""),
+            [],
+        )
+        current_evidence = current_evidence_by_finding.get(
+            str(current_finding.get("finding_id") or ""),
+            [],
+        )
+        if str(previous_finding.get("severity")) != str(
+            current_finding.get("severity")
         ):
-            previous_evidence = previous_evidence_by_finding.get(
-                str(previous_finding.get("finding_id") or ""),
-                [],
+            severity_changed.append(
+                {
+                    "title": str(current_finding.get("title") or "Untitled finding"),
+                    "description": str(
+                        current_finding.get("description")
+                        or previous_finding.get("description")
+                        or ""
+                    ),
+                    "previous_severity": str(
+                        previous_finding.get("severity") or "unknown"
+                    ),
+                    "current_severity": str(
+                        current_finding.get("severity") or "unknown"
+                    ),
+                }
             )
-            current_evidence = current_evidence_by_finding.get(
-                str(current_finding.get("finding_id") or ""),
-                [],
-            )
-            if str(previous_finding.get("severity")) != str(
-                current_finding.get("severity")
-            ):
-                severity_changed.append(
-                    {
-                        "title": str(
-                            current_finding.get("title") or "Untitled finding"
-                        ),
-                        "description": str(
-                            current_finding.get("description")
-                            or previous_finding.get("description")
-                            or ""
-                        ),
-                        "previous_severity": str(
-                            previous_finding.get("severity") or "unknown"
-                        ),
-                        "current_severity": str(
-                            current_finding.get("severity") or "unknown"
-                        ),
-                    }
-                )
-            added, removed = _evidence_diff(
-                previous_finding=previous_finding,
-                current_finding=current_finding,
+        added, removed = _evidence_diff(
+            previous_finding=previous_finding,
+            current_finding=current_finding,
+            previous_evidence_items=previous_evidence,
+            current_evidence_items=current_evidence,
+        )
+        findings_persistent.append(
+            _comparison_persistent_finding_summary(
+                previous_finding,
+                current_finding,
                 previous_evidence_items=previous_evidence,
                 current_evidence_items=current_evidence,
             )
-            evidence_added.extend(added)
-            evidence_removed.extend(removed)
+        )
+        context_changes = _comparison_context_change_labels(
+            previous_finding,
+            current_finding,
+            previous_evidence_items=previous_evidence,
+            current_evidence_items=current_evidence,
+        )
+        if context_changes:
+            context_changed.append(
+                {
+                    **_comparison_persistent_finding_summary(
+                        previous_finding,
+                        current_finding,
+                        previous_evidence_items=previous_evidence,
+                        current_evidence_items=current_evidence,
+                    ),
+                    "changes": context_changes,
+                    "description": "; ".join(context_changes),
+                }
+            )
+        evidence_added.extend(added)
+        evidence_removed.extend(removed)
 
     current_score = int(current_report.get("risk_score") or 0)
     previous_score = int(previous_report.get("risk_score") or 0)
@@ -1118,7 +1707,9 @@ def _build_report_comparison(
         "findings": {
             "added": findings_added,
             "removed": findings_removed,
+            "persistent": findings_persistent,
             "severity_changed": severity_changed,
+            "context_changed": context_changed,
         },
         "evidence": {
             "added": evidence_added,
@@ -1127,9 +1718,22 @@ def _build_report_comparison(
         "summary": {
             "findings_added": len(findings_added),
             "findings_removed": len(findings_removed),
+            "findings_persistent": len(findings_persistent),
             "severity_changes": len(severity_changed),
+            "context_changes": len(context_changed),
             "evidence_added": len(evidence_added),
             "evidence_removed": len(evidence_removed),
+            "approximate_matching": approximate_matching_used,
+            "warnings": (
+                [
+                    (
+                        "Dense duplicate evidence matching used deterministic "
+                        "approximate pairing."
+                    )
+                ]
+                if approximate_matching_used
+                else []
+            ),
         },
     }
 
@@ -1142,30 +1746,73 @@ def _find_previous_comparable_report(
     if not current_signature:
         return None
     current_id = int(current_report["id"])
-    current_project_id = int(current_report.get("project", {}).get("id") or 0)
-    current_workspace_id = int((current_report.get("workspace") or {}).get("id") or 0)
+    current_context = _comparison_workflow_context(current_report)
     previous_candidates = sorted(
         (
-            report
+            (rank, report)
             for report in candidate_reports
             if int(report["id"]) < current_id
-            and int(report.get("project", {}).get("id") or 0) == current_project_id
+            for rank in [
+                _workflow_context_match_rank(
+                    _comparison_workflow_context(report),
+                    current_context,
+                )
+            ]
+            if rank > 0
+            and int(report.get("project", {}).get("id") or 0)
+            == int(current_report.get("project", {}).get("id") or 0)
             and int((report.get("workspace") or {}).get("id") or 0)
-            == current_workspace_id
+            == int((current_report.get("workspace") or {}).get("id") or 0)
             and _comparison_signatures_match(
-                _comparison_artifact_signature(report), current_signature
+                _comparison_artifact_signature(report),
+                current_signature,
             )
         ),
-        key=lambda report: int(report["id"]),
+        key=lambda item: (item[0], int(item[1]["id"])),
         reverse=True,
     )
-    return previous_candidates[0] if previous_candidates else None
+    return previous_candidates[0][1] if previous_candidates else None
 
 
-def _list_serialized_reports(*, include_evidence: bool) -> list[dict[str, Any]]:
+def _serialize_readable_reports(
+    reports: list[Any],
+    *,
+    include_evidence: bool,
+) -> list[dict[str, Any]]:
+    serialized_reports = []
+    for report in reports:
+        try:
+            serialized_reports.append(
+                _serialize_report(report, include_evidence=include_evidence)
+            )
+        except ReportSchemaVersionError:
+            if include_evidence:
+                raise
+            continue
+    return serialized_reports
+
+
+def _list_serialized_reports(
+    *,
+    include_evidence: bool,
+    skip_unreadable_schema: bool = False,
+) -> list[dict[str, Any]]:
     def operation():
         with SessionLocal() as session:
-            reports = list_analysis_reports(session, include_evidence=include_evidence)
+            reports = list_analysis_reports(
+                session,
+                include_evidence=include_evidence,
+                report_schema_versions=(
+                    _readable_report_schema_versions()
+                    if skip_unreadable_schema
+                    else None
+                ),
+            )
+            if skip_unreadable_schema:
+                return _serialize_readable_reports(
+                    reports,
+                    include_evidence=include_evidence,
+                )
             return [
                 _serialize_report(report, include_evidence=include_evidence)
                 for report in reports
@@ -1193,14 +1840,22 @@ def fetch_previous_comparable_report(
     if current_report is None:
         return None
     if previous_report_id is not None:
-        return fetch_analysis_report(
+        previous_report = fetch_analysis_report(
             previous_report_id,
             project_id=project_id,
             project_key=project_key,
             workspace_id=workspace_id,
             workspace_key=workspace_key,
         )
-    serialized_reports = _list_serialized_reports(include_evidence=False)
+        if previous_report is None:
+            return None
+        if not _reports_are_comparable(current_report, previous_report):
+            return None
+        return previous_report
+    serialized_reports = _list_serialized_reports(
+        include_evidence=False,
+        skip_unreadable_schema=True,
+    )
     return _find_previous_comparable_report(current_report, serialized_reports)
 
 
@@ -1249,6 +1904,14 @@ def _redact_report_comparison(
                 }
                 for item in comparison["findings"]["removed"]
             ],
+            "persistent": [
+                {
+                    **item,
+                    "title": _redact_text_value(item.get("title"), pairs),
+                    "description": _redact_text_value(item.get("description"), pairs),
+                }
+                for item in comparison["findings"]["persistent"]
+            ],
             "severity_changed": [
                 {
                     **item,
@@ -1256,6 +1919,14 @@ def _redact_report_comparison(
                     "description": _redact_text_value(item.get("description"), pairs),
                 }
                 for item in comparison["findings"]["severity_changed"]
+            ],
+            "context_changed": [
+                {
+                    **item,
+                    "title": _redact_text_value(item.get("title"), pairs),
+                    "description": _redact_text_value(item.get("description"), pairs),
+                }
+                for item in comparison["findings"]["context_changed"]
             ],
         },
         "evidence": {
@@ -1322,18 +1993,36 @@ def _attach_previous_scan_diffs(
     previous_by_id: dict[int, dict[str, Any]] = {}
     latest_by_scope: dict[
         tuple[int, int],
-        dict[tuple[ComparisonArtifact, ...], dict[str, Any]],
+        dict[
+            tuple[ComparisonArtifact, ...],
+            list[tuple[tuple[str, str, str], dict[str, Any]]],
+        ],
     ] = defaultdict(dict)
 
     for report in sorted(all_reports, key=lambda item: int(item["id"])):
         signature = _history_signature(report)
         if signature:
             scope = (signature[0], signature[1])
-            scoped_reports = latest_by_scope[scope]
-            previous = scoped_reports.get(signature[2])
-            if previous is not None:
+            context = signature[2]
+            artifact_signature = signature[3]
+            previous_candidates = [
+                (rank, previous)
+                for previous_context, previous in latest_by_scope[scope].get(
+                    artifact_signature,
+                    [],
+                )
+                for rank in [_workflow_context_match_rank(previous_context, context)]
+                if rank > 0
+            ]
+            if previous_candidates:
+                _rank, previous = max(
+                    previous_candidates,
+                    key=lambda candidate: (candidate[0], int(candidate[1]["id"])),
+                )
                 previous_by_id[int(report["id"])] = previous
-            scoped_reports[signature[2]] = report
+            latest_by_scope[scope].setdefault(artifact_signature, []).append(
+                (context, report)
+            )
 
     annotated: list[dict[str, Any]] = []
     for report in reports:
@@ -2253,6 +2942,13 @@ def can_read_report_schema(
         return False
 
 
+def _readable_report_schema_versions() -> tuple[str, ...]:
+    return tuple(
+        f"v{version}"
+        for version in range(1, _report_schema_major(REPORT_SCHEMA_VERSION) + 1)
+    )
+
+
 def _load_submission_manifest_payload(
     raw_value: str | None,
 ) -> tuple[dict[str, Any] | None, str | None]:
@@ -3138,6 +3834,7 @@ def fetch_shared_report_comparison(
     *,
     password: str | None = None,
     bypass_password: bool = False,
+    previous_bypass_password: bool = False,
 ) -> dict | None:
     shared_current_report = fetch_shared_analysis_report(
         report_id,
@@ -3152,7 +3849,7 @@ def fetch_shared_report_comparison(
     shared_previous_report = fetch_shared_analysis_report(
         int(previous_report["id"]),
         password=password,
-        bypass_password=False,
+        bypass_password=previous_bypass_password,
     )
     if shared_previous_report is None:
         return None
@@ -3210,6 +3907,7 @@ def fetch_filtered_analysis_history_page(
     search: str | None = None,
     page: int = 1,
     page_size: int = 50,
+    skip_unreadable_schema: bool = False,
 ) -> dict[str, Any]:
     page = max(page, 1)
     page_size = max(1, min(page_size, 100))
@@ -3220,45 +3918,77 @@ def fetch_filtered_analysis_history_page(
         workspace_id=workspace_id,
         workspace_key=workspace_key,
     )
+    readable_schema_versions = (
+        _readable_report_schema_versions() if skip_unreadable_schema else None
+    )
 
     def operation():
         with SessionLocal() as session:
-            reports = list_analysis_reports(
-                session,
-                project_id=resolved_project_id,
-                workspace_id=resolved_workspace_id,
-                severity=severity,
-                recommendation=recommendation,
-                search=search,
-                limit=page_size,
-                offset=offset,
-                include_evidence=False,
-            )
             all_reports = list_analysis_reports(
                 session,
                 project_id=resolved_project_id,
                 workspace_id=resolved_workspace_id,
+                report_schema_versions=readable_schema_versions,
                 include_evidence=False,
             )
-            total_count = count_analysis_reports(
-                session,
-                project_id=resolved_project_id,
-                workspace_id=resolved_workspace_id,
-                severity=severity,
-                recommendation=recommendation,
-                search=search,
-            )
-            serialized_reports = [
-                _serialize_report(report, include_evidence=False) for report in reports
-            ]
-            serialized_all_reports = []
-            for report in all_reports:
-                try:
-                    serialized_all_reports.append(
-                        _serialize_report(report, include_evidence=False)
-                    )
-                except ReportSchemaVersionError:
-                    continue
+            if skip_unreadable_schema:
+                reports = list_analysis_reports(
+                    session,
+                    project_id=resolved_project_id,
+                    workspace_id=resolved_workspace_id,
+                    severity=severity,
+                    recommendation=recommendation,
+                    search=search,
+                    report_schema_versions=readable_schema_versions,
+                    limit=page_size,
+                    offset=offset,
+                    include_evidence=False,
+                )
+                serialized_reports = [
+                    _serialize_report(report, include_evidence=False)
+                    for report in reports
+                ]
+                serialized_all_reports = [
+                    _serialize_report(report, include_evidence=False)
+                    for report in all_reports
+                ]
+                total_count = count_analysis_reports(
+                    session,
+                    project_id=resolved_project_id,
+                    workspace_id=resolved_workspace_id,
+                    severity=severity,
+                    recommendation=recommendation,
+                    search=search,
+                    report_schema_versions=readable_schema_versions,
+                )
+            else:
+                reports = list_analysis_reports(
+                    session,
+                    project_id=resolved_project_id,
+                    workspace_id=resolved_workspace_id,
+                    severity=severity,
+                    recommendation=recommendation,
+                    search=search,
+                    limit=page_size,
+                    offset=offset,
+                    include_evidence=False,
+                )
+                serialized_reports = [
+                    _serialize_report(report, include_evidence=False)
+                    for report in reports
+                ]
+                serialized_all_reports = [
+                    _serialize_report(report, include_evidence=False)
+                    for report in all_reports
+                ]
+                total_count = count_analysis_reports(
+                    session,
+                    project_id=resolved_project_id,
+                    workspace_id=resolved_workspace_id,
+                    severity=severity,
+                    recommendation=recommendation,
+                    search=search,
+                )
             return (
                 _attach_previous_scan_diffs(serialized_reports, serialized_all_reports),
                 total_count,

--- a/tests/e2e/report_review.keyboard.spec.js
+++ b/tests/e2e/report_review.keyboard.spec.js
@@ -374,7 +374,10 @@ test.describe("review keyboard flow", () => {
     await expect(page.getByText("Comparison with report #1")).toBeVisible();
     await expect(page.getByText("Risk score delta")).toBeVisible();
     await expect(page.getByText("+48")).toBeVisible();
-    await expect(page.getByText(/MEDIUM.*CRITICAL/)).toBeVisible();
+    await expect(page.getByText("MEDIUM → CRITICAL", { exact: true })).toBeVisible();
+    await expect(page.getByText("Persistent findings", { exact: true })).toBeVisible();
+    await expect(page.getByText("Changed context", { exact: true })).toBeVisible();
+    await expect(page.getByText("Evidence changed")).toBeVisible();
   });
 
   test("opens unavailable evidence with sanitized legacy finding ids", async ({

--- a/tests/e2e/seeded_server.py
+++ b/tests/e2e/seeded_server.py
@@ -175,7 +175,7 @@ def _seed_review_report(report_service_module) -> None:
                 analysis_id=0,
                 finding_id="finding-prev",
                 source_type="artifact",
-                source_ref="artifact://plan.json#line=10",
+                source_ref="terraform://plan.json#aws_security_group.main?action=modify",
                 summary="Security group ingress remains under review.",
                 severity_hint="medium",
                 deterministic=True,

--- a/tests/test_services/test_report_service.py
+++ b/tests/test_services/test_report_service.py
@@ -3627,6 +3627,7 @@ class ReportServiceTests(unittest.TestCase):
         findings: list[Finding],
         evidence_items: list[EvidenceItem],
         parse_files: list[ParsedFileResult] | None = None,
+        audit_context: dict[str, object] | None = None,
     ) -> dict:
         parsed_files = parse_files or [
             ParsedFileResult(
@@ -3685,7 +3686,8 @@ class ReportServiceTests(unittest.TestCase):
             narrative,
             findings=findings,
             evidence_items=evidence_items,
-            audit_context={"source_interface": "api", "trigger_type": "pull_request"},
+            audit_context=audit_context
+            or {"source_interface": "api", "trigger_type": "pull_request"},
         )
 
     def test_persist_analysis_report_stores_and_returns_metadata(self) -> None:
@@ -6003,7 +6005,7 @@ class ReportServiceTests(unittest.TestCase):
                     finding_id="finding-shared",
                     analysis_id=0,
                     title="CRITICAL: aws_security_group.main",
-                    description="Security group ingress is broader than expected.",
+                    description="Security group ingress now exposes database reachability.",
                     severity="critical",
                     category="networking/ingress",
                     deterministic=True,
@@ -6088,6 +6090,22 @@ class ReportServiceTests(unittest.TestCase):
         self.assertEqual(
             comparison["findings"]["severity_changed"][0]["current_severity"],
             "critical",
+        )
+        self.assertEqual(
+            comparison["findings"]["persistent"][0]["title"],
+            "CRITICAL: aws_security_group.main",
+        )
+        self.assertEqual(
+            comparison["findings"]["context_changed"][0]["title"],
+            "CRITICAL: aws_security_group.main",
+        )
+        self.assertIn(
+            "Evidence changed",
+            comparison["findings"]["context_changed"][0]["changes"],
+        )
+        self.assertIn(
+            "Description changed",
+            comparison["findings"]["context_changed"][0]["changes"],
         )
         self.assertIn(
             "terraform://prod/network/plan.json#L26",
@@ -6342,9 +6360,918 @@ class ReportServiceTests(unittest.TestCase):
         self.assertEqual(comparison["current_report"]["id"], current["id"])
         self.assertEqual(comparison["findings"]["added"], [])
         self.assertEqual(comparison["findings"]["removed"], [])
+        self.assertEqual(len(comparison["findings"]["persistent"]), 2)
+        self.assertEqual(comparison["findings"]["context_changed"], [])
         self.assertEqual(comparison["findings"]["severity_changed"], [])
         self.assertEqual(comparison["evidence"]["added"], [])
         self.assertEqual(comparison["evidence"]["removed"], [])
+
+    def test_fetch_report_comparison_does_not_mispair_duplicate_title_category_findings(
+        self,
+    ) -> None:
+        previous = self._persist_comparison_report(
+            score=42,
+            severity="medium",
+            recommendation="caution",
+            top_risk="Two same-title findings exist.",
+            findings=[
+                Finding(
+                    finding_id="finding-persistent",
+                    analysis_id=0,
+                    title="MEDIUM: aws_security_group.main",
+                    description="Ingress exposure remains persistent.",
+                    severity="medium",
+                    category="networking/ingress",
+                    deterministic=True,
+                    confidence=1.0,
+                    uncertainty_note=None,
+                    evidence_refs=["ev-persistent"],
+                    skill_id=None,
+                ),
+                Finding(
+                    finding_id="finding-removed",
+                    analysis_id=0,
+                    title="MEDIUM: aws_security_group.main",
+                    description="SSH exposure was removed.",
+                    severity="medium",
+                    category="networking/ingress",
+                    deterministic=True,
+                    confidence=0.91,
+                    uncertainty_note=None,
+                    evidence_refs=["ev-removed"],
+                    skill_id=None,
+                ),
+            ],
+            evidence_items=[
+                EvidenceItem(
+                    evidence_id="ev-persistent",
+                    analysis_id=0,
+                    finding_id="pending:persistent",
+                    source_type="artifact",
+                    source_ref="terraform://prod/network/plan.json#L14",
+                    summary="Ingress stays open to the VPC.",
+                    severity_hint="medium",
+                    deterministic=True,
+                    confidence=1.0,
+                    related_change_ids=["change-1"],
+                ),
+                EvidenceItem(
+                    evidence_id="ev-removed",
+                    analysis_id=0,
+                    finding_id="pending:removed",
+                    source_type="artifact",
+                    source_ref="terraform://prod/network/plan.json#L22",
+                    summary="Port 22 remains reachable.",
+                    severity_hint="medium",
+                    deterministic=True,
+                    confidence=0.91,
+                    related_change_ids=["change-2"],
+                ),
+            ],
+        )
+        current = self._persist_comparison_report(
+            score=71,
+            severity="critical",
+            recommendation="no-go",
+            top_risk="One same-title finding persists and one is new.",
+            findings=[
+                Finding(
+                    finding_id="finding-persistent",
+                    analysis_id=0,
+                    title="CRITICAL: aws_security_group.main",
+                    description="Ingress exposure remains persistent.",
+                    severity="critical",
+                    category="networking/ingress",
+                    deterministic=True,
+                    confidence=1.0,
+                    uncertainty_note=None,
+                    evidence_refs=["ev-persistent"],
+                    skill_id=None,
+                ),
+                Finding(
+                    finding_id="finding-added",
+                    analysis_id=0,
+                    title="HIGH: aws_security_group.main",
+                    description="Database exposure is newly reachable.",
+                    severity="high",
+                    category="networking/ingress",
+                    deterministic=True,
+                    confidence=0.93,
+                    uncertainty_note=None,
+                    evidence_refs=["ev-added"],
+                    skill_id=None,
+                ),
+            ],
+            evidence_items=[
+                EvidenceItem(
+                    evidence_id="ev-persistent",
+                    analysis_id=0,
+                    finding_id="pending:persistent",
+                    source_type="artifact",
+                    source_ref="terraform://prod/network/plan.json#L14",
+                    summary="Ingress stays open to the VPC.",
+                    severity_hint="critical",
+                    deterministic=True,
+                    confidence=1.0,
+                    related_change_ids=["change-1"],
+                ),
+                EvidenceItem(
+                    evidence_id="ev-added",
+                    analysis_id=0,
+                    finding_id="pending:added",
+                    source_type="artifact",
+                    source_ref="terraform://prod/network/plan.json#L40",
+                    summary="Port 3306 is newly reachable.",
+                    severity_hint="high",
+                    deterministic=True,
+                    confidence=0.93,
+                    related_change_ids=["change-4"],
+                ),
+            ],
+        )
+
+        comparison = report_service_module.fetch_report_comparison(current["id"])
+
+        self.assertIsNotNone(comparison)
+        assert comparison is not None
+        self.assertEqual(comparison["previous_report"]["id"], previous["id"])
+        self.assertEqual(
+            [item["description"] for item in comparison["findings"]["persistent"]],
+            ["Ingress exposure remains persistent."],
+        )
+        self.assertEqual(
+            [item["description"] for item in comparison["findings"]["removed"]],
+            ["SSH exposure was removed."],
+        )
+        self.assertEqual(
+            [item["description"] for item in comparison["findings"]["added"]],
+            ["Database exposure is newly reachable."],
+        )
+
+    def test_fetch_report_comparison_matches_duplicate_same_description_by_evidence(
+        self,
+    ) -> None:
+        previous = self._persist_comparison_report(
+            score=42,
+            severity="medium",
+            recommendation="caution",
+            top_risk="Two same-description findings exist.",
+            findings=[
+                Finding(
+                    finding_id="finding-persistent",
+                    analysis_id=0,
+                    title="MEDIUM: aws_security_group.main",
+                    description="Security group ingress is broader than expected.",
+                    severity="medium",
+                    category="networking/ingress",
+                    deterministic=True,
+                    confidence=1.0,
+                    uncertainty_note=None,
+                    evidence_refs=["ev-persistent"],
+                    skill_id=None,
+                ),
+                Finding(
+                    finding_id="finding-removed",
+                    analysis_id=0,
+                    title="MEDIUM: aws_security_group.main",
+                    description="Security group ingress is broader than expected.",
+                    severity="medium",
+                    category="networking/ingress",
+                    deterministic=True,
+                    confidence=0.91,
+                    uncertainty_note=None,
+                    evidence_refs=["ev-removed"],
+                    skill_id=None,
+                ),
+            ],
+            evidence_items=[
+                EvidenceItem(
+                    evidence_id="ev-persistent",
+                    analysis_id=0,
+                    finding_id="pending:persistent",
+                    source_type="artifact",
+                    source_ref="terraform://prod/network/plan.json#L14",
+                    summary="Ingress stays open to the VPC.",
+                    severity_hint="medium",
+                    deterministic=True,
+                    confidence=1.0,
+                    related_change_ids=["change-1"],
+                ),
+                EvidenceItem(
+                    evidence_id="ev-removed",
+                    analysis_id=0,
+                    finding_id="pending:removed",
+                    source_type="artifact",
+                    source_ref="terraform://prod/network/plan.json#L22",
+                    summary="Port 22 remains reachable.",
+                    severity_hint="medium",
+                    deterministic=True,
+                    confidence=0.91,
+                    related_change_ids=["change-2"],
+                ),
+            ],
+        )
+        current = self._persist_comparison_report(
+            score=71,
+            severity="critical",
+            recommendation="no-go",
+            top_risk="One same-description finding persists and one is new.",
+            findings=[
+                Finding(
+                    finding_id="finding-persistent",
+                    analysis_id=0,
+                    title="CRITICAL: aws_security_group.main",
+                    description="Security group ingress is broader than expected.",
+                    severity="critical",
+                    category="networking/ingress",
+                    deterministic=True,
+                    confidence=1.0,
+                    uncertainty_note=None,
+                    evidence_refs=["ev-persistent"],
+                    skill_id=None,
+                ),
+                Finding(
+                    finding_id="finding-added",
+                    analysis_id=0,
+                    title="HIGH: aws_security_group.main",
+                    description="Security group ingress is broader than expected.",
+                    severity="high",
+                    category="networking/ingress",
+                    deterministic=True,
+                    confidence=0.93,
+                    uncertainty_note=None,
+                    evidence_refs=["ev-added"],
+                    skill_id=None,
+                ),
+            ],
+            evidence_items=[
+                EvidenceItem(
+                    evidence_id="ev-persistent",
+                    analysis_id=0,
+                    finding_id="pending:persistent",
+                    source_type="artifact",
+                    source_ref="terraform://prod/network/plan.json#L14",
+                    summary="Ingress stays open to the VPC.",
+                    severity_hint="critical",
+                    deterministic=True,
+                    confidence=1.0,
+                    related_change_ids=["change-1"],
+                ),
+                EvidenceItem(
+                    evidence_id="ev-added",
+                    analysis_id=0,
+                    finding_id="pending:added",
+                    source_type="artifact",
+                    source_ref="terraform://prod/network/plan.json#L40",
+                    summary="Port 3306 is newly reachable.",
+                    severity_hint="high",
+                    deterministic=True,
+                    confidence=0.93,
+                    related_change_ids=["change-4"],
+                ),
+            ],
+        )
+
+        comparison = report_service_module.fetch_report_comparison(current["id"])
+
+        self.assertIsNotNone(comparison)
+        assert comparison is not None
+        self.assertEqual(comparison["previous_report"]["id"], previous["id"])
+        self.assertEqual(len(comparison["findings"]["persistent"]), 1)
+        self.assertEqual(len(comparison["findings"]["removed"]), 1)
+        self.assertEqual(len(comparison["findings"]["added"]), 1)
+        self.assertIn(
+            "terraform://prod/network/plan.json#L22",
+            {item["source_ref"] for item in comparison["evidence"]["removed"]},
+        )
+        self.assertIn(
+            "terraform://prod/network/plan.json#L40",
+            {item["source_ref"] for item in comparison["evidence"]["added"]},
+        )
+
+    def test_fetch_report_comparison_uses_optimal_evidence_matching(
+        self,
+    ) -> None:
+        previous = self._persist_comparison_report(
+            score=42,
+            severity="medium",
+            recommendation="caution",
+            top_risk="Two overlapping findings require stable pairing.",
+            findings=[
+                Finding(
+                    finding_id="finding-alpha",
+                    analysis_id=0,
+                    title="MEDIUM: aws_security_group.alpha",
+                    description="Alpha ingress remains broad.",
+                    severity="medium",
+                    category="networking/ingress",
+                    deterministic=True,
+                    confidence=0.92,
+                    uncertainty_note=None,
+                    evidence_refs=["ev-alpha-one", "ev-alpha-two"],
+                    skill_id=None,
+                ),
+                Finding(
+                    finding_id="finding-beta",
+                    analysis_id=0,
+                    title="MEDIUM: aws_security_group.beta",
+                    description="Beta ingress remains broad.",
+                    severity="medium",
+                    category="networking/ingress",
+                    deterministic=True,
+                    confidence=0.91,
+                    uncertainty_note=None,
+                    evidence_refs=["ev-beta"],
+                    skill_id=None,
+                ),
+            ],
+            evidence_items=[
+                EvidenceItem(
+                    evidence_id="ev-alpha-one",
+                    analysis_id=0,
+                    finding_id="pending:alpha",
+                    source_type="artifact",
+                    source_ref="terraform://prod/network/plan.json#L14",
+                    summary="Alpha ingress includes SSH.",
+                    severity_hint="medium",
+                    deterministic=True,
+                    confidence=0.92,
+                    related_change_ids=["change-alpha-one"],
+                ),
+                EvidenceItem(
+                    evidence_id="ev-alpha-two",
+                    analysis_id=0,
+                    finding_id="pending:alpha",
+                    source_type="artifact",
+                    source_ref="terraform://prod/network/plan.json#L18",
+                    summary="Alpha ingress includes database access.",
+                    severity_hint="medium",
+                    deterministic=True,
+                    confidence=0.92,
+                    related_change_ids=["change-alpha-two"],
+                ),
+                EvidenceItem(
+                    evidence_id="ev-beta",
+                    analysis_id=0,
+                    finding_id="pending:beta",
+                    source_type="artifact",
+                    source_ref="terraform://prod/network/plan.json#L22",
+                    summary="Beta ingress includes admin access.",
+                    severity_hint="medium",
+                    deterministic=True,
+                    confidence=0.91,
+                    related_change_ids=["change-beta"],
+                ),
+            ],
+        )
+        current = self._persist_comparison_report(
+            score=71,
+            severity="critical",
+            recommendation="no-go",
+            top_risk="Both overlapping findings still require review.",
+            findings=[
+                Finding(
+                    finding_id="finding-cross",
+                    analysis_id=0,
+                    title="CRITICAL: aws_security_group.cross",
+                    description="Beta ingress remains broad.",
+                    severity="critical",
+                    category="networking/ingress",
+                    deterministic=True,
+                    confidence=0.94,
+                    uncertainty_note=None,
+                    evidence_refs=["ev-cross-alpha", "ev-cross-beta"],
+                    skill_id=None,
+                ),
+                Finding(
+                    finding_id="finding-alpha-tail",
+                    analysis_id=0,
+                    title="HIGH: aws_security_group.alpha",
+                    description="Database access remains broad.",
+                    severity="high",
+                    category="networking/ingress",
+                    deterministic=True,
+                    confidence=0.93,
+                    uncertainty_note=None,
+                    evidence_refs=["ev-alpha-two"],
+                    skill_id=None,
+                ),
+            ],
+            evidence_items=[
+                EvidenceItem(
+                    evidence_id="ev-cross-alpha",
+                    analysis_id=0,
+                    finding_id="pending:cross",
+                    source_type="artifact",
+                    source_ref="terraform://prod/network/plan.json#L14",
+                    summary="Alpha ingress still includes SSH.",
+                    severity_hint="critical",
+                    deterministic=True,
+                    confidence=0.94,
+                    related_change_ids=["change-alpha-one"],
+                ),
+                EvidenceItem(
+                    evidence_id="ev-cross-beta",
+                    analysis_id=0,
+                    finding_id="pending:cross",
+                    source_type="artifact",
+                    source_ref="terraform://prod/network/plan.json#L22",
+                    summary="Beta ingress still includes admin access.",
+                    severity_hint="critical",
+                    deterministic=True,
+                    confidence=0.94,
+                    related_change_ids=["change-beta"],
+                ),
+                EvidenceItem(
+                    evidence_id="ev-alpha-two",
+                    analysis_id=0,
+                    finding_id="pending:alpha-tail",
+                    source_type="artifact",
+                    source_ref="terraform://prod/network/plan.json#L18",
+                    summary="Alpha ingress still includes database access.",
+                    severity_hint="high",
+                    deterministic=True,
+                    confidence=0.93,
+                    related_change_ids=["change-alpha-two"],
+                ),
+            ],
+        )
+
+        comparison = report_service_module.fetch_report_comparison(current["id"])
+
+        self.assertIsNotNone(comparison)
+        assert comparison is not None
+        self.assertEqual(comparison["previous_report"]["id"], previous["id"])
+        self.assertEqual(comparison["findings"]["added"], [])
+        self.assertEqual(comparison["findings"]["removed"], [])
+        self.assertEqual(len(comparison["findings"]["persistent"]), 2)
+
+    def test_fetch_report_comparison_caps_dense_evidence_matching(
+        self,
+    ) -> None:
+        previous_findings = []
+        previous_evidence = []
+        current_findings = []
+        current_evidence = []
+        for index in range(9):
+            description = f"Dense overlap finding {index} remains broad."
+            previous_findings.append(
+                Finding(
+                    finding_id=f"previous-dense-{index}",
+                    analysis_id=0,
+                    title="MEDIUM: duplicate dense ingress",
+                    description=description,
+                    severity="medium",
+                    category="networking/ingress",
+                    deterministic=True,
+                    confidence=0.91,
+                    uncertainty_note=None,
+                    evidence_refs=[f"previous-dense-ev-{index}"],
+                    skill_id=None,
+                )
+            )
+            previous_evidence.append(
+                EvidenceItem(
+                    evidence_id=f"previous-dense-ev-{index}",
+                    analysis_id=0,
+                    finding_id=f"pending:previous-dense-{index}",
+                    source_type="artifact",
+                    source_ref="terraform://prod/network/plan.json#shared",
+                    summary="Shared dense ingress evidence.",
+                    severity_hint="medium",
+                    deterministic=True,
+                    confidence=0.91,
+                    related_change_ids=["change-dense"],
+                )
+            )
+            current_findings.append(
+                Finding(
+                    finding_id=f"current-dense-{index}",
+                    analysis_id=0,
+                    title="MEDIUM: duplicate dense ingress",
+                    description=description,
+                    severity="medium",
+                    category="networking/ingress",
+                    deterministic=True,
+                    confidence=0.91,
+                    uncertainty_note=None,
+                    evidence_refs=[f"current-dense-ev-{index}"],
+                    skill_id=None,
+                )
+            )
+            current_evidence.append(
+                EvidenceItem(
+                    evidence_id=f"current-dense-ev-{index}",
+                    analysis_id=0,
+                    finding_id=f"pending:current-dense-{index}",
+                    source_type="artifact",
+                    source_ref="terraform://prod/network/plan.json#shared",
+                    summary="Shared dense ingress evidence.",
+                    severity_hint="medium",
+                    deterministic=True,
+                    confidence=0.91,
+                    related_change_ids=["change-dense"],
+                )
+            )
+        self._persist_comparison_report(
+            score=42,
+            severity="medium",
+            recommendation="caution",
+            top_risk="Dense overlap findings require bounded matching.",
+            findings=previous_findings,
+            evidence_items=previous_evidence,
+        )
+        current = self._persist_comparison_report(
+            score=43,
+            severity="medium",
+            recommendation="caution",
+            top_risk="Dense overlap findings remain bounded.",
+            findings=current_findings,
+            evidence_items=current_evidence,
+        )
+
+        comparison = report_service_module.fetch_report_comparison(current["id"])
+
+        self.assertIsNotNone(comparison)
+        assert comparison is not None
+        self.assertEqual(comparison["findings"]["added"], [])
+        self.assertEqual(comparison["findings"]["removed"], [])
+        self.assertEqual(len(comparison["findings"]["persistent"]), 9)
+        self.assertTrue(comparison["summary"]["approximate_matching"])
+        self.assertEqual(
+            comparison["summary"]["warnings"],
+            [
+                "Dense duplicate evidence matching used deterministic approximate pairing."
+            ],
+        )
+
+    def test_evidence_identity_counts_preserve_repeated_identities(self) -> None:
+        repeated_items = [
+            {
+                "source_type": "artifact",
+                "source_ref": "terraform://prod/network/plan.json#shared",
+                "artifact": "",
+                "location": "",
+                "resource": "aws_security_group.main",
+                "operation": "modify",
+                "related_change_ids": ["change-dense"],
+                "summary": f"Repeated occurrence {index}",
+            }
+            for index in range(2)
+        ]
+
+        identity_counts = report_service_module._evidence_identity_counts(
+            repeated_items
+        )
+
+        self.assertEqual(sum(identity_counts.values()), 2)
+        self.assertEqual(len(identity_counts), 1)
+
+    def test_fetch_report_comparison_pairs_title_category_drift_by_evidence(
+        self,
+    ) -> None:
+        previous = self._persist_comparison_report(
+            score=42,
+            severity="medium",
+            recommendation="caution",
+            top_risk="Security group ingress requires review.",
+            findings=[
+                Finding(
+                    finding_id="finding-shared",
+                    analysis_id=0,
+                    title="MEDIUM: aws_security_group.main",
+                    description="Security group ingress is broader than expected.",
+                    severity="medium",
+                    category="networking/ingress",
+                    deterministic=True,
+                    confidence=0.91,
+                    uncertainty_note=None,
+                    evidence_refs=["ev-shared"],
+                    skill_id=None,
+                )
+            ],
+            evidence_items=[
+                EvidenceItem(
+                    evidence_id="ev-shared",
+                    analysis_id=0,
+                    finding_id="pending:shared",
+                    source_type="artifact",
+                    source_ref="terraform://prod/network/plan.json#L14",
+                    summary="Ingress stays open to the VPC.",
+                    severity_hint="medium",
+                    deterministic=True,
+                    confidence=0.91,
+                    related_change_ids=["change-1"],
+                )
+            ],
+        )
+        current = self._persist_comparison_report(
+            score=71,
+            severity="critical",
+            recommendation="no-go",
+            top_risk="Public ingress now requires release review.",
+            findings=[
+                Finding(
+                    finding_id="finding-shared",
+                    analysis_id=0,
+                    title="CRITICAL: aws_security_group.public",
+                    description="Security group ingress is broader than expected.",
+                    severity="critical",
+                    category="security/network",
+                    deterministic=True,
+                    confidence=0.91,
+                    uncertainty_note=None,
+                    evidence_refs=["ev-shared"],
+                    skill_id=None,
+                )
+            ],
+            evidence_items=[
+                EvidenceItem(
+                    evidence_id="ev-shared",
+                    analysis_id=0,
+                    finding_id="pending:shared",
+                    source_type="artifact",
+                    source_ref="terraform://prod/network/plan.json#L14",
+                    summary="Ingress stays open to the VPC.",
+                    severity_hint="medium",
+                    deterministic=True,
+                    confidence=0.91,
+                    related_change_ids=["change-1"],
+                )
+            ],
+        )
+
+        comparison = report_service_module.fetch_report_comparison(current["id"])
+
+        self.assertIsNotNone(comparison)
+        assert comparison is not None
+        self.assertEqual(comparison["previous_report"]["id"], previous["id"])
+        self.assertEqual(comparison["findings"]["added"], [])
+        self.assertEqual(comparison["findings"]["removed"], [])
+        self.assertEqual(len(comparison["findings"]["persistent"]), 1)
+        self.assertEqual(len(comparison["findings"]["context_changed"]), 1)
+        self.assertEqual(
+            comparison["findings"]["context_changed"][0]["changes"],
+            ["Title changed", "Category changed"],
+        )
+
+    def test_fetch_report_comparison_does_not_pair_different_findings_on_same_evidence(
+        self,
+    ) -> None:
+        previous = self._persist_comparison_report(
+            score=42,
+            severity="medium",
+            recommendation="caution",
+            top_risk="Database encryption requires review.",
+            findings=[
+                Finding(
+                    finding_id="finding-encryption",
+                    analysis_id=0,
+                    title="MEDIUM: database encryption disabled",
+                    description="Database encryption is disabled.",
+                    severity="medium",
+                    category="storage/encryption",
+                    deterministic=True,
+                    confidence=0.91,
+                    uncertainty_note=None,
+                    evidence_refs=["ev-shared"],
+                    skill_id=None,
+                )
+            ],
+            evidence_items=[
+                EvidenceItem(
+                    evidence_id="ev-shared",
+                    analysis_id=0,
+                    finding_id="pending:shared",
+                    source_type="artifact",
+                    source_ref="terraform://prod/database/plan.json#L14",
+                    summary="Database resource changed.",
+                    severity_hint="medium",
+                    deterministic=True,
+                    confidence=0.91,
+                    related_change_ids=["change-db"],
+                )
+            ],
+        )
+        current = self._persist_comparison_report(
+            score=71,
+            severity="critical",
+            recommendation="no-go",
+            top_risk="Public database ingress requires review.",
+            findings=[
+                Finding(
+                    finding_id="finding-ingress",
+                    analysis_id=0,
+                    title="CRITICAL: public database ingress",
+                    description="Database ingress is public.",
+                    severity="critical",
+                    category="networking/ingress",
+                    deterministic=True,
+                    confidence=0.94,
+                    uncertainty_note=None,
+                    evidence_refs=["ev-shared"],
+                    skill_id=None,
+                )
+            ],
+            evidence_items=[
+                EvidenceItem(
+                    evidence_id="ev-shared",
+                    analysis_id=0,
+                    finding_id="pending:shared",
+                    source_type="artifact",
+                    source_ref="terraform://prod/database/plan.json#L14",
+                    summary="Database resource changed.",
+                    severity_hint="critical",
+                    deterministic=True,
+                    confidence=0.94,
+                    related_change_ids=["change-db"],
+                )
+            ],
+        )
+
+        comparison = report_service_module.fetch_report_comparison(current["id"])
+
+        self.assertIsNotNone(comparison)
+        assert comparison is not None
+        self.assertEqual(comparison["previous_report"]["id"], previous["id"])
+        self.assertEqual(comparison["findings"]["persistent"], [])
+        self.assertEqual(comparison["findings"]["context_changed"], [])
+        self.assertEqual(
+            [item["description"] for item in comparison["findings"]["removed"]],
+            ["Database encryption is disabled."],
+        )
+        self.assertEqual(
+            [item["description"] for item in comparison["findings"]["added"]],
+            ["Database ingress is public."],
+        )
+
+    def test_fetch_report_comparison_does_not_pair_singletons_without_identity(
+        self,
+    ) -> None:
+        self._persist_comparison_report(
+            score=42,
+            severity="medium",
+            recommendation="caution",
+            top_risk="Old singleton finding.",
+            findings=[
+                Finding(
+                    finding_id="finding-old",
+                    analysis_id=0,
+                    title="MEDIUM: aws_security_group.main",
+                    description="SSH exposure was removed.",
+                    severity="medium",
+                    category="networking/ingress",
+                    deterministic=True,
+                    confidence=0.91,
+                    uncertainty_note=None,
+                    evidence_refs=["ev-old"],
+                    skill_id=None,
+                )
+            ],
+            evidence_items=[
+                EvidenceItem(
+                    evidence_id="ev-old",
+                    analysis_id=0,
+                    finding_id="pending:old",
+                    source_type="artifact",
+                    source_ref="terraform://prod/network/plan.json#L22",
+                    summary="Port 22 remains reachable.",
+                    severity_hint="medium",
+                    deterministic=True,
+                    confidence=0.91,
+                    related_change_ids=["change-2"],
+                )
+            ],
+        )
+        current = self._persist_comparison_report(
+            score=71,
+            severity="critical",
+            recommendation="no-go",
+            top_risk="New singleton finding.",
+            findings=[
+                Finding(
+                    finding_id="finding-new",
+                    analysis_id=0,
+                    title="HIGH: aws_security_group.main",
+                    description="Database exposure is newly reachable.",
+                    severity="high",
+                    category="networking/ingress",
+                    deterministic=True,
+                    confidence=0.93,
+                    uncertainty_note=None,
+                    evidence_refs=["ev-new"],
+                    skill_id=None,
+                )
+            ],
+            evidence_items=[
+                EvidenceItem(
+                    evidence_id="ev-new",
+                    analysis_id=0,
+                    finding_id="pending:new",
+                    source_type="artifact",
+                    source_ref="terraform://prod/network/plan.json#L40",
+                    summary="Port 3306 is newly reachable.",
+                    severity_hint="high",
+                    deterministic=True,
+                    confidence=0.93,
+                    related_change_ids=["change-4"],
+                )
+            ],
+        )
+
+        comparison = report_service_module.fetch_report_comparison(current["id"])
+
+        self.assertIsNotNone(comparison)
+        assert comparison is not None
+        self.assertEqual(comparison["findings"]["persistent"], [])
+        self.assertEqual(
+            [item["description"] for item in comparison["findings"]["removed"]],
+            ["SSH exposure was removed."],
+        )
+        self.assertEqual(
+            [item["description"] for item in comparison["findings"]["added"]],
+            ["Database exposure is newly reachable."],
+        )
+
+    def test_fetch_report_comparison_ignores_guidance_reordering(self) -> None:
+        self._persist_comparison_report(
+            score=42,
+            severity="medium",
+            recommendation="caution",
+            top_risk="Guidance order one.",
+            findings=[
+                Finding(
+                    finding_id="finding-guidance",
+                    analysis_id=0,
+                    title="MEDIUM: aws_security_group.main",
+                    description="Security group ingress is broader than expected.",
+                    severity="medium",
+                    category="networking/ingress",
+                    deterministic=True,
+                    confidence=1.0,
+                    uncertainty_note=None,
+                    guidance=["Review ingress.", "Confirm owner."],
+                    evidence_refs=["ev-guidance"],
+                    skill_id=None,
+                )
+            ],
+            evidence_items=[
+                EvidenceItem(
+                    evidence_id="ev-guidance",
+                    analysis_id=0,
+                    finding_id="pending:guidance",
+                    source_type="artifact",
+                    source_ref="terraform://prod/network/plan.json#L14",
+                    summary="Ingress stays open to the VPC.",
+                    severity_hint="medium",
+                    deterministic=True,
+                    confidence=1.0,
+                    related_change_ids=["change-1"],
+                )
+            ],
+        )
+        current = self._persist_comparison_report(
+            score=42,
+            severity="medium",
+            recommendation="caution",
+            top_risk="Guidance order two.",
+            findings=[
+                Finding(
+                    finding_id="finding-guidance",
+                    analysis_id=0,
+                    title="MEDIUM: aws_security_group.main",
+                    description="Security group ingress is broader than expected.",
+                    severity="medium",
+                    category="networking/ingress",
+                    deterministic=True,
+                    confidence=1.0,
+                    uncertainty_note=None,
+                    guidance=["Confirm owner.", "Review ingress."],
+                    evidence_refs=["ev-guidance"],
+                    skill_id=None,
+                )
+            ],
+            evidence_items=[
+                EvidenceItem(
+                    evidence_id="ev-guidance",
+                    analysis_id=0,
+                    finding_id="pending:guidance",
+                    source_type="artifact",
+                    source_ref="terraform://prod/network/plan.json#L14",
+                    summary="Ingress stays open to the VPC.",
+                    severity_hint="medium",
+                    deterministic=True,
+                    confidence=1.0,
+                    related_change_ids=["change-1"],
+                )
+            ],
+        )
+
+        comparison = report_service_module.fetch_report_comparison(current["id"])
+
+        self.assertIsNotNone(comparison)
+        assert comparison is not None
+        self.assertEqual(comparison["findings"]["context_changed"], [])
 
     def test_fetch_shared_report_comparison_respects_filename_redaction(self) -> None:
         self._persist_comparison_report(
@@ -8325,6 +9252,281 @@ class ReportServiceTests(unittest.TestCase):
         self.assertNotIn("previous_scan_diff", by_id[int(first["id"])])
         self.assertNotIn("previous_scan_diff", by_id[int(second["id"])])
 
+    def test_previous_scan_diffs_do_not_cross_workflow_contexts(self) -> None:
+        first = self._persist_comparison_report(
+            score=40,
+            severity="medium",
+            recommendation="caution",
+            top_risk="Interactive review",
+            findings=[],
+            evidence_items=[],
+            audit_context={"source_interface": "api", "trigger_type": "session"},
+        )
+        second = self._persist_comparison_report(
+            score=88,
+            severity="critical",
+            recommendation="no-go",
+            top_risk="Pull request review",
+            findings=[],
+            evidence_items=[],
+            audit_context={"source_interface": "api", "trigger_type": "pull_request"},
+        )
+
+        comparison = report_service_module.fetch_report_comparison(second["id"])
+        explicit_comparison = report_service_module.fetch_report_comparison(
+            second["id"],
+            previous_report_id=first["id"],
+        )
+        history = report_service_module.fetch_filtered_analysis_history_page()
+        by_id = {item["id"]: item for item in history["items"]}
+
+        self.assertIsNone(comparison)
+        self.assertIsNone(explicit_comparison)
+        self.assertNotIn("previous_scan_diff", by_id[int(second["id"])])
+
+    def test_previous_scan_diffs_do_not_cross_trigger_ids(self) -> None:
+        first = self._persist_comparison_report(
+            score=40,
+            severity="medium",
+            recommendation="caution",
+            top_risk="First pull request review",
+            findings=[],
+            evidence_items=[],
+            audit_context={
+                "source_interface": "api",
+                "trigger_type": "pull_request",
+                "trigger_id": "pr-41",
+            },
+        )
+        second = self._persist_comparison_report(
+            score=88,
+            severity="critical",
+            recommendation="no-go",
+            top_risk="Second pull request review",
+            findings=[],
+            evidence_items=[],
+            audit_context={
+                "source_interface": "api",
+                "trigger_type": "pull_request",
+                "trigger_id": "pr-42",
+            },
+        )
+
+        comparison = report_service_module.fetch_report_comparison(second["id"])
+        explicit_comparison = report_service_module.fetch_report_comparison(
+            second["id"],
+            previous_report_id=first["id"],
+        )
+        history = report_service_module.fetch_filtered_analysis_history_page()
+        by_id = {item["id"]: item for item in history["items"]}
+
+        self.assertIsNone(comparison)
+        self.assertIsNone(explicit_comparison)
+        self.assertNotIn("previous_scan_diff", by_id[int(second["id"])])
+
+    def test_previous_scan_diffs_normalize_workflow_contexts(self) -> None:
+        first = self._persist_comparison_report(
+            score=40,
+            severity="medium",
+            recommendation="caution",
+            top_risk="Interactive review",
+            findings=[],
+            evidence_items=[],
+            audit_context={
+                "source_interface": " API ",
+                "trigger_type": " Session ",
+                "trigger_id": " RUN-123 ",
+            },
+        )
+        second = self._persist_comparison_report(
+            score=88,
+            severity="critical",
+            recommendation="no-go",
+            top_risk="Same workflow review",
+            findings=[],
+            evidence_items=[],
+            audit_context={
+                "source_interface": "api",
+                "trigger_type": "session",
+                "trigger_id": "run-123",
+            },
+        )
+
+        comparison = report_service_module.fetch_report_comparison(second["id"])
+        explicit_comparison = report_service_module.fetch_report_comparison(
+            second["id"],
+            previous_report_id=first["id"],
+        )
+        history = report_service_module.fetch_filtered_analysis_history_page()
+        by_id = {item["id"]: item for item in history["items"]}
+
+        self.assertIsNotNone(comparison)
+        assert comparison is not None
+        self.assertEqual(comparison["previous_report"]["id"], first["id"])
+        self.assertIsNotNone(explicit_comparison)
+        self.assertEqual(
+            by_id[int(second["id"])]["previous_scan_diff"]["previous_report_id"],
+            first["id"],
+        )
+
+    def test_previous_scan_diffs_match_legacy_blank_workflow_context(
+        self,
+    ) -> None:
+        first = self._persist_comparison_report(
+            score=40,
+            severity="medium",
+            recommendation="caution",
+            top_risk="Legacy review",
+            findings=[],
+            evidence_items=[],
+        )
+        with database_module.SessionLocal() as session:
+            report = analysis_reports_repository_module.get_analysis_report(
+                session,
+                int(first["id"]),
+                include_evidence=True,
+            )
+            assert report is not None
+            report.source_interface = None
+            report.trigger_type = None
+            report.trigger_id = None
+            report.submission_manifest_json = "{}"
+            session.commit()
+        second = self._persist_comparison_report(
+            score=88,
+            severity="critical",
+            recommendation="no-go",
+            top_risk="Current workflow review",
+            findings=[],
+            evidence_items=[],
+            audit_context={
+                "source_interface": "api",
+                "trigger_type": "pull_request",
+                "trigger_id": "pr-42",
+            },
+        )
+
+        comparison = report_service_module.fetch_report_comparison(second["id"])
+        explicit_comparison = report_service_module.fetch_report_comparison(
+            second["id"],
+            previous_report_id=first["id"],
+        )
+        history = report_service_module.fetch_filtered_analysis_history_page()
+        by_id = {item["id"]: item for item in history["items"]}
+
+        self.assertIsNotNone(comparison)
+        assert comparison is not None
+        self.assertEqual(comparison["previous_report"]["id"], first["id"])
+        self.assertIsNotNone(explicit_comparison)
+        self.assertEqual(
+            by_id[int(second["id"])]["previous_scan_diff"]["previous_report_id"],
+            first["id"],
+        )
+
+    def test_previous_scan_diffs_prefer_exact_context_over_legacy_blank(
+        self,
+    ) -> None:
+        exact = self._persist_comparison_report(
+            score=40,
+            severity="medium",
+            recommendation="caution",
+            top_risk="Exact workflow review",
+            findings=[],
+            evidence_items=[],
+            audit_context={
+                "source_interface": "api",
+                "trigger_type": "pull_request",
+                "trigger_id": "pr-42",
+            },
+        )
+        legacy = self._persist_comparison_report(
+            score=55,
+            severity="medium",
+            recommendation="caution",
+            top_risk="Legacy blank workflow review",
+            findings=[],
+            evidence_items=[],
+        )
+        with database_module.SessionLocal() as session:
+            report = analysis_reports_repository_module.get_analysis_report(
+                session,
+                int(legacy["id"]),
+                include_evidence=True,
+            )
+            assert report is not None
+            report.source_interface = None
+            report.trigger_type = None
+            report.trigger_id = None
+            report.submission_manifest_json = "{}"
+            session.commit()
+        current = self._persist_comparison_report(
+            score=88,
+            severity="critical",
+            recommendation="no-go",
+            top_risk="Current workflow review",
+            findings=[],
+            evidence_items=[],
+            audit_context={
+                "source_interface": "api",
+                "trigger_type": "pull_request",
+                "trigger_id": "pr-42",
+            },
+        )
+
+        comparison = report_service_module.fetch_report_comparison(current["id"])
+        history = report_service_module.fetch_filtered_analysis_history_page()
+        by_id = {item["id"]: item for item in history["items"]}
+
+        self.assertIsNotNone(comparison)
+        assert comparison is not None
+        self.assertEqual(comparison["previous_report"]["id"], exact["id"])
+        self.assertEqual(
+            by_id[int(current["id"])]["previous_scan_diff"]["previous_report_id"],
+            exact["id"],
+        )
+
+    def test_previous_scan_diffs_do_not_treat_partial_context_as_wildcard(
+        self,
+    ) -> None:
+        first = self._persist_comparison_report(
+            score=40,
+            severity="medium",
+            recommendation="caution",
+            top_risk="Pull request review",
+            findings=[],
+            evidence_items=[],
+            audit_context={
+                "source_interface": "api",
+                "trigger_type": "pull_request",
+                "trigger_id": "pr-42",
+            },
+        )
+        second = self._persist_comparison_report(
+            score=88,
+            severity="critical",
+            recommendation="no-go",
+            top_risk="Partial workflow review",
+            findings=[],
+            evidence_items=[],
+            audit_context={
+                "source_interface": "api",
+                "trigger_type": "pull_request",
+                "trigger_id": "",
+            },
+        )
+
+        comparison = report_service_module.fetch_report_comparison(second["id"])
+        explicit_comparison = report_service_module.fetch_report_comparison(
+            second["id"],
+            previous_report_id=first["id"],
+        )
+        history = report_service_module.fetch_filtered_analysis_history_page()
+        by_id = {item["id"]: item for item in history["items"]}
+
+        self.assertIsNone(comparison)
+        self.assertIsNone(explicit_comparison)
+        self.assertNotIn("previous_scan_diff", by_id[int(second["id"])])
+
     def test_previous_scan_diffs_use_immediately_previous_comparable_report(
         self,
     ) -> None:
@@ -8393,11 +9595,244 @@ class ReportServiceTests(unittest.TestCase):
             session.commit()
 
         history = report_service_module.fetch_filtered_analysis_history_page(
-            severity="low"
+            severity="low",
+            skip_unreadable_schema=True,
         )
 
         self.assertEqual(history["total_count"], 1)
         self.assertEqual(history["items"][0]["id"], readable["id"])
+
+    def test_filtered_history_ignores_visible_unreadable_reports(self) -> None:
+        readable = self._persist_comparison_report(
+            score=30,
+            severity="low",
+            recommendation="go",
+            top_risk="Readable review",
+            findings=[],
+            evidence_items=[],
+        )
+        unreadable = self._persist_comparison_report(
+            score=90,
+            severity="critical",
+            recommendation="no-go",
+            top_risk="Future schema review",
+            findings=[],
+            evidence_items=[],
+        )
+        with database_module.SessionLocal() as session:
+            report = analysis_reports_repository_module.get_analysis_report(
+                session,
+                int(unreadable["id"]),
+                include_evidence=True,
+            )
+            assert report is not None
+            report.report_schema_version = "v3"
+            session.commit()
+
+        history = report_service_module.fetch_filtered_analysis_history_page(
+            skip_unreadable_schema=True
+        )
+
+        item_ids = {item["id"] for item in history["items"]}
+        self.assertIn(readable["id"], item_ids)
+        self.assertNotIn(unreadable["id"], item_ids)
+
+    def test_filtered_history_backfills_after_visible_unreadable_reports(
+        self,
+    ) -> None:
+        readable = self._persist_comparison_report(
+            score=30,
+            severity="low",
+            recommendation="go",
+            top_risk="Readable review",
+            findings=[],
+            evidence_items=[],
+        )
+        unreadable = self._persist_comparison_report(
+            score=90,
+            severity="critical",
+            recommendation="no-go",
+            top_risk="Future schema review",
+            findings=[],
+            evidence_items=[],
+        )
+        with database_module.SessionLocal() as session:
+            report = analysis_reports_repository_module.get_analysis_report(
+                session,
+                int(unreadable["id"]),
+                include_evidence=True,
+            )
+            assert report is not None
+            report.report_schema_version = "v3"
+            session.commit()
+
+        history = report_service_module.fetch_filtered_analysis_history_page(
+            page=1,
+            page_size=1,
+            skip_unreadable_schema=True,
+        )
+
+        self.assertEqual(history["total_count"], 1)
+        self.assertEqual([item["id"] for item in history["items"]], [readable["id"]])
+
+    def test_filtered_history_includes_legacy_blank_schema_reports(self) -> None:
+        blank_schema = self._persist_comparison_report(
+            score=31,
+            severity="low",
+            recommendation="go",
+            top_risk="Blank schema legacy review",
+            findings=[],
+            evidence_items=[],
+        )
+        future_schema = self._persist_comparison_report(
+            score=90,
+            severity="critical",
+            recommendation="no-go",
+            top_risk="Future schema review",
+            findings=[],
+            evidence_items=[],
+        )
+        with database_module.SessionLocal() as session:
+            for report_id, schema_version in (
+                (blank_schema["id"], ""),
+                (future_schema["id"], "v3"),
+            ):
+                report = analysis_reports_repository_module.get_analysis_report(
+                    session,
+                    int(report_id),
+                    include_evidence=True,
+                )
+                assert report is not None
+                report.report_schema_version = schema_version
+            session.commit()
+
+        history = report_service_module.fetch_filtered_analysis_history_page(
+            skip_unreadable_schema=True
+        )
+
+        self.assertEqual(history["total_count"], 1)
+        self.assertEqual(
+            {item["id"] for item in history["items"]},
+            {blank_schema["id"]},
+        )
+
+    def test_fetch_report_comparison_uses_legacy_blank_schema_previous_report(
+        self,
+    ) -> None:
+        previous = self._persist_comparison_report(
+            score=30,
+            severity="low",
+            recommendation="go",
+            top_risk="Legacy previous review",
+            findings=[],
+            evidence_items=[],
+        )
+        current = self._persist_comparison_report(
+            score=45,
+            severity="medium",
+            recommendation="caution",
+            top_risk="Current readable review",
+            findings=[],
+            evidence_items=[],
+        )
+        with database_module.SessionLocal() as session:
+            report = analysis_reports_repository_module.get_analysis_report(
+                session,
+                int(previous["id"]),
+                include_evidence=True,
+            )
+            assert report is not None
+            report.report_schema_version = ""
+            session.commit()
+
+        comparison = report_service_module.fetch_report_comparison(current["id"])
+
+        self.assertIsNotNone(comparison)
+        assert comparison is not None
+        self.assertEqual(comparison["previous_report"]["id"], previous["id"])
+
+    def test_filtered_history_skip_unreadable_keeps_database_pagination(
+        self,
+    ) -> None:
+        for index in range(3):
+            self._persist_comparison_report(
+                score=30 + index,
+                severity="low",
+                recommendation="go",
+                top_risk=f"Readable review {index}",
+                findings=[],
+                evidence_items=[],
+            )
+        original_list_analysis_reports = report_service_module.list_analysis_reports
+        list_calls: list[dict[str, object]] = []
+
+        def recording_list_analysis_reports(*args, **kwargs):
+            list_calls.append(dict(kwargs))
+            return original_list_analysis_reports(*args, **kwargs)
+
+        with patch.object(
+            report_service_module,
+            "list_analysis_reports",
+            side_effect=recording_list_analysis_reports,
+        ):
+            history = report_service_module.fetch_filtered_analysis_history_page(
+                page=2,
+                page_size=1,
+                skip_unreadable_schema=True,
+            )
+
+        paged_calls = [
+            call
+            for call in list_calls
+            if call.get("limit") == 1 and call.get("offset") == 1
+        ]
+        self.assertEqual(history["total_count"], 3)
+        self.assertEqual(len(history["items"]), 1)
+        self.assertEqual(len(paged_calls), 1)
+        self.assertIsNotNone(paged_calls[0].get("report_schema_versions"))
+
+    def test_fetch_report_comparison_ignores_unreadable_off_path_reports(
+        self,
+    ) -> None:
+        previous = self._persist_comparison_report(
+            score=30,
+            severity="low",
+            recommendation="go",
+            top_risk="Readable previous review",
+            findings=[],
+            evidence_items=[],
+        )
+        unreadable = self._persist_comparison_report(
+            score=90,
+            severity="critical",
+            recommendation="no-go",
+            top_risk="Future schema review",
+            findings=[],
+            evidence_items=[],
+        )
+        current = self._persist_comparison_report(
+            score=45,
+            severity="medium",
+            recommendation="caution",
+            top_risk="Readable current review",
+            findings=[],
+            evidence_items=[],
+        )
+        with database_module.SessionLocal() as session:
+            report = analysis_reports_repository_module.get_analysis_report(
+                session,
+                int(unreadable["id"]),
+                include_evidence=True,
+            )
+            assert report is not None
+            report.report_schema_version = "v3"
+            session.commit()
+
+        comparison = report_service_module.fetch_report_comparison(current["id"])
+
+        self.assertIsNotNone(comparison)
+        assert comparison is not None
+        self.assertEqual(comparison["previous_report"]["id"], previous["id"])
 
     def test_previous_scan_diffs_compute_history_signature_once_per_report(
         self,

--- a/tests/test_ui/test_history_page.py
+++ b/tests/test_ui/test_history_page.py
@@ -1113,9 +1113,18 @@ class HistoryPageRenderingTests(unittest.TestCase):
 
         self.assertEqual(compare_response.status_code, 200)
         self.assertIn("Comparison with report #1", compare_response.text)
+        self.assertIn(
+            "previous comparable report in the same project, workspace, and workflow context",
+            compare_response.text,
+        )
         self.assertIn("Risk score delta", compare_response.text)
         self.assertIn("+48", compare_response.text)
         self.assertIn("MEDIUM → CRITICAL", compare_response.text)
+        self.assertIn("Resolved findings", compare_response.text)
+        self.assertIn("Evidence resolved", compare_response.text)
+        self.assertIn("New findings", compare_response.text)
+        self.assertIn("Persistent findings", compare_response.text)
+        self.assertIn("Changed context", compare_response.text)
         self.assertIn("Topology freshness", compare_response.text)
         self.assertIn("12 days old", compare_response.text)
         self.assertIn("95 days old", compare_response.text)
@@ -1164,9 +1173,18 @@ class HistoryPageRenderingTests(unittest.TestCase):
 
         self.assertEqual(compare_response.status_code, 200)
         self.assertIn("Comparison with report #1", compare_response.text)
+        self.assertIn(
+            "previous comparable report in the same project, workspace, and workflow context",
+            compare_response.text,
+        )
         self.assertIn("Risk score delta", compare_response.text)
         self.assertIn("+48", compare_response.text)
         self.assertIn("MEDIUM → CRITICAL", compare_response.text)
+        self.assertIn("Resolved findings", compare_response.text)
+        self.assertIn("Evidence resolved", compare_response.text)
+        self.assertIn("New findings", compare_response.text)
+        self.assertIn("Persistent findings", compare_response.text)
+        self.assertIn("Changed context", compare_response.text)
         self.assertIn("Topology freshness", compare_response.text)
         self.assertIn("12 days old", compare_response.text)
         self.assertIn("95 days old", compare_response.text)
@@ -1268,10 +1286,79 @@ class HistoryPageRenderingTests(unittest.TestCase):
 
         self.assertEqual(compare_response.status_code, 200)
         self.assertIn(
-            "The previous comparable report is not available in this shared context.",
+            "The previous shared report requires a password before comparison.",
             compare_response.text,
         )
         self.assertNotIn("Comparison with report #1", compare_response.text)
+
+        unlocked_response = self.client.post(
+            "/reports/1/unlock",
+            data={
+                "password": "previous-only",
+                "next": "/reports/2?compare=previous#report-comparison",
+            },
+            follow_redirects=True,
+        )
+
+        self.assertEqual(unlocked_response.status_code, 200)
+        self.assertIn("Comparison with report #1", unlocked_response.text)
+
+    def test_public_report_compare_allows_same_password_protected_reruns(
+        self,
+    ) -> None:
+        self._persist_report(
+            score=42,
+            severity="medium",
+            recommendation="caution",
+            top_risk="Initial security group review",
+            opening_sentence="Initial review of the security group change.",
+            finding_description="Security group exposure risk",
+        )
+        report_service_module.configure_report_share(
+            1,
+            password="shared-secret",
+            redact_filenames=False,
+        )
+        self._persist_report(
+            score=88,
+            severity="critical",
+            recommendation="no-go",
+            top_risk="Security group exposure risk",
+            opening_sentence="Ingress widens access to production resources.",
+            finding_description="Security group exposure risk",
+        )
+        report_service_module.configure_report_share(
+            2,
+            password="shared-secret",
+            redact_filenames=False,
+        )
+
+        current_unlock = self.client.post(
+            "/reports/2/unlock",
+            data={
+                "password": "shared-secret",
+                "next": "/reports/2?compare=previous#report-comparison",
+            },
+            follow_redirects=True,
+        )
+
+        self.assertEqual(current_unlock.status_code, 200)
+        self.assertIn(
+            "The previous shared report requires a password before comparison.",
+            current_unlock.text,
+        )
+        previous_unlock = self.client.post(
+            "/reports/1/unlock",
+            data={
+                "password": "shared-secret",
+                "next": "/reports/2?compare=previous#report-comparison",
+            },
+            follow_redirects=True,
+        )
+
+        self.assertEqual(previous_unlock.status_code, 200)
+        self.assertIn("Comparison with report #1", previous_unlock.text)
+        self.assertIn("Risk score delta", previous_unlock.text)
 
     def test_history_page_renders_toolbar_and_report_actions(self) -> None:
         self._persist_report(
@@ -1595,7 +1682,7 @@ class HistoryPageRenderingTests(unittest.TestCase):
         cookie_header = response.headers.get("set-cookie", "")
         self.assertIn("Secure", cookie_header)
         self.assertIn("HttpOnly", cookie_header)
-        self.assertIn("Path=/reports/1", cookie_header)
+        self.assertIn("Path=/reports", cookie_header)
 
     def test_history_page_keeps_legacy_query_parameter_as_detail_fallback(self) -> None:
         self._persist_report()

--- a/ui/routes/history.py
+++ b/ui/routes/history.py
@@ -100,6 +100,7 @@ def build_history_page() -> None:
                 project_id=active_project_id,
                 page=1,
                 page_size=5,
+                skip_unreadable_schema=True,
             )
         )
         reports = reports_page["items"]
@@ -185,6 +186,7 @@ def build_history_page() -> None:
                         search=query,
                         page=page_state["page"],
                         page_size=page_state["page_size"],
+                        skip_unreadable_schema=True,
                     )
                 )
                 reports = page_payload["items"]
@@ -449,7 +451,7 @@ def _render_history_report_comparison(
                     f"Comparison with report #{int(comparison['previous_report']['id'])}"
                 ).classes("text-xl font-semibold dw-text")
                 ui.label(
-                    "Side-by-side changes against the previous saved scan of the same analyzed artifacts."
+                    "Side-by-side changes against the previous comparable report in the same project, workspace, and workflow context."
                 ).classes("text-sm dw-muted leading-6")
             with ui.column().classes("gap-1 shrink-0"):
                 ui.label("Risk score delta").classes(
@@ -461,6 +463,10 @@ def _render_history_report_comparison(
                 ui.label(
                     f"{int(comparison['previous_report']['risk_score'])} -> {int(comparison['current_report']['risk_score'])}"
                 ).classes("text-xs dw-muted")
+        for warning in comparison.get("summary", {}).get("warnings") or []:
+            ui.label(f"Comparison warning: {warning}").classes(
+                "text-sm dw-warning-text leading-6"
+            )
         with ui.row().classes("w-full gap-4 flex-wrap mt-2"):
             with ui.card().classes("dw-panel-soft shadow-none min-w-[260px] flex-1"):
                 with ui.column().classes("gap-2 p-4"):
@@ -474,14 +480,14 @@ def _render_history_report_comparison(
                         comparison["previous_report"].get("context_completeness") or {}
                     )
                     _render_history_comparison_items(
-                        "Findings removed",
+                        "Resolved findings",
                         comparison["findings"]["removed"],
-                        empty_message="No findings were removed.",
+                        empty_message="No resolved findings were found.",
                     )
                     _render_history_comparison_items(
-                        "Evidence removed",
+                        "Evidence resolved",
                         comparison["evidence"]["removed"],
-                        empty_message="No evidence was removed.",
+                        empty_message="No evidence was resolved.",
                     )
             with ui.card().classes("dw-panel-soft shadow-none min-w-[260px] flex-1"):
                 with ui.column().classes("gap-2 p-4"):
@@ -495,15 +501,22 @@ def _render_history_report_comparison(
                         comparison["current_report"].get("context_completeness") or {}
                     )
                     _render_history_comparison_items(
-                        "Findings added",
+                        "New findings",
                         comparison["findings"]["added"],
-                        empty_message="No findings were added.",
+                        empty_message="No new findings were found.",
                     )
                     _render_history_comparison_items(
                         "Evidence added",
                         comparison["evidence"]["added"],
                         empty_message="No evidence was added.",
                     )
+        with ui.card().classes("w-full dw-panel-soft shadow-none mt-4"):
+            with ui.column().classes("gap-3 p-4"):
+                _render_history_comparison_items(
+                    "Persistent findings",
+                    comparison["findings"]["persistent"],
+                    empty_message="No findings persisted across both reports.",
+                )
         with ui.card().classes("w-full dw-panel-soft shadow-none mt-4"):
             with ui.column().classes("gap-3 p-4"):
                 ui.label("Severity changes").classes("text-sm font-semibold dw-text")
@@ -526,6 +539,13 @@ def _render_history_report_comparison(
                                 f"{str(item.get('previous_severity') or 'unknown').upper()} → "
                                 f"{str(item.get('current_severity') or 'unknown').upper()}"
                             ).classes("text-sm font-semibold dw-text")
+        with ui.card().classes("w-full dw-panel-soft shadow-none mt-4"):
+            with ui.column().classes("gap-3 p-4"):
+                _render_history_comparison_items(
+                    "Changed context",
+                    comparison["findings"]["context_changed"],
+                    empty_message="No persistent findings changed evidence or context.",
+                )
 
 
 def build_history_detail_page(report_id: int, *, show_comparison: bool = False) -> None:


### PR DESCRIPTION
Story 3.6 needs reviewers to distinguish new, resolved, persistent, severity-changed, and context-changed findings after reruns without crossing project, workspace, workflow, redaction, or readable-schema boundaries. The implementation keeps comparison logic in the shared report service, adapts UI/shared-report rendering, and locks the reviewer-discovered edge cases with service, UI, and browser coverage.

Constraint: Preserve local-first advisory report semantics and shared service reuse across UI/API/shared-report surfaces

Rejected: Artifact-only previous-scan matching | it violated Story 3.6 workflow-context scoping

Rejected: Greedy duplicate pairing as the only matcher | it hid duplicate finding add/remove transitions

Confidence: high

Scope-risk: moderate

Directive: Do not loosen comparable-report scoping without regression coverage for project, workspace, workflow context, schema readability, and redaction

Tested: ./.venv/bin/python -m unittest discover -q

Tested: bash scripts/ci-local.sh

Tested: APP_PORT=18080 npm run test:ui-review

Tested: ./.venv/bin/ruff check .; ./.venv/bin/ruff format --check .; git diff --check

Tested: ./.venv/bin/bandit -r app.py services ui tests/e2e/seeded_server.py --severity-level high --confidence-level high -q

Tested: ./.venv/bin/python -m pip_audit -r requirements.txt

Not-tested: VoiceOver validation intentionally not run per project directive

## What does this PR do?

<!-- Brief description of changes -->

## Type of change
- [ ] Feature (new functionality)
- [ ] Bugfix (non-breaking fix)
- [ ] Release preparation
- [ ] Hotfix (critical production fix)
- [ ] Docs / refactor / chore

## Checklist
- [ ] I have followed the branch naming convention
- [ ] Tests pass locally (`pytest tests/ -v`)
- [ ] Linting passes (`ruff check .`)
- [ ] Docker build succeeds
- [ ] I have updated docs if needed
- [ ] No secrets or .env values committed

## Related issue
Closes #