### PR TITLE
Make historical report filtering project-safe

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ What users can use today:
 - **Local-first safety posture**: keep raw IaC processing local, avoid storing provider API keys in the database, exclude sensitive files from unsafe handling, and keep every verdict advisory rather than automatically blocking a release.
 - **Evidence-backed confidence**: trace the report back to findings, resource-level contributors, uploaded artifact references, confidence factors, why-not-lower/higher reasoning, parser coverage, topology freshness, context TODOs, and warning signals when context is limited.
 - **Blast-radius and rollback context**: use service-topology input to explain likely downstream impact and generate rollback steps with complexity scoring.
-- **Analysis history**: review saved reports later, filter previous analyses, inspect audit metadata, and compare repeated scans of the same artifact set with new, resolved, persistent, severity-changed, and context-changed findings.
+- **Analysis history**: review saved reports later, filter previous analyses by project, workspace, time range, risk verdict, toolchain, and analysis status, inspect audit metadata, and compare repeated scans of the same artifact set with new, resolved, persistent, severity-changed, and context-changed findings.
 - **Provider and admin settings UI**: configure LLM provider metadata, upload topology context, manage custom AI Skills, and see provider readiness before running analysis.
 - **REST API and CLI access**: run the same analysis pipeline from `/api/v1` endpoints or the headless CLI for local automation and CI workflows.
 - **Shareable reports**: create read-only report links, optionally protect sensitive shared reports with a password, redact filenames, and compare shared reruns when previous scans exist.
@@ -396,11 +396,25 @@ GET /api/v1/analyses
 
 Supports filtering by:
 
+- `project_id`
+- `project_key`
+- `workspace_id`
+- `workspace_key`
 - `severity`
 - `recommendation`
 - `search`
+- `toolchain`
+- `analysis_status` (`complete`, `degraded`, or `fallback`)
+- `created_from` (timezone-aware ISO 8601 timestamp)
+- `created_to` (timezone-aware ISO 8601 timestamp)
 - `page`
 - `page_size`
+
+Example:
+
+```http
+GET /api/v1/analyses?project_key=payments&workspace_key=prod&toolchain=terraform&analysis_status=complete&created_from=2026-05-01T00:00:00Z&created_to=2026-05-20T00:00:00Z
+```
 
 ### Fetch One Analysis
 

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -78,7 +78,7 @@ development_status:
   3-5-context-completeness-and-todo-panel: done
   3-6-report-diff-after-rerun: done
   3-7-keyboard-and-accessibility-review-pass: done
-  3-8-historical-report-search-and-filtering: ready-for-dev
+  3-8-historical-report-search-and-filtering: done
   epic-3-retrospective: optional
 
   epic-4: in-progress

--- a/api/routes/analyses.py
+++ b/api/routes/analyses.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import hmac
 import os
+from datetime import UTC, datetime
 from typing import Annotated
 
 from fastapi import APIRouter, Depends, File, Form, Header, Query, UploadFile
@@ -48,6 +49,7 @@ from services.project_service import resolve_project_reference
 
 router = APIRouter(prefix="/api/v1/analyses", tags=["analyses"], route_class=ApiRoute)
 READ_CHUNK_BYTES = 1024 * 1024
+_HISTORY_ANALYSIS_STATUSES = {"complete", "degraded", "fallback"}
 
 
 def _list_report_schema_meta(reports: list[dict]) -> dict[str, object]:
@@ -117,6 +119,53 @@ def _project_scope_forbidden_error() -> ApiError:
         code="project_scope_forbidden",
         message="Caller is not authorized for the requested project.",
     )
+
+
+def _normalize_history_bound(
+    value: datetime | None, *, field_name: str
+) -> datetime | None:
+    if value is None:
+        return None
+    if value.tzinfo is None or value.utcoffset() is None:
+        raise ApiError(
+            status_code=400,
+            code="invalid_history_time_bound",
+            message=f"{field_name} must include a timezone offset.",
+        )
+    return value.astimezone(UTC)
+
+
+def _normalize_history_analysis_status(value: str | None) -> str | None:
+    if value is None:
+        return None
+    normalized = value.strip().lower()
+    if not normalized:
+        return None
+    if normalized not in _HISTORY_ANALYSIS_STATUSES:
+        raise ApiError(
+            status_code=400,
+            code="invalid_analysis_status",
+            message=("analysis_status must be one of: complete, degraded, fallback."),
+        )
+    return normalized
+
+
+def _empty_analysis_list_response(*, page: int, page_size: int) -> AnalysisListResponse:
+    return AnalysisListResponse(
+        data=[],
+        meta=build_report_meta(
+            report_schema_version=REPORT_SCHEMA_VERSION,
+            report_schema_versions=[],
+            count=0,
+            total_count=0,
+            page=page,
+            page_size=page_size,
+        ),
+    )
+
+
+def _should_return_empty_history_for_scope_error(exc: PermissionError) -> bool:
+    return getattr(exc, "code", None) == "project_scope_forbidden"
 
 
 def _should_mask_project_reference_error(
@@ -322,6 +371,10 @@ def list_analyses(
     severity: str | None = Query(default=None),
     recommendation: str | None = Query(default=None),
     search: str | None = Query(default=None),
+    toolchain: str | None = Query(default=None),
+    analysis_status: str | None = Query(default=None),
+    created_from: datetime | None = Query(default=None),
+    created_to: datetime | None = Query(default=None),
     page: int = Query(default=1, ge=1),
     page_size: int = Query(default=50, ge=1, le=100),
     authorization: dict[str, object] = Depends(_authorization_context),
@@ -345,6 +398,15 @@ def list_analyses(
             project_id=project_id,
             project_key=project_key,
         )
+        created_from = _normalize_history_bound(
+            created_from,
+            field_name="created_from",
+        )
+        created_to = _normalize_history_bound(
+            created_to,
+            field_name="created_to",
+        )
+        analysis_status = _normalize_history_analysis_status(analysis_status)
         page_payload = fetch_filtered_analysis_history_page(
             project_id=project_id,
             project_key=project_key,
@@ -353,11 +415,21 @@ def list_analyses(
             severity=severity,
             recommendation=recommendation,
             search=search,
+            toolchain=toolchain,
+            analysis_status=analysis_status,
+            created_from=created_from,
+            created_to=created_to,
             page=page,
             page_size=page_size,
         )
     except PermissionError as exc:
+        if _should_return_empty_history_for_scope_error(exc):
+            return _empty_analysis_list_response(page=page, page_size=page_size)
         _raise_authorization_error(exc)
+    except ApiError as exc:
+        if exc.code == "project_scope_forbidden":
+            return _empty_analysis_list_response(page=page, page_size=page_size)
+        raise
     except ValueError as exc:
         if _should_mask_project_reference_error(
             authorization=authorization,
@@ -367,7 +439,7 @@ def list_analyses(
             authorization=authorization,
             exc=exc,
         ):
-            raise _project_scope_forbidden_error() from exc
+            return _empty_analysis_list_response(page=page, page_size=page_size)
         raise _project_api_error(exc) from exc
     reports = page_payload["items"]
     return AnalysisListResponse(

--- a/api/schemas.py
+++ b/api/schemas.py
@@ -355,6 +355,14 @@ class PersistedReportData(BaseModel):
     report_schema_version: str = Field(
         ..., description="Persisted report schema version"
     )
+    tool_mix: list[str] = Field(
+        default_factory=list,
+        description="Supported toolchains represented in this persisted report",
+    )
+    analysis_status: Literal["complete", "degraded", "fallback"] = Field(
+        default="complete",
+        description="High-level persisted analysis completion/degradation status",
+    )
     top_risk_contributors: list[str] = Field(default_factory=list)
     context_completeness: "ContextCompletenessData" = Field(
         default_factory=lambda: ContextCompletenessData()

--- a/models/repositories/analysis_reports.py
+++ b/models/repositories/analysis_reports.py
@@ -5,11 +5,11 @@ from __future__ import annotations
 import json
 import math
 import re
-from datetime import UTC, datetime, timedelta
 from collections.abc import Sequence
+from datetime import UTC, datetime, timedelta
 from typing import Any
 
-from sqlalchemy import func, or_, select
+from sqlalchemy import and_, func, not_, or_, select
 from sqlalchemy.orm import Session, selectinload
 
 from evidence.models import EvidenceItem as EvidenceItemPayload
@@ -34,6 +34,83 @@ _VERDICT_PREFIX_PATTERN = re.compile(
     r"security|permission|policy|blast|radius)\b))",
     flags=re.IGNORECASE,
 )
+
+
+def _escape_like_value(value: str) -> str:
+    return value.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+
+
+def _json_tool_like_patterns(toolchain: str) -> list[str]:
+    normalized = toolchain.strip().lower()
+    if not normalized:
+        return []
+    encoded = _escape_like_value(json.dumps(normalized)[1:-1])
+    return [f'%"tool":"{encoded}"%', f'%"tool": "{encoded}"%']
+
+
+def _toolchain_predicate(toolchain: str):
+    patterns = _json_tool_like_patterns(toolchain)
+    if not patterns:
+        return None
+    predicates = []
+    for column in (
+        AnalysisReport.contributors_json,
+        AnalysisReport.submission_manifest_json,
+        AnalysisReport.submission_manifest_fallback_json,
+        AnalysisReport.analyzed_files_json,
+    ):
+        lowered = func.lower(column)
+        predicates.extend(lowered.like(pattern, escape="\\") for pattern in patterns)
+    return or_(*predicates)
+
+
+def _narrative_source_not_fallback_predicate():
+    return or_(
+        AnalysisReport.narrative_source.is_(None),
+        AnalysisReport.narrative_source != "fallback",
+    )
+
+
+def _narrative_available_predicate():
+    return or_(
+        func.length(func.trim(func.coalesce(AnalysisReport.narrative_opening, ""))) > 0,
+        func.length(func.trim(func.coalesce(AnalysisReport.narrative_explanation, "")))
+        > 0,
+    )
+
+
+def _narrative_failure_notice_predicate():
+    return (
+        func.length(
+            func.trim(func.coalesce(AnalysisReport.narrative_failure_notice, ""))
+        )
+        > 0
+    )
+
+
+def _analysis_status_predicate(analysis_status: str):
+    if analysis_status == "complete":
+        return and_(
+            _narrative_source_not_fallback_predicate(),
+            or_(
+                AnalysisReport.narrative_degraded.is_(False),
+                AnalysisReport.narrative_degraded.is_(None),
+            ),
+            not_(_narrative_failure_notice_predicate()),
+            _narrative_available_predicate(),
+        )
+    if analysis_status == "degraded":
+        return and_(
+            _narrative_source_not_fallback_predicate(),
+            or_(
+                AnalysisReport.narrative_degraded.is_(True),
+                _narrative_failure_notice_predicate(),
+                not_(_narrative_available_predicate()),
+            ),
+        )
+    if analysis_status == "fallback":
+        return AnalysisReport.narrative_source == "fallback"
+    return None
 
 
 def _normalize_report_severity(severity: str) -> str:
@@ -571,6 +648,10 @@ def list_analysis_reports(
     severity: str | None = None,
     recommendation: str | None = None,
     search: str | None = None,
+    toolchain: str | None = None,
+    analysis_status: str | None = None,
+    created_from: datetime | None = None,
+    created_to: datetime | None = None,
     report_schema_versions: Sequence[str] | None = None,
     limit: int | None = None,
     offset: int | None = None,
@@ -589,6 +670,18 @@ def list_analysis_reports(
         stmt = stmt.where(AnalysisReport.severity == severity)
     if recommendation:
         stmt = stmt.where(AnalysisReport.recommendation == recommendation)
+    if created_from is not None:
+        stmt = stmt.where(AnalysisReport.created_at >= created_from)
+    if created_to is not None:
+        stmt = stmt.where(AnalysisReport.created_at <= created_to)
+    if toolchain:
+        predicate = _toolchain_predicate(toolchain)
+        if predicate is not None:
+            stmt = stmt.where(predicate)
+    if analysis_status:
+        predicate = _analysis_status_predicate(analysis_status)
+        if predicate is not None:
+            stmt = stmt.where(predicate)
     if search:
         like = f"%{search}%"
         stmt = stmt.where(
@@ -622,6 +715,10 @@ def count_analysis_reports(
     severity: str | None = None,
     recommendation: str | None = None,
     search: str | None = None,
+    toolchain: str | None = None,
+    analysis_status: str | None = None,
+    created_from: datetime | None = None,
+    created_to: datetime | None = None,
     report_schema_versions: Sequence[str] | None = None,
 ) -> int:
     stmt = select(func.count()).select_from(AnalysisReport)
@@ -633,6 +730,18 @@ def count_analysis_reports(
         stmt = stmt.where(AnalysisReport.severity == severity)
     if recommendation:
         stmt = stmt.where(AnalysisReport.recommendation == recommendation)
+    if created_from is not None:
+        stmt = stmt.where(AnalysisReport.created_at >= created_from)
+    if created_to is not None:
+        stmt = stmt.where(AnalysisReport.created_at <= created_to)
+    if toolchain:
+        predicate = _toolchain_predicate(toolchain)
+        if predicate is not None:
+            stmt = stmt.where(predicate)
+    if analysis_status:
+        predicate = _analysis_status_predicate(analysis_status)
+        if predicate is not None:
+            stmt = stmt.where(predicate)
     if search:
         like = f"%{search}%"
         stmt = stmt.where(

--- a/services/report_service.py
+++ b/services/report_service.py
@@ -2949,6 +2949,50 @@ def _readable_report_schema_versions() -> tuple[str, ...]:
     )
 
 
+def _history_tool_mix(
+    contributors: list[dict[str, Any]],
+    submission_manifest: dict[str, Any],
+    analyzed_files: list[dict[str, Any]] | None = None,
+    submission_manifest_fallback: list[dict[str, Any]] | None = None,
+) -> list[str]:
+    tools: set[str] = set()
+    for contributor in contributors:
+        tool = str(contributor.get("tool") or "").strip().lower()
+        if tool:
+            tools.add(tool)
+    for item in submission_manifest.get("items") or []:
+        if not isinstance(item, dict):
+            continue
+        tool = str(item.get("tool") or "").strip().lower()
+        if tool:
+            tools.add(tool)
+    for analyzed_file in analyzed_files or []:
+        if not isinstance(analyzed_file, dict):
+            continue
+        tool = str(analyzed_file.get("tool") or "").strip().lower()
+        if tool:
+            tools.add(tool)
+    for fallback_item in submission_manifest_fallback or []:
+        if not isinstance(fallback_item, dict):
+            continue
+        tool = str(fallback_item.get("tool") or "").strip().lower()
+        if tool and tool != "unknown":
+            tools.add(tool)
+    return sorted(tools)
+
+
+def _history_analysis_status(
+    *,
+    narrative_degraded: bool,
+    narrative_source: str | None,
+) -> str:
+    if narrative_source == "fallback":
+        return "fallback"
+    if narrative_degraded:
+        return "degraded"
+    return "complete"
+
+
 def _load_submission_manifest_payload(
     raw_value: str | None,
 ) -> tuple[dict[str, Any] | None, str | None]:
@@ -3254,12 +3298,14 @@ def _serialize_report(report, *, include_evidence: bool = True) -> dict:
     if created_at.tzinfo is None:
         created_at = created_at.replace(tzinfo=UTC)
     warnings = json.loads(report.warnings_json or "[]")
+    contributors = json.loads(report.contributors_json or "[]")
     submission_manifest, manifest_warning = _load_submission_manifest_payload(
         getattr(report, "submission_manifest_json", None)
     )
     submission_manifest_fallback = _load_submission_manifest_fallback_payload(
         getattr(report, "submission_manifest_fallback_json", None)
     )
+    analyzed_files = json.loads(report.analyzed_files_json or "[]")
     manifest_provenance = (
         dict(submission_manifest.get("provenance") or {})
         if isinstance(submission_manifest, dict)
@@ -3277,7 +3323,7 @@ def _serialize_report(report, *, include_evidence: bool = True) -> dict:
     )
     persisted_at = created_at.isoformat()
     audit = {
-        "files_analyzed": json.loads(report.analyzed_files_json or "[]"),
+        "files_analyzed": analyzed_files,
         "llm_provider": report.llm_provider,
         "llm_model": report.llm_model,
         "llm_local_mode": report.llm_local_mode == "true"
@@ -3411,6 +3457,16 @@ def _serialize_report(report, *, include_evidence: bool = True) -> dict:
         "report_schema_version": readable_report_schema_version(
             getattr(report, "report_schema_version", None)
         ),
+        "tool_mix": _history_tool_mix(
+            contributors,
+            submission_manifest or {},
+            analyzed_files,
+            submission_manifest_fallback,
+        ),
+        "analysis_status": _history_analysis_status(
+            narrative_degraded=narrative_degraded,
+            narrative_source=narrative_source,
+        ),
         "top_risk_contributors": json.loads(
             report.risk_assessment.top_risk_contributors_json
             if report.risk_assessment is not None
@@ -3464,7 +3520,7 @@ def _serialize_report(report, *, include_evidence: bool = True) -> dict:
             for finding in report.findings
         ],
         "evidence_items": evidence_items,
-        "contributors": json.loads(report.contributors_json or "[]"),
+        "contributors": contributors,
         "dashboard_display_duration_seconds": report.dashboard_display_duration_seconds,
         "share_password_hash": getattr(report, "share_password_hash", None),
         "share_password_salt": getattr(report, "share_password_salt", None),
@@ -3883,6 +3939,10 @@ def fetch_filtered_analysis_history(
     severity: str | None = None,
     recommendation: str | None = None,
     search: str | None = None,
+    toolchain: str | None = None,
+    analysis_status: str | None = None,
+    created_from: datetime | None = None,
+    created_to: datetime | None = None,
 ) -> list[dict]:
     page = fetch_filtered_analysis_history_page(
         project_id=project_id,
@@ -3892,6 +3952,10 @@ def fetch_filtered_analysis_history(
         severity=severity,
         recommendation=recommendation,
         search=search,
+        toolchain=toolchain,
+        analysis_status=analysis_status,
+        created_from=created_from,
+        created_to=created_to,
     )
     return page["items"]
 
@@ -3905,6 +3969,10 @@ def fetch_filtered_analysis_history_page(
     severity: str | None = None,
     recommendation: str | None = None,
     search: str | None = None,
+    toolchain: str | None = None,
+    analysis_status: str | None = None,
+    created_from: datetime | None = None,
+    created_to: datetime | None = None,
     page: int = 1,
     page_size: int = 50,
     skip_unreadable_schema: bool = False,
@@ -3939,6 +4007,10 @@ def fetch_filtered_analysis_history_page(
                     severity=severity,
                     recommendation=recommendation,
                     search=search,
+                    toolchain=toolchain,
+                    analysis_status=analysis_status,
+                    created_from=created_from,
+                    created_to=created_to,
                     report_schema_versions=readable_schema_versions,
                     limit=page_size,
                     offset=offset,
@@ -3959,6 +4031,10 @@ def fetch_filtered_analysis_history_page(
                     severity=severity,
                     recommendation=recommendation,
                     search=search,
+                    toolchain=toolchain,
+                    analysis_status=analysis_status,
+                    created_from=created_from,
+                    created_to=created_to,
                     report_schema_versions=readable_schema_versions,
                 )
             else:
@@ -3969,6 +4045,10 @@ def fetch_filtered_analysis_history_page(
                     severity=severity,
                     recommendation=recommendation,
                     search=search,
+                    toolchain=toolchain,
+                    analysis_status=analysis_status,
+                    created_from=created_from,
+                    created_to=created_to,
                     limit=page_size,
                     offset=offset,
                     include_evidence=False,
@@ -3988,6 +4068,10 @@ def fetch_filtered_analysis_history_page(
                     severity=severity,
                     recommendation=recommendation,
                     search=search,
+                    toolchain=toolchain,
+                    analysis_status=analysis_status,
+                    created_from=created_from,
+                    created_to=created_to,
                 )
             return (
                 _attach_previous_scan_diffs(serialized_reports, serialized_all_reports),
@@ -4001,6 +4085,63 @@ def fetch_filtered_analysis_history_page(
         "page": page,
         "page_size": page_size,
     }
+
+
+def fetch_history_toolchains(
+    *,
+    project_id: int | None = None,
+    project_key: str | None = None,
+    workspace_id: int | None = None,
+    workspace_key: str | None = None,
+    skip_unreadable_schema: bool = False,
+) -> list[str]:
+    """Return distinct structured tool names for the authorized history scope."""
+    resolved_project_id, resolved_workspace_id = _resolve_report_scope(
+        project_id=project_id,
+        project_key=project_key,
+        workspace_id=workspace_id,
+        workspace_key=workspace_key,
+    )
+    readable_schema_versions = (
+        _readable_report_schema_versions() if skip_unreadable_schema else None
+    )
+
+    def operation():
+        with SessionLocal() as session:
+            reports = list_analysis_reports(
+                session,
+                project_id=resolved_project_id,
+                workspace_id=resolved_workspace_id,
+                report_schema_versions=readable_schema_versions,
+                include_evidence=False,
+            )
+            tools: set[str] = set()
+            for report in reports:
+                try:
+                    contributors = json.loads(report.contributors_json or "[]")
+                    analyzed_files = json.loads(report.analyzed_files_json or "[]")
+                except json.JSONDecodeError:
+                    contributors = []
+                    analyzed_files = []
+                submission_manifest, _ = _load_submission_manifest_payload(
+                    getattr(report, "submission_manifest_json", None)
+                )
+                submission_manifest_fallback = (
+                    _load_submission_manifest_fallback_payload(
+                        getattr(report, "submission_manifest_fallback_json", None)
+                    )
+                )
+                tools.update(
+                    _history_tool_mix(
+                        contributors if isinstance(contributors, list) else [],
+                        submission_manifest or {},
+                        analyzed_files if isinstance(analyzed_files, list) else [],
+                        submission_manifest_fallback,
+                    )
+                )
+            return sorted(tools)
+
+    return _run_with_schema_retry(operation)
 
 
 def fetch_risk_trends(

--- a/services/report_service.py
+++ b/services/report_service.py
@@ -2369,6 +2369,15 @@ def _score_matches_severity(score: int, severity: str) -> bool:
     return _SEVERITY_SCORE_FLOOR[severity] <= score <= _SEVERITY_SCORE_CEILING[severity]
 
 
+def _text_claims_severe_risk(value: str | None) -> bool:
+    normalized = str(value or "").strip().lower()
+    if not normalized:
+        return False
+    return _verdict_label(normalized) in {"high", "critical", "no-go"} or bool(
+        re.search(r"\bsevere\b", normalized)
+    )
+
+
 def _verdict_label(value: str | None) -> str | None:
     match = _VERDICT_PREFIX_PATTERN.match(str(value or ""))
     if match is None:
@@ -2467,8 +2476,12 @@ def _apply_evidence_law_runtime_gate(
         if finding.severity in {"high", "critical"}
         and _has_linked_deterministic_evidence(finding, evidence_by_id)
     ]
+    report_level_severe_signal = assessment.severity in {"high", "critical"} or (
+        assessment.score >= _SEVERITY_SCORE_FLOOR["high"]
+        and _text_claims_severe_risk(assessment.top_risk)
+    )
     unsupported_report_severity = (
-        assessment.severity in {"high", "critical"} and not supported_severe_findings
+        report_level_severe_signal and not supported_severe_findings
     )
     top_supported_finding = (
         _highest_severity_finding(supported_severe_findings)

--- a/tests/e2e/report_review.keyboard.spec.js
+++ b/tests/e2e/report_review.keyboard.spec.js
@@ -604,6 +604,15 @@ test.describe("review keyboard flow", () => {
       page.getByRole("main", { name: "Analysis history workspace" })
     ).toBeVisible();
     await expect(page.locator(".dw-history-card")).toHaveCount(2);
+    await expect(page.getByText("Project filter", { exact: true })).toBeVisible();
+    await expect(page.getByText("Workspace", { exact: true }).first()).toBeVisible();
+    await expect(page.getByText("Time range", { exact: true })).toBeVisible();
+    await expect(page.getByText("Risk verdict", { exact: true })).toBeVisible();
+    await expect(page.getByText("Toolchain", { exact: true })).toBeVisible();
+    await expect(page.getByText("Analysis status", { exact: true })).toBeVisible();
+    await expect(page.getByText(/Tools: /).first()).toBeVisible();
+    await expect(page.getByText("Schema: v2").first()).toBeVisible();
+    await expect(page.getByText(/Status: /).first()).toBeVisible();
     await expect(page.getByText("Rescan diff")).toBeVisible();
     await expect(page.getByText("+48 risk vs report #1")).toBeVisible();
     await page.locator(".dw-history-card").first().click();

--- a/tests/test_api/test_analyses.py
+++ b/tests/test_api/test_analyses.py
@@ -6,6 +6,7 @@ import os
 import sqlite3
 import tempfile
 import unittest
+from datetime import UTC, datetime
 from importlib import reload
 from pathlib import Path
 from unittest.mock import patch
@@ -478,6 +479,172 @@ class AnalysesApiTests(unittest.TestCase):
         payload = scoped_list_response.json()
         self.assertEqual(payload["meta"]["total_count"], 1)
         self.assertEqual(payload["data"][0]["workspace"]["workspace_key"], "prod")
+
+    def test_list_analyses_filters_history_facets_without_cross_project_leaks(
+        self,
+    ) -> None:
+        payments = project_service_module.create_project(
+            project_key="payments",
+            display_name="Payments",
+        )
+        prod = project_service_module.create_workspace(
+            project_key=payments.project_key,
+            workspace_key="prod",
+            display_name="Production",
+            environment="prod",
+        )
+        platform = project_service_module.create_project(
+            project_key="platform",
+            display_name="Platform",
+        )
+        payments_report = report_service_module.persist_analysis_report(
+            ParseBatchResult(
+                files=[
+                    ParsedFileResult(
+                        file_name="payments-prod.tfplan",
+                        tool="terraform",
+                        status="parsed",
+                        changes=[],
+                    )
+                ]
+            ),
+            RiskAssessment(
+                score=91,
+                severity="critical",
+                recommendation="no-go",
+                top_risk="Payments production ingress widened.",
+                contributors=[
+                    RiskContributor(
+                        source_file="payments-prod.tfplan",
+                        tool="terraform",
+                        resource_id="aws_security_group.payments",
+                        action="modify",
+                        contribution=30,
+                        summary="Payments production ingress widened.",
+                    )
+                ],
+                interaction_risks=[],
+                partial_context=False,
+                warnings=[],
+            ),
+            NarrativeResult(
+                opening_sentence="NO-GO: payments production ingress widened.",
+                explanation="Payments production report.",
+                guidance=[],
+                degraded=False,
+                warnings=[],
+                source="llm",
+            ),
+            project_id=payments.id,
+            workspace_id=prod.id,
+            audit_context={"source_interface": "api"},
+        )
+        report_service_module.persist_analysis_report(
+            ParseBatchResult(
+                files=[
+                    ParsedFileResult(
+                        file_name="platform-rollout.yaml",
+                        tool="kubernetes",
+                        status="parsed",
+                        changes=[],
+                    )
+                ]
+            ),
+            RiskAssessment(
+                score=92,
+                severity="critical",
+                recommendation="no-go",
+                top_risk="Platform production ingress widened.",
+                contributors=[
+                    RiskContributor(
+                        source_file="platform-rollout.yaml",
+                        tool="kubernetes",
+                        resource_id="deployment/platform",
+                        action="modify",
+                        contribution=30,
+                        summary="Platform production ingress widened.",
+                    )
+                ],
+                interaction_risks=[],
+                partial_context=False,
+                warnings=[],
+            ),
+            NarrativeResult(
+                opening_sentence="NO-GO: platform production ingress widened.",
+                explanation="Platform production report.",
+                guidance=[],
+                degraded=False,
+                warnings=[],
+                source="llm",
+            ),
+            project_id=platform.id,
+            audit_context={"source_interface": "api"},
+        )
+        with database_module.SessionLocal() as session:
+            session.get(
+                tables_module.AnalysisReport, payments_report["id"]
+            ).created_at = datetime(2026, 5, 18, 12, 0, tzinfo=UTC)
+            session.commit()
+
+        response = self.client.get(
+            "/api/v1/analyses",
+            params={
+                "project_key": payments.project_key,
+                "workspace_key": prod.workspace_key,
+                "severity": "medium",
+                "recommendation": "caution",
+                "toolchain": "terraform",
+                "analysis_status": "complete",
+                "created_from": "2026-05-01T00:00:00Z",
+                "created_to": "2026-05-20T00:00:00Z",
+            },
+        )
+        foreign_response = self.client.get(
+            "/api/v1/analyses",
+            params={"project_key": platform.project_key},
+            headers={
+                "X-DeployWhisper-Project-Role": "read-only",
+                "X-DeployWhisper-Project-Keys": payments.project_key,
+            },
+        )
+
+        self.assertEqual(response.status_code, 200)
+        payload = response.json()
+        self.assertEqual(payload["meta"]["total_count"], 1)
+        self.assertEqual(payload["data"][0]["id"], payments_report["id"])
+        self.assertEqual(payload["data"][0]["project"]["project_key"], "payments")
+        self.assertEqual(payload["data"][0]["workspace"]["workspace_key"], "prod")
+        self.assertEqual(payload["data"][0]["tool_mix"], ["terraform"])
+        self.assertEqual(payload["data"][0]["analysis_status"], "complete")
+        self.assertNotIn("Platform production ingress widened.", response.text)
+        self.assertEqual(foreign_response.status_code, 200)
+        self.assertEqual(foreign_response.json()["meta"]["total_count"], 0)
+        self.assertEqual(foreign_response.json()["data"], [])
+        self.assertNotIn("Platform production ingress widened.", foreign_response.text)
+
+    def test_list_analyses_rejects_naive_history_time_bounds(self) -> None:
+        response = self.client.get(
+            "/api/v1/analyses",
+            params={"created_from": "2026-05-01T00:00:00"},
+        )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(
+            response.json()["error"]["code"],
+            "invalid_history_time_bound",
+        )
+
+    def test_list_analyses_rejects_invalid_analysis_status(self) -> None:
+        response = self.client.get(
+            "/api/v1/analyses",
+            params={"analysis_status": "degradded"},
+        )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(
+            response.json()["error"]["code"],
+            "invalid_analysis_status",
+        )
 
     def test_configure_share_is_disabled_without_management_token(self) -> None:
         response = self.client.post(
@@ -1378,8 +1545,9 @@ class AnalysesApiTests(unittest.TestCase):
             },
         )
 
-        self.assertEqual(response.status_code, 403)
-        self.assertEqual(response.json()["error"]["code"], "project_scope_forbidden")
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()["meta"]["total_count"], 0)
+        self.assertEqual(response.json()["data"], [])
 
     def test_analysis_reads_mask_conflicting_project_reference_for_scoped_actor(
         self,
@@ -1414,10 +1582,9 @@ class AnalysesApiTests(unittest.TestCase):
             headers=headers,
         )
 
-        self.assertEqual(list_response.status_code, 403)
-        self.assertEqual(
-            list_response.json()["error"]["code"], "project_scope_forbidden"
-        )
+        self.assertEqual(list_response.status_code, 200)
+        self.assertEqual(list_response.json()["meta"]["total_count"], 0)
+        self.assertEqual(list_response.json()["data"], [])
         self.assertEqual(detail_response.status_code, 403)
         self.assertEqual(
             detail_response.json()["error"]["code"], "project_scope_forbidden"
@@ -1476,11 +1643,9 @@ class AnalysesApiTests(unittest.TestCase):
             headers=headers,
         )
 
-        self.assertEqual(list_response.status_code, 403)
-        self.assertEqual(
-            list_response.json()["error"]["code"], "project_scope_forbidden"
-        )
-        self.assertNotIn("payments", list_response.json()["error"]["message"])
+        self.assertEqual(list_response.status_code, 200)
+        self.assertEqual(list_response.json()["meta"]["total_count"], 0)
+        self.assertEqual(list_response.json()["data"], [])
         self.assertEqual(detail_response.status_code, 403)
         self.assertEqual(
             detail_response.json()["error"]["code"], "project_scope_forbidden"

--- a/tests/test_services/test_report_service.py
+++ b/tests/test_services/test_report_service.py
@@ -1450,8 +1450,8 @@ class ReportServiceTests(unittest.TestCase):
         )
         assessment = RiskAssessment(
             score=91,
-            severity="critical",
-            recommendation="no-go",
+            severity="medium",
+            recommendation="caution",
             top_risk="Report-level severe risk without evidence.",
             contributors=[],
             interaction_risks=[],
@@ -9206,6 +9206,427 @@ class ReportServiceTests(unittest.TestCase):
         self.assertEqual(scoped_page["items"][0]["id"], prod_report["id"])
         self.assertEqual(scoped_page["items"][0]["workspace"]["workspace_key"], "prod")
         self.assertIsNone(wrong_workspace)
+
+    def test_fetch_history_filters_by_time_toolchain_and_analysis_status(self) -> None:
+        project = project_service_module.create_project(
+            project_key="payments",
+            display_name="Payments",
+        )
+        prod = project_service_module.create_workspace(
+            project_key=project.project_key,
+            workspace_key="prod",
+            display_name="Production",
+            environment="prod",
+        )
+        staging = project_service_module.create_workspace(
+            project_key=project.project_key,
+            workspace_key="staging",
+            display_name="Staging",
+            environment="staging",
+        )
+
+        prod_report = report_service_module.persist_analysis_report(
+            ParseBatchResult(
+                files=[
+                    ParsedFileResult(
+                        file_name="prod-plan.json",
+                        tool="terraform",
+                        status="parsed",
+                        changes=[],
+                    )
+                ]
+            ),
+            RiskAssessment(
+                score=91,
+                severity="critical",
+                recommendation="no-go",
+                top_risk="Production ingress widened.",
+                contributors=[
+                    RiskContributor(
+                        source_file="prod-plan.json",
+                        tool="terraform",
+                        resource_id="aws_security_group.main",
+                        action="modify",
+                        contribution=20,
+                        summary="Production ingress widened.",
+                    )
+                ],
+                interaction_risks=[],
+                partial_context=False,
+                warnings=[],
+            ),
+            NarrativeResult(
+                opening_sentence="NO-GO: production ingress widened.",
+                explanation="Production report.",
+                guidance=[],
+                degraded=False,
+                warnings=[],
+                source="llm",
+            ),
+            project_id=project.id,
+            workspace_id=prod.id,
+            audit_context={"source_interface": "api"},
+        )
+        staging_report = report_service_module.persist_analysis_report(
+            ParseBatchResult(
+                files=[
+                    ParsedFileResult(
+                        file_name="staging-rollout.yaml",
+                        tool="kubernetes",
+                        status="parsed",
+                        changes=[],
+                    )
+                ]
+            ),
+            RiskAssessment(
+                score=35,
+                severity="medium",
+                recommendation="caution",
+                top_risk="Staging rollout image changed.",
+                contributors=[
+                    RiskContributor(
+                        source_file="staging-rollout.yaml",
+                        tool="kubernetes",
+                        resource_id="deployment/payments",
+                        action="modify",
+                        contribution=12,
+                        summary="Staging rollout image changed.",
+                    )
+                ],
+                interaction_risks=[],
+                partial_context=False,
+                warnings=[],
+            ),
+            NarrativeResult(
+                opening_sentence="CAUTION: staging rollout image changed.",
+                explanation="Fallback report.",
+                guidance=[],
+                degraded=True,
+                warnings=["Narrative used fallback mode."],
+                source="fallback",
+            ),
+            project_id=project.id,
+            workspace_id=staging.id,
+            audit_context={"source_interface": "api"},
+        )
+        degraded_report = report_service_module.persist_analysis_report(
+            ParseBatchResult(
+                files=[
+                    ParsedFileResult(
+                        file_name="staging-policy.yaml",
+                        tool="kubernetes",
+                        status="parsed",
+                        changes=[],
+                    )
+                ]
+            ),
+            RiskAssessment(
+                score=44,
+                severity="medium",
+                recommendation="caution",
+                top_risk="Staging policy degraded narrative.",
+                contributors=[
+                    RiskContributor(
+                        source_file="staging-policy.yaml",
+                        tool="kubernetes",
+                        resource_id="network-policy/payments",
+                        action="modify",
+                        contribution=10,
+                        summary="Staging policy degraded narrative.",
+                    )
+                ],
+                interaction_risks=[],
+                partial_context=True,
+                warnings=[],
+            ),
+            NarrativeResult(
+                opening_sentence="CAUTION: degraded narrative.",
+                explanation="LLM report degraded by partial context.",
+                guidance=[],
+                degraded=True,
+                warnings=["Narrative degraded by partial context."],
+                source="llm",
+            ),
+            project_id=project.id,
+            workspace_id=staging.id,
+            audit_context={"source_interface": "api"},
+        )
+        legacy_degraded_report = report_service_module.persist_analysis_report(
+            ParseBatchResult(
+                files=[
+                    ParsedFileResult(
+                        file_name="legacy-policy.yaml",
+                        tool="kubernetes",
+                        status="parsed",
+                        changes=[],
+                    )
+                ]
+            ),
+            RiskAssessment(
+                score=46,
+                severity="medium",
+                recommendation="caution",
+                top_risk="Legacy narrative failure notice.",
+                contributors=[
+                    RiskContributor(
+                        source_file="legacy-policy.yaml",
+                        tool="kubernetes",
+                        resource_id="network-policy/legacy",
+                        action="modify",
+                        contribution=10,
+                        summary="Legacy narrative failure notice.",
+                    )
+                ],
+                interaction_risks=[],
+                partial_context=False,
+                warnings=[],
+            ),
+            NarrativeResult(
+                opening_sentence="CAUTION: legacy narrative failure notice.",
+                explanation="Legacy report serialized as degraded by failure notice.",
+                guidance=[],
+                degraded=False,
+                warnings=[],
+                source="llm",
+            ),
+            project_id=project.id,
+            workspace_id=staging.id,
+            audit_context={"source_interface": "api"},
+        )
+        misleading_tool_report = report_service_module.persist_analysis_report(
+            ParseBatchResult(
+                files=[
+                    ParsedFileResult(
+                        file_name="terraform-notes.yaml",
+                        tool="kubernetes",
+                        status="parsed",
+                        changes=[],
+                    )
+                ]
+            ),
+            RiskAssessment(
+                score=43,
+                severity="medium",
+                recommendation="caution",
+                top_risk="Kubernetes notes changed.",
+                contributors=[
+                    RiskContributor(
+                        source_file="terraform-notes.yaml",
+                        tool="kubernetes",
+                        resource_id="deployment/notes",
+                        action="modify",
+                        contribution=8,
+                        summary="Kubernetes notes changed.",
+                    )
+                ],
+                interaction_risks=[],
+                partial_context=False,
+                warnings=[],
+            ),
+            NarrativeResult(
+                opening_sentence="CAUTION: kubernetes notes changed.",
+                explanation="Kubernetes report.",
+                guidance=[],
+                degraded=False,
+                warnings=[],
+                source="llm",
+            ),
+            project_id=project.id,
+            workspace_id=prod.id,
+            audit_context={"source_interface": "api"},
+        )
+        old_report = report_service_module.persist_analysis_report(
+            ParseBatchResult(
+                files=[
+                    ParsedFileResult(
+                        file_name="old-plan.json",
+                        tool="terraform",
+                        status="parsed",
+                        changes=[],
+                    )
+                ]
+            ),
+            RiskAssessment(
+                score=18,
+                severity="low",
+                recommendation="go",
+                top_risk="Old production review.",
+                contributors=[],
+                interaction_risks=[],
+                partial_context=False,
+                warnings=[],
+            ),
+            NarrativeResult(
+                opening_sentence="GO: old production review.",
+                explanation="Old report.",
+                guidance=[],
+                degraded=False,
+                warnings=[],
+                source="llm",
+            ),
+            project_id=project.id,
+            workspace_id=prod.id,
+            audit_context={"source_interface": "api"},
+        )
+        unreadable_schema_report = report_service_module.persist_analysis_report(
+            ParseBatchResult(
+                files=[
+                    ParsedFileResult(
+                        file_name="legacy-release.yaml",
+                        tool="ansible",
+                        status="parsed",
+                        changes=[],
+                    )
+                ]
+            ),
+            RiskAssessment(
+                score=63,
+                severity="high",
+                recommendation="caution",
+                top_risk="Legacy release metadata changed.",
+                contributors=[
+                    RiskContributor(
+                        source_file="legacy-release.yaml",
+                        tool="ansible",
+                        resource_id="release/payments",
+                        action="modify",
+                        contribution=12,
+                        summary="Legacy release metadata changed.",
+                    )
+                ],
+                interaction_risks=[],
+                partial_context=False,
+                warnings=[],
+            ),
+            NarrativeResult(
+                opening_sentence="CAUTION: legacy release metadata changed.",
+                explanation="Legacy report.",
+                guidance=[],
+                degraded=False,
+                warnings=[],
+                source="llm",
+            ),
+            project_id=project.id,
+            workspace_id=prod.id,
+            audit_context={"source_interface": "api"},
+        )
+        with database_module.SessionLocal() as session:
+            session.get(
+                tables_module.AnalysisReport, prod_report["id"]
+            ).created_at = datetime(2026, 5, 18, 12, 0, tzinfo=UTC)
+            session.get(
+                tables_module.AnalysisReport, staging_report["id"]
+            ).created_at = datetime(2026, 5, 19, 12, 0, tzinfo=UTC)
+            session.get(
+                tables_module.AnalysisReport, degraded_report["id"]
+            ).created_at = datetime(2026, 5, 19, 13, 0, tzinfo=UTC)
+            legacy_degraded = session.get(
+                tables_module.AnalysisReport, legacy_degraded_report["id"]
+            )
+            legacy_degraded.created_at = datetime(2026, 5, 19, 13, 30, tzinfo=UTC)
+            legacy_degraded.narrative_degraded = None
+            legacy_degraded.narrative_failure_notice = "LLM narrative unavailable."
+            session.get(
+                tables_module.AnalysisReport, misleading_tool_report["id"]
+            ).created_at = datetime(2026, 5, 19, 14, 0, tzinfo=UTC)
+            old = session.get(tables_module.AnalysisReport, old_report["id"])
+            old.created_at = datetime(2026, 4, 1, 12, 0, tzinfo=UTC)
+            old.contributors_json = "[]"
+            old.analyzed_files_json = "[]"
+            old.submission_manifest_json = "{}"
+            old.submission_manifest_fallback_json = json.dumps(
+                [
+                    {
+                        "name": "legacy-template.yaml",
+                        "tool": "cloudformation",
+                        "status": "accepted",
+                    }
+                ]
+            )
+            legacy = session.get(
+                tables_module.AnalysisReport, unreadable_schema_report["id"]
+            )
+            legacy.created_at = datetime(2026, 5, 19, 15, 0, tzinfo=UTC)
+            legacy.report_schema_version = "v999"
+            session.commit()
+
+        filtered = report_service_module.fetch_filtered_analysis_history_page(
+            project_key=project.project_key,
+            workspace_key=prod.workspace_key,
+            severity="medium",
+            recommendation="caution",
+            toolchain="terraform",
+            analysis_status="complete",
+            created_from=datetime(2026, 5, 1, tzinfo=UTC),
+            created_to=datetime(2026, 5, 20, tzinfo=UTC),
+            skip_unreadable_schema=True,
+        )
+        degraded = report_service_module.fetch_filtered_analysis_history_page(
+            project_key=project.project_key,
+            toolchain="kubernetes",
+            analysis_status="degraded",
+            skip_unreadable_schema=True,
+        )
+        fallback = report_service_module.fetch_filtered_analysis_history_page(
+            project_key=project.project_key,
+            toolchain="kubernetes",
+            analysis_status="fallback",
+            skip_unreadable_schema=True,
+        )
+        fallback_manifest_tool = (
+            report_service_module.fetch_filtered_analysis_history_page(
+                project_key=project.project_key,
+                toolchain="cloudformation",
+                skip_unreadable_schema=True,
+            )
+        )
+        toolchains = report_service_module.fetch_history_toolchains(
+            project_key=project.project_key,
+        )
+        readable_toolchains = report_service_module.fetch_history_toolchains(
+            project_key=project.project_key,
+            skip_unreadable_schema=True,
+        )
+        staging_toolchains = report_service_module.fetch_history_toolchains(
+            project_key=project.project_key,
+            workspace_key=staging.workspace_key,
+            skip_unreadable_schema=True,
+        )
+
+        self.assertEqual(filtered["total_count"], 1)
+        self.assertEqual(filtered["items"][0]["id"], prod_report["id"])
+        self.assertEqual(filtered["items"][0]["tool_mix"], ["terraform"])
+        self.assertEqual(filtered["items"][0]["analysis_status"], "complete")
+        self.assertEqual(degraded["total_count"], 2)
+        self.assertEqual(
+            {item["id"] for item in degraded["items"]},
+            {degraded_report["id"], legacy_degraded_report["id"]},
+        )
+        self.assertTrue(
+            all(item["tool_mix"] == ["kubernetes"] for item in degraded["items"])
+        )
+        self.assertTrue(
+            all(item["analysis_status"] == "degraded" for item in degraded["items"])
+        )
+        self.assertEqual(fallback["total_count"], 1)
+        self.assertEqual(fallback["items"][0]["id"], staging_report["id"])
+        self.assertEqual(fallback["items"][0]["tool_mix"], ["kubernetes"])
+        self.assertEqual(fallback["items"][0]["analysis_status"], "fallback")
+        self.assertEqual(fallback_manifest_tool["total_count"], 1)
+        self.assertEqual(fallback_manifest_tool["items"][0]["id"], old_report["id"])
+        self.assertEqual(
+            fallback_manifest_tool["items"][0]["tool_mix"],
+            ["cloudformation"],
+        )
+        self.assertEqual(
+            toolchains,
+            ["ansible", "cloudformation", "kubernetes", "terraform"],
+        )
+        self.assertEqual(
+            readable_toolchains,
+            ["cloudformation", "kubernetes", "terraform"],
+        )
+        self.assertEqual(staging_toolchains, ["kubernetes"])
 
     def test_previous_scan_diffs_do_not_cross_project_boundaries(self) -> None:
         payments = project_service_module.create_project(

--- a/tests/test_ui/test_history_page.py
+++ b/tests/test_ui/test_history_page.py
@@ -46,6 +46,16 @@ class HistoryPageHelpersTests(unittest.TestCase):
         self.assertEqual(page_selection_state({1, 2, 3}, {1}), (False, 1))
         self.assertEqual(page_selection_state({1, 2, 3}, {1, 2, 3, 4}), (True, 3))
 
+    def test_history_toolchain_options_keeps_empty_default(self) -> None:
+        self.assertEqual(
+            history_module._history_toolchain_options(["kubernetes", "terraform"]),
+            {
+                "": "Any toolchain",
+                "kubernetes": "Kubernetes",
+                "terraform": "Terraform",
+            },
+        )
+
     def test_recommendation_helpers_preserve_semantic_go_no_go_styling(self) -> None:
         self.assertEqual(recommendation_text("no-go"), "NO-GO")
         self.assertIn("dw-danger-text", recommendation_classes("no-go"))
@@ -938,6 +948,7 @@ class HistoryPageRenderingTests(unittest.TestCase):
         database_module.engine.dispose()
         os.environ.pop("APP_BASE_URL", None)
         os.environ.pop("DATABASE_URL", None)
+        os.environ.pop("DEPLOYWHISPER_PROJECT_KEYS", None)
         self.tempdir.cleanup()
 
     def _persist_report(
@@ -952,17 +963,21 @@ class HistoryPageRenderingTests(unittest.TestCase):
         context_completeness: dict | None = None,
         assessment_confidence: float = 1.0,
         finding_confidence: float = 1.0,
+        project_id: int | None = None,
+        workspace_id: int | None = None,
+        tool: str = "terraform",
     ) -> dict:
+        source_file = "plan.json" if tool == "terraform" else f"{tool}-review.yaml"
         parse_batch = ParseBatchResult(
             files=[
                 ParsedFileResult(
-                    file_name="plan.json",
-                    tool="terraform",
+                    file_name=source_file,
+                    tool=tool,
                     status="parsed",
                     changes=[
                         UnifiedChange(
-                            source_file="plan.json",
-                            tool="terraform",
+                            source_file=source_file,
+                            tool=tool,
                             resource_id="aws_security_group.main",
                             action="modify",
                             summary="Security group exposure risk",
@@ -986,8 +1001,8 @@ class HistoryPageRenderingTests(unittest.TestCase):
             contributors=[
                 RiskContributor(
                     evidence_id="ev-001",
-                    source_file="plan.json",
-                    tool="terraform",
+                    source_file=source_file,
+                    tool=tool,
                     resource_id="aws_security_group.main",
                     action="modify",
                     contribution=20,
@@ -1069,7 +1084,99 @@ class HistoryPageRenderingTests(unittest.TestCase):
                 )
             ],
             audit_context={"source_interface": "ui"},
+            project_id=project_id,
+            workspace_id=workspace_id,
         )
+
+    def test_history_page_exposes_filters_and_row_metadata(self) -> None:
+        project = project_service_module.create_project(
+            project_key="payments",
+            display_name="Payments",
+        )
+        prod = project_service_module.create_workspace(
+            project_key=project.project_key,
+            workspace_key="prod",
+            display_name="Production",
+            environment="prod",
+        )
+        self._persist_report(
+            score=91,
+            severity="critical",
+            recommendation="no-go",
+            top_risk="Payments production ingress widened.",
+            opening_sentence="NO-GO: payments production ingress widened.",
+            project_id=project.id,
+            workspace_id=prod.id,
+            tool="terraform",
+        )
+        legacy_report = self._persist_report(
+            score=63,
+            severity="high",
+            recommendation="caution",
+            top_risk="Legacy Ansible release metadata changed.",
+            opening_sentence="CAUTION: legacy Ansible release metadata changed.",
+            project_id=project.id,
+            workspace_id=prod.id,
+            tool="ansible",
+        )
+        with database_module.SessionLocal() as session:
+            report = session.get(
+                tables_module.AnalysisReport,
+                legacy_report["id"],
+            )
+            report.report_schema_version = "v999"
+            session.commit()
+        project_service_module.set_active_project(project.id)
+
+        response = self.client.get("/history")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("Search top risk or summary", response.text)
+        self.assertIn("Project filter", response.text)
+        self.assertIn("Workspace", response.text)
+        self.assertIn("Time range", response.text)
+        self.assertIn("Risk verdict", response.text)
+        self.assertIn("Toolchain", response.text)
+        self.assertIn("Analysis status", response.text)
+        self.assertIn("Payments", response.text)
+        self.assertIn("Production", response.text)
+        self.assertIn("Tools: terraform", response.text)
+        self.assertIn("Schema: v2", response.text)
+        self.assertIn("Status: complete", response.text)
+        self.assertNotIn("Ansible", response.text)
+
+    def test_history_page_scopes_unselected_project_to_authorized_project(
+        self,
+    ) -> None:
+        payments = project_service_module.create_project(
+            project_key="payments",
+            display_name="Payments",
+        )
+        platform = project_service_module.create_project(
+            project_key="platform",
+            display_name="Platform",
+        )
+        self._persist_report(
+            top_risk="Payments production ingress widened.",
+            opening_sentence="NO-GO: payments production ingress widened.",
+            project_id=payments.id,
+        )
+        self._persist_report(
+            top_risk="Platform production ingress widened.",
+            opening_sentence="NO-GO: platform production ingress widened.",
+            project_id=platform.id,
+            tool="kubernetes",
+        )
+        project_service_module.clear_active_project_selection()
+        os.environ["DEPLOYWHISPER_PROJECT_KEYS"] = "payments"
+        try:
+            response = self.client.get("/history")
+        finally:
+            os.environ.pop("DEPLOYWHISPER_PROJECT_KEYS", None)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("NO-GO: payments production ingress widened.", response.text)
+        self.assertNotIn("NO-GO: platform production ingress widened.", response.text)
 
     def test_public_report_route_shows_compare_button_and_diff_view(self) -> None:
         self._persist_report(

--- a/ui/components/analysis_history_row.py
+++ b/ui/components/analysis_history_row.py
@@ -42,6 +42,20 @@ def _report_confidence(report: dict) -> float | None:
     return coerce_confidence(report.get("confidence"))
 
 
+def _scope_label(report: dict) -> str:
+    project = report.get("project") or {}
+    workspace = report.get("workspace") or {}
+    project_label = str(
+        project.get("display_name") or project.get("project_key") or "Unassigned"
+    )
+    if not workspace:
+        return f"Project: {project_label} · Workspace: All"
+    workspace_label = str(
+        workspace.get("display_name") or workspace.get("workspace_key") or "Workspace"
+    )
+    return f"Project: {project_label} · Workspace: {workspace_label}"
+
+
 def render_analysis_history_row(
     report: dict, on_open, *, on_toggle=None, on_delete=None, selected: bool = False
 ):
@@ -79,6 +93,18 @@ def render_analysis_history_row(
                 )
                 if summary:
                     ui.label(summary).classes("text-xs dw-muted leading-5")
+                tool_mix = report.get("tool_mix") or ["unknown"]
+                with ui.row().classes(
+                    "w-full items-center gap-2 flex-wrap text-[11px] leading-5"
+                ):
+                    ui.label(_scope_label(report)).classes("dw-muted")
+                    ui.label(f"Tools: {', '.join(tool_mix)}").classes("dw-muted")
+                    ui.label(
+                        f"Schema: {report.get('report_schema_version') or 'unknown'}"
+                    ).classes("dw-muted")
+                    ui.label(
+                        f"Status: {report.get('analysis_status') or 'complete'}"
+                    ).classes("dw-muted")
                 context = report.get("context_completeness") or {}
                 with ui.row().classes("w-full items-center gap-2 flex-wrap"):
                     ui.label("Topology freshness").classes(

--- a/ui/routes/history.py
+++ b/ui/routes/history.py
@@ -2,14 +2,17 @@
 
 from __future__ import annotations
 
+from datetime import UTC, datetime, timedelta
 from typing import Any
 
 from nicegui import ui
 
 from services.backtesting_service import fetch_calibration_dashboard_seed
+from services.project_service import ProjectResolutionError, list_workspaces
 from services.report_service import (
     fetch_analysis_report,
     fetch_filtered_analysis_history_page,
+    fetch_history_toolchains,
     fetch_report_comparison,
     fetch_risk_trends,
     remove_analysis_report,
@@ -23,6 +26,7 @@ from ui.components.review_accessibility import (
 )
 from ui.components.topology_freshness_banner import render_topology_freshness_banner
 from ui.project_authorization import resolve_authorized_ui_active_project
+from ui.project_authorization import load_authorized_ui_projects
 from ui.theme import apply_theme, build_navigation_shell, build_page_header
 
 
@@ -45,6 +49,10 @@ def resolve_history_active_project():
 def resolve_history_project_context():
     """Return the effective project and any authorization setup error."""
     _, active_project, authorization_error = resolve_authorized_ui_active_project()
+    if active_project is None and authorization_error is None:
+        projects, authorization_error = load_authorized_ui_projects()
+        if authorization_error is None and len(projects) == 1:
+            active_project = projects[0]
     return active_project, authorization_error
 
 
@@ -75,6 +83,39 @@ def _empty_calibration_dashboard_seed() -> dict[str, Any]:
     }
 
 
+def _history_workspace_options(project_key: str | None) -> dict[str, str]:
+    if project_key is None:
+        return {"": "All workspaces"}
+    try:
+        workspaces = list_workspaces(project_key=project_key)
+    except ProjectResolutionError:
+        return {"": "All workspaces"}
+    options = {"": "All workspaces"}
+    options.update(
+        {workspace.workspace_key: workspace.display_name for workspace in workspaces}
+    )
+    return options
+
+
+def _history_time_bounds(value: str | None) -> tuple[datetime | None, datetime | None]:
+    now = datetime.now(UTC)
+    if value == "24h":
+        return now - timedelta(hours=24), now
+    if value == "7d":
+        return now - timedelta(days=7), now
+    if value == "30d":
+        return now - timedelta(days=30), now
+    if value == "90d":
+        return now - timedelta(days=90), now
+    return None, None
+
+
+def _history_toolchain_options(toolchains: list[str]) -> dict[str, str]:
+    options = {"": "Any toolchain"}
+    options.update({str(tool): str(tool).title() for tool in toolchains})
+    return options
+
+
 def build_history_page() -> None:
     """Render a scanable history view with direct report retrieval."""
     apply_theme()
@@ -93,9 +134,10 @@ def build_history_page() -> None:
     def render_history_content() -> None:
         active_project, authorization_error = resolve_history_project_context()
         active_project_id = active_project.id if active_project is not None else None
+        has_history_scope = authorization_error is None and active_project is not None
         reports_page = (
             _empty_history_page()
-            if authorization_error is not None
+            if not has_history_scope
             else fetch_filtered_analysis_history_page(
                 project_id=active_project_id,
                 page=1,
@@ -107,13 +149,21 @@ def build_history_page() -> None:
         total_report_count = reports_page["total_count"]
         trends = (
             _empty_risk_trends()
-            if authorization_error is not None
+            if not has_history_scope
             else fetch_risk_trends(project_id=active_project_id)
         )
         calibration = (
             _empty_calibration_dashboard_seed()
-            if authorization_error is not None
+            if not has_history_scope
             else fetch_calibration_dashboard_seed(project_id=active_project_id)
+        )
+        history_toolchains = (
+            []
+            if not has_history_scope
+            else fetch_history_toolchains(
+                project_id=active_project_id,
+                skip_unreadable_schema=True,
+            )
         )
         selected_ids: set[int] = set()
         page_state = {"page": 1, "page_size": 5}
@@ -132,9 +182,13 @@ def build_history_page() -> None:
                     subtitle=(
                         authorization_error
                         if authorization_error is not None
-                        else "Review earlier deploy briefings, audit metadata, and risk trends."
+                        else "Select a project to review historical reports."
                         if active_project is None
-                        else f"Project-scoped history for {active_project.display_name} ({active_project.project_key})."
+                        else (
+                            "Project-scoped history for "
+                            f"{active_project.display_name} "
+                            f"({active_project.project_key})."
+                        )
                     ),
                     back_href="/",
                     back_label="Back to dashboard",
@@ -175,6 +229,86 @@ def build_history_page() -> None:
                 .props("outlined dense clearable prepend-icon=search")
                 .classes("w-full dw-search-input")
             )
+            with ui.card().classes("w-full dw-panel shadow-none p-4"):
+                with ui.column().classes("gap-3"):
+                    with ui.row().classes("w-full items-start gap-4 flex-wrap"):
+                        with ui.column().classes("gap-0 min-w-[220px] flex-1"):
+                            ui.label("Project filter").classes("dw-eyebrow mb-1")
+                            ui.label(
+                                "Select a project"
+                                if active_project is None
+                                else (
+                                    f"{active_project.display_name} "
+                                    f"({active_project.project_key})"
+                                )
+                            ).classes("text-sm font-medium dw-text leading-5")
+                        workspace_select = (
+                            ui.select(
+                                _history_workspace_options(
+                                    active_project.project_key
+                                    if active_project is not None
+                                    else None
+                                ),
+                                value="",
+                                label="Workspace",
+                            )
+                            .props("outlined dense emit-value map-options")
+                            .classes("min-w-[180px] flex-1")
+                        )
+                        time_range_select = (
+                            ui.select(
+                                {
+                                    "": "Any time",
+                                    "24h": "Last 24 hours",
+                                    "7d": "Last 7 days",
+                                    "30d": "Last 30 days",
+                                    "90d": "Last 90 days",
+                                },
+                                value="",
+                                label="Time range",
+                            )
+                            .props("outlined dense emit-value map-options")
+                            .classes("min-w-[170px] flex-1")
+                        )
+                        severity_select = (
+                            ui.select(
+                                {
+                                    "": "Any risk",
+                                    "critical": "Critical",
+                                    "high": "High",
+                                    "medium": "Medium",
+                                    "low": "Low",
+                                },
+                                value="",
+                                label="Risk verdict",
+                            )
+                            .props("outlined dense emit-value map-options")
+                            .classes("min-w-[170px] flex-1")
+                        )
+                    with ui.row().classes("w-full items-start gap-4 flex-wrap"):
+                        toolchain_select = (
+                            ui.select(
+                                _history_toolchain_options(history_toolchains),
+                                value="",
+                                label="Toolchain",
+                            )
+                            .props("outlined dense emit-value map-options")
+                            .classes("min-w-[170px] flex-1")
+                        )
+                        status_select = (
+                            ui.select(
+                                {
+                                    "": "Any status",
+                                    "complete": "Complete",
+                                    "degraded": "Degraded",
+                                    "fallback": "Fallback",
+                                },
+                                value="",
+                                label="Analysis status",
+                            )
+                            .props("outlined dense emit-value map-options")
+                            .classes("min-w-[170px] flex-1")
+                        )
             actions_row = ui.row().classes(
                 "w-full items-center justify-between gap-4 flex-wrap"
             )
@@ -182,12 +316,21 @@ def build_history_page() -> None:
 
             def refresh_data(query: str | None = None) -> list[dict]:
                 nonlocal reports, trends, total_report_count, calibration
+                created_from, created_to = _history_time_bounds(
+                    str(time_range_select.value or "")
+                )
                 page_payload = (
                     _empty_history_page()
-                    if authorization_error is not None
+                    if not has_history_scope
                     else fetch_filtered_analysis_history_page(
                         project_id=active_project_id,
+                        workspace_key=str(workspace_select.value or "") or None,
+                        severity=str(severity_select.value or "") or None,
                         search=query,
+                        toolchain=str(toolchain_select.value or "") or None,
+                        analysis_status=str(status_select.value or "") or None,
+                        created_from=created_from,
+                        created_to=created_to,
                         page=page_state["page"],
                         page_size=page_state["page_size"],
                         skip_unreadable_schema=True,
@@ -197,12 +340,12 @@ def build_history_page() -> None:
                 total_report_count = page_payload["total_count"]
                 trends = (
                     _empty_risk_trends()
-                    if authorization_error is not None
+                    if not has_history_scope
                     else fetch_risk_trends(project_id=active_project_id)
                 )
                 calibration = (
                     _empty_calibration_dashboard_seed()
-                    if authorization_error is not None
+                    if not has_history_scope
                     else fetch_calibration_dashboard_seed(project_id=active_project_id)
                 )
                 max_page = max(
@@ -210,6 +353,26 @@ def build_history_page() -> None:
                 )
                 page_state["page"] = min(page_state["page"], max_page)
                 return reports
+
+            def current_workspace_key() -> str | None:
+                return str(workspace_select.value or "") or None
+
+            def sync_toolchain_options() -> None:
+                selected_toolchain = str(toolchain_select.value or "")
+                scoped_toolchains = (
+                    []
+                    if not has_history_scope
+                    else fetch_history_toolchains(
+                        project_id=active_project_id,
+                        workspace_key=current_workspace_key(),
+                        skip_unreadable_schema=True,
+                    )
+                )
+                options = _history_toolchain_options(scoped_toolchains)
+                toolchain_select.set_options(options)
+                if selected_toolchain and selected_toolchain not in options:
+                    toolchain_select.value = ""
+                toolchain_select.update()
 
             def current_page_reports() -> list[dict]:
                 return reports
@@ -381,11 +544,21 @@ def build_history_page() -> None:
             def apply_filters() -> None:
                 query = search_input.value.strip() if search_input.value else None
                 page_state["page"] = 1
+                selected_ids.clear()
                 refresh_data(query)
                 render_history()
                 render_actions()
 
+            def apply_workspace_filter() -> None:
+                sync_toolchain_options()
+                apply_filters()
+
             search_input.on("update:model-value", lambda *_: apply_filters())
+            workspace_select.on_value_change(lambda *_: apply_workspace_filter())
+            time_range_select.on_value_change(lambda *_: apply_filters())
+            severity_select.on_value_change(lambda *_: apply_filters())
+            toolchain_select.on_value_change(lambda *_: apply_filters())
+            status_select.on_value_change(lambda *_: apply_filters())
             render_history()
             render_actions()
 


### PR DESCRIPTION
Story 3.8 adds reviewer-facing history filters across the shared service, API, and NiceGUI history route while preserving project/workspace scope boundaries. The implementation keeps the query logic in the repository/service layer so UI and API behavior stay aligned, and it records the story as done after a clean BMad review rerun.

Constraint: Story 3.8 requires filtering by project, workspace, time range, risk verdict, toolchain, and analysis status without leaking inaccessible report metadata.

Rejected: Surface forbidden project filters as 403 on the history list | AC2 requires empty or authorized-only result sets for out-of-scope history filters.

Confidence: high

Scope-risk: moderate

Directive: Keep history filter semantics shared across service, API, and UI; do not add UI-only filtering that bypasses project/workspace scoping.

Tested: Focused reviewer regression bundle, full unittest suite, Playwright ui-review lane, local CI, pip-audit, git diff --check.

Not-tested: VoiceOver-specific UI review; Story 3.8 did not change screen-reader-specific semantics.

## What does this PR do?

<!-- Brief description of changes -->

## Type of change
- [ ] Feature (new functionality)
- [ ] Bugfix (non-breaking fix)
- [ ] Release preparation
- [ ] Hotfix (critical production fix)
- [ ] Docs / refactor / chore

## Checklist
- [ ] I have followed the branch naming convention
- [ ] Tests pass locally (`pytest tests/ -v`)
- [ ] Linting passes (`ruff check .`)
- [ ] Docker build succeeds
- [ ] I have updated docs if needed
- [ ] No secrets or .env values committed

## Related issue
Closes #