### PR TITLE
Make report review usable without pointer input

### DIFF
--- a/README.md
+++ b/README.md
@@ -556,12 +556,16 @@ Run the local CI-equivalent checks:
 bash scripts/ci-local.sh
 ```
 
-Run the browser keyboard smoke for the review flow:
+Run the browser keyboard/accessibility smoke for the review flow:
 
 ```bash
 npm install
 npm run test:ui-review
 ```
+
+This validates the seeded report review route with keyboard navigation, review
+section focus order, landmarks, labels, and live status announcements for
+evidence inspector open/close changes.
 
 Run the real macOS VoiceOver smoke on a GUI-enabled Mac:
 
@@ -689,7 +693,7 @@ The CI pipeline is backend-focused and intentionally skips frontend-style burn-i
 
 For accessibility-sensitive UI changes, the repo also ships an opt-in macOS verification lane:
 
-- `npm run test:ui-review` exercises the seeded review flow with Playwright keyboard automation.
+- `npm run test:ui-review` exercises the seeded review flow with Playwright keyboard automation, including review landmarks and status announcements.
 - `npm run test:ui-review:voiceover` exercises the same flow with real VoiceOver on macOS after `npm run setup:ui-review`.
 - `RUN_UI_A11Y=1 bash scripts/ci-local.sh` appends both lanes locally when Node dependencies are installed. The VoiceOver step auto-skips on non-macOS hosts.
 

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -77,7 +77,7 @@ development_status:
   3-4-confidence-ledger-and-why-not-lower-higher: done
   3-5-context-completeness-and-todo-panel: done
   3-6-report-diff-after-rerun: done
-  3-7-keyboard-and-accessibility-review-pass: ready-for-dev
+  3-7-keyboard-and-accessibility-review-pass: done
   3-8-historical-report-search-and-filtering: ready-for-dev
   epic-3-retrospective: optional
 

--- a/tests/e2e/report_review.keyboard.spec.js
+++ b/tests/e2e/report_review.keyboard.spec.js
@@ -1,4 +1,5 @@
 const { test, expect } = require("@playwright/test");
+const zlib = require("zlib");
 
 const REVIEW_ORDER = [
   "verdict",
@@ -104,21 +105,257 @@ async function expectDelayedEvidenceFocusDoesNotStealUserFocus(page) {
     .toBe("dw-focus-steal-sentinel");
 }
 
+function parseCssColor(value) {
+  const match = String(value).match(/rgba?\(([^)]+)\)/i);
+  if (!match) {
+    return null;
+  }
+  const parts = match[1]
+    .split(/[,/ ]+/)
+    .filter(Boolean)
+    .map((part) => Number.parseFloat(part));
+  if (parts.length < 3 || parts.slice(0, 3).some(Number.isNaN)) {
+    return null;
+  }
+  return parts.slice(0, 3).map((part) => Math.max(0, Math.min(255, part)));
+}
+
+function luminance(color) {
+  const channels = color.map((channel) => {
+    const normalized = channel / 255;
+    return normalized <= 0.03928
+      ? normalized / 12.92
+      : ((normalized + 0.055) / 1.055) ** 2.4;
+  });
+  return 0.2126 * channels[0] + 0.7152 * channels[1] + 0.0722 * channels[2];
+}
+
+function contrastRatio(foreground, background) {
+  const light = Math.max(luminance(foreground), luminance(background));
+  const dark = Math.min(luminance(foreground), luminance(background));
+  return (light + 0.05) / (dark + 0.05);
+}
+
+function decodePng(buffer) {
+  const signature = "89504e470d0a1a0a";
+  if (buffer.subarray(0, 8).toString("hex") !== signature) {
+    throw new Error("Expected PNG screenshot");
+  }
+
+  const idatChunks = [];
+  let width = 0;
+  let height = 0;
+  let bitDepth = 0;
+  let colorType = 0;
+  let interlace = 0;
+  let offset = 8;
+
+  while (offset < buffer.length) {
+    const length = buffer.readUInt32BE(offset);
+    const type = buffer.toString("ascii", offset + 4, offset + 8);
+    const dataStart = offset + 8;
+    const dataEnd = dataStart + length;
+    const data = buffer.subarray(dataStart, dataEnd);
+    if (type === "IHDR") {
+      width = data.readUInt32BE(0);
+      height = data.readUInt32BE(4);
+      bitDepth = data[8];
+      colorType = data[9];
+      interlace = data[12];
+    } else if (type === "IDAT") {
+      idatChunks.push(data);
+    } else if (type === "IEND") {
+      break;
+    }
+    offset = dataEnd + 4;
+  }
+
+  if (bitDepth !== 8 || interlace !== 0 || ![2, 6].includes(colorType)) {
+    throw new Error(
+      `Unsupported PNG format: bitDepth=${bitDepth} colorType=${colorType} interlace=${interlace}`
+    );
+  }
+
+  const bytesPerPixel = colorType === 6 ? 4 : 3;
+  const stride = width * bytesPerPixel;
+  const inflated = zlib.inflateSync(Buffer.concat(idatChunks));
+  const pixels = new Uint8Array(width * height * 4);
+  let sourceOffset = 0;
+  let previous = new Uint8Array(stride);
+
+  const paeth = (left, up, upLeft) => {
+    const predictor = left + up - upLeft;
+    const leftDistance = Math.abs(predictor - left);
+    const upDistance = Math.abs(predictor - up);
+    const upLeftDistance = Math.abs(predictor - upLeft);
+    if (leftDistance <= upDistance && leftDistance <= upLeftDistance) {
+      return left;
+    }
+    return upDistance <= upLeftDistance ? up : upLeft;
+  };
+
+  for (let y = 0; y < height; y += 1) {
+    const filter = inflated[sourceOffset];
+    sourceOffset += 1;
+    const row = new Uint8Array(stride);
+    for (let x = 0; x < stride; x += 1) {
+      const raw = inflated[sourceOffset + x];
+      const left = x >= bytesPerPixel ? row[x - bytesPerPixel] : 0;
+      const up = previous[x] || 0;
+      const upLeft = x >= bytesPerPixel ? previous[x - bytesPerPixel] || 0 : 0;
+      let value = raw;
+      if (filter === 1) {
+        value += left;
+      } else if (filter === 2) {
+        value += up;
+      } else if (filter === 3) {
+        value += Math.floor((left + up) / 2);
+      } else if (filter === 4) {
+        value += paeth(left, up, upLeft);
+      } else if (filter !== 0) {
+        throw new Error(`Unsupported PNG filter: ${filter}`);
+      }
+      row[x] = value & 0xff;
+    }
+    sourceOffset += stride;
+    for (let x = 0; x < width; x += 1) {
+      const sourceIndex = x * bytesPerPixel;
+      const pixelIndex = (y * width + x) * 4;
+      pixels[pixelIndex] = row[sourceIndex];
+      pixels[pixelIndex + 1] = row[sourceIndex + 1];
+      pixels[pixelIndex + 2] = row[sourceIndex + 2];
+      pixels[pixelIndex + 3] = colorType === 6 ? row[sourceIndex + 3] : 255;
+    }
+    previous = row;
+  }
+
+  return { width, height, pixels };
+}
+
+function renderedBackgroundFromScreenshot(buffer) {
+  const { width, height, pixels } = decodePng(buffer);
+  const edgeSize = Math.min(3, Math.ceil(Math.min(width, height) / 2));
+  const buckets = new Map();
+
+  const addPixel = (x, y) => {
+    const index = (y * width + x) * 4;
+    if (pixels[index + 3] === 0) {
+      return;
+    }
+    const color = [pixels[index], pixels[index + 1], pixels[index + 2]];
+    const key = color.map((channel) => Math.round(channel / 4) * 4).join(",");
+    const bucket = buckets.get(key) || { count: 0, total: [0, 0, 0] };
+    bucket.count += 1;
+    bucket.total[0] += color[0];
+    bucket.total[1] += color[1];
+    bucket.total[2] += color[2];
+    buckets.set(key, bucket);
+  };
+
+  for (let y = 0; y < height; y += 1) {
+    for (let x = 0; x < width; x += 1) {
+      if (
+        x < edgeSize ||
+        y < edgeSize ||
+        x >= width - edgeSize ||
+        y >= height - edgeSize
+      ) {
+        addPixel(x, y);
+      }
+    }
+  }
+
+  const background = [...buckets.values()].sort((left, right) => {
+    return right.count - left.count;
+  })[0];
+  if (!background) {
+    throw new Error("Could not sample rendered background pixels");
+  }
+  return {
+    background: background.total.map((total) => total / background.count),
+    height,
+    width,
+  };
+}
+
+async function expectRenderedTextContrast(locator, minimumRatio = 4.5) {
+  const style = await locator.evaluate((element) => {
+    const computed = window.getComputedStyle(element);
+    return {
+      color: computed.color,
+      text: element.textContent?.trim() || element.getAttribute("aria-label") || "",
+    };
+  });
+  const foreground = parseCssColor(style.color);
+  if (!foreground) {
+    throw new Error(`Could not parse foreground color: ${style.color}`);
+  }
+  const screenshot = await locator.screenshot();
+  const { background, height, width } = renderedBackgroundFromScreenshot(screenshot);
+  const result = {
+    background: `rgb(${background.map(Math.round).join(", ")})`,
+    foreground: style.color,
+    ratio: contrastRatio(foreground, background),
+    size: `${width}x${height}`,
+    text: style.text,
+  };
+  expect(
+    result.ratio,
+    `${result.text} contrast ${result.foreground} on rendered ${result.background} (${result.size})`
+  ).toBeGreaterThanOrEqual(minimumRatio);
+}
+
 test.describe("review keyboard flow", () => {
   test("tabs through review sections in order and supports arrow/escape controls", async ({
     page,
   }) => {
     await page.goto("/", { waitUntil: "networkidle" });
+    await expect(
+      page.getByRole("navigation", { name: "Primary navigation" })
+    ).toBeVisible();
+    await expect(
+      page.getByRole("main", { name: "Deployment review workspace" })
+    ).toBeVisible();
+    const reviewStatus = page.getByRole("status", {
+      name: "Review status updates",
+    });
+    await expect(reviewStatus).toBeAttached();
+    await page.evaluate(() => {
+      window.dwAnnounceReviewStatus("stale evidence status");
+      window.dwAnnounceReviewStatus("latest evidence status");
+    });
+    await expect(reviewStatus).toHaveText("latest evidence status");
     await expect(page.getByText("5-second verdict")).toBeVisible();
+    await expect(
+      page.getByRole("heading", { name: "5-second verdict" })
+    ).toBeVisible();
     await expect(page.getByText("Advisory posture").first()).toBeVisible();
     await expect(page.getByText("Evidence Law").first()).toBeVisible();
     await expect(page.getByText("Next action").first()).toBeVisible();
     await expect(page.getByText("Review linked evidence").first()).toBeVisible();
     await expect(page.getByText("Confidence ledger").first()).toBeVisible();
+    await expect(
+      page.getByRole("heading", { name: "Confidence ledger" }).first()
+    ).toBeVisible();
     await expect(page.getByText("Why not lower").first()).toBeVisible();
     await expect(page.getByText("Why not higher").first()).toBeVisible();
     await expect(page.getByText("Uncertainty drivers").first()).toBeVisible();
     await expect(page.getByText("Summary context check").first()).toBeVisible();
+    await expect(
+      page.getByRole("heading", { name: "Summary context check" }).first()
+    ).toBeVisible();
+    await expect(
+      page.getByRole("heading", { name: "Findings table" }).first()
+    ).toBeVisible();
+    await expect(
+      page.getByRole("heading", { name: "Context completeness" }).first()
+    ).toBeVisible();
+    await expect(
+      page.getByRole("heading", { name: "Blast radius" }).first()
+    ).toBeVisible();
+    await expect(
+      page.getByRole("heading", { name: "Rollback plan" }).first()
+    ).toBeVisible();
     await expect(page.getByText("Context follow-ups").first()).toBeVisible();
     await expect(page.getByText("Manage topology").first()).toBeVisible();
     await expect(page.getByText("Report schema guide").first()).toBeVisible();
@@ -128,6 +365,9 @@ test.describe("review keyboard flow", () => {
     await expect(page.getByText("Evidence Law satisfied").first()).toBeVisible();
     await expect(page.getByText("External").first()).toBeVisible();
     await page.waitForFunction(() => window.dwReviewAccessibilityInstalled === true);
+    await expectRenderedTextContrast(page.getByRole("link", { name: "Dashboard" }));
+    await expectRenderedTextContrast(page.getByText("5-second verdict").first());
+    await expectRenderedTextContrast(page.getByText("Confidence ledger").first());
     await expectDelayedEvidenceFocusDoesNotStealUserFocus(page);
     await expect(page.getByText("Module: module.network").first()).toBeVisible();
     await expect(
@@ -154,8 +394,14 @@ test.describe("review keyboard flow", () => {
     const firstPanelId = await firstFinding.getAttribute("aria-controls");
     expect(firstPanelId).toMatch(/^evidence-inspector-/);
     await page.keyboard.press("Enter");
+    await expect(reviewStatus).toHaveText(
+      /Evidence inspector opened for CRITICAL: aws_security_group\.main/
+    );
     const firstEvidenceInspector = page.locator(`[id="${firstPanelId}"]`);
     await expect(firstEvidenceInspector).toBeVisible();
+    await expect(
+      firstEvidenceInspector.getByRole("heading", { name: "Evidence inspector" })
+    ).toBeVisible();
     await expect(firstFinding).toBeFocused();
     await expect(
       firstEvidenceInspector.getByText("Ingress CIDR widened to 0.0.0.0/0.")
@@ -178,6 +424,9 @@ test.describe("review keyboard flow", () => {
     await expect(evidenceInspector).toBeVisible();
     await expect(focusedFinding).toBeFocused();
     await page.keyboard.press("Space");
+    await expect(reviewStatus).toHaveText(
+      /Evidence inspector closed for HIGH: aws_db_instance\.primary/
+    );
     await expect(evidenceInspector).toBeHidden();
     await expect(focusedFinding).toBeFocused();
     await page.keyboard.press("ArrowUp");
@@ -244,6 +493,9 @@ test.describe("review keyboard flow", () => {
     await expect(focusedFinding).toHaveAttribute("aria-expanded", "false");
     await expect(focusedFinding).toBeFocused();
     await page.keyboard.press("Space");
+    await expect(reviewStatus).toHaveText(
+      /Evidence inspector opened for HIGH: aws_db_instance\.primary/
+    );
     await expect(evidenceInspector).toBeVisible();
     await expect(focusedFinding).toHaveAttribute("aria-expanded", "true");
     await expect(focusedFinding).toBeFocused();
@@ -345,12 +597,24 @@ test.describe("review keyboard flow", () => {
     expect(seen).toEqual(REVIEW_ORDER);
 
     await page.goto("/history", { waitUntil: "networkidle" });
+    await expect(
+      page.getByRole("navigation", { name: "Primary navigation" })
+    ).toBeVisible();
+    await expect(
+      page.getByRole("main", { name: "Analysis history workspace" })
+    ).toBeVisible();
     await expect(page.locator(".dw-history-card")).toHaveCount(2);
     await expect(page.getByText("Rescan diff")).toBeVisible();
     await expect(page.getByText("+48 risk vs report #1")).toBeVisible();
     await page.locator(".dw-history-card").first().click();
     await expect(page).toHaveURL(/\/history\/2$/);
     await page.waitForFunction(() => window.dwReviewAccessibilityInstalled === true);
+    await expect(
+      page.getByRole("navigation", { name: "Primary navigation" })
+    ).toBeVisible();
+    await expect(
+      page.getByRole("main", { name: "Analysis report workspace" })
+    ).toBeVisible();
     await expect(page.getByText("Analysis report detail")).toBeVisible();
     await expect(page.getByText("Back to History")).toBeVisible();
     await expect(page.getByText("Module: module.network").first()).toBeVisible();
@@ -370,7 +634,18 @@ test.describe("review keyboard flow", () => {
       page.locator('[data-dw-review-section="blast-radius"]')
     ).toBeVisible();
     await expect(page.locator('[data-dw-review-section="rollback"]')).toBeVisible();
+    await page.goto("/history/999", { waitUntil: "networkidle" });
+    await expect(
+      page.getByRole("main", { name: "Analysis report unavailable" })
+    ).toBeVisible();
+    await expect(page.getByText("Analysis report not found")).toBeVisible();
     await page.goto("/history/2/compare", { waitUntil: "networkidle" });
+    await expect(
+      page.getByRole("navigation", { name: "Primary navigation" })
+    ).toBeVisible();
+    await expect(
+      page.getByRole("main", { name: "Analysis report workspace" })
+    ).toBeVisible();
     await expect(page.getByText("Comparison with report #1")).toBeVisible();
     await expect(page.getByText("Risk score delta")).toBeVisible();
     await expect(page.getByText("+48")).toBeVisible();

--- a/ui/components/blast_radius_graph.py
+++ b/ui/components/blast_radius_graph.py
@@ -102,7 +102,9 @@ def render_blast_radius_panel(result: BlastRadiusResult, *, severity: str) -> No
     direct_text = f"{result.direct_count} services directly affected, {result.transitive_count} transitively"
     with ui.card().classes("w-full dw-panel shadow-none") as panel:
         decorate_review_section(panel, section="blast-radius", label="Blast radius")
-        ui.label("Blast radius").classes("text-lg font-medium dw-text")
+        ui.label("Blast radius").classes("text-lg font-medium dw-text").props(
+            "role=heading aria-level=2"
+        )
         ui.label(direct_text).classes("text-sm dw-muted")
         ui.label(
             "Legend: depth 0 = directly affected, depth 1+ = transitively affected."

--- a/ui/components/confidence_ledger.py
+++ b/ui/components/confidence_ledger.py
@@ -44,7 +44,9 @@ def render_confidence_ledger(report: dict[str, Any]) -> None:
         )
         with ui.column().classes("gap-4"):
             with ui.column().classes("gap-1"):
-                ui.label("Confidence ledger").classes("text-lg font-medium dw-text")
+                ui.label("Confidence ledger").classes(
+                    "text-lg font-medium dw-text"
+                ).props("role=heading aria-level=2")
                 ui.label(
                     "Reasoning details that explain the verdict using persisted evidence, contributors, confidence, and context quality."
                 ).classes("text-sm dw-muted leading-6")

--- a/ui/components/context_completeness_panel.py
+++ b/ui/components/context_completeness_panel.py
@@ -153,7 +153,7 @@ def render_context_summary_panel(
                 with ui.column().classes("gap-1 min-w-0 flex-1"):
                     ui.label("Summary context check").classes(
                         "text-sm font-semibold dw-text"
-                    )
+                    ).props("role=heading aria-level=3")
                     ui.label(
                         "Context completeness and TODOs that may change how much confidence to place in this report."
                     ).classes("text-xs dw-muted leading-5")
@@ -199,7 +199,9 @@ def render_context_completeness_panel(
         decorate_review_section(panel, section="context", label="Context completeness")
         with ui.row().classes("w-full items-start justify-between gap-3 flex-wrap"):
             with ui.column().classes("gap-2 min-w-0 flex-1"):
-                ui.label("Context completeness").classes("text-lg font-medium dw-text")
+                ui.label("Context completeness").classes(
+                    "text-lg font-medium dw-text"
+                ).props("role=heading aria-level=2")
                 ui.label(
                     "Review how much topology, evidence, parser, and incident context supported this report."
                 ).classes("text-sm dw-muted leading-6")

--- a/ui/components/findings_table.py
+++ b/ui/components/findings_table.py
@@ -678,6 +678,10 @@ def render_findings_table(
         id(finding): _finding_row_key(finding, index)
         for index, finding in enumerate(findings)
     }
+    finding_title_by_row_key = {
+        finding_row_keys[id(finding)]: str(finding.get("title") or "Untitled finding")
+        for finding in findings
+    }
     fallback_finding_ids = _unique_finding_ids(findings)
     expanded_ids: set[str] = {
         finding_row_keys[id(finding)]
@@ -743,6 +747,12 @@ def render_findings_table(
         if not was_expanded:
             expanded_ids.add(finding_id)
         render_rows()
+        title = finding_title_by_row_key.get(finding_id, "Untitled finding")
+        action = "closed" if was_expanded else "opened"
+        ui.run_javascript(
+            "window.dwAnnounceReviewStatus && "
+            f"window.dwAnnounceReviewStatus({json.dumps(f'Evidence inspector {action} for {title}')})"
+        )
         if focus_target == "row":
             restore_row_focus(evidence_panel_id)
         elif focus_target == "button":
@@ -926,7 +936,7 @@ def render_findings_table(
                             )
                             ui.label("Evidence inspector").classes(
                                 "text-sm font-semibold dw-text mt-2"
-                            )
+                            ).props("role=heading aria-level=3")
                             _render_missing_evidence_notice(missing_evidence_refs)
                             if not matched_evidence and not missing_evidence_refs:
                                 ui.label(
@@ -1043,7 +1053,9 @@ def render_findings_table(
         findings_card.props('data-dw-findings-table="1"')
         decorate_review_section(findings_card, section="findings", label=title)
         with ui.row().classes("w-full items-center justify-between gap-3 flex-wrap"):
-            ui.label(title).classes("text-lg font-medium dw-text")
+            ui.label(title).classes("text-lg font-medium dw-text").props(
+                "role=heading aria-level=2"
+            )
             ui.label(
                 "Severity, evidence count, confidence, and deterministic status stay visible while evidence expands inline."
             ).classes("text-xs dw-muted")

--- a/ui/components/review_accessibility.py
+++ b/ui/components/review_accessibility.py
@@ -13,6 +13,17 @@ _REVIEW_ACCESSIBILITY_HEAD = """
   outline: 2px solid var(--dw-accent);
   outline-offset: 4px;
 }
+.dw-sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
 </style>
 <script>
 (() => {
@@ -20,6 +31,43 @@ _REVIEW_ACCESSIBILITY_HEAD = """
     return;
   }
   window.dwReviewAccessibilityInstalled = true;
+
+  const ensureStatusRegion = () => {
+    let region = document.getElementById('dw-review-status');
+    if (region) {
+      return region;
+    }
+    region = document.createElement('div');
+    region.id = 'dw-review-status';
+    region.className = 'dw-sr-only';
+    region.setAttribute('role', 'status');
+    region.setAttribute('aria-live', 'polite');
+    region.setAttribute('aria-atomic', 'true');
+    region.setAttribute('aria-label', 'Review status updates');
+    document.body.appendChild(region);
+    return region;
+  };
+  window.dwAnnounceReviewStatus = (message) => {
+    const region = ensureStatusRegion();
+    const sequence = (window.dwReviewStatusSequence || 0) + 1;
+    window.dwReviewStatusSequence = sequence;
+    if (window.dwReviewStatusTimer) {
+      window.clearTimeout(window.dwReviewStatusTimer);
+    }
+    region.textContent = '';
+    window.dwReviewStatusTimer = window.setTimeout(() => {
+      if (window.dwReviewStatusSequence !== sequence) {
+        return;
+      }
+      region.textContent = String(message || '');
+      window.dwReviewStatusTimer = null;
+    }, 20);
+  };
+  if (document.body) {
+    ensureStatusRegion();
+  } else {
+    window.addEventListener('DOMContentLoaded', ensureStatusRegion, { once: true });
+  }
 
   const isVisible = (element) =>
     Boolean(element && (element.offsetWidth || element.offsetHeight || element.getClientRects().length));

--- a/ui/components/rollback_plan.py
+++ b/ui/components/rollback_plan.py
@@ -59,7 +59,9 @@ def render_rollback_plan(plan: RollbackPlan) -> None:
         decorate_review_section(panel, section="rollback", label="Rollback plan")
         with ui.row().classes("w-full items-start justify-between gap-3 flex-wrap"):
             with ui.column().classes("gap-1 min-w-0 flex-1"):
-                ui.label("Rollback plan").classes("text-lg font-medium dw-text")
+                ui.label("Rollback plan").classes("text-lg font-medium dw-text").props(
+                    "role=heading aria-level=2"
+                )
                 ui.label(
                     f"Complexity: {plan.complexity_score}/5 ({plan.complexity})"
                 ).classes("text-sm dw-muted")

--- a/ui/components/verdict_card.py
+++ b/ui/components/verdict_card.py
@@ -71,7 +71,9 @@ def render_verdict_card(report: dict) -> None:
         decorate_review_section(card, section="verdict", label="Verdict card")
         with ui.row().classes("w-full items-start justify-between gap-5 flex-wrap"):
             with ui.column().classes("gap-3 min-w-0 flex-1"):
-                ui.label("5-second verdict").classes("dw-eyebrow")
+                ui.label("5-second verdict").classes("dw-eyebrow").props(
+                    "role=heading aria-level=2"
+                )
                 with ui.row().classes("items-start gap-4 flex-wrap"):
                     with ui.column().classes("dw-verdict-score-block shrink-0 gap-1"):
                         ui.label(str(report.get("risk_score", "—"))).classes(

--- a/ui/routes/dashboard.py
+++ b/ui/routes/dashboard.py
@@ -73,7 +73,11 @@ def build_dashboard() -> None:
             project = current_project()
             return project.id if project is not None else None
 
-        with ui.column().classes("dw-main-content dw-shell gap-5"):
+        with (
+            ui.column()
+            .classes("dw-main-content dw-shell gap-5")
+            .props('role=main aria-label="Deployment review workspace"')
+        ):
             briefing_mount = None
             stats_mount = None
             result_mount = None

--- a/ui/routes/history.py
+++ b/ui/routes/history.py
@@ -120,7 +120,11 @@ def build_history_page() -> None:
         card_checkboxes: dict[int, Any] = {}
         selection_sync = {"active": False}
 
-        with ui.column().classes("dw-main-content dw-shell gap-5"):
+        with (
+            ui.column()
+            .classes("dw-main-content dw-shell gap-5")
+            .props('role=main aria-label="Analysis history workspace"')
+        ):
             with ui.card().classes("w-full dw-panel dw-page-header shadow-none"):
                 build_page_header(
                     eyebrow="History",
@@ -576,8 +580,17 @@ def build_history_detail_page(report_id: int, *, show_comparison: bool = False) 
             if authorization_error is not None or not show_comparison
             else fetch_report_comparison(report_id, project_id=active_project_id)
         )
+        main_label = (
+            "Analysis report unavailable"
+            if report is None
+            else "Analysis report workspace"
+        )
 
-        with ui.column().classes("dw-main-content dw-shell gap-5"):
+        with (
+            ui.column()
+            .classes("dw-main-content dw-shell gap-5")
+            .props(f'role=main aria-label="{main_label}"')
+        ):
             with ui.card().classes("w-full dw-panel dw-page-header shadow-none"):
                 if report is None:
                     build_page_header(

--- a/ui/theme.py
+++ b/ui/theme.py
@@ -511,7 +511,7 @@ code,
 }
 
 .dw-eyebrow {
-  color: var(--dw-accent);
+  color: var(--dw-accent-contrast);
   font-size: 12px;
   font-weight: 600;
   letter-spacing: 0.12em;
@@ -537,7 +537,7 @@ code,
 }
 
 .dw-accent-text {
-  color: var(--dw-accent);
+  color: var(--dw-accent-contrast);
 }
 
 .dw-warning-text {
@@ -1056,8 +1056,12 @@ def build_navigation_shell(
         with ui.column().classes("dw-topbar-shell w-full"):
             with ui.row().classes("dw-topbar-primary w-full justify-between flex-wrap"):
                 build_brand_lockup(compact=True)
-                with ui.row().classes(
-                    "dw-topbar-nav items-center gap-1 flex-wrap grow justify-center max-md:w-full"
+                with (
+                    ui.row()
+                    .classes(
+                        "dw-topbar-nav items-center gap-1 flex-wrap grow justify-center max-md:w-full"
+                    )
+                    .props('role=navigation aria-label="Primary navigation"')
                 ):
                     for label, href, key in nav_items:
                         classes = "dw-nav-link no-underline"


### PR DESCRIPTION
Story 3.7 needed the report review flow to expose keyboard and assistive-technology affordances across the primary review path. The change adds review landmarks, semantic headings, live evidence status announcements, and browser assertions that exercise the seeded report/history flows.

Constraint: Preserve NiceGUI composition patterns and existing advisory report behavior

Constraint: VoiceOver validation is not run locally unless explicitly requested by project directive

Rejected: Add a new PNG parsing dependency for contrast checks | no new dependencies were needed for the browser smoke

Confidence: high

Scope-risk: moderate

Directive: Keep review accessibility assertions tied to rendered browser behavior, not synthetic CSS-only checks

Tested: APP_PORT=18080 npm run test:ui-review

Tested: node --check tests/e2e/report_review.keyboard.spec.js

Tested: ./.venv/bin/ruff check .

Tested: ./.venv/bin/ruff format --check .

Tested: git diff --check

Tested: ./.venv/bin/python -m unittest tests.test_ui.test_history_page.HistoryPageRenderingTests -q

Tested: ./.venv/bin/python -m unittest discover -q

Tested: ./.venv/bin/bandit -r app.py services ui tests/e2e/seeded_server.py --severity-level high --confidence-level high -q

Tested: ./.venv/bin/python -m pip_audit -r requirements.txt

Tested: bash scripts/ci-local.sh

Not-tested: npm run test:ui-review:voiceover per local project directive

## What does this PR do?

<!-- Brief description of changes -->

## Type of change
- [ ] Feature (new functionality)
- [ ] Bugfix (non-breaking fix)
- [ ] Release preparation
- [ ] Hotfix (critical production fix)
- [ ] Docs / refactor / chore

## Checklist
- [ ] I have followed the branch naming convention
- [ ] Tests pass locally (`pytest tests/ -v`)
- [ ] Linting passes (`ruff check .`)
- [ ] Docker build succeeds
- [ ] I have updated docs if needed
- [ ] No secrets or .env values committed

## Related issue
Closes #