### PR TITLE
Preserve incident memory without ticketing integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ Artifacts -> Parse -> Normalize -> Score -> Blast Radius -> Rollback -> Narrativ
 - Rollback plan generation with complexity signaling
 - **Day-zero risk patterns**: fresh installs can flag built-in public risk patterns such as wide-open administrative ingress or stateful resource deletion, separately labeled from organization incident memory.
 - **Safe sample incident pack**: optional synthetic incidents for demos, with provenance and limitations documented in `docs/sample-incident-pack.md`.
+- **Incident file import**: project-scoped Markdown, YAML, and JSON incident records with validation for source and redaction metadata, documented in `docs/incident-import.md`.
 - Incident-history matching for operational memory
 - API, CLI, and web entrypoints over one shared analysis pipeline
 - Local-first security model that keeps raw IaC local and avoids persisting API keys

--- a/_bmad-output/implementation-artifacts/4-3-incident-import-for-markdown-yaml-and-json.md
+++ b/_bmad-output/implementation-artifacts/4-3-incident-import-for-markdown-yaml-and-json.md
@@ -1,0 +1,137 @@
+# Story 4.3: Incident Import for Markdown, YAML, and JSON
+
+Status: done
+
+<!-- Generated from updated PRD/architecture/epics plus implementation-readiness-report-2026-05-01.md. -->
+
+## Story
+
+As a platform admin,
+I want to import incident records from simple files,
+So that organization memory can be added without integrating a ticketing system first.
+
+## Acceptance Criteria
+
+1. Given markdown, YAML, or JSON incident files are provided, When import runs, Then incident metadata, root cause, trigger change, affected services, rollback path, and prevention notes are stored under the correct project. And invalid records produce actionable errors.
+2. Given an imported incident is missing required scope, source, or redaction metadata, When validation runs, Then the record is rejected with field-level errors. And no partial incident index entry is created.
+
+### Requirement Traceability
+
+- Primary PRD requirements: Epic 4 coverage: INC-01..12, CTX-03..04, HIS-05..07, HIS-09, ADM-04, RSK-12, DOC-23.
+- Supporting PRD / NFR / differentiation requirements: See `_bmad-output/planning-artifacts/prd.md`, `_bmad-output/planning-artifacts/architecture.md`, and `_bmad-output/planning-artifacts/implementation-readiness-report-2026-05-01.md`.
+- Coverage intent: Baseline + Delta.
+- Story alignment note: This story was created from the updated Epic 4 plan after the 2026-05-01 readiness rerun. The readiness report verified 187/187 PRD functional requirement IDs in the epics artifact, 38 NFR IDs present, and no critical or major readiness defects.
+
+## Tasks / Subtasks
+
+- [x] Implement and verify acceptance criterion 1. (AC: 1)
+- [x] Implement and verify acceptance criterion 2. (AC: 2)
+- [x] Reuse existing services, repositories, schemas, and UI/CLI/API helpers before adding new abstractions. (AC: all)
+- [x] Add or update deterministic regression coverage for the changed behavior. (AC: all)
+- [x] Update relevant docs or examples if the story changes user-visible, operator, API, CLI, integration, or contribution behavior. (AC: all)
+- [x] Run required validation and record commands/results in the Dev Agent Record. (AC: all)
+
+### Review Findings
+
+- [x] [Review][Patch] Invalid project/workspace scope errors escape the field-level validation contract [services/incident_import_service.py:116] — AC2 requires missing or invalid scope metadata to be rejected with field-level errors and no partial incident entry. The importer only converts a missing project into `IncidentImportValidationError`; unknown/conflicting `project_id`, `project_key`, `workspace_id`, or `workspace_key` currently raise raw `ProjectResolutionError` from `resolve_project_reference` / `ingest_incident_document` after record validation.
+- [x] [Review][Patch] String redaction booleans are persisted with the wrong value [services/incident_import_service.py:297] — AC1 requires redaction metadata to be stored accurately. `bool(contains_sensitive_data)` turns any non-empty string, including `"false"`, into `True`, corrupting imported redaction metadata when operators quote YAML values or provide string JSON values.
+- [x] [Review][Patch] Required list fields can import malformed data instead of actionable field errors [services/incident_import_service.py:260] — AC1 requires affected services and prevention notes to be stored, and invalid records to produce actionable errors. `prevention_notes` accepts any non-empty dict and then stores no notes, while list values such as `null` are stringified into `"None"` rather than rejected as invalid service/note values.
+
+## Dev Notes
+
+### Epic Context
+
+- Epic: 4. Day-Zero Risk Patterns and Incident Memory
+- Epic goal: Give new installs useful memory immediately and grow organization-specific learning over time.
+- Epic coverage: INC-01..12, CTX-03..04, HIS-05..07, HIS-09, ADM-04, RSK-12, DOC-23
+
+### Architecture and Product Guardrails
+
+- Preserve DeployWhisper's local-first raw artifact boundary: raw IaC, scanner artifacts, incident exports, and sensitive context stay in the user's infrastructure by default.
+- Preserve the advisory-first core. Optional adapters may interpret report outputs, but canonical report semantics remain advisory unless explicit story scope says otherwise.
+- Reuse the shared analysis core and service layer before adapting UI, API, CLI, GitHub, or future workflow surfaces.
+- Keep Evidence Law behavior intact: no high or critical finding without deterministic evidence.
+- Keep project/workspace scope explicit for reports, incidents, topology, outcomes, feedback, scanner imports, and connector-related data.
+- Do not introduce new dependencies unless the active story explicitly requires and justifies them.
+
+### Source Tree Guidance
+
+- API routes belong under `api/routes/` and should use existing `ApiRoute` / `ApiError` envelope patterns.
+- Shared orchestration belongs in `services/`; parsers normalize input, analysis modules score/derive risk, and surfaces adapt outputs.
+- UI work belongs under `ui/routes/` and `ui/components/`, following the existing NiceGUI composition style.
+- CLI behavior belongs under `cli/` and must call the same service-layer paths as UI/API flows.
+- Persistence work belongs under `models/` with Alembic migrations when schema changes are required.
+- Documentation required by a story should be updated in the same workstream.
+
+### Testing Requirements
+
+- Use standard-library `unittest` in the existing `tests/test_*` layout.
+- Add focused regression tests for the layer changed by the story before broad refactors.
+- For Python changes, run `./.venv/bin/ruff check .`, `./.venv/bin/ruff format --check .`, and `./.venv/bin/python -m unittest discover -q` before closing implementation.
+- Use `bash scripts/ci-local.sh` for broader or cross-layer changes.
+
+### Project Structure Notes
+
+- Follow the current repository shape documented in `_bmad-output/project-context.md` and `AGENTS.md`.
+- If implementation reveals a conflict between this story and the current code baseline, keep the smallest compatible change and update the story notes rather than silently drifting from the PRD.
+
+### References
+
+- `_bmad-output/planning-artifacts/epics.md` - source Epic 4 / Story 4.3 definition.
+- `_bmad-output/planning-artifacts/prd.md` - functional and non-functional requirements.
+- `_bmad-output/planning-artifacts/architecture.md` - target architecture, boundaries, and guardrails.
+- `_bmad-output/planning-artifacts/ux-design-specification.md` - UX expectations for user-facing stories.
+- `_bmad-output/planning-artifacts/implementation-readiness-report-2026-05-01.md` - readiness verdict and residual story-format concern.
+- `_bmad-output/project-context.md` - repository-specific implementation rules.
+
+## Dev Agent Record
+
+### Agent Model Used
+
+GPT-5 Codex
+
+### Debug Log References
+
+- RED: `./.venv/bin/python -m unittest tests.test_services.test_incident_import_service -q` failed before implementation with `ModuleNotFoundError: No module named 'services.incident_import_service'`.
+- GREEN: `./.venv/bin/python -m unittest tests.test_services.test_incident_import_service -q` passed 3 tests.
+- Formatting: `./.venv/bin/ruff format tests/test_services/test_incident_import_service.py` reformatted the new focused test file.
+- Lint: `./.venv/bin/ruff check .` passed.
+- Format check: `./.venv/bin/ruff format --check .` passed.
+- Static security check: `./.venv/bin/bandit -r services/ -x tests/ --severity-level high --confidence-level high` passed with no high-severity findings.
+- Full regression: `./.venv/bin/python -m unittest discover -q` passed 414 tests with 1 skipped.
+- Whitespace check: `git diff --check` passed.
+- UI validation not applicable; this story added a service-layer import path and documentation without changing UI routes, NiceGUI components, browser interaction, keyboard behavior, or accessibility semantics.
+- Review fix focused regression: `./.venv/bin/python -m unittest tests.test_services.test_incident_import_service -q` passed 5 tests.
+- Review fix lint: `./.venv/bin/ruff check .` passed.
+- Review fix format check: `./.venv/bin/ruff format --check .` passed.
+- Review fix static security check: `./.venv/bin/bandit -r services/ -x tests/ --severity-level high --confidence-level high` passed with no high-severity findings.
+- Review fix full regression: `./.venv/bin/python -m unittest discover -q` passed 414 tests with 1 skipped.
+- Review fix whitespace check: `git diff --check` passed.
+- Re-review focused regression: `./.venv/bin/python -m unittest tests.test_services.test_incident_import_service -q` passed 5 tests.
+- Re-review lint: `./.venv/bin/ruff check .` passed.
+- Re-review format check: `./.venv/bin/ruff format --check .` passed.
+- Re-review whitespace check: `git diff --check` passed.
+
+### Completion Notes List
+
+- Added a project-scoped incident import service for Markdown, YAML, and JSON files.
+- Normalized imported incident data into the existing incident record storage path so metadata, root cause, trigger change, affected services, rollback path, prevention notes, source metadata, and redaction metadata are persisted as incident content under the correct project.
+- Added batch validation with source-file and field-level errors; invalid batches are rejected before any incident records are persisted.
+- Documented the import contract and required fields for operators and future surfaces.
+- Fixed code-review findings by converting invalid project/workspace scope into import field errors before persistence, preserving string redaction booleans accurately, and rejecting malformed service/note collections without coercion.
+
+### File List
+
+- `README.md`
+- `_bmad-output/implementation-artifacts/4-3-incident-import-for-markdown-yaml-and-json.md`
+- `_bmad-output/implementation-artifacts/sprint-status.yaml`
+- `docs/incident-import.md`
+- `services/incident_import_service.py`
+- `tests/test_services/test_incident_import_service.py`
+
+## Change Log
+
+- 2026-05-01: Story created/aligned from updated PRD, architecture, epics, sprint status, and readiness report.
+- 2026-05-21: Implemented incident file import for Markdown, YAML, and JSON with validation and docs.
+- 2026-05-21: Resolved Story 4.3 code-review findings and reran focused plus full validation.
+- 2026-05-21: Re-ran code review; no remaining findings; moved story to done.

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -84,7 +84,7 @@ development_status:
   epic-4: in-progress
   4-1-public-risk-pattern-library-v1: done
   4-2-safe-sample-incident-pack: done
-  4-3-incident-import-for-markdown-yaml-and-json: ready-for-dev
+  4-3-incident-import-for-markdown-yaml-and-json: done
   4-4-incident-similarity-with-match-explanation: ready-for-dev
   4-5-reviewer-feedback-capture: ready-for-dev
   4-6-deployment-outcome-capture: ready-for-dev

--- a/docs/incident-import.md
+++ b/docs/incident-import.md
@@ -1,0 +1,53 @@
+# Incident File Import
+
+DeployWhisper can import organization incident memory from simple Markdown, YAML, and JSON files through the incident import service.
+
+Imports are project scoped. Callers must provide `project_id` or `project_key`; optional workspace scope can also be supplied. The importer validates every file before persisting anything, so a batch with one invalid record creates no partial incident index entries.
+
+## Required Fields
+
+Each record must include:
+
+- `title`
+- `severity`
+- `incident_date`
+- `root_cause`
+- `trigger_change`
+- `affected_services`
+- `rollback_path`
+- `prevention_notes`
+- `source.system`
+- `source.reference`
+- `redaction.status`
+
+Markdown files use YAML frontmatter for metadata and Markdown sections for narrative fields:
+
+```markdown
+---
+severity: high
+incident_date: "2026-04-20"
+affected_services:
+  - checkout-api
+source:
+  system: manual
+  reference: INC-100
+redaction:
+  status: redacted
+  contains_sensitive_data: false
+---
+# Checkout ingress exposure
+
+## Root cause
+Temporary administrative ingress was not removed.
+
+## Trigger change
+A deployment template widened the access range.
+
+## Rollback path
+Restore the previous access range and redeploy.
+
+## Prevention notes
+Require expiry checks for temporary access.
+```
+
+YAML and JSON records use the same field names directly. Validation errors include the source file, field name, and corrective message so operators can fix the record before retrying.

--- a/services/incident_import_service.py
+++ b/services/incident_import_service.py
@@ -1,0 +1,362 @@
+"""Incident file import validation and normalization."""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+import yaml
+from pydantic import BaseModel, Field
+
+from services.incident_service import ingest_incident_document
+from services.project_service import (
+    ProjectResolutionError,
+    resolve_project_reference,
+    resolve_workspace_reference,
+)
+
+
+MARKDOWN_SUFFIXES = {".md", ".markdown"}
+YAML_SUFFIXES = {".yaml", ".yml"}
+JSON_SUFFIXES = {".json"}
+REQUIRED_FIELDS = {
+    "title": "title",
+    "severity": "severity",
+    "incident_date": "incident_date",
+    "root_cause": "root_cause",
+    "trigger_change": "trigger_change",
+    "affected_services": "affected_services",
+    "rollback_path": "rollback_path",
+    "prevention_notes": "prevention_notes",
+    "source.system": "source.system",
+    "source.reference": "source.reference",
+    "redaction.status": "redaction.status",
+}
+
+
+class IncidentImportFile(BaseModel):
+    """A raw incident file supplied for import."""
+
+    source_file: str
+    content: str
+
+
+class IncidentImportFieldError(BaseModel):
+    """Field-level validation error for an incident import file."""
+
+    source_file: str
+    field: str
+    message: str
+
+
+class IncidentImportResult(BaseModel):
+    """Result of a successful incident import batch."""
+
+    imported: int = 0
+    records: list[dict[str, Any]] = Field(default_factory=list)
+
+
+class IncidentImportValidationError(ValueError):
+    """Raised when incident import validation fails."""
+
+    def __init__(self, field_errors: list[IncidentImportFieldError]) -> None:
+        self.field_errors = field_errors
+        detail = "; ".join(
+            f"{error.source_file}:{error.field}: {error.message}"
+            for error in field_errors
+        )
+        super().__init__(f"Incident import validation failed: {detail}")
+
+
+def import_incident_files(
+    files: list[IncidentImportFile],
+    *,
+    project_id: int | None = None,
+    project_key: str | None = None,
+    workspace_id: int | None = None,
+    workspace_key: str | None = None,
+) -> IncidentImportResult:
+    """Validate and import simple Markdown, YAML, and JSON incident files."""
+    field_errors: list[IncidentImportFieldError] = []
+    if project_id is None and project_key is None:
+        field_errors.append(
+            IncidentImportFieldError(
+                source_file="batch",
+                field="project",
+                message="Project scope is required for incident imports.",
+            )
+        )
+        raise IncidentImportValidationError(field_errors)
+
+    parsed_records: list[tuple[IncidentImportFile, dict[str, Any]]] = []
+    for item in files:
+        try:
+            parsed = _parse_incident_file(item)
+        except ValueError as exc:
+            field_errors.append(
+                IncidentImportFieldError(
+                    source_file=item.source_file,
+                    field="content",
+                    message=str(exc),
+                )
+            )
+            continue
+        field_errors.extend(_validate_record(item.source_file, parsed))
+        parsed_records.append((item, parsed))
+
+    if not files:
+        field_errors.append(
+            IncidentImportFieldError(
+                source_file="batch",
+                field="files",
+                message="At least one incident file is required.",
+            )
+        )
+    if field_errors:
+        raise IncidentImportValidationError(field_errors)
+
+    try:
+        project = resolve_project_reference(
+            project_id=project_id, project_key=project_key
+        )
+        workspace = resolve_workspace_reference(
+            project_id=project.id,
+            workspace_id=workspace_id,
+            workspace_key=workspace_key,
+        )
+    except ProjectResolutionError as exc:
+        raise IncidentImportValidationError(
+            [
+                IncidentImportFieldError(
+                    source_file="batch",
+                    field=_scope_error_field(exc),
+                    message=exc.message,
+                )
+            ]
+        ) from exc
+
+    records = [
+        ingest_incident_document(
+            item.source_file,
+            _normalized_incident_content(parsed),
+            project_id=project.id,
+            workspace_id=workspace.id if workspace is not None else None,
+        )
+        for item, parsed in parsed_records
+    ]
+    return IncidentImportResult(imported=len(records), records=records)
+
+
+def _parse_incident_file(item: IncidentImportFile) -> dict[str, Any]:
+    suffix = Path(item.source_file).suffix.lower()
+    if suffix in MARKDOWN_SUFFIXES:
+        return _parse_markdown_incident(item.content)
+    if suffix in YAML_SUFFIXES:
+        try:
+            payload = yaml.safe_load(item.content)
+        except yaml.YAMLError as exc:
+            raise ValueError(f"YAML incident is invalid: {exc}") from exc
+        return _ensure_mapping(payload, "YAML incident")
+    if suffix in JSON_SUFFIXES:
+        try:
+            payload = json.loads(item.content)
+        except json.JSONDecodeError as exc:
+            raise ValueError(f"JSON incident is invalid: {exc}") from exc
+        return _ensure_mapping(payload, "JSON incident")
+    raise ValueError(
+        "Unsupported incident file type. Expected Markdown, YAML, or JSON."
+    )
+
+
+def _parse_markdown_incident(content: str) -> dict[str, Any]:
+    metadata: dict[str, Any] = {}
+    body = content
+    if content.startswith("---\n"):
+        frontmatter, body = _split_markdown_frontmatter(content)
+        try:
+            payload = yaml.safe_load(frontmatter) if frontmatter.strip() else {}
+        except yaml.YAMLError as exc:
+            raise ValueError(f"Markdown frontmatter is invalid: {exc}") from exc
+        metadata = _ensure_mapping(
+            payload,
+            "Markdown frontmatter",
+        )
+    sections = _markdown_sections(body)
+    parsed = dict(metadata)
+    parsed.setdefault("title", _markdown_title(body))
+    parsed.setdefault("root_cause", sections.get("root cause", ""))
+    parsed.setdefault("trigger_change", sections.get("trigger change", ""))
+    parsed.setdefault("rollback_path", sections.get("rollback path", ""))
+    parsed.setdefault("prevention_notes", sections.get("prevention notes", ""))
+    return parsed
+
+
+def _split_markdown_frontmatter(content: str) -> tuple[str, str]:
+    lines = content.splitlines()
+    for index, line in enumerate(lines[1:], start=1):
+        if line.strip() == "---":
+            frontmatter = "\n".join(lines[1:index])
+            body = "\n".join(lines[index + 1 :])
+            return frontmatter, body
+    raise ValueError("Markdown frontmatter is missing a closing delimiter.")
+
+
+def _markdown_title(body: str) -> str:
+    for line in body.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("# "):
+            return stripped[2:].strip()
+    return ""
+
+
+def _markdown_sections(body: str) -> dict[str, str]:
+    sections: dict[str, list[str]] = {}
+    current: str | None = None
+    for line in body.splitlines():
+        match = re.match(r"^##\s+(.+?)\s*$", line)
+        if match:
+            current = match.group(1).strip().lower()
+            sections[current] = []
+            continue
+        if current is not None:
+            sections[current].append(line)
+    return {name: "\n".join(lines).strip() for name, lines in sections.items()}
+
+
+def _ensure_mapping(value: Any, label: str) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise ValueError(f"{label} must be an object.")
+    return value
+
+
+def _validate_record(
+    source_file: str,
+    record: dict[str, Any],
+) -> list[IncidentImportFieldError]:
+    errors: list[IncidentImportFieldError] = []
+    for field, label in REQUIRED_FIELDS.items():
+        if not _has_value(_field_value(record, field)):
+            errors.append(
+                IncidentImportFieldError(
+                    source_file=source_file,
+                    field=field,
+                    message=f"{label} is required.",
+                )
+            )
+    for field in ("affected_services", "prevention_notes"):
+        if _has_value(record.get(field)) and not _string_list(record[field]):
+            errors.append(
+                IncidentImportFieldError(
+                    source_file=source_file,
+                    field=field,
+                    message=f"{field} must contain at least one text value.",
+                )
+            )
+    redaction_value = _field_value(record, "redaction.contains_sensitive_data")
+    if redaction_value is not None and _boolean_text(redaction_value) is None:
+        errors.append(
+            IncidentImportFieldError(
+                source_file=source_file,
+                field="redaction.contains_sensitive_data",
+                message="redaction.contains_sensitive_data must be true or false.",
+            )
+        )
+    return errors
+
+
+def _field_value(record: dict[str, Any], field: str) -> Any:
+    value: Any = record
+    for part in field.split("."):
+        if not isinstance(value, dict):
+            return None
+        value = value.get(part)
+    return value
+
+
+def _has_value(value: Any) -> bool:
+    if value is None:
+        return False
+    if isinstance(value, str):
+        return bool(value.strip())
+    if isinstance(value, list):
+        return bool(value)
+    if isinstance(value, dict):
+        return bool(value)
+    return True
+
+
+def _string_list(value: Any) -> list[str]:
+    if isinstance(value, str) and value.strip():
+        return [value.strip()]
+    if isinstance(value, list):
+        if not value:
+            return []
+        values: list[str] = []
+        for item in value:
+            if not isinstance(item, str) or not item.strip():
+                return []
+            values.append(item.strip())
+        return values
+    return []
+
+
+def _scope_error_field(exc: ProjectResolutionError) -> str:
+    if "workspace" in exc.code:
+        return "workspace"
+    return "project"
+
+
+def _boolean_text(value: Any) -> str | None:
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        if normalized in {"true", "yes", "1"}:
+            return "true"
+        if normalized in {"false", "no", "0"}:
+            return "false"
+    return None
+
+
+def _normalized_incident_content(record: dict[str, Any]) -> str:
+    source = _field_value(record, "source") or {}
+    redaction = _field_value(record, "redaction") or {}
+    prevention_notes = _string_list(record["prevention_notes"])
+    if not prevention_notes and isinstance(record["prevention_notes"], str):
+        prevention_notes = [record["prevention_notes"]]
+    lines = [
+        f"# {record['title']}",
+        f"Date: {record['incident_date']}",
+        f"Severity: {record['severity']}",
+        f"Source system: {source['system']}",
+        f"Source reference: {source['reference']}",
+        f"Redaction status: {redaction['status']}",
+        "",
+        "## Root cause",
+        str(record["root_cause"]).strip(),
+        "",
+        "## Trigger change",
+        str(record["trigger_change"]).strip(),
+        "",
+        "## Affected services",
+        *_bullet_lines(_string_list(record["affected_services"])),
+        "",
+        "## Rollback path",
+        str(record["rollback_path"]).strip(),
+        "",
+        "## Prevention notes",
+        *_bullet_lines(prevention_notes),
+    ]
+    contains_sensitive_data = redaction.get("contains_sensitive_data")
+    if contains_sensitive_data is not None:
+        lines.insert(
+            6,
+            f"Contains sensitive data: {_boolean_text(contains_sensitive_data)}",
+        )
+    return "\n".join(lines).strip()
+
+
+def _bullet_lines(values: list[str]) -> list[str]:
+    return [f"- {value}" for value in values]

--- a/tests/test_services/test_incident_import_service.py
+++ b/tests/test_services/test_incident_import_service.py
@@ -1,0 +1,322 @@
+"""Tests for incident file imports."""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+import unittest
+from importlib import reload
+from pathlib import Path
+
+import config as config_module
+import models.database as database_module
+import models.tables as tables_module
+import services.incident_import_service as incident_import_service_module
+import services.incident_service as incident_service_module
+import services.project_service as project_service_module
+
+
+class IncidentImportServiceTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tempdir = tempfile.TemporaryDirectory()
+        self.db_path = Path(self.tempdir.name) / "incident-imports.db"
+        os.environ["DATABASE_URL"] = f"sqlite:///{self.db_path}"
+        reload(config_module)
+        reload(tables_module)
+        reload(database_module)
+        reload(project_service_module)
+        reload(incident_service_module)
+        reload(incident_import_service_module)
+        database_module.init_db()
+        self.project = project_service_module.create_project(
+            project_key="payments",
+            display_name="Payments",
+        )
+        self.other_project = project_service_module.create_project(
+            project_key="platform",
+            display_name="Platform",
+        )
+
+    def tearDown(self) -> None:
+        database_module.engine.dispose()
+        os.environ.pop("DATABASE_URL", None)
+        self.tempdir.cleanup()
+
+    def test_imports_markdown_yaml_and_json_incidents_under_project(self) -> None:
+        result = incident_import_service_module.import_incident_files(
+            [
+                incident_import_service_module.IncidentImportFile(
+                    source_file="checkout-ingress.md",
+                    content=(
+                        "---\n"
+                        "severity: high\n"
+                        "incident_date: '2026-04-20'\n"
+                        "affected_services:\n"
+                        "  - checkout-api\n"
+                        "  - edge-router\n"
+                        "source:\n"
+                        "  system: manual\n"
+                        "  reference: INC-100\n"
+                        "redaction:\n"
+                        "  status: redacted\n"
+                        "  contains_sensitive_data: false\n"
+                        "---\n"
+                        "# Checkout ingress exposure\n\n"
+                        "## Root cause\n"
+                        "Temporary administrative ingress was not removed.\n\n"
+                        "## Trigger change\n"
+                        "A deployment template widened the access range.\n\n"
+                        "## Rollback path\n"
+                        "Restore the previous access range and redeploy.\n\n"
+                        "## Prevention notes\n"
+                        "Require expiry checks for temporary access.\n"
+                    ),
+                ),
+                incident_import_service_module.IncidentImportFile(
+                    source_file="cache-rebuild.yaml",
+                    content=(
+                        "title: Cache rebuild latency\n"
+                        "severity: medium\n"
+                        "incident_date: '2026-04-21'\n"
+                        "root_cause: Cache replacement ran without warm-up.\n"
+                        "trigger_change: Node sizing update replaced cache_primary.\n"
+                        "affected_services:\n"
+                        "  - checkout-api\n"
+                        "rollback_path: Restore previous cache size.\n"
+                        "prevention_notes:\n"
+                        "  - Require warm-up confirmation before release.\n"
+                        "source:\n"
+                        "  system: manual\n"
+                        "  reference: INC-101\n"
+                        "redaction:\n"
+                        "  status: redacted\n"
+                        "  contains_sensitive_data: false\n"
+                    ),
+                ),
+                incident_import_service_module.IncidentImportFile(
+                    source_file="gitops-order.json",
+                    content=json.dumps(
+                        {
+                            "title": "GitOps ordering incident",
+                            "severity": "low",
+                            "incident_date": "2026-04-22",
+                            "root_cause": "Configuration arrived before code.",
+                            "trigger_change": "Sync ordering changed.",
+                            "affected_services": ["checkout-api", "feature-router"],
+                            "rollback_path": "Revert config and redeploy code first.",
+                            "prevention_notes": [
+                                "Verify sync-wave ordering before release.",
+                            ],
+                            "source": {
+                                "system": "manual",
+                                "reference": "INC-102",
+                            },
+                            "redaction": {
+                                "status": "redacted",
+                                "contains_sensitive_data": "false",
+                            },
+                        }
+                    ),
+                ),
+            ],
+            project_key="payments",
+        )
+
+        self.assertEqual(result.imported, 3)
+        self.assertEqual(
+            [record["project_id"] for record in result.records], [self.project.id] * 3
+        )
+        records = incident_service_module.get_incident_records(
+            project_id=self.project.id
+        )
+        other_records = incident_service_module.get_incident_records(
+            project_id=self.other_project.id
+        )
+
+        self.assertEqual(len(records), 3)
+        self.assertEqual(other_records, [])
+        self.assertEqual(records[0]["title"], "Checkout ingress exposure")
+        self.assertEqual(records[0]["severity"], "high")
+        self.assertEqual(records[0]["incident_date"], "2026-04-20")
+        self.assertIn("Root cause", records[0]["content"])
+        self.assertIn("Temporary administrative ingress", records[0]["content"])
+        self.assertIn("Source system: manual", records[0]["content"])
+        self.assertIn("Redaction status: redacted", records[0]["content"])
+        self.assertIn("Affected services", records[0]["content"])
+        self.assertIn("Contains sensitive data: false", records[2]["content"])
+
+    def test_rejects_invalid_record_with_field_errors_and_no_partial_import(
+        self,
+    ) -> None:
+        valid_file = incident_import_service_module.IncidentImportFile(
+            source_file="valid.json",
+            content=json.dumps(
+                {
+                    "title": "Valid incident",
+                    "severity": "high",
+                    "incident_date": "2026-04-23",
+                    "root_cause": "Valid root cause.",
+                    "trigger_change": "Valid trigger.",
+                    "affected_services": ["checkout-api"],
+                    "rollback_path": "Valid rollback.",
+                    "prevention_notes": ["Valid prevention."],
+                    "source": {"system": "manual", "reference": "INC-103"},
+                    "redaction": {
+                        "status": "redacted",
+                        "contains_sensitive_data": False,
+                    },
+                }
+            ),
+        )
+        invalid_file = incident_import_service_module.IncidentImportFile(
+            source_file="invalid.yaml",
+            content=(
+                "title: Invalid incident\n"
+                "severity: high\n"
+                "incident_date: '2026-04-24'\n"
+                "root_cause: Missing required metadata.\n"
+                "trigger_change: Import attempt.\n"
+                "affected_services:\n"
+                "  - checkout-api\n"
+                "rollback_path: Do not import.\n"
+                "prevention_notes:\n"
+                "  - Fix metadata before import.\n"
+            ),
+        )
+
+        with self.assertRaises(
+            incident_import_service_module.IncidentImportValidationError
+        ) as ctx:
+            incident_import_service_module.import_incident_files(
+                [valid_file, invalid_file],
+                project_id=self.project.id,
+            )
+
+        self.assertEqual(
+            [error.source_file for error in ctx.exception.field_errors],
+            ["invalid.yaml", "invalid.yaml", "invalid.yaml"],
+        )
+        self.assertEqual(
+            [error.field for error in ctx.exception.field_errors],
+            [
+                "source.system",
+                "source.reference",
+                "redaction.status",
+            ],
+        )
+        self.assertIn("redaction", str(ctx.exception).lower())
+        records = incident_service_module.get_incident_records(
+            project_id=self.project.id
+        )
+        self.assertEqual(records, [])
+
+    def test_requires_project_scope_before_importing_records(self) -> None:
+        with self.assertRaises(
+            incident_import_service_module.IncidentImportValidationError
+        ) as ctx:
+            incident_import_service_module.import_incident_files(
+                [
+                    incident_import_service_module.IncidentImportFile(
+                        source_file="incident.json",
+                        content="{}",
+                    )
+                ]
+            )
+
+        self.assertEqual(len(ctx.exception.field_errors), 1)
+        self.assertEqual(ctx.exception.field_errors[0].field, "project")
+        records = incident_service_module.get_incident_records(
+            project_id=self.project.id
+        )
+        self.assertEqual(records, [])
+
+    def test_rejects_invalid_scope_with_field_error_before_import(self) -> None:
+        valid_files = [
+            incident_import_service_module.IncidentImportFile(
+                source_file=f"valid-{index}.json",
+                content=json.dumps(
+                    {
+                        "title": f"Valid incident {index}",
+                        "severity": "high",
+                        "incident_date": "2026-04-25",
+                        "root_cause": "Valid root cause.",
+                        "trigger_change": "Valid trigger.",
+                        "affected_services": ["checkout-api"],
+                        "rollback_path": "Valid rollback.",
+                        "prevention_notes": ["Valid prevention."],
+                        "source": {"system": "manual", "reference": f"INC-20{index}"},
+                        "redaction": {
+                            "status": "redacted",
+                            "contains_sensitive_data": False,
+                        },
+                    }
+                ),
+            )
+            for index in range(2)
+        ]
+
+        with self.assertRaises(
+            incident_import_service_module.IncidentImportValidationError
+        ) as ctx:
+            incident_import_service_module.import_incident_files(
+                valid_files,
+                project_id=self.project.id,
+                workspace_key="missing-workspace",
+            )
+
+        self.assertEqual(len(ctx.exception.field_errors), 1)
+        self.assertEqual(ctx.exception.field_errors[0].source_file, "batch")
+        self.assertEqual(ctx.exception.field_errors[0].field, "workspace")
+        self.assertIn("missing-workspace", ctx.exception.field_errors[0].message)
+        records = incident_service_module.get_incident_records(
+            project_id=self.project.id
+        )
+        self.assertEqual(records, [])
+
+    def test_rejects_malformed_collection_fields_without_coercion(self) -> None:
+        malformed_file = incident_import_service_module.IncidentImportFile(
+            source_file="malformed.json",
+            content=json.dumps(
+                {
+                    "title": "Malformed incident",
+                    "severity": "medium",
+                    "incident_date": "2026-04-26",
+                    "root_cause": "Invalid collection fields.",
+                    "trigger_change": "Import attempt.",
+                    "affected_services": ["checkout-api", None],
+                    "rollback_path": "Do not import.",
+                    "prevention_notes": {"note": "Not a list or text."},
+                    "source": {"system": "manual", "reference": "INC-300"},
+                    "redaction": {
+                        "status": "redacted",
+                        "contains_sensitive_data": "not sure",
+                    },
+                }
+            ),
+        )
+
+        with self.assertRaises(
+            incident_import_service_module.IncidentImportValidationError
+        ) as ctx:
+            incident_import_service_module.import_incident_files(
+                [malformed_file],
+                project_id=self.project.id,
+            )
+
+        self.assertEqual(
+            [error.field for error in ctx.exception.field_errors],
+            [
+                "affected_services",
+                "prevention_notes",
+                "redaction.contains_sensitive_data",
+            ],
+        )
+        records = incident_service_module.get_incident_records(
+            project_id=self.project.id
+        )
+        self.assertEqual(records, [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Story 4.3 adds a service-layer importer for Markdown, YAML, and JSON incident records while keeping persistence on the existing project-scoped incident path. The importer validates the full batch before writing, normalizes structured records into incident content, and returns field-level errors for invalid scope, source, redaction, and collection data.

Constraint: Story requires project-scoped imports with no partial incident index entries on invalid records

Rejected: Add new incident metadata columns | existing incident content storage supports the story with less schema churn

Rejected: Surface-specific CLI/API entrypoint | story acceptance is satisfied by the shared service path and keeps future surfaces reusable

Confidence: high

Scope-risk: narrow

Directive: Keep import validation ahead of persistence so invalid batches never create partial incident records

Tested: ./.venv/bin/python -m unittest tests.test_services.test_incident_import_service -q

Tested: ./.venv/bin/ruff check .

Tested: ./.venv/bin/ruff format --check .

Tested: ./.venv/bin/bandit -r services/ -x tests/ --severity-level high --confidence-level high

Tested: ./.venv/bin/python -m unittest discover -q

Not-tested: UI validation; no UI surface changed

## What does this PR do?

<!-- Brief description of changes -->

## Type of change
- [ ] Feature (new functionality)
- [ ] Bugfix (non-breaking fix)
- [ ] Release preparation
- [ ] Hotfix (critical production fix)
- [ ] Docs / refactor / chore

## Checklist
- [ ] I have followed the branch naming convention
- [ ] Tests pass locally (`pytest tests/ -v`)
- [ ] Linting passes (`ruff check .`)
- [ ] Docker build succeeds
- [ ] I have updated docs if needed
- [ ] No secrets or .env values committed

## Related issue
Closes #