### PR TITLE
Surface day-zero risk patterns in reports

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ DeployWhisper helps platform engineers, DevOps teams, and SREs review deployment
 
 DeployWhisper exists because deployment risk is rarely visible in a single file. A Terraform change might look safe on its own, a Kubernetes manifest might look routine on its own, and a Jenkins pipeline change might look minor on its own, but the real risk often appears only when those artifacts are reviewed together.
 
-DeployWhisper treats deployment review as a context problem. It combines multi-tool parsing, local-first analysis, tool-specific AI Skills, incident-memory matching, and advisory summaries so teams can make better go/no-go decisions before changes reach production.
+DeployWhisper treats deployment review as a context problem. It combines multi-tool parsing, local-first analysis, tool-specific AI Skills, public risk pattern matching, incident-memory matching, and advisory summaries so teams can make better go/no-go decisions before changes reach production.
 
 The current implementation is built as a pure-Python application with:
 
@@ -61,7 +61,7 @@ The current implementation is built as a pure-Python application with:
 1. Upload one or more supported deployment artifacts.
 2. DeployWhisper detects the tool type and filters unsupported or sensitive inputs.
 3. Parsers normalize changes into a shared internal model.
-4. The analysis pipeline scores risk, computes blast radius, generates rollback guidance, and checks incident similarity.
+4. The analysis pipeline scores risk, computes blast radius, generates rollback guidance, and checks built-in public risk patterns plus incident similarity.
 5. A narrative layer produces a plain-English deploy briefing.
 6. The report is persisted with audit metadata before it is shown in the UI or returned through the API or CLI.
 
@@ -78,6 +78,7 @@ Artifacts -> Parse -> Normalize -> Score -> Blast Radius -> Rollback -> Narrativ
 - Advisory-only output with explicit human-review posture
 - Blast radius analysis using a project-scoped service-topology graph with a shared multi-source import foundation
 - Rollback plan generation with complexity signaling
+- **Day-zero risk patterns**: fresh installs can flag built-in public risk patterns such as wide-open administrative ingress or stateful resource deletion, separately labeled from organization incident memory.
 - Incident-history matching for operational memory
 - API, CLI, and web entrypoints over one shared analysis pipeline
 - Local-first security model that keeps raw IaC local and avoids persisting API keys
@@ -112,7 +113,7 @@ review layer before infrastructure changes are shipped.
 
 What users can use today:
 
-- **Web review workflow**: upload deployment artifacts in the NiceGUI dashboard and get a persisted advisory report with risk score, severity, recommendation, findings, evidence, context quality, blast radius, rollback guidance, and audit metadata.
+- **Web review workflow**: upload deployment artifacts in the NiceGUI dashboard and get a persisted advisory report with risk score, severity, recommendation, findings, evidence, public risk pattern/incident matches, context quality, blast radius, rollback guidance, and audit metadata.
 - **Multi-tool analysis**: analyze Terraform, Kubernetes, Ansible, Jenkins, and CloudFormation inputs through one shared pipeline instead of reviewing every tool in isolation.
 - **LLM-assisted narrative**: connect deterministic scoring with plain-English deployment guidance using Ollama, OpenAI, Anthropic, Gemini, OpenRouter, Groq, or xAI provider settings.
 - **Local-first safety posture**: keep raw IaC processing local, avoid storing provider API keys in the database, exclude sensitive files from unsafe handling, and keep every verdict advisory rather than automatically blocking a release.

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -1,5 +1,5 @@
 # generated: 2026-05-01
-# last_updated: 2026-05-20
+# last_updated: 2026-05-21
 # project: deploywhisper
 # project_key: NOKEY
 # tracking_system: file-system
@@ -35,7 +35,7 @@
 # - Dev moves story to review, then runs code-review
 
 generated: 2026-05-01
-last_updated: 2026-05-20
+last_updated: 2026-05-21
 project: deploywhisper
 project_key: NOKEY
 tracking_system: file-system
@@ -82,7 +82,7 @@ development_status:
   epic-3-retrospective: optional
 
   epic-4: in-progress
-  4-1-public-risk-pattern-library-v1: ready-for-dev
+  4-1-public-risk-pattern-library-v1: done
   4-2-safe-sample-incident-pack: ready-for-dev
   4-3-incident-import-for-markdown-yaml-and-json: ready-for-dev
   4-4-incident-similarity-with-match-explanation: ready-for-dev

--- a/analysis/incident_matcher.py
+++ b/analysis/incident_matcher.py
@@ -4,15 +4,23 @@ from __future__ import annotations
 
 from datetime import UTC, datetime
 import re
+from typing import Any, Literal
 
 from pydantic import BaseModel, Field
 
-from parsers.base import UnifiedChange
+from parsers.base import UnifiedChange, normalize_change_action
 from services.incident_service import get_incident_records
 
 
 class IncidentMatch(BaseModel):
     incident_id: int = Field(..., description="Matched incident identifier")
+    match_type: Literal["organization_incident", "public_risk_pattern"] = Field(
+        default="organization_incident",
+        description="Whether the match came from org incident memory or public patterns.",
+    )
+    public_pattern_id: str | None = Field(
+        default=None, description="Built-in public risk pattern identifier."
+    )
     title: str = Field(..., description="Incident title")
     severity: str = Field(..., description="Incident severity")
     source_file: str = Field(..., description="Incident source file")
@@ -20,6 +28,19 @@ class IncidentMatch(BaseModel):
         default=None, description="Incident date if available"
     )
     similarity: float = Field(..., description="Similarity score between 0 and 1")
+    confidence: float = Field(
+        default=0.0, description="Confidence that this memory signal applies."
+    )
+    reason: str = Field(
+        default="", description="Why the incident or public pattern matched."
+    )
+    evidence: list[str] = Field(
+        default_factory=list, description="Concrete evidence supporting the match."
+    )
+    verification_guidance: list[str] = Field(
+        default_factory=list,
+        description="Human verification steps before acting on the match.",
+    )
     summary: str = Field(..., description="Short operational explanation")
 
 
@@ -58,6 +79,217 @@ STOP_WORDS = {
     "destroy",
     "service",
 }
+
+
+ADMIN_INGRESS_PORTS = {"22", "3389", "5432", "3306", "6379", "9200", "9300"}
+STATEFUL_RESOURCE_TYPES = {
+    "aws_db_instance",
+    "aws_rds_cluster",
+    "aws_dynamodb_table",
+    "aws_elasticache_cluster",
+    "aws_elasticache_replication_group",
+    "aws_s3_bucket",
+    "aws_ebs_volume",
+    "azurerm_postgresql_server",
+    "azurerm_mssql_server",
+    "azurerm_storage_account",
+    "google_sql_database_instance",
+    "google_storage_bucket",
+    "persistentvolume",
+    "persistentvolumeclaim",
+}
+
+
+def _metadata_text_parts(value: Any) -> list[str]:
+    if isinstance(value, dict):
+        parts: list[str] = []
+        for key, nested in value.items():
+            parts.append(str(key))
+            parts.extend(_metadata_text_parts(nested))
+        return parts
+    if isinstance(value, list | tuple | set):
+        parts = []
+        for nested in value:
+            parts.extend(_metadata_text_parts(nested))
+        return parts
+    if value is None:
+        return []
+    return [str(value)]
+
+
+def _change_text(change: UnifiedChange) -> str:
+    metadata_text = " ".join(_metadata_text_parts(change.metadata))
+    return " ".join(
+        str(part or "")
+        for part in [
+            change.source_file,
+            change.tool,
+            change.resource_id,
+            change.action,
+            change.summary,
+            metadata_text,
+        ]
+    ).lower()
+
+
+def _evidence_line(change: UnifiedChange) -> str:
+    return (
+        f"{change.source_file}: {change.resource_id} "
+        f"({normalize_change_action(change.action)}) - {change.summary}"
+    )
+
+
+def _matches_wide_open_ingress(change: UnifiedChange) -> bool:
+    if isinstance(change.metadata.get("network_ingress_rules"), list):
+        return _matches_structured_wide_open_ingress(change)
+    text = _change_text(change)
+    has_public_cidr = "0.0.0.0/0" in text or "::/0" in text
+    has_ingress_signal = any(
+        signal in text
+        for signal in (
+            "ingress",
+            "security_group",
+            "security group",
+            "firewall",
+            "network security group",
+        )
+    )
+    has_admin_port_signal = (
+        "ssh" in text
+        or "rdp" in text
+        or any(f"port {port}" in text for port in ADMIN_INGRESS_PORTS)
+        or any(f":{port}" in text for port in ADMIN_INGRESS_PORTS)
+    )
+    return has_public_cidr and has_ingress_signal and has_admin_port_signal
+
+
+def _matches_structured_wide_open_ingress(change: UnifiedChange) -> bool:
+    resource_type = _resource_type(change)
+    if resource_type and (
+        "security_group" not in resource_type and "firewall" not in resource_type
+    ):
+        return False
+    rules = change.metadata.get("network_ingress_rules")
+    if not isinstance(rules, list):
+        return False
+    for rule in rules:
+        if not isinstance(rule, dict):
+            continue
+        cidrs = [
+            str(cidr)
+            for cidr in [
+                *(rule.get("cidr_blocks") or []),
+                *(rule.get("ipv6_cidr_blocks") or []),
+            ]
+        ]
+        if not any(cidr in {"0.0.0.0/0", "::/0"} for cidr in cidrs):
+            continue
+        if _rule_exposes_admin_port(rule):
+            return True
+    return False
+
+
+def _rule_exposes_admin_port(rule: dict[str, Any]) -> bool:
+    protocol = str(rule.get("protocol") or "").lower()
+    if protocol in {"-1", "all", "any"}:
+        return True
+    from_port = _int_or_none(rule.get("from_port"))
+    to_port = _int_or_none(rule.get("to_port"))
+    if from_port is None or to_port is None:
+        return False
+    low, high = sorted((from_port, to_port))
+    return any(low <= int(port) <= high for port in ADMIN_INGRESS_PORTS)
+
+
+def _int_or_none(value: Any) -> int | None:
+    if isinstance(value, bool) or value is None:
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _resource_type(change: UnifiedChange) -> str:
+    metadata_type = change.metadata.get("resource_type")
+    if isinstance(metadata_type, str) and metadata_type.strip():
+        return metadata_type.strip().lower()
+    parts = [part for part in change.resource_id.lower().split(".") if part]
+    if len(parts) >= 2:
+        return parts[-2]
+    return parts[0] if parts else ""
+
+
+def _matches_stateful_destroy(change: UnifiedChange) -> bool:
+    if normalize_change_action(change.action) not in {"destroy", "replace"}:
+        return False
+    return _resource_type(change) in STATEFUL_RESOURCE_TYPES
+
+
+def find_public_risk_pattern_matches(
+    changes: list[UnifiedChange],
+) -> list[IncidentMatch]:
+    """Return built-in public risk pattern matches for fresh installs."""
+    matches: list[IncidentMatch] = []
+    for change in changes:
+        if _matches_wide_open_ingress(change):
+            matches.append(
+                IncidentMatch(
+                    incident_id=0,
+                    match_type="public_risk_pattern",
+                    public_pattern_id="public-ingress-wide-open",
+                    title="Wide-open administrative ingress",
+                    severity="high",
+                    source_file=change.source_file,
+                    incident_date=None,
+                    similarity=0.86,
+                    confidence=0.86,
+                    reason=(
+                        "The change appears to expose administrative or data-plane "
+                        "network access to the public internet."
+                    ),
+                    evidence=[_evidence_line(change)],
+                    verification_guidance=[
+                        "Confirm whether the public CIDR is intentional and time-bound.",
+                        "Restrict administrative ingress to trusted networks or a managed access path.",
+                        "Verify compensating controls such as just-in-time access, MFA, and alerting.",
+                    ],
+                    summary=(
+                        "Public risk pattern match: wide-open administrative ingress "
+                        "has caused common deployment incidents."
+                    ),
+                )
+            )
+        if _matches_stateful_destroy(change):
+            matches.append(
+                IncidentMatch(
+                    incident_id=0,
+                    match_type="public_risk_pattern",
+                    public_pattern_id="public-stateful-resource-destroy",
+                    title="Stateful resource replacement or deletion",
+                    severity="high",
+                    source_file=change.source_file,
+                    incident_date=None,
+                    similarity=0.82,
+                    confidence=0.82,
+                    reason=(
+                        "The change appears to destroy or replace a stateful resource "
+                        "where data loss or prolonged recovery is a common failure mode."
+                    ),
+                    evidence=[_evidence_line(change)],
+                    verification_guidance=[
+                        "Confirm a tested backup, restore, or migration path exists.",
+                        "Check retention, deletion protection, and rollback timing.",
+                        "Review downstream services that depend on the stateful resource.",
+                    ],
+                    summary=(
+                        "Public risk pattern match: stateful resource deletion or "
+                        "replacement can create recovery and data-loss incidents."
+                    ),
+                )
+            )
+    matches.sort(key=lambda match: match.confidence, reverse=True)
+    return matches
 
 
 def _tokenize(text: str) -> set[str]:
@@ -108,6 +340,7 @@ def find_incident_matches(
     workspace_key: str | None = None,
 ) -> list[IncidentMatch]:
     """Return incident matches ranked by simple token overlap."""
+    public_pattern_matches = find_public_risk_pattern_matches(changes)
     candidates = load_incident_candidates(
         project_id=project_id,
         project_key=project_key,
@@ -115,7 +348,7 @@ def find_incident_matches(
         workspace_key=workspace_key,
     )
     if not candidates:
-        return []
+        return public_pattern_matches
 
     change_text = " ".join(
         " ".join([change.source_file, change.tool, change.resource_id, change.summary])
@@ -123,7 +356,7 @@ def find_incident_matches(
     )
     change_tokens = _tokenize(change_text)
     if not change_tokens:
-        return []
+        return public_pattern_matches
 
     matches: list[IncidentMatch] = []
     for candidate in candidates:
@@ -152,11 +385,26 @@ def find_incident_matches(
         matches.append(
             IncidentMatch(
                 incident_id=candidate["id"],
+                match_type="organization_incident",
+                public_pattern_id=None,
                 title=candidate["title"],
                 severity=candidate["severity"],
                 source_file=candidate["source_file"],
                 incident_date=candidate.get("incident_date"),
                 similarity=round(similarity, 2),
+                confidence=round(similarity, 2),
+                reason=(
+                    "The current change shares deployment tokens with an "
+                    "organization-specific incident record."
+                ),
+                evidence=[
+                    f"overlap: {', '.join(sorted(overlap)[:8])}",
+                    f"incident source: {candidate['source_file']}",
+                ],
+                verification_guidance=[
+                    "Compare the current change path against the prior incident timeline.",
+                    "Confirm whether the same affected service, dependency, or rollback path applies.",
+                ],
                 summary=(
                     f"Similar to prior incident '{candidate['title']}' "
                     f"({candidate['severity']}) with {round(similarity * 100)}% token overlap."
@@ -164,5 +412,6 @@ def find_incident_matches(
             )
         )
 
+    matches.extend(public_pattern_matches)
     matches.sort(key=lambda match: match.similarity, reverse=True)
     return matches

--- a/api/schemas.py
+++ b/api/schemas.py
@@ -400,6 +400,7 @@ class PersistedReportData(BaseModel):
     warnings: list[str] = Field(default_factory=list)
     findings: list["FindingData"] = Field(default_factory=list)
     evidence_items: list["EvidenceItemData"] = Field(default_factory=list)
+    incident_matches: list["IncidentMatchData"] = Field(default_factory=list)
     contributors: list["RiskContributorData"] = Field(default_factory=list)
     confidence_ledger: ConfidenceLedgerData = Field(
         default_factory=ConfidenceLedgerData,
@@ -937,6 +938,13 @@ class RollbackPlanData(BaseModel):
 
 class IncidentMatchData(BaseModel):
     incident_id: int = Field(..., description="Matched incident identifier")
+    match_type: Literal["organization_incident", "public_risk_pattern"] = Field(
+        default="organization_incident",
+        description="Whether the match came from org incident memory or public patterns.",
+    )
+    public_pattern_id: str | None = Field(
+        default=None, description="Built-in public risk pattern identifier."
+    )
     title: str = Field(..., description="Incident title")
     severity: str = Field(..., description="Incident severity")
     source_file: str = Field(..., description="Incident source file")
@@ -944,6 +952,19 @@ class IncidentMatchData(BaseModel):
         default=None, description="Incident date if available"
     )
     similarity: float = Field(..., description="Similarity score between 0 and 1")
+    confidence: float = Field(
+        default=0.0, description="Confidence that this memory signal applies."
+    )
+    reason: str = Field(
+        default="", description="Why the incident or public pattern matched."
+    )
+    evidence: list[str] = Field(
+        default_factory=list, description="Concrete evidence supporting the match."
+    )
+    verification_guidance: list[str] = Field(
+        default_factory=list,
+        description="Human verification steps before acting on the match.",
+    )
     summary: str = Field(..., description="Short operational explanation")
 
 

--- a/app.py
+++ b/app.py
@@ -388,6 +388,47 @@ def _shared_report_confidence_ledger_html(report: dict) -> str:
     )
 
 
+def _shared_report_incident_matches_html(report: dict) -> str:
+    matches = report.get("incident_matches") or []
+    if not matches:
+        return (
+            "<section class='panel'><h2>Incident and risk pattern similarity</h2>"
+            "<p class='empty'>No similar incidents found.</p></section>"
+        )
+
+    rows = []
+    for match in matches:
+        evidence_html = _shared_report_ledger_list(
+            [f"Evidence: {item}" for item in (match.get("evidence") or [])],
+            "No evidence was recorded for this match.",
+        )
+        guidance_html = _shared_report_ledger_list(
+            [str(item) for item in (match.get("verification_guidance") or [])],
+            "No verification guidance was recorded for this match.",
+        )
+        match_type = (
+            "Public risk pattern"
+            if match.get("match_type") == "public_risk_pattern"
+            else "Organization incident"
+        )
+        confidence = round(float(match.get("confidence") or 0) * 100)
+        rows.append(
+            "<li>"
+            f"<strong>{escape(str(match.get('title') or 'Incident match'))}</strong>"
+            f" <span class='badge'>{escape(match_type)}</span>"
+            f" <span class='badge'>{confidence}% confidence</span>"
+            f"<p>{escape(str(match.get('summary') or ''))}</p>"
+            f"<p>{escape(str(match.get('reason') or ''))}</p>"
+            f"{evidence_html}"
+            f"{guidance_html}"
+            "</li>"
+        )
+    return (
+        "<section class='panel'><h2>Incident and risk pattern similarity</h2>"
+        f"<ul>{''.join(rows)}</ul></section>"
+    )
+
+
 def _shared_report_comparison_html(
     report: dict,
     comparison: dict | None,
@@ -604,6 +645,7 @@ def _shared_report_html(
         f"{_shared_report_comparison_html(report, comparison, show_comparison=show_comparison)}"
         "</section>"
         f"{_shared_report_confidence_ledger_html(report)}"
+        f"{_shared_report_incident_matches_html(report)}"
         "<section class='panel'><div class='grid'>"
         f"<div><strong>Created</strong><p>{escape(str(report.get('created_at') or ''))}</p></div>"
         f"<div><strong>Share URL</strong><p><a href='{escape(str(share.get('share_url') or ''))}'>{escape(str(share.get('share_url') or ''))}</a></p></div>"

--- a/docs/schemas/report-v2.md
+++ b/docs/schemas/report-v2.md
@@ -338,6 +338,28 @@ without storing raw plan internals in a separate contract.
   ],
   "findings": [],
   "evidence_items": [],
+  "incident_matches": [
+    {
+      "incident_id": 0,
+      "match_type": "public_risk_pattern",
+      "public_pattern_id": "public-ingress-wide-open",
+      "title": "Wide-open administrative ingress",
+      "severity": "high",
+      "source_file": "plan.json",
+      "incident_date": null,
+      "similarity": 0.86,
+      "confidence": 0.86,
+      "reason": "The change appears to expose administrative or data-plane network access to the public internet.",
+      "evidence": [
+        "plan.json: aws_security_group.web (modify) - Terraform opened SSH ingress from 0.0.0.0/0 on port 22."
+      ],
+      "verification_guidance": [
+        "Confirm whether the public CIDR is intentional and time-bound.",
+        "Restrict administrative ingress to trusted networks or a managed access path."
+      ],
+      "summary": "Public risk pattern match: wide-open administrative ingress has caused common deployment incidents."
+    }
+  ],
   "contributors": [
     {
       "source_file": "plan.json",
@@ -360,6 +382,15 @@ without storing raw plan internals in a separate contract.
   }
 }
 ```
+
+### Analysis run incident and pattern matches
+
+Live API/CLI analysis responses and persisted report retrieval payloads include
+`incident_matches`. Matches from stored organization incident memory use
+`match_type: "organization_incident"`. Built-in day-zero risk patterns use
+`match_type: "public_risk_pattern"` and include `public_pattern_id`, `reason`,
+`evidence`, `confidence`, and `verification_guidance` so consumers can
+distinguish public guidance from a prior incident in their own environment.
 
 ## Compatibility contract
 

--- a/migrations/versions/021_add_incident_matches_payload.py
+++ b/migrations/versions/021_add_incident_matches_payload.py
@@ -1,0 +1,43 @@
+"""Persist incident and public risk pattern matches.
+
+Revision ID: 021_add_incident_matches_payload
+Revises: 020_add_narrative_state_fields
+Create Date: 2026-05-21
+"""
+
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "021_add_incident_matches_payload"
+down_revision = "020_add_narrative_state_fields"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "analysis_reports",
+        sa.Column(
+            "incident_matches_json",
+            sa.Text(),
+            nullable=False,
+            server_default="[]",
+        ),
+    )
+    op.execute(
+        "UPDATE analysis_reports SET incident_matches_json = '[]' "
+        "WHERE incident_matches_json IS NULL OR incident_matches_json = ''"
+    )
+    with op.batch_alter_table("analysis_reports") as batch_op:
+        batch_op.alter_column(
+            "incident_matches_json",
+            existing_type=sa.Text(),
+            server_default=None,
+        )
+
+
+def downgrade() -> None:
+    op.drop_column("analysis_reports", "incident_matches_json")

--- a/models/database.py
+++ b/models/database.py
@@ -50,6 +50,7 @@ _KNOWN_ALEMBIC_REVISIONS = {
     "018_add_evidence_identity_fields",
     "019_add_finding_context_fields",
     "020_add_narrative_state_fields",
+    "021_add_incident_matches_payload",
 }
 _BASELINE_TABLES = {"analysis_reports", "app_settings"}
 _EVIDENCE_TABLES = {
@@ -375,6 +376,20 @@ def _analysis_report_narrative_state_complete(connection) -> bool:
     )
 
 
+def _analysis_report_incident_matches_complete(connection) -> bool:
+    column_map = {
+        column["name"]: column
+        for column in inspect(connection).get_columns("analysis_reports")
+    }
+    incident_matches_column = column_map.get("incident_matches_json")
+    return (
+        incident_matches_column is not None
+        and incident_matches_column["type"]._type_affinity is String
+        and incident_matches_column.get("nullable") is False
+        and incident_matches_column.get("default") is None
+    )
+
+
 def _learning_context_scope_complete(connection) -> bool:
     inspector = inspect(connection)
     workspace_unique_columns = {
@@ -588,6 +603,11 @@ def _bootstrap_brownfield_revision() -> None:
             has_narrative_state_fields
             and _analysis_report_narrative_state_complete(connection)
         )
+        has_incident_matches_payload = "incident_matches_json" in report_columns
+        has_complete_incident_matches_payload = (
+            has_incident_matches_payload
+            and _analysis_report_incident_matches_complete(connection)
+        )
         if scoped_learning_columns_present and not has_complete_learning_context_scope:
             raise RuntimeError(
                 "Detected a partial learning/context scope schema without a complete "
@@ -631,6 +651,28 @@ def _bootstrap_brownfield_revision() -> None:
                 "Detected a partial narrative state schema without a complete "
                 "migration history. Manual recovery is required."
             )
+        if has_incident_matches_payload and not (
+            has_complete_learning_context_scope
+            and has_complete_submission_manifest_payload
+            and has_complete_evidence_identity_fields
+            and has_complete_finding_context_fields
+            and has_complete_narrative_state_fields
+            and has_complete_incident_matches_payload
+        ):
+            raise RuntimeError(
+                "Detected a partial incident matches payload schema without a complete "
+                "migration history. Manual recovery is required."
+            )
+        if (
+            has_complete_learning_context_scope
+            and has_complete_submission_manifest_payload
+            and has_complete_evidence_identity_fields
+            and has_complete_finding_context_fields
+            and has_complete_narrative_state_fields
+            and has_complete_incident_matches_payload
+        ):
+            _write_alembic_revision(connection, "021_add_incident_matches_payload")
+            return
         if (
             has_complete_learning_context_scope
             and has_complete_submission_manifest_payload

--- a/models/repositories/analysis_reports.py
+++ b/models/repositories/analysis_reports.py
@@ -428,6 +428,7 @@ def create_analysis_report(
     narrative_failure_notice: str | None = None,
     top_risk_contributors_json: str = "[]",
     context_completeness_json: str = "{}",
+    incident_matches_json: str = "[]",
     findings_payload: list[dict[str, Any]] | None = None,
     evidence_payload: list[dict[str, Any]] | None = None,
 ) -> AnalysisReport:
@@ -456,6 +457,7 @@ def create_analysis_report(
         submission_manifest_fallback_json=submission_manifest_fallback_json,
         blast_radius_json=blast_radius_json,
         rollback_plan_json=rollback_plan_json,
+        incident_matches_json=incident_matches_json,
         llm_provider=llm_provider,
         llm_model=llm_model,
         llm_local_mode=llm_local_mode,

--- a/models/tables.py
+++ b/models/tables.py
@@ -212,6 +212,7 @@ if "AnalysisReport" not in globals():
         )
         blast_radius_json: Mapped[str] = mapped_column(Text, default="{}")
         rollback_plan_json: Mapped[str] = mapped_column(Text, default="{}")
+        incident_matches_json: Mapped[str] = mapped_column(Text, default="[]")
         llm_provider: Mapped[str | None] = mapped_column(String(50), nullable=True)
         llm_model: Mapped[str | None] = mapped_column(String(120), nullable=True)
         llm_local_mode: Mapped[str | None] = mapped_column(String(10), nullable=True)

--- a/parsers/terraform_parser.py
+++ b/parsers/terraform_parser.py
@@ -241,6 +241,73 @@ def _unsupported_fields(resource: dict[str, Any], change: dict[str, Any]) -> lis
     ]
 
 
+def _string_values(*values: Any) -> list[str]:
+    normalized: list[str] = []
+    for value in values:
+        if isinstance(value, list):
+            normalized.extend(str(item) for item in value if item is not None)
+        elif value is not None:
+            normalized.append(str(value))
+    return normalized
+
+
+def _int_or_none(value: Any) -> int | None:
+    if isinstance(value, bool) or value is None:
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _normalized_ingress_rule(rule: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "protocol": str(rule.get("protocol") or rule.get("ip_protocol") or ""),
+        "from_port": _int_or_none(rule.get("from_port")),
+        "to_port": _int_or_none(rule.get("to_port")),
+        "cidr_blocks": _string_values(rule.get("cidr_blocks"), rule.get("cidr_ipv4")),
+        "ipv6_cidr_blocks": _string_values(
+            rule.get("ipv6_cidr_blocks"), rule.get("cidr_ipv6")
+        ),
+    }
+
+
+def _network_ingress_rules(
+    resource: dict[str, Any], change: dict[str, Any]
+) -> list[dict[str, Any]]:
+    after = change.get("after")
+    if not isinstance(after, dict):
+        return []
+    resource_type = str(resource.get("type") or "").lower()
+
+    if resource_type == "aws_security_group_rule":
+        if str(after.get("type") or "").lower() != "ingress":
+            return []
+        normalized = _normalized_ingress_rule(after)
+        if normalized["cidr_blocks"] or normalized["ipv6_cidr_blocks"]:
+            return [normalized]
+        return []
+
+    if resource_type == "aws_vpc_security_group_ingress_rule":
+        normalized = _normalized_ingress_rule(after)
+        if normalized["cidr_blocks"] or normalized["ipv6_cidr_blocks"]:
+            return [normalized]
+        return []
+
+    ingress = after.get("ingress")
+    if not isinstance(ingress, list):
+        return []
+
+    rules: list[dict[str, Any]] = []
+    for rule in ingress:
+        if not isinstance(rule, dict):
+            continue
+        normalized = _normalized_ingress_rule(rule)
+        if normalized["cidr_blocks"] or normalized["ipv6_cidr_blocks"]:
+            rules.append(normalized)
+    return rules
+
+
 def _plan_metadata(
     resource: dict[str, Any],
     change: dict[str, Any],
@@ -270,6 +337,9 @@ def _plan_metadata(
         ),
         "unsupported_fields": _unsupported_fields(resource, change),
     }
+    ingress_rules = _network_ingress_rules(resource, change)
+    if ingress_rules:
+        metadata["network_ingress_rules"] = ingress_rules
     if include_plan_unsupported_fields:
         metadata["plan_unsupported_fields"] = _unsupported_plan_fields(payload)
     return metadata

--- a/services/analysis_service.py
+++ b/services/analysis_service.py
@@ -283,6 +283,15 @@ def _collect_changes(parse_batch: ParseBatchResult) -> list[UnifiedChange]:
     return changes
 
 
+def _normalize_incident_matches(matches: list[IncidentMatch]) -> list[IncidentMatch]:
+    return [
+        IncidentMatch.model_validate(match.model_dump())
+        if isinstance(match, BaseModel)
+        else IncidentMatch.model_validate(match)
+        for match in matches
+    ]
+
+
 def _raw_files_for_parse_batch(
     files: list[tuple[str, bytes | None]],
     parse_batch: ParseBatchResult,
@@ -978,7 +987,7 @@ def build_analysis_artifacts(
     )
     blast_radius = compute_blast_radius(changes, topology, topology_warning)
     rollback_plan = generate_rollback_plan(changes, partial_context=partial_context)
-    incident_matches = (
+    incident_matches = _normalize_incident_matches(
         []
         if project_id is None and project_key is None
         else find_incident_matches(
@@ -1075,6 +1084,7 @@ def analyze_uploaded_files(
             artifacts.narrative,
             blast_radius=artifacts.blast_radius,
             rollback_plan=artifacts.rollback_plan,
+            incident_matches=artifacts.incident_matches,
             findings=artifacts.findings,
             evidence_items=artifacts.evidence_items,
             artifact_snapshots={name: raw_content for name, raw_content in files},

--- a/services/report_service.py
+++ b/services/report_service.py
@@ -20,6 +20,7 @@ from typing import Any
 from pydantic import ValidationError
 
 from analysis.blast_radius import BlastRadiusResult
+from analysis.incident_matcher import IncidentMatch
 from analysis.rollback_planner import RollbackPlan
 from analysis.risk_scorer import (
     RiskAssessment,
@@ -694,6 +695,16 @@ def _default_rollback_plan_payload() -> dict[str, Any]:
         ),
         "warning": None,
     }
+
+
+def _load_incident_matches_payload(raw_value: str | None) -> list[dict[str, Any]]:
+    try:
+        decoded = json.loads(raw_value or "[]")
+    except (TypeError, json.JSONDecodeError):
+        return []
+    if not isinstance(decoded, list):
+        return []
+    return [item for item in decoded if isinstance(item, dict)]
 
 
 def _pending_analysis_from_parse_batch(
@@ -3495,6 +3506,9 @@ def _serialize_report(report, *, include_evidence: bool = True) -> dict:
             json.loads(getattr(report, "rollback_plan_json", "") or "{}")
             or _default_rollback_plan_payload()
         ),
+        "incident_matches": _load_incident_matches_payload(
+            getattr(report, "incident_matches_json", None)
+        ),
         "parse_summary": report.parse_summary,
         "submission_manifest": submission_manifest,
         "submission_manifest_fallback": submission_manifest_fallback,
@@ -3555,6 +3569,7 @@ def persist_analysis_report(
     narrative: NarrativeResult,
     blast_radius: BlastRadiusResult | None = None,
     rollback_plan: RollbackPlan | None = None,
+    incident_matches: list[IncidentMatch] | None = None,
     findings: list[Finding] | None = None,
     evidence_items: list[EvidenceItem] | None = None,
     artifact_snapshots: dict[str, bytes | None] | None = None,
@@ -3729,6 +3744,12 @@ def persist_analysis_report(
                         rollback_plan.model_dump(mode="json")
                         if rollback_plan is not None
                         else {}
+                    ),
+                    incident_matches_json=json.dumps(
+                        [
+                            match.model_dump(mode="json")
+                            for match in (incident_matches or [])
+                        ]
                     ),
                     llm_provider=audit["llm_provider"],
                     llm_model=audit["llm_model"],

--- a/tests/test_analysis/test_incident_matcher.py
+++ b/tests/test_analysis/test_incident_matcher.py
@@ -15,6 +15,7 @@ import services.incident_service as incident_service_module
 import services.project_service as project_service_module
 import analysis.incident_matcher as incident_matcher_module
 from parsers.base import UnifiedChange
+from parsers.terraform_parser import parse_terraform
 
 
 class IncidentMatcherTests(unittest.TestCase):
@@ -77,6 +78,187 @@ class IncidentMatcherTests(unittest.TestCase):
             changes,
             project_id=self.project.id,
         )
+        self.assertEqual(matches, [])
+
+    def test_find_incident_matches_returns_public_pattern_without_incidents(
+        self,
+    ) -> None:
+        changes = [
+            UnifiedChange(
+                source_file="plan.json",
+                tool="terraform",
+                resource_id="aws_security_group.ssh",
+                action="modify",
+                summary="Terraform opened SSH ingress from 0.0.0.0/0 on port 22.",
+            )
+        ]
+
+        matches = incident_matcher_module.find_incident_matches(
+            changes,
+            project_id=self.project.id,
+        )
+
+        self.assertEqual(len(matches), 1)
+        self.assertEqual(matches[0].match_type, "public_risk_pattern")
+        self.assertEqual(matches[0].public_pattern_id, "public-ingress-wide-open")
+        self.assertIn("Public risk pattern", matches[0].summary)
+        self.assertIn("0.0.0.0/0", " ".join(matches[0].evidence))
+        self.assertGreaterEqual(matches[0].confidence, 0.8)
+        self.assertTrue(matches[0].verification_guidance)
+
+    def test_find_incident_matches_detects_structured_terraform_ingress(
+        self,
+    ) -> None:
+        changes = parse_terraform(
+            "plan.json",
+            b"""{
+  "resource_changes": [
+    {
+      "address": "aws_security_group.ssh",
+      "type": "aws_security_group",
+      "change": {
+        "actions": ["update"],
+        "after": {
+          "ingress": [
+            {
+              "protocol": "tcp",
+              "from_port": 22,
+              "to_port": 22,
+              "cidr_blocks": ["0.0.0.0/0"]
+            }
+          ]
+        }
+      }
+    }
+  ]
+}""",
+        )
+
+        matches = incident_matcher_module.find_incident_matches(
+            changes,
+            project_id=self.project.id,
+        )
+
+        self.assertEqual(len(matches), 1)
+        self.assertEqual(matches[0].public_pattern_id, "public-ingress-wide-open")
+        self.assertIn("aws_security_group.ssh", " ".join(matches[0].evidence))
+
+    def test_find_incident_matches_detects_standalone_terraform_ingress_rule(
+        self,
+    ) -> None:
+        changes = parse_terraform(
+            "plan.json",
+            b"""{
+  "resource_changes": [
+    {
+      "address": "aws_security_group_rule.ssh",
+      "type": "aws_security_group_rule",
+      "change": {
+        "actions": ["create"],
+        "after": {
+          "type": "ingress",
+          "protocol": "tcp",
+          "from_port": 22,
+          "to_port": 22,
+          "cidr_blocks": ["0.0.0.0/0"]
+        }
+      }
+    }
+  ]
+}""",
+        )
+
+        matches = incident_matcher_module.find_incident_matches(
+            changes,
+            project_id=self.project.id,
+        )
+
+        self.assertEqual(len(matches), 1)
+        self.assertEqual(matches[0].public_pattern_id, "public-ingress-wide-open")
+        self.assertIn("aws_security_group_rule.ssh", " ".join(matches[0].evidence))
+
+    def test_find_incident_matches_trusts_structured_non_admin_ingress(
+        self,
+    ) -> None:
+        changes = parse_terraform(
+            "plan.json",
+            b"""{
+  "resource_changes": [
+    {
+      "address": "aws_security_group.ssh_docs",
+      "type": "aws_security_group",
+      "change": {
+        "actions": ["update"],
+        "after": {
+          "ingress": [
+            {
+              "protocol": "tcp",
+              "from_port": 80,
+              "to_port": 80,
+              "cidr_blocks": ["0.0.0.0/0"]
+            }
+          ]
+        }
+      }
+    }
+  ]
+}""",
+        )
+
+        matches = incident_matcher_module.find_incident_matches(
+            changes,
+            project_id=self.project.id,
+        )
+
+        self.assertEqual(matches, [])
+
+    def test_find_incident_matches_returns_stateful_destroy_public_pattern(
+        self,
+    ) -> None:
+        changes = [
+            UnifiedChange(
+                source_file="plan.json",
+                tool="terraform",
+                resource_id="aws_db_instance.primary",
+                action="destroy",
+                summary="Terraform will destroy database aws_db_instance.primary.",
+            )
+        ]
+
+        matches = incident_matcher_module.find_incident_matches(
+            changes,
+            project_id=self.project.id,
+        )
+
+        self.assertEqual(len(matches), 1)
+        self.assertEqual(matches[0].match_type, "public_risk_pattern")
+        self.assertEqual(
+            matches[0].public_pattern_id, "public-stateful-resource-destroy"
+        )
+        self.assertIn("stateful resource", matches[0].reason)
+        self.assertIn("aws_db_instance.primary", " ".join(matches[0].evidence))
+        self.assertGreaterEqual(matches[0].confidence, 0.8)
+        self.assertTrue(matches[0].verification_guidance)
+
+    def test_find_incident_matches_ignores_stateful_helper_destroy(
+        self,
+    ) -> None:
+        changes = [
+            UnifiedChange(
+                source_file="plan.json",
+                tool="terraform",
+                resource_id="aws_s3_bucket_policy.logs",
+                action="destroy",
+                summary="Terraform will destroy bucket policy aws_s3_bucket_policy.logs.",
+                metadata={"resource_type": "aws_s3_bucket_policy"},
+            )
+        ]
+
+        matches = incident_matcher_module.find_incident_matches(
+            changes,
+            project_id=self.project.id,
+        )
+
         self.assertEqual(matches, [])
 
     def test_find_incident_matches_avoids_generic_token_false_positive(self) -> None:

--- a/tests/test_api/test_analyses.py
+++ b/tests/test_api/test_analyses.py
@@ -18,6 +18,7 @@ import models.tables as tables_module
 import services.project_service as project_service_module
 import services.report_service as report_service_module
 from services.analysis_service import AnalysisPersistenceError
+from analysis.incident_matcher import IncidentMatch
 from analysis.risk_scorer import RiskAssessment, RiskContributor
 from app import create_app
 from evidence.models import EvidenceItem
@@ -865,6 +866,25 @@ class AnalysesApiTests(unittest.TestCase):
             )
         ]
 
+        incident_match = IncidentMatch(
+            incident_id=0,
+            match_type="public_risk_pattern",
+            public_pattern_id="public-ingress-wide-open",
+            title="Wide-open administrative ingress",
+            severity="high",
+            source_file="plan.json",
+            incident_date=None,
+            similarity=0.86,
+            confidence=0.86,
+            reason="The change exposes administrative ingress publicly.",
+            evidence=["plan.json: aws_security_group.main (modify) - public SSH"],
+            verification_guidance=[
+                "Confirm public CIDR is intentional.",
+                "Restrict ingress to trusted networks.",
+            ],
+            summary="Public risk pattern match: wide-open administrative ingress.",
+        )
+
         with (
             patch(
                 "services.analysis_service.evaluate_parse_batch",
@@ -877,7 +897,10 @@ class AnalysesApiTests(unittest.TestCase):
             patch(
                 "services.analysis_service.generate_narrative", return_value=narrative
             ),
-            patch("services.analysis_service.find_incident_matches", return_value=[]),
+            patch(
+                "services.analysis_service.find_incident_matches",
+                return_value=[incident_match],
+            ),
         ):
             response = self.client.post(
                 "/api/v1/analyses",
@@ -913,6 +936,23 @@ class AnalysesApiTests(unittest.TestCase):
         self.assertEqual(
             payload["data"]["persisted_report"]["confidence"],
             payload["data"]["assessment"]["confidence"],
+        )
+        self.assertEqual(
+            payload["data"]["incident_matches"][0]["public_pattern_id"],
+            "public-ingress-wide-open",
+        )
+        self.assertEqual(
+            payload["data"]["incident_matches"][0]["confidence"],
+            0.86,
+        )
+        self.assertEqual(
+            payload["data"]["persisted_report"]["incident_matches"][0][
+                "public_pattern_id"
+            ],
+            "public-ingress-wide-open",
+        )
+        self.assertTrue(
+            payload["data"]["persisted_report"]["incident_matches"][0]["evidence"]
         )
         self.assertFalse(payload["data"]["persisted_report"]["narrative_degraded"])
         self.assertEqual(

--- a/tests/test_api/test_schemas.py
+++ b/tests/test_api/test_schemas.py
@@ -6,7 +6,7 @@ import unittest
 
 from pydantic import ValidationError
 
-from api.schemas import PersistedReportData
+from api.schemas import IncidentMatchData, PersistedReportData
 
 
 class ApiSchemaTests(unittest.TestCase):
@@ -85,6 +85,29 @@ class ApiSchemaTests(unittest.TestCase):
 
         with self.assertRaises(ValidationError):
             PersistedReportData.model_validate(payload)
+
+    def test_incident_match_schema_exposes_public_risk_pattern_context(self) -> None:
+        match = IncidentMatchData.model_validate(
+            {
+                "incident_id": 0,
+                "match_type": "public_risk_pattern",
+                "public_pattern_id": "public-ingress-wide-open",
+                "title": "Wide-open administrative ingress",
+                "severity": "high",
+                "source_file": "plan.json",
+                "incident_date": None,
+                "similarity": 0.86,
+                "confidence": 0.86,
+                "reason": "Public ingress matched a built-in failure mode.",
+                "evidence": ["plan.json: aws_security_group.ssh"],
+                "verification_guidance": ["Restrict SSH ingress."],
+                "summary": "Public risk pattern match.",
+            }
+        )
+
+        self.assertEqual(match.match_type, "public_risk_pattern")
+        self.assertEqual(match.public_pattern_id, "public-ingress-wide-open")
+        self.assertEqual(match.verification_guidance, ["Restrict SSH ingress."])
 
 
 if __name__ == "__main__":

--- a/tests/test_cli/test_analyze.py
+++ b/tests/test_cli/test_analyze.py
@@ -19,6 +19,7 @@ import models.tables as tables_module
 import services.report_service as report_service_module
 import services.analysis_service as analysis_service_module
 import services.project_service as project_service_module
+from analysis.incident_matcher import IncidentMatch
 from analysis.risk_scorer import RiskAssessment, RiskContributor
 from cli.analyze import main
 from importlib import reload
@@ -590,12 +591,33 @@ class AnalyzeCliTests(unittest.TestCase):
             warnings=[],
         )
         output = io.StringIO()
+        incident_match = IncidentMatch(
+            incident_id=0,
+            match_type="public_risk_pattern",
+            public_pattern_id="public-ingress-wide-open",
+            title="Wide-open administrative ingress",
+            severity="high",
+            source_file="plan.json",
+            incident_date=None,
+            similarity=0.86,
+            confidence=0.86,
+            reason="The change exposes administrative ingress publicly.",
+            evidence=["plan.json: aws_security_group.main (modify) - public SSH"],
+            verification_guidance=[
+                "Confirm public CIDR is intentional.",
+                "Restrict ingress to trusted networks.",
+            ],
+            summary="Public risk pattern match: wide-open administrative ingress.",
+        )
 
         with (
             patch(
                 "services.analysis_service.generate_narrative", return_value=narrative
             ),
-            patch("services.analysis_service.find_incident_matches", return_value=[]),
+            patch(
+                "services.analysis_service.find_incident_matches",
+                return_value=[incident_match],
+            ),
             patch(
                 "sys.argv",
                 [
@@ -619,6 +641,19 @@ class AnalyzeCliTests(unittest.TestCase):
         self.assertEqual(payload["meta"]["accepted_artifact_count"], 1)
         self.assertIn(payload["data"]["assessment"]["severity"], {"high", "critical"})
         self.assertIn("context_completeness", payload["data"]["assessment"])
+        self.assertEqual(
+            payload["data"]["incident_matches"][0]["public_pattern_id"],
+            "public-ingress-wide-open",
+        )
+        self.assertEqual(
+            payload["data"]["persisted_report"]["incident_matches"][0][
+                "public_pattern_id"
+            ],
+            "public-ingress-wide-open",
+        )
+        self.assertTrue(
+            payload["data"]["persisted_report"]["incident_matches"][0]["evidence"]
+        )
         self.assertTrue(payload["data"]["findings"])
         self.assertEqual(payload["data"]["findings"][0]["confidence"], 1.0)
         self.assertFalse(payload["data"]["advisory"]["should_block"])

--- a/tests/test_infra/test_container_contract.py
+++ b/tests/test_infra/test_container_contract.py
@@ -34,6 +34,7 @@ class ContainerContractTests(unittest.TestCase):
                 "018_add_evidence_identity_fields.py",
                 "019_add_finding_context_fields.py",
                 "020_add_narrative_state_fields.py",
+                "021_add_incident_matches_payload.py",
             ],
         )
         baseline_content = migrations[0].read_text(encoding="utf-8")
@@ -53,6 +54,7 @@ class ContainerContractTests(unittest.TestCase):
         evidence_identity_content = migrations[14].read_text(encoding="utf-8")
         finding_context_content = migrations[15].read_text(encoding="utf-8")
         narrative_state_content = migrations[16].read_text(encoding="utf-8")
+        incident_matches_content = migrations[17].read_text(encoding="utf-8")
         self.assertIn("down_revision = None", baseline_content)
         self.assertIn('"app_settings"', baseline_content)
         self.assertIn(
@@ -139,6 +141,11 @@ class ContainerContractTests(unittest.TestCase):
         )
         self.assertIn('"narrative_degraded"', narrative_state_content)
         self.assertIn('"narrative_failure_notice"', narrative_state_content)
+        self.assertIn(
+            'down_revision = "020_add_narrative_state_fields"',
+            incident_matches_content,
+        )
+        self.assertIn('"incident_matches_json"', incident_matches_content)
 
     def test_dockerfile_exists(self) -> None:
         self.assertTrue(Path("Dockerfile").exists())

--- a/tests/test_infra/test_migrations.py
+++ b/tests/test_infra/test_migrations.py
@@ -198,6 +198,7 @@ class MigrationTests(unittest.TestCase):
         self.assertIn("report_schema_version", self._table_columns("analysis_reports"))
         self.assertIn("blast_radius_json", self._table_columns("analysis_reports"))
         self.assertIn("rollback_plan_json", self._table_columns("analysis_reports"))
+        self.assertIn("incident_matches_json", self._table_columns("analysis_reports"))
         self.assertIn("narrative_degraded", self._table_columns("analysis_reports"))
         self.assertIn(
             "narrative_failure_notice", self._table_columns("analysis_reports")
@@ -976,7 +977,7 @@ class MigrationTests(unittest.TestCase):
         self.assertIn("evidence_items", tables)
         self.assertIn("projects", tables)
         self.assertIn("topology_versions", tables)
-        self.assertEqual(revision, "020_add_narrative_state_fields")
+        self.assertEqual(revision, "021_add_incident_matches_payload")
 
     def test_init_db_repairs_partial_evidence_schema_without_alembic_version(
         self,
@@ -1025,7 +1026,7 @@ class MigrationTests(unittest.TestCase):
         self.assertIn("findings", tables)
         self.assertIn("evidence_items", tables)
         self.assertIn("projects", tables)
-        self.assertEqual(revision, "020_add_narrative_state_fields")
+        self.assertEqual(revision, "021_add_incident_matches_payload")
 
     def test_init_db_repairs_current_schema_without_alembic_version(self) -> None:
         command.upgrade(self._config(), "head")
@@ -1051,13 +1052,31 @@ class MigrationTests(unittest.TestCase):
         finally:
             sqlite_conn.close()
 
-        self.assertEqual(revision, "020_add_narrative_state_fields")
+        self.assertEqual(revision, "021_add_incident_matches_payload")
         self.assertIn("report_schema_version", columns)
         self.assertIn("blast_radius_json", columns)
         self.assertIn("project_id", columns)
         self.assertIn("workspace_id", columns)
         self.assertIn("submission_manifest_json", columns)
         self.assertIn("submission_manifest_fallback_json", columns)
+
+    def test_init_db_accepts_current_incident_matches_revision(self) -> None:
+        command.upgrade(self._config(), "head")
+
+        reload(config_module)
+        reload(tables_module)
+        reload(database_module)
+        database_module.init_db()
+
+        sqlite_conn = sqlite3.connect(self.db_path)
+        try:
+            revision = sqlite_conn.execute(
+                "SELECT version_num FROM alembic_version"
+            ).fetchone()[0]
+        finally:
+            sqlite_conn.close()
+
+        self.assertEqual(revision, "021_add_incident_matches_payload")
 
     def test_init_db_rejects_partial_report_workspace_scope_schema(self) -> None:
         command.upgrade(self._config(), "014_add_project_workspace_records")
@@ -1327,7 +1346,7 @@ class MigrationTests(unittest.TestCase):
         finally:
             sqlite_conn.close()
 
-        self.assertEqual(revision, "020_add_narrative_state_fields")
+        self.assertEqual(revision, "021_add_incident_matches_payload")
 
 
 if __name__ == "__main__":

--- a/tests/test_parsers/test_terraform_parser.py
+++ b/tests/test_parsers/test_terraform_parser.py
@@ -98,6 +98,135 @@ class TerraformParserTests(unittest.TestCase):
         self.assertIn("changes network access rules", change.summary)
         self.assertNotIn("Plan metadata:", change.summary)
 
+    def test_parse_terraform_plan_json_extracts_ingress_rule_facts(self) -> None:
+        raw = b"""{
+  "resource_changes": [
+    {
+      "address": "aws_security_group.admin",
+      "type": "aws_security_group",
+      "change": {
+        "actions": ["update"],
+        "after": {
+          "ingress": [
+            {
+              "protocol": "tcp",
+              "from_port": 22,
+              "to_port": 22,
+              "cidr_blocks": ["0.0.0.0/0"],
+              "ipv6_cidr_blocks": ["::/0"]
+            }
+          ]
+        }
+      }
+    }
+  ]
+}"""
+
+        changes = parse_terraform("tfplan.json", raw)
+
+        self.assertEqual(
+            changes[0].metadata["network_ingress_rules"],
+            [
+                {
+                    "protocol": "tcp",
+                    "from_port": 22,
+                    "to_port": 22,
+                    "cidr_blocks": ["0.0.0.0/0"],
+                    "ipv6_cidr_blocks": ["::/0"],
+                }
+            ],
+        )
+
+    def test_parse_terraform_plan_json_extracts_standalone_ingress_rule_facts(
+        self,
+    ) -> None:
+        raw = b"""{
+  "resource_changes": [
+    {
+      "address": "aws_security_group_rule.ssh",
+      "type": "aws_security_group_rule",
+      "change": {
+        "actions": ["create"],
+        "after": {
+          "type": "ingress",
+          "protocol": "tcp",
+          "from_port": 22,
+          "to_port": 22,
+          "cidr_blocks": ["0.0.0.0/0"],
+          "ipv6_cidr_blocks": ["::/0"]
+        }
+      }
+    },
+    {
+      "address": "aws_vpc_security_group_ingress_rule.rdp",
+      "type": "aws_vpc_security_group_ingress_rule",
+      "change": {
+        "actions": ["create"],
+        "after": {
+          "ip_protocol": "tcp",
+          "from_port": 3389,
+          "to_port": 3389,
+          "cidr_ipv4": "0.0.0.0/0",
+          "cidr_ipv6": "::/0"
+        }
+      }
+    }
+  ]
+}"""
+
+        changes = parse_terraform("tfplan.json", raw)
+
+        self.assertEqual(
+            changes[0].metadata["network_ingress_rules"],
+            [
+                {
+                    "protocol": "tcp",
+                    "from_port": 22,
+                    "to_port": 22,
+                    "cidr_blocks": ["0.0.0.0/0"],
+                    "ipv6_cidr_blocks": ["::/0"],
+                }
+            ],
+        )
+        self.assertEqual(
+            changes[1].metadata["network_ingress_rules"],
+            [
+                {
+                    "protocol": "tcp",
+                    "from_port": 3389,
+                    "to_port": 3389,
+                    "cidr_blocks": ["0.0.0.0/0"],
+                    "ipv6_cidr_blocks": ["::/0"],
+                }
+            ],
+        )
+
+    def test_parse_terraform_plan_json_ignores_standalone_egress_rule_facts(
+        self,
+    ) -> None:
+        raw = b"""{
+  "resource_changes": [
+    {
+      "address": "aws_security_group_rule.outbound",
+      "type": "aws_security_group_rule",
+      "change": {
+        "actions": ["create"],
+        "after": {
+          "type": "egress",
+          "protocol": "tcp",
+          "from_port": 22,
+          "to_port": 22,
+          "cidr_blocks": ["0.0.0.0/0"]
+        }
+      }
+    }
+  ]
+}"""
+
+        changes = parse_terraform("tfplan.json", raw)
+
+        self.assertNotIn("network_ingress_rules", changes[0].metadata)
+
     def test_parse_terraform_plan_json_trims_resource_addresses(self) -> None:
         raw = b"""{
   "resource_changes": [

--- a/tests/test_services/test_analysis_service.py
+++ b/tests/test_services/test_analysis_service.py
@@ -182,6 +182,104 @@ class AnalysisServiceTests(unittest.TestCase):
         self.assertTrue(artifacts.assessment.context_completeness.insufficient_context)
         self.assertIn("INSUFFICIENT CONTEXT", artifacts.assessment.top_risk)
 
+    def test_build_analysis_artifacts_labels_public_pattern_when_incidents_empty(
+        self,
+    ) -> None:
+        assessment = RiskAssessment(
+            score=68,
+            severity="high",
+            recommendation="caution",
+            top_risk="Public ingress requires review.",
+            contributors=[],
+            interaction_risks=[],
+            partial_context=False,
+            warnings=[],
+        )
+        blast_radius = BlastRadiusResult(
+            affected=[],
+            direct_count=0,
+            transitive_count=0,
+            warning=None,
+            unmatched_resources=[],
+        )
+        rollback_plan = RollbackPlan(steps=[], complexity="low", warning=None)
+        narrative = NarrativeResult(
+            opening_sentence="CAUTION: review public ingress.",
+            explanation="The deployment should be reviewed.",
+            guidance=[],
+            degraded=False,
+            warnings=[],
+        )
+
+        with (
+            patch(
+                "services.analysis_service.build_parse_batch",
+                return_value=ParseBatchResult(
+                    files=[
+                        ParsedFileResult(
+                            file_name="plan.json",
+                            tool="terraform",
+                            status="parsed",
+                            changes=[
+                                UnifiedChange(
+                                    source_file="plan.json",
+                                    tool="terraform",
+                                    resource_id="aws_security_group.ssh",
+                                    action="modify",
+                                    summary=(
+                                        "Terraform opened SSH ingress from "
+                                        "0.0.0.0/0 on port 22."
+                                    ),
+                                )
+                            ],
+                        )
+                    ]
+                ),
+            ),
+            patch("services.analysis_service.extract_batch_evidence", return_value=[]),
+            patch("services.analysis_service.load_topology", return_value=({}, None)),
+            patch(
+                "services.analysis_service.get_topology_status",
+                return_value=SimpleNamespace(updated_at=None),
+            ),
+            patch(
+                "services.analysis_service.load_incident_candidates", return_value=[]
+            ),
+            patch(
+                "analysis.incident_matcher.load_incident_candidates", return_value=[]
+            ),
+            patch(
+                "services.analysis_service.evaluate_parse_batch",
+                return_value=assessment,
+            ),
+            patch(
+                "services.analysis_service.compute_blast_radius",
+                return_value=blast_radius,
+            ),
+            patch(
+                "services.analysis_service.generate_rollback_plan",
+                return_value=rollback_plan,
+            ),
+            patch(
+                "services.analysis_service.generate_narrative", return_value=narrative
+            ),
+        ):
+            artifacts = build_analysis_artifacts(
+                [("plan.json", b"{}")],
+                project_id=123,
+            )
+
+        self.assertEqual(len(artifacts.incident_matches), 1)
+        self.assertEqual(
+            artifacts.incident_matches[0].match_type,
+            "public_risk_pattern",
+        )
+        self.assertEqual(
+            artifacts.incident_matches[0].public_pattern_id,
+            "public-ingress-wide-open",
+        )
+        self.assertTrue(artifacts.incident_matches[0].verification_guidance)
+
     def _share_report_payload(self) -> dict:
         return {
             "id": 17,

--- a/tests/test_services/test_report_service.py
+++ b/tests/test_services/test_report_service.py
@@ -21,6 +21,7 @@ import services.project_service as project_service_module
 import services.report_service as report_service_module
 import services.settings_service as settings_service_module
 from analysis.blast_radius import BlastRadiusResult, ImpactNode
+from analysis.incident_matcher import IncidentMatch
 from analysis.rollback_planner import RollbackPlan, RollbackStep
 from analysis.risk_scorer import RiskAssessment, RiskContributor
 from evidence.models import EvidenceItem, Finding
@@ -3825,6 +3826,28 @@ class ReportServiceTests(unittest.TestCase):
             narrative,
             blast_radius=blast_radius,
             rollback_plan=rollback_plan,
+            incident_matches=[
+                IncidentMatch(
+                    incident_id=0,
+                    match_type="public_risk_pattern",
+                    public_pattern_id="public-ingress-wide-open",
+                    title="Wide-open administrative ingress",
+                    severity="high",
+                    source_file="plan.json",
+                    incident_date=None,
+                    similarity=0.86,
+                    confidence=0.86,
+                    reason="The change exposes administrative ingress publicly.",
+                    evidence=[
+                        "plan.json: aws_security_group.main (modify) - public SSH"
+                    ],
+                    verification_guidance=[
+                        "Confirm public CIDR is intentional.",
+                        "Restrict ingress to trusted networks.",
+                    ],
+                    summary="Public risk pattern match: wide-open administrative ingress.",
+                )
+            ],
             findings=findings,
             evidence_items=evidence_items,
             audit_context={
@@ -3867,6 +3890,13 @@ class ReportServiceTests(unittest.TestCase):
         self.assertEqual(persisted["context_completeness"]["context_score"], 0.84)
         self.assertEqual(persisted["blast_radius"]["direct_count"], 1)
         self.assertEqual(persisted["rollback_plan"]["complexity_score"], 3)
+        self.assertEqual(len(persisted["incident_matches"]), 1)
+        self.assertEqual(
+            persisted["incident_matches"][0]["public_pattern_id"],
+            "public-ingress-wide-open",
+        )
+        self.assertEqual(persisted["incident_matches"][0]["confidence"], 0.86)
+        self.assertTrue(persisted["incident_matches"][0]["evidence"])
         self.assertEqual(
             persisted["rollback_plan"]["steps"][0]["estimated_minutes"], 15
         )
@@ -3924,6 +3954,17 @@ class ReportServiceTests(unittest.TestCase):
         self.assertEqual(fetched["top_risk_contributors"], [persisted_evidence_id])
         self.assertEqual(fetched["context_completeness"]["topology_freshness_days"], 12)
         self.assertEqual(fetched["blast_radius"]["affected"][0]["label"], "Database")
+        self.assertEqual(
+            fetched["incident_matches"][0]["public_pattern_id"],
+            "public-ingress-wide-open",
+        )
+        self.assertEqual(
+            fetched["incident_matches"][0]["verification_guidance"],
+            [
+                "Confirm public CIDR is intentional.",
+                "Restrict ingress to trusted networks.",
+            ],
+        )
         self.assertEqual(
             fetched["rollback_plan"]["steps"][0]["title"],
             "Revert aws_security_group.main",

--- a/tests/test_ui/test_history_page.py
+++ b/tests/test_ui/test_history_page.py
@@ -32,6 +32,7 @@ from services.confidence_ledger import (
 from ui.formatters.datetime import format_history_timestamp
 from ui.formatters.recommendations import recommendation_classes, recommendation_text
 from ui.routes.history import page_selection_state
+from analysis.incident_matcher import IncidentMatch
 
 
 class HistoryPageHelpersTests(unittest.TestCase):
@@ -966,6 +967,7 @@ class HistoryPageRenderingTests(unittest.TestCase):
         project_id: int | None = None,
         workspace_id: int | None = None,
         tool: str = "terraform",
+        incident_matches: list[IncidentMatch] | None = None,
     ) -> dict:
         source_file = "plan.json" if tool == "terraform" else f"{tool}-review.yaml"
         parse_batch = ParseBatchResult(
@@ -1086,6 +1088,7 @@ class HistoryPageRenderingTests(unittest.TestCase):
             audit_context={"source_interface": "ui"},
             project_id=project_id,
             workspace_id=workspace_id,
+            incident_matches=incident_matches,
         )
 
     def test_history_page_exposes_filters_and_row_metadata(self) -> None:
@@ -1237,6 +1240,40 @@ class HistoryPageRenderingTests(unittest.TestCase):
         self.assertIn("95 days old", compare_response.text)
         self.assertIn("CURRENT", compare_response.text)
         self.assertIn("CRITICAL 90+", compare_response.text)
+
+    def test_public_report_route_renders_incident_matches(self) -> None:
+        report = self._persist_report(
+            incident_matches=[
+                IncidentMatch(
+                    incident_id=0,
+                    match_type="public_risk_pattern",
+                    public_pattern_id="public-ingress-wide-open",
+                    title="Wide-open administrative ingress",
+                    severity="high",
+                    source_file="plan.json",
+                    incident_date=None,
+                    similarity=0.86,
+                    confidence=0.86,
+                    reason="The change exposes administrative ingress publicly.",
+                    evidence=[
+                        "plan.json: aws_security_group.main (modify) - public SSH"
+                    ],
+                    verification_guidance=["Confirm public CIDR is intentional."],
+                    summary=(
+                        "Public risk pattern match: wide-open administrative ingress."
+                    ),
+                )
+            ],
+        )
+
+        response = self.client.get(f"/reports/{report['id']}")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("Incident and risk pattern similarity", response.text)
+        self.assertIn("Public risk pattern", response.text)
+        self.assertIn("86% confidence", response.text)
+        self.assertIn("Evidence:", response.text)
+        self.assertIn("Confirm public CIDR is intentional.", response.text)
 
     def test_history_detail_route_shows_compare_button_and_diff_view(self) -> None:
         self._persist_report(

--- a/tests/test_ui/test_incident_match_card.py
+++ b/tests/test_ui/test_incident_match_card.py
@@ -1,0 +1,128 @@
+"""Rendered smoke tests for incident and public risk pattern matches."""
+
+from __future__ import annotations
+
+import unittest
+from unittest.mock import patch
+
+import app as app_module
+from fastapi.testclient import TestClient
+from nicegui import ui
+
+from analysis.incident_matcher import IncidentMatch
+from ui.components.incident_match_card import render_incident_matches
+from ui.components.report_detail_page import render_report_detail_page
+
+
+@ui.page("/_test/incident-match-card")
+def incident_match_card_test_page() -> None:
+    render_incident_matches(
+        [
+            IncidentMatch(
+                incident_id=0,
+                match_type="public_risk_pattern",
+                public_pattern_id="public-ingress-wide-open",
+                title="Wide-open administrative ingress",
+                severity="high",
+                source_file="plan.json",
+                incident_date=None,
+                similarity=0.86,
+                confidence=0.86,
+                reason="The change exposes administrative ingress publicly.",
+                evidence=["plan.json: aws_security_group.main (modify) - public SSH"],
+                verification_guidance=[
+                    "Confirm public CIDR is intentional.",
+                    "Restrict ingress to trusted networks.",
+                ],
+                summary="Public risk pattern match: wide-open administrative ingress.",
+            )
+        ]
+    )
+
+
+@ui.page("/_test/incident-match-card-empty")
+def incident_match_card_empty_test_page() -> None:
+    render_incident_matches([])
+
+
+@ui.page("/_test/report-detail-incident-matches")
+def report_detail_incident_matches_test_page() -> None:
+    match = IncidentMatch(
+        incident_id=0,
+        match_type="public_risk_pattern",
+        public_pattern_id="public-ingress-wide-open",
+        title="Wide-open administrative ingress",
+        severity="high",
+        source_file="plan.json",
+        incident_date=None,
+        similarity=0.86,
+        confidence=0.86,
+        reason="The change exposes administrative ingress publicly.",
+        evidence=["plan.json: aws_security_group.main (modify) - public SSH"],
+        verification_guidance=["Confirm public CIDR is intentional."],
+        summary="Public risk pattern match: wide-open administrative ingress.",
+    )
+    with patch(
+        "ui.components.report_detail_page.fetch_report_feedback_state",
+        return_value={"finding_feedback": {}, "false_negative_notes": []},
+    ):
+        render_report_detail_page(
+            {
+                "id": 1,
+                "created_at": "2026-05-21T10:00:00Z",
+                "severity": "high",
+                "recommendation": "caution",
+                "risk_score": 82,
+                "confidence": 0.86,
+                "top_risk": "Wide-open administrative ingress",
+                "summary": "Review public ingress.",
+                "narrative_opening": "Review public ingress.",
+                "parse_summary": "1 Terraform change parsed.",
+                "incident_matches": [match.model_dump(mode="json")],
+                "findings": [],
+                "evidence_items": [],
+                "audit": {"files_analyzed": ["plan.json"]},
+                "context_completeness": {},
+                "blast_radius": {},
+                "rollback_plan": {},
+            }
+        )
+
+
+class IncidentMatchCardRenderingTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.client = TestClient(app_module.create_app())
+
+    def test_public_risk_pattern_card_renders_confidence_evidence_and_guidance(
+        self,
+    ) -> None:
+        response = self.client.get("/_test/incident-match-card")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("Incident and risk pattern similarity", response.text)
+        self.assertIn("Public risk pattern", response.text)
+        self.assertIn("86% confidence", response.text)
+        self.assertIn("Evidence:", response.text)
+        self.assertIn("aws_security_group.main", response.text)
+        self.assertIn("Confirm public CIDR is intentional.", response.text)
+        self.assertIn("Restrict ingress to trusted networks.", response.text)
+
+    def test_empty_card_renders_no_matches_state(self) -> None:
+        response = self.client.get("/_test/incident-match-card-empty")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("Incident and risk pattern similarity", response.text)
+        self.assertIn("No similar incidents found.", response.text)
+
+    def test_report_detail_renders_persisted_public_risk_pattern(self) -> None:
+        response = self.client.get("/_test/report-detail-incident-matches")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("Public risk pattern", response.text)
+        self.assertIn("86% confidence", response.text)
+        self.assertIn("Evidence:", response.text)
+        self.assertIn("Confirm public CIDR is intentional.", response.text)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_ui/test_upload_panel.py
+++ b/tests/test_ui/test_upload_panel.py
@@ -13,6 +13,7 @@ from ui.components.upload_panel import (
     format_submission_manifest_partial_notice,
     format_submission_manifest_summary,
     process_uploaded_files,
+    render_report_incident_matches,
     resolve_initial_project_selection,
     should_clear_pending_uploads,
     uploads_allowed,
@@ -366,6 +367,12 @@ class UploadPanelTests(unittest.TestCase):
         )
         self.assertIn("No mutating normalized changes available.", fake_ui.labels)
         self.assertNotIn("Terraform plan has no resource changes.", fake_ui.labels)
+
+    def test_report_incident_matches_preserves_empty_state(self) -> None:
+        with patch("ui.components.upload_panel.render_incident_matches") as render_mock:
+            render_report_incident_matches({"incident_matches": []})
+
+        render_mock.assert_called_once_with([])
 
     def test_change_table_surfaces_hidden_non_mutating_metadata_by_file(
         self,

--- a/ui/components/incident_match_card.py
+++ b/ui/components/incident_match_card.py
@@ -10,7 +10,9 @@ from ui.formatters.risk_labels import render_risk_badge
 def render_incident_matches(matches: list[IncidentMatch]) -> None:
     """Render incident similarity context."""
     with ui.card().classes("w-full dw-panel shadow-none"):
-        ui.label("Incident similarity").classes("text-lg font-medium dw-text")
+        ui.label("Incident and risk pattern similarity").classes(
+            "text-lg font-medium dw-text"
+        )
         if not matches:
             ui.label("No similar incidents found.").classes("text-sm dw-muted")
             return
@@ -19,7 +21,7 @@ def render_incident_matches(matches: list[IncidentMatch]) -> None:
                 with ui.row().classes(
                     "w-full items-start gap-3 dw-panel-soft px-3 py-3"
                 ):
-                    ui.label(f"{round(match.similarity * 100)}%").classes(
+                    ui.label(f"{round(match.confidence * 100)}% confidence").classes(
                         "text-sm font-medium dw-accent-text"
                     )
                     with ui.column().classes("gap-1"):
@@ -29,8 +31,20 @@ def render_incident_matches(matches: list[IncidentMatch]) -> None:
                         with ui.row().classes("items-center gap-2"):
                             ui.label(match.title).classes("text-sm font-medium dw-text")
                             render_risk_badge(match.severity, match.severity)
+                            if match.match_type == "public_risk_pattern":
+                                ui.label("Public risk pattern").classes(
+                                    "text-xs dw-muted"
+                                )
                             if date_label:
                                 ui.label(date_label.replace(" · ", "")).classes(
                                     "text-xs dw-muted"
                                 )
                         ui.label(match.summary).classes("text-sm dw-muted")
+                        if match.reason:
+                            ui.label(match.reason).classes("text-sm dw-muted")
+                        for evidence in match.evidence:
+                            ui.label(f"Evidence: {evidence}").classes(
+                                "text-xs dw-muted"
+                            )
+                        for guidance in match.verification_guidance:
+                            ui.label(guidance).classes("text-xs dw-muted")

--- a/ui/components/report_detail_page.py
+++ b/ui/components/report_detail_page.py
@@ -10,6 +10,7 @@ from urllib.parse import urlencode
 from nicegui import ui
 
 from analysis.blast_radius import BlastRadiusResult
+from analysis.incident_matcher import IncidentMatch
 from analysis.rollback_planner import RollbackPlan
 from services.feedback_service import (
     FeedbackError,
@@ -30,6 +31,7 @@ from ui.components.findings_table import (
     describe_evidence_item,
     render_findings_table,
 )
+from ui.components.incident_match_card import render_incident_matches
 from ui.components.review_accessibility import decorate_review_section
 from ui.components.rollback_plan import render_rollback_plan
 from ui.components.topology_freshness_banner import render_topology_freshness_banner
@@ -818,6 +820,12 @@ def render_report_detail_page(
     render_context_summary_panel(context)
     _render_operational_narrative(report)
     render_confidence_ledger(report)
+    render_incident_matches(
+        [
+            IncidentMatch.model_validate(match)
+            for match in (report.get("incident_matches") or [])
+        ]
+    )
     render_findings_table(
         findings,
         evidence_items,

--- a/ui/components/upload_panel.py
+++ b/ui/components/upload_panel.py
@@ -8,6 +8,7 @@ from typing import Any
 from nicegui import events, run, ui
 
 from analysis.blast_radius import BlastRadiusResult
+from analysis.incident_matcher import IncidentMatch
 from analysis.rollback_planner import RollbackPlan
 from parsers.registry import detect_tool_type
 from services.analysis_service import AnalysisPersistenceError, analyze_uploaded_files
@@ -39,6 +40,7 @@ from ui.components.change_table import (
     render_change_table,
 )
 from ui.components.confidence_ledger import render_confidence_ledger
+from ui.components.incident_match_card import render_incident_matches
 from ui.components.report_detail_page import (
     format_submission_manifest_fallback_summary,
     format_submission_manifest_partial_notice,
@@ -195,6 +197,16 @@ def build_feedback_rerender_handler(
         )
 
     return rerender
+
+
+def render_report_incident_matches(report: dict[str, Any]) -> None:
+    """Render incident matches from a report, including the empty state."""
+    render_incident_matches(
+        [
+            IncidentMatch.model_validate(match)
+            for match in (report.get("incident_matches") or [])
+        ]
+    )
 
 
 def build_upload_panel(
@@ -496,6 +508,7 @@ def build_upload_panel(
                 render_topology_freshness_banner(context)
                 render_context_summary_panel(context)
                 render_confidence_ledger(report)
+                render_report_incident_matches(report)
                 if parse_batch is not None:
                     render_change_table(parse_batch)
                 findings = report.get("findings", [])
@@ -678,6 +691,9 @@ def build_upload_panel(
             display_report["narrative_provider"] = narrative.provider
             display_report["narrative_model"] = narrative.model
             display_report["skills_applied"] = list(narrative.skills_applied)
+            display_report["incident_matches"] = [
+                match.model_dump() for match in result.incident_matches
+            ]
 
             render_result_card(
                 display_report,


### PR DESCRIPTION
Story 4.1 needed fresh installs to see public risk pattern matches without relying on organization incident history. This wires deterministic pattern matches through analysis, persistence, API/CLI/UI/report surfaces, and the report schema while keeping the matcher advisory and evidence-backed.

Constraint: Preserve local-first advisory report semantics and existing shared analysis core.

Rejected: Render matches only in the transient upload result | saved, history, and shared report surfaces must retain the AC1 payload.

Confidence: high

Scope-risk: moderate

Directive: Keep structured parser facts authoritative over text fallback for ingress matching.

Tested: ./.venv/bin/python -m unittest discover -q (414 tests, 1 skipped)

Tested: ./.venv/bin/python -m unittest tests.test_analysis.test_incident_matcher tests.test_parsers.test_terraform_parser tests.test_services.test_report_service tests.test_ui.test_incident_match_card -q (172 tests)

Tested: ./.venv/bin/ruff check .; ./.venv/bin/ruff format --check .; ./.venv/bin/bandit -r api/ analysis/ services/ parsers/ llm/ models/ cli/ ui/ evidence/ --severity-level high --confidence-level high -x tests/; git diff --check

Tested: APP_PORT=18080 npm run test:ui-review (3 tests)

Not-tested: PR creation via gh CLI.

## What does this PR do?

<!-- Brief description of changes -->

## Type of change
- [ ] Feature (new functionality)
- [ ] Bugfix (non-breaking fix)
- [ ] Release preparation
- [ ] Hotfix (critical production fix)
- [ ] Docs / refactor / chore

## Checklist
- [ ] I have followed the branch naming convention
- [ ] Tests pass locally (`pytest tests/ -v`)
- [ ] Linting passes (`ruff check .`)
- [ ] Docker build succeeds
- [ ] I have updated docs if needed
- [ ] No secrets or .env values committed

## Related issue
Closes #