### PR TITLE
Provide safe sample incidents for demos

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ Artifacts -> Parse -> Normalize -> Score -> Blast Radius -> Rollback -> Narrativ
 - Blast radius analysis using a project-scoped service-topology graph with a shared multi-source import foundation
 - Rollback plan generation with complexity signaling
 - **Day-zero risk patterns**: fresh installs can flag built-in public risk patterns such as wide-open administrative ingress or stateful resource deletion, separately labeled from organization incident memory.
+- **Safe sample incident pack**: optional synthetic incidents for demos, with provenance and limitations documented in `docs/sample-incident-pack.md`.
 - Incident-history matching for operational memory
 - API, CLI, and web entrypoints over one shared analysis pipeline
 - Local-first security model that keeps raw IaC local and avoids persisting API keys

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -83,7 +83,7 @@ development_status:
 
   epic-4: in-progress
   4-1-public-risk-pattern-library-v1: done
-  4-2-safe-sample-incident-pack: ready-for-dev
+  4-2-safe-sample-incident-pack: done
   4-3-incident-import-for-markdown-yaml-and-json: ready-for-dev
   4-4-incident-similarity-with-match-explanation: ready-for-dev
   4-5-reviewer-feedback-capture: ready-for-dev

--- a/docs/sample-incident-pack.md
+++ b/docs/sample-incident-pack.md
@@ -1,0 +1,26 @@
+# Safe Sample Incident Pack
+
+DeployWhisper includes an optional safe sample incident pack for demos and local evaluation of incident-memory behavior.
+
+## Provenance
+
+The bundled pack at `samples/incidents/safe-pack-v1/` contains original synthetic incidents authored for DeployWhisper documentation and tests. The records are not copied from customer data, private production incidents, or non-public postmortems.
+
+Each sample incident declares:
+
+- `Sample data: yes`
+- provenance and permission text
+- no real customer data
+- no real organization names
+- no non-public postmortem content
+- limitations for the specific record
+
+## Loading Behavior
+
+The sample pack is not loaded by default. It must be explicitly loaded into a project scope through the sample incident pack service. This keeps production installs from silently mixing demo records with organization-specific incident memory.
+
+## Limitations
+
+The pack is for product demos, documentation, and regression tests. It is intentionally generic and should not be used as evidence of real incident rates, real outage causes, or real operational behavior.
+
+The safety inspection checks required declarations and rejects obvious unsafe content such as common real organization names, non-example email addresses, and non-documentation public IP addresses. It is a guardrail, not a replacement for human review when adding new public sample records.

--- a/samples/incidents/safe-pack-v1/gitops-ordering-window.md
+++ b/samples/incidents/safe-pack-v1/gitops-ordering-window.md
@@ -1,0 +1,40 @@
+# Sample incident: GitOps sync ordering exposed stale configuration
+
+Sample data: yes
+Provenance: Synthetic scenario authored for public documentation and demos.
+Permission: Original synthetic documentation content approved for public sample use.
+Contains real customer data: no
+Contains real organization names: no
+Contains non-public postmortem content: no
+
+Limitations:
+- This record is a fictional GitOps ordering example.
+- The sequence is condensed to keep demos short and understandable.
+
+Date: 2026-04-18
+Severity: low
+
+## Summary
+
+A configuration map update reached the cluster before the deployment that understood the new key. The service stayed online, but feature flags briefly used stale defaults.
+
+## Root cause
+
+The sync wave placed configuration ahead of application rollout without a compatibility check for old pods.
+
+## Trigger change
+
+`checkout-flags` added a required setting before `checkout-api` pods with the matching parser were available.
+
+## Affected services
+
+- checkout-api
+- feature-router
+
+## Rollback path
+
+Revert the configuration map to the prior compatible key set, wait for pods to converge, and apply the application update before reintroducing the setting.
+
+## Prevention notes
+
+Review GitOps ordering, verify backward compatibility for configuration keys, and include sync-wave assumptions in the deployment report.

--- a/samples/incidents/safe-pack-v1/manifest.json
+++ b/samples/incidents/safe-pack-v1/manifest.json
@@ -1,0 +1,23 @@
+{
+  "pack_id": "safe-sample-incidents-v1",
+  "title": "Safe Sample Incident Pack v1",
+  "sample": true,
+  "loaded_by_default": false,
+  "provenance": "Original synthetic incidents authored for public documentation and demos. They are not derived from customer data, real organization postmortems, or private incident records.",
+  "limitations": [
+    "The records are designed to demonstrate incident-memory matching, not to represent production incident frequency.",
+    "Service names, timelines, and remediation details are fictional and intentionally generic.",
+    "The pack is optional and must be explicitly loaded into a project scope."
+  ],
+  "records": [
+    {
+      "source_file": "public-admin-ingress.md"
+    },
+    {
+      "source_file": "stateful-cache-replacement.md"
+    },
+    {
+      "source_file": "gitops-ordering-window.md"
+    }
+  ]
+}

--- a/samples/incidents/safe-pack-v1/public-admin-ingress.md
+++ b/samples/incidents/safe-pack-v1/public-admin-ingress.md
@@ -1,0 +1,40 @@
+# Sample incident: public SSH ingress during checkout deploy
+
+Sample data: yes
+Provenance: Synthetic scenario authored for public documentation and demos.
+Permission: Original synthetic documentation content approved for public sample use.
+Contains real customer data: no
+Contains real organization names: no
+Contains non-public postmortem content: no
+
+Limitations:
+- This record is not evidence that any real team experienced this failure.
+- The service names and timeline are fictional and intentionally generic.
+
+Date: 2026-04-02
+Severity: high
+
+## Summary
+
+An infrastructure-as-code change opened SSH ingress on port 22 from `0.0.0.0/0` while preparing a checkout-api deployment. The review missed the rule because the change was bundled with unrelated tag updates.
+
+## Root cause
+
+The security group rule used a broad CIDR for temporary troubleshooting and the rollback checklist did not include a network exposure check.
+
+## Trigger change
+
+`cloud_security_group_rule.checkout_admin_ssh` changed `cidr_blocks` to `["0.0.0.0/0"]` for port 22.
+
+## Affected services
+
+- checkout-api
+- deployment-runner
+
+## Rollback path
+
+Replace the public CIDR with the documented trusted access range and rerun the network policy check before redeploying.
+
+## Prevention notes
+
+Require evidence for public administrative ingress, keep temporary access time-boxed, and verify report warnings before approval.

--- a/samples/incidents/safe-pack-v1/stateful-cache-replacement.md
+++ b/samples/incidents/safe-pack-v1/stateful-cache-replacement.md
@@ -1,0 +1,40 @@
+# Sample incident: cache cluster replacement during release
+
+Sample data: yes
+Provenance: Synthetic scenario authored for public documentation and demos.
+Permission: Original synthetic documentation content approved for public sample use.
+Contains real customer data: no
+Contains real organization names: no
+Contains non-public postmortem content: no
+
+Limitations:
+- This record is not a real cache outage report.
+- The resource names and operational details are simplified for demonstration.
+
+Date: 2026-04-09
+Severity: medium
+
+## Summary
+
+A release replaced `cache_primary` without a warm-up window. Checkout pages remained available, but response latency increased while the cache rebuilt from backing services.
+
+## Root cause
+
+The infrastructure change treated a stateful cache replacement as a routine update and did not include a capacity or warm-up verification step.
+
+## Trigger change
+
+The plan replaced `cache_primary` after a configuration change to node sizing and maintenance timing.
+
+## Affected services
+
+- checkout-api
+- catalog-query
+
+## Rollback path
+
+Pause the rollout, restore the prior cache configuration, and confirm the rebuilt cache has reached the expected hit ratio before continuing.
+
+## Prevention notes
+
+Treat stateful cache replacement as a risk pattern, confirm restore or warm-up behavior, and call out degraded-cache effects in the deployment briefing.

--- a/services/sample_incident_pack.py
+++ b/services/sample_incident_pack.py
@@ -1,0 +1,337 @@
+"""Safe sample incident pack helpers."""
+
+from __future__ import annotations
+
+import ipaddress
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+from services.incident_service import ingest_incident_document
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_SAMPLE_PACK_DIR = REPO_ROOT / "samples" / "incidents" / "safe-pack-v1"
+MANIFEST_NAME = "manifest.json"
+
+EMAIL_PATTERN = re.compile(r"\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b", re.IGNORECASE)
+IPV4_PATTERN = re.compile(r"\b(?:\d{1,3}\.){3}\d{1,3}\b")
+REAL_ORGANIZATION_TERMS = {
+    "airbnb",
+    "amazon",
+    "apple",
+    "aws",
+    "aws_security_group_rule",
+    "cloudflare",
+    "deploywhisper",
+    "facebook",
+    "github",
+    "google",
+    "hashicorp",
+    "microsoft",
+    "netflix",
+    "openai",
+    "shopify",
+    "slack",
+    "stripe",
+    "terraform",
+    "uber",
+}
+
+
+class SampleIncidentRecord(BaseModel):
+    """A sample incident document with safety declarations."""
+
+    source_file: str
+    content: str
+    sample: bool = False
+    provenance: str = ""
+    permission: str = ""
+    contains_real_customer_data: bool = True
+    contains_real_organization_names: bool = True
+    contains_non_public_postmortem: bool = True
+    limitations: list[str] = Field(default_factory=list)
+
+
+class SampleIncidentPackInspection(BaseModel):
+    """Inspection result for the bundled sample incident pack."""
+
+    pack_id: str
+    title: str = ""
+    loaded_by_default: bool = False
+    safe: bool
+    errors: list[str] = Field(default_factory=list)
+    warnings: list[str] = Field(default_factory=list)
+    provenance: str = ""
+    limitations: list[str] = Field(default_factory=list)
+    records: list[SampleIncidentRecord] = Field(default_factory=list)
+
+
+def inspect_sample_incident_pack(
+    pack_dir: Path | None = None,
+) -> SampleIncidentPackInspection:
+    """Inspect the bundled sample pack before loading it anywhere."""
+    pack_dir = pack_dir or DEFAULT_SAMPLE_PACK_DIR
+    manifest_path = pack_dir / MANIFEST_NAME
+    try:
+        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        return SampleIncidentPackInspection(
+            pack_id="missing",
+            safe=False,
+            errors=[f"Sample pack manifest not found: {manifest_path}"],
+        )
+    except json.JSONDecodeError as exc:
+        return SampleIncidentPackInspection(
+            pack_id="invalid",
+            safe=False,
+            errors=[f"Sample pack manifest is invalid JSON: {exc}"],
+        )
+
+    records: dict[str, str] = {}
+    for item in manifest.get("records", []):
+        source_file = item.get("source_file") if isinstance(item, dict) else None
+        if not isinstance(source_file, str) or not source_file:
+            continue
+        record_path = pack_dir / source_file
+        try:
+            records[source_file] = record_path.read_text(encoding="utf-8")
+        except FileNotFoundError:
+            return SampleIncidentPackInspection(
+                pack_id=str(manifest.get("pack_id") or "unknown"),
+                title=str(manifest.get("title") or ""),
+                loaded_by_default=bool(manifest.get("loaded_by_default")),
+                safe=False,
+                errors=[f"Sample incident record not found: {record_path}"],
+                provenance=str(manifest.get("provenance") or ""),
+                limitations=[
+                    str(item)
+                    for item in manifest.get("limitations", [])
+                    if isinstance(item, str) and item.strip()
+                ],
+            )
+
+    return inspect_sample_incident_documents(
+        records,
+        pack_id=str(manifest.get("pack_id") or "unknown"),
+        title=str(manifest.get("title") or ""),
+        loaded_by_default=bool(manifest.get("loaded_by_default")),
+        provenance=str(manifest.get("provenance") or ""),
+        limitations=[
+            str(item)
+            for item in manifest.get("limitations", [])
+            if isinstance(item, str) and item.strip()
+        ],
+        manifest_sample=bool(manifest.get("sample")),
+    )
+
+
+def inspect_sample_incident_documents(
+    documents: dict[str, str],
+    *,
+    pack_id: str = "ad-hoc",
+    title: str = "",
+    loaded_by_default: bool = False,
+    provenance: str = "",
+    limitations: list[str] | None = None,
+    manifest_sample: bool = True,
+) -> SampleIncidentPackInspection:
+    """Inspect supplied sample incident documents for safety declarations."""
+    errors: list[str] = []
+    warnings: list[str] = []
+    records: list[SampleIncidentRecord] = []
+    limitations = limitations or []
+
+    if not manifest_sample:
+        errors.append("Manifest must declare sample: true.")
+    if loaded_by_default:
+        errors.append("Sample incident packs must not be loaded by default.")
+    if pack_id != "ad-hoc" and not provenance:
+        errors.append("Sample incident pack manifest must declare provenance.")
+    if pack_id != "ad-hoc" and not limitations:
+        errors.append("Sample incident pack manifest must declare limitations.")
+    manifest_text = " ".join([pack_id, title, provenance, *limitations])
+    errors.extend(_unsafe_text_errors("manifest", manifest_text))
+
+    for source_file, content in sorted(documents.items()):
+        record = _parse_sample_record(source_file, content)
+        records.append(record)
+        errors.extend(_record_safety_errors(record))
+        errors.extend(_unsafe_content_errors(record))
+
+    if not records:
+        errors.append("Sample incident pack must contain at least one record.")
+
+    return SampleIncidentPackInspection(
+        pack_id=pack_id,
+        title=title,
+        loaded_by_default=loaded_by_default,
+        safe=not errors,
+        errors=errors,
+        warnings=warnings,
+        provenance=provenance,
+        limitations=limitations,
+        records=records,
+    )
+
+
+def load_safe_sample_incident_pack(
+    *,
+    project_id: int | None = None,
+    project_key: str | None = None,
+    workspace_id: int | None = None,
+    workspace_key: str | None = None,
+) -> dict[str, Any]:
+    """Explicitly load the safe sample incident pack into a project scope."""
+    inspection = inspect_sample_incident_pack()
+    if not inspection.safe:
+        raise ValueError(
+            "Sample incident pack failed safety inspection: "
+            + "; ".join(inspection.errors)
+        )
+
+    loaded_records = [
+        ingest_incident_document(
+            record.source_file,
+            record.content,
+            project_id=project_id,
+            project_key=project_key,
+            workspace_id=workspace_id,
+            workspace_key=workspace_key,
+        )
+        for record in inspection.records
+    ]
+    return {
+        "pack_id": inspection.pack_id,
+        "loaded": len(loaded_records),
+        "records": loaded_records,
+    }
+
+
+def _parse_sample_record(source_file: str, content: str) -> SampleIncidentRecord:
+    return SampleIncidentRecord(
+        source_file=source_file,
+        content=content,
+        sample=_value_is_yes(_field_value(content, "Sample data")),
+        provenance=_field_value(content, "Provenance"),
+        permission=_field_value(content, "Permission"),
+        contains_real_customer_data=_value_is_yes(
+            _field_value(content, "Contains real customer data")
+        ),
+        contains_real_organization_names=_value_is_yes(
+            _field_value(content, "Contains real organization names")
+        ),
+        contains_non_public_postmortem=_value_is_yes(
+            _field_value(content, "Contains non-public postmortem content")
+        ),
+        limitations=_bullet_values_after(content, "Limitations"),
+    )
+
+
+def _field_value(content: str, field_name: str) -> str:
+    prefix = f"{field_name}:"
+    for line in content.splitlines():
+        stripped = line.strip()
+        if stripped.lower().startswith(prefix.lower()):
+            return stripped[len(prefix) :].strip()
+    return ""
+
+
+def _bullet_values_after(content: str, field_name: str) -> list[str]:
+    values: list[str] = []
+    in_section = False
+    for line in content.splitlines():
+        stripped = line.strip()
+        if stripped.lower() == f"{field_name}:".lower():
+            in_section = True
+            continue
+        if not in_section:
+            continue
+        if not stripped:
+            if values:
+                break
+            continue
+        if not stripped.startswith("- "):
+            break
+        values.append(stripped[2:].strip())
+    return values
+
+
+def _value_is_yes(value: str) -> bool:
+    return value.strip().lower() in {"yes", "true"}
+
+
+def _value_is_no(value: str) -> bool:
+    return value.strip().lower() in {"no", "false"}
+
+
+def _record_safety_errors(record: SampleIncidentRecord) -> list[str]:
+    errors: list[str] = []
+    prefix = f"{record.source_file}:"
+    if not record.sample:
+        errors.append(f"{prefix} sample data declaration must be yes.")
+    if not record.provenance:
+        errors.append(f"{prefix} provenance declaration is required.")
+    if not record.permission:
+        errors.append(f"{prefix} permission declaration is required.")
+    if not _value_is_no(_field_value(record.content, "Contains real customer data")):
+        errors.append(f"{prefix} must declare that it contains no real customer data.")
+    if not _value_is_no(
+        _field_value(record.content, "Contains real organization names")
+    ):
+        errors.append(
+            f"{prefix} must declare that it contains no real organization names."
+        )
+    if not _value_is_no(
+        _field_value(record.content, "Contains non-public postmortem content")
+    ):
+        errors.append(
+            f"{prefix} must declare no non-public postmortem content is included."
+        )
+    if not record.limitations:
+        errors.append(f"{prefix} limitations declaration is required.")
+    return errors
+
+
+def _unsafe_content_errors(record: SampleIncidentRecord) -> list[str]:
+    return _unsafe_text_errors(record.source_file, record.content)
+
+
+def _unsafe_text_errors(source_name: str, content: str) -> list[str]:
+    errors: list[str] = []
+    lower_content = content.lower()
+    for term in sorted(REAL_ORGANIZATION_TERMS):
+        if re.search(rf"\b{re.escape(term)}\b", lower_content):
+            errors.append(
+                f"{source_name}: possible real organization name found: {term}."
+            )
+    for email in EMAIL_PATTERN.findall(content):
+        if not _is_example_email(email):
+            errors.append(f"{source_name}: possible real email address: {email}.")
+    for match in IPV4_PATTERN.findall(content):
+        if not _is_allowed_sample_ip(match):
+            errors.append(f"{source_name}: possible real IP address found: {match}.")
+    return errors
+
+
+def _is_example_email(value: str) -> bool:
+    return value.lower().endswith(
+        ("@example.com", "@example.net", "@example.org", "@example.invalid")
+    )
+
+
+def _is_allowed_sample_ip(value: str) -> bool:
+    if value == "0.0.0.0":
+        return True
+    try:
+        ip = ipaddress.ip_address(value)
+    except ValueError:
+        return False
+    return (
+        ip in ipaddress.ip_network("192.0.2.0/24")
+        or ip in ipaddress.ip_network("198.51.100.0/24")
+        or ip in ipaddress.ip_network("203.0.113.0/24")
+    )

--- a/tests/test_services/test_sample_incident_pack.py
+++ b/tests/test_services/test_sample_incident_pack.py
@@ -1,0 +1,217 @@
+"""Tests for the safe sample incident pack."""
+
+from __future__ import annotations
+
+import os
+import tempfile
+import unittest
+from importlib import reload
+from pathlib import Path
+
+import config as config_module
+import models.database as database_module
+import models.tables as tables_module
+import services.incident_service as incident_service_module
+import services.project_service as project_service_module
+import services.sample_incident_pack as sample_incident_pack_module
+
+
+class SampleIncidentPackTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tempdir = tempfile.TemporaryDirectory()
+        self.db_path = Path(self.tempdir.name) / "sample-incidents.db"
+        os.environ["DATABASE_URL"] = f"sqlite:///{self.db_path}"
+        reload(config_module)
+        reload(tables_module)
+        reload(database_module)
+        reload(project_service_module)
+        reload(incident_service_module)
+        reload(sample_incident_pack_module)
+        database_module.init_db()
+        self.project = project_service_module.create_project(
+            project_key="demo",
+            display_name="Demo",
+        )
+
+    def tearDown(self) -> None:
+        database_module.engine.dispose()
+        os.environ.pop("DATABASE_URL", None)
+        self.tempdir.cleanup()
+
+    def test_sample_pack_inspection_passes_safety_contract(self) -> None:
+        inspection = sample_incident_pack_module.inspect_sample_incident_pack()
+
+        self.assertTrue(inspection.safe, inspection.errors)
+        self.assertEqual(inspection.pack_id, "safe-sample-incidents-v1")
+        self.assertFalse(inspection.loaded_by_default)
+        self.assertGreaterEqual(len(inspection.records), 3)
+        self.assertTrue(inspection.provenance)
+        self.assertTrue(inspection.limitations)
+        for record in inspection.records:
+            self.assertTrue(record.sample)
+            self.assertTrue(record.provenance)
+            self.assertTrue(record.permission)
+            self.assertFalse(record.contains_real_customer_data)
+            self.assertFalse(record.contains_real_organization_names)
+            self.assertFalse(record.contains_non_public_postmortem)
+
+    def test_sample_pack_inspection_rejects_unsafe_demo_content(self) -> None:
+        inspection = sample_incident_pack_module.inspect_sample_incident_documents(
+            {
+                "unsafe.md": (
+                    "# Sample incident: unsafe\n"
+                    "Sample data: yes\n"
+                    "Provenance: Synthetic scenario authored for this sample pack.\n"
+                    "Permission: Original synthetic documentation content.\n"
+                    "Contains real customer data: no\n"
+                    "Contains real organization names: no\n"
+                    "Contains non-public postmortem content: no\n\n"
+                    "The outage affected Google and alice@gmail.com from 8.8.8.8."
+                )
+            }
+        )
+
+        self.assertFalse(inspection.safe)
+        self.assertTrue(
+            any("real organization" in error.lower() for error in inspection.errors),
+            inspection.errors,
+        )
+        self.assertTrue(
+            any("email" in error.lower() for error in inspection.errors),
+            inspection.errors,
+        )
+        self.assertTrue(
+            any("ip address" in error.lower() for error in inspection.errors),
+            inspection.errors,
+        )
+
+    def test_sample_pack_inspection_rejects_project_name_in_record_content(
+        self,
+    ) -> None:
+        inspection = sample_incident_pack_module.inspect_sample_incident_documents(
+            {
+                "unsafe.md": (
+                    "# Sample incident: unsafe\n"
+                    "Sample data: yes\n"
+                    "Provenance: Synthetic scenario authored for DeployWhisper.\n"
+                    "Permission: Original synthetic documentation content.\n"
+                    "Contains real customer data: no\n"
+                    "Contains real organization names: no\n"
+                    "Contains non-public postmortem content: no\n\n"
+                    "A synthetic rollout failed."
+                )
+            }
+        )
+
+        self.assertFalse(inspection.safe)
+        self.assertTrue(
+            any("deploywhisper" in error.lower() for error in inspection.errors),
+            inspection.errors,
+        )
+
+    def test_sample_pack_inspection_rejects_vendor_toolchain_names(self) -> None:
+        inspection = sample_incident_pack_module.inspect_sample_incident_documents(
+            {
+                "unsafe.md": (
+                    "# Sample incident: unsafe\n"
+                    "Sample data: yes\n"
+                    "Provenance: Synthetic scenario authored for this sample pack.\n"
+                    "Permission: Original synthetic documentation content.\n"
+                    "Contains real customer data: no\n"
+                    "Contains real organization names: no\n"
+                    "Contains non-public postmortem content: no\n\n"
+                    "Limitations:\n"
+                    "- Synthetic demo record.\n\n"
+                    "A Terraform change updated aws_security_group_rule.example."
+                )
+            }
+        )
+
+        self.assertFalse(inspection.safe)
+        self.assertTrue(
+            any("terraform" in error.lower() for error in inspection.errors),
+            inspection.errors,
+        )
+        self.assertTrue(
+            any(
+                "aws_security_group_rule" in error.lower()
+                for error in inspection.errors
+            ),
+            inspection.errors,
+        )
+
+    def test_sample_pack_inspection_rejects_project_name_in_manifest_metadata(
+        self,
+    ) -> None:
+        pack_dir = Path(self.tempdir.name) / "unsafe-pack"
+        pack_dir.mkdir()
+        (pack_dir / "manifest.json").write_text(
+            """{
+  "pack_id": "unsafe-pack",
+  "title": "Unsafe Pack",
+  "sample": true,
+  "loaded_by_default": false,
+  "provenance": "Original synthetic incidents authored for DeployWhisper.",
+  "limitations": ["Only for demos."],
+  "records": [{"source_file": "incident.md"}]
+}""",
+            encoding="utf-8",
+        )
+        (pack_dir / "incident.md").write_text(
+            "# Sample incident: safe declarations\n"
+            "Sample data: yes\n"
+            "Provenance: Synthetic scenario authored for this sample pack.\n"
+            "Permission: Original synthetic documentation content.\n"
+            "Contains real customer data: no\n"
+            "Contains real organization names: no\n"
+            "Contains non-public postmortem content: no\n\n"
+            "Limitations:\n"
+            "- Synthetic demo record.\n",
+            encoding="utf-8",
+        )
+
+        inspection = sample_incident_pack_module.inspect_sample_incident_pack(pack_dir)
+
+        self.assertFalse(inspection.safe)
+        self.assertTrue(
+            any("deploywhisper" in error.lower() for error in inspection.errors),
+            inspection.errors,
+        )
+
+    def test_sample_pack_loads_only_by_explicit_project_scope(self) -> None:
+        load_result = sample_incident_pack_module.load_safe_sample_incident_pack(
+            project_id=self.project.id
+        )
+
+        records = incident_service_module.get_incident_records(
+            project_id=self.project.id
+        )
+        self.assertEqual(load_result["loaded"], len(load_result["records"]))
+        self.assertEqual(len(records), load_result["loaded"])
+        self.assertGreaterEqual(len(records), 3)
+        self.assertTrue(
+            all(record["title"].startswith("Sample incident:") for record in records)
+        )
+        self.assertTrue(
+            all("Sample data: yes" in record["content"] for record in records)
+        )
+
+    def test_sample_pack_load_requires_project_scope(self) -> None:
+        with self.assertRaises(ValueError) as ctx:
+            sample_incident_pack_module.load_safe_sample_incident_pack()
+
+        self.assertIn("Project scope is required", str(ctx.exception))
+
+    def test_sample_pack_documentation_explains_provenance_and_limitations(
+        self,
+    ) -> None:
+        docs = Path("docs/sample-incident-pack.md").read_text(encoding="utf-8")
+
+        self.assertIn("Provenance", docs)
+        self.assertIn("not copied from customer data", docs)
+        self.assertIn("not loaded by default", docs)
+        self.assertIn("Limitations", docs)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Story 4.2 needs demo incident memory without relying on customer data, so the sample pack is synthetic, explicitly scoped, documented, and inspected before loading.

Constraint: Sample incidents must contain no real customer data, organization names, or non-public postmortem content

Constraint: Preserve local-first and project-scoped incident memory boundaries

Rejected: Auto-loading sample records | would mix demo incidents into real project memory without explicit user action

Rejected: Real provider-specific sample names | would violate the sample-pack safety contract

Confidence: high

Scope-risk: narrow

Directive: Keep bundled sample records generic; update the safety-term regression tests before adding public sample data

Tested: ./.venv/bin/python -m unittest tests.test_services.test_sample_incident_pack -q

Tested: ./.venv/bin/ruff check .

Tested: ./.venv/bin/ruff format --check .

Tested: git diff --check

Tested: ./.venv/bin/bandit -r services/ -x tests/ --severity-level high --confidence-level high

Tested: ./.venv/bin/python -m unittest discover -q

Not-tested: Browser UI validation; no UI surface changed

## What does this PR do?

<!-- Brief description of changes -->

## Type of change
- [ ] Feature (new functionality)
- [ ] Bugfix (non-breaking fix)
- [ ] Release preparation
- [ ] Hotfix (critical production fix)
- [ ] Docs / refactor / chore

## Checklist
- [ ] I have followed the branch naming convention
- [ ] Tests pass locally (`pytest tests/ -v`)
- [ ] Linting passes (`ruff check .`)
- [ ] Docker build succeeds
- [ ] I have updated docs if needed
- [ ] No secrets or .env values committed

## Related issue
Closes #