### PR TITLE
Explain incident matches without overstating prior history

### DIFF
--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -85,7 +85,7 @@ development_status:
   4-1-public-risk-pattern-library-v1: done
   4-2-safe-sample-incident-pack: done
   4-3-incident-import-for-markdown-yaml-and-json: done
-  4-4-incident-similarity-with-match-explanation: ready-for-dev
+  4-4-incident-similarity-with-match-explanation: done
   4-5-reviewer-feedback-capture: ready-for-dev
   4-6-deployment-outcome-capture: ready-for-dev
   4-7-incident-ingestion-management-and-indexing: ready-for-dev

--- a/analysis/incident_matcher.py
+++ b/analysis/incident_matcher.py
@@ -6,7 +6,7 @@ from datetime import UTC, datetime
 import re
 from typing import Any, Literal
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
 
 from parsers.base import UnifiedChange, normalize_change_action
 from services.incident_service import get_incident_records
@@ -31,17 +31,42 @@ class IncidentMatch(BaseModel):
     confidence: float = Field(
         default=0.0, description="Confidence that this memory signal applies."
     )
+    confidence_label: Literal["high", "medium", "low"] = Field(
+        default="low", description="Human-readable confidence bucket."
+    )
     reason: str = Field(
         default="", description="Why the incident or public pattern matched."
     )
     evidence: list[str] = Field(
         default_factory=list, description="Concrete evidence supporting the match."
     )
+    matched_signals: list[str] = Field(
+        default_factory=list,
+        description="Specific tokens, services, or risk signals that matched.",
+    )
+    affected_services: list[str] = Field(
+        default_factory=list,
+        description="Services affected in the matched incident or pattern.",
+    )
+    prevention_notes: list[str] = Field(
+        default_factory=list,
+        description="Prevention guidance from the incident or public pattern.",
+    )
     verification_guidance: list[str] = Field(
         default_factory=list,
         description="Human verification steps before acting on the match.",
     )
     summary: str = Field(..., description="Short operational explanation")
+
+    @model_validator(mode="before")
+    @classmethod
+    def _derive_confidence_label(cls, value: Any) -> Any:
+        if not isinstance(value, dict) or value.get("confidence_label"):
+            return value
+        return {
+            **value,
+            "confidence_label": _confidence_label(value.get("confidence", 0.0)),
+        }
 
 
 def load_incident_candidates(
@@ -78,6 +103,20 @@ STOP_WORDS = {
     "delete",
     "destroy",
     "service",
+}
+
+LOW_CONFIDENCE_FLOOR = 0.05
+GENERIC_SERVICE_SEGMENTS = {
+    "api",
+    "app",
+    "auth",
+    "backend",
+    "frontend",
+    "job",
+    "service",
+    "server",
+    "web",
+    "worker",
 }
 
 
@@ -137,6 +176,97 @@ def _evidence_line(change: UnifiedChange) -> str:
         f"{change.source_file}: {change.resource_id} "
         f"({normalize_change_action(change.action)}) - {change.summary}"
     )
+
+
+def _confidence_label(confidence: Any) -> Literal["high", "medium", "low"]:
+    try:
+        numeric_confidence = float(confidence or 0.0)
+    except (TypeError, ValueError):
+        numeric_confidence = 0.0
+    if numeric_confidence >= 0.5:
+        return "high"
+    if numeric_confidence >= 0.35:
+        return "medium"
+    return "low"
+
+
+def _extract_markdown_list_section(content: str, section_title: str) -> list[str]:
+    lines = content.splitlines()
+    in_section = False
+    values: list[str] = []
+    wanted = _section_title_aliases(section_title)
+    for line in lines:
+        stripped = line.strip()
+        if stripped.startswith("#"):
+            title = _normalize_section_title(stripped.lstrip("#").strip())
+            if in_section and title not in wanted:
+                break
+            in_section = title in wanted
+            continue
+        if not in_section or not stripped:
+            continue
+        if stripped.startswith(("- ", "* ")):
+            values.append(stripped[2:].strip())
+        elif not values:
+            values.append(stripped)
+    return values
+
+
+def _normalize_section_title(title: str) -> str:
+    normalized = re.sub(r"[_:-]+", " ", title.casefold())
+    normalized = re.sub(r"\s+", " ", normalized).strip(" .")
+    return normalized
+
+
+def _section_title_aliases(section_title: str) -> set[str]:
+    normalized = _normalize_section_title(section_title)
+    aliases = {normalized}
+    if normalized.endswith("s"):
+        aliases.add(normalized[:-1])
+    else:
+        aliases.add(f"{normalized}s")
+    return aliases
+
+
+def _sorted_signals(signals: set[str], limit: int = 8) -> list[str]:
+    return sorted(signals, key=lambda signal: (len(signal), signal), reverse=True)[
+        :limit
+    ]
+
+
+def _text_segments(text: str) -> set[str]:
+    return {segment for segment in re.findall(r"[a-z0-9]+", text.casefold()) if segment}
+
+
+def _meaningful_service_segments(service: str) -> set[str]:
+    return {
+        segment
+        for segment in _text_segments(service)
+        if len(segment) > 2 and segment not in GENERIC_SERVICE_SEGMENTS
+    }
+
+
+def _service_matches_change(service: str, change_text: str) -> bool:
+    normalized = service.strip().casefold()
+    if not normalized:
+        return False
+    if normalized in _tokenize(change_text):
+        return True
+    meaningful_segments = _meaningful_service_segments(normalized)
+    if not meaningful_segments:
+        return False
+    return meaningful_segments <= _text_segments(change_text)
+
+
+def _affected_service_bonus(
+    affected_services: list[str], change_text: str
+) -> tuple[float, list[str]]:
+    matched_services = [
+        service
+        for service in affected_services
+        if _service_matches_change(service, change_text)
+    ]
+    return min(len(matched_services) * 0.18, 0.35), matched_services
 
 
 def _matches_wide_open_ingress(change: UnifiedChange) -> bool:
@@ -244,11 +374,22 @@ def find_public_risk_pattern_matches(
                     incident_date=None,
                     similarity=0.86,
                     confidence=0.86,
+                    confidence_label="high",
                     reason=(
                         "The change appears to expose administrative or data-plane "
                         "network access to the public internet."
                     ),
                     evidence=[_evidence_line(change)],
+                    matched_signals=[
+                        signal
+                        for signal in ["0.0.0.0/0", "::/0", "ssh", "rdp", "ingress"]
+                        if signal in _change_text(change)
+                    ],
+                    affected_services=[change.resource_id],
+                    prevention_notes=[
+                        "Use a trusted administrative access path instead of broad public ingress.",
+                        "Time-bound any exception and verify compensating controls before deployment.",
+                    ],
                     verification_guidance=[
                         "Confirm whether the public CIDR is intentional and time-bound.",
                         "Restrict administrative ingress to trusted networks or a managed access path.",
@@ -272,11 +413,21 @@ def find_public_risk_pattern_matches(
                     incident_date=None,
                     similarity=0.82,
                     confidence=0.82,
+                    confidence_label="high",
                     reason=(
                         "The change appears to destroy or replace a stateful resource "
                         "where data loss or prolonged recovery is a common failure mode."
                     ),
                     evidence=[_evidence_line(change)],
+                    matched_signals=[
+                        normalize_change_action(change.action),
+                        _resource_type(change),
+                    ],
+                    affected_services=[change.resource_id],
+                    prevention_notes=[
+                        "Require a tested backup, restore, or migration path before deployment.",
+                        "Confirm retention and deletion protection match the intended recovery posture.",
+                    ],
                     verification_guidance=[
                         "Confirm a tested backup, restore, or migration path exists.",
                         "Check retention, deletion protection, and rollback timing.",
@@ -332,7 +483,7 @@ def _recency_bonus(incident_date: str | None) -> float:
 
 def find_incident_matches(
     changes: list[UnifiedChange],
-    min_similarity: float = 0.2,
+    min_similarity: float = LOW_CONFIDENCE_FLOOR,
     *,
     project_id: int | None = None,
     project_key: str | None = None,
@@ -360,12 +511,13 @@ def find_incident_matches(
 
     matches: list[IncidentMatch] = []
     for candidate in candidates:
+        content = candidate.get("content", "")
         incident_text = " ".join(
             [
                 candidate.get("title", ""),
                 candidate.get("severity", ""),
                 candidate.get("source_file", ""),
-                candidate.get("content", ""),
+                content,
             ]
         )
         incident_tokens = _tokenize(incident_text)
@@ -373,15 +525,27 @@ def find_incident_matches(
             continue
         overlap = change_tokens & incident_tokens
         union = change_tokens | incident_tokens
+        affected_services = _extract_markdown_list_section(content, "Affected services")
+        service_bonus, matched_services = _affected_service_bonus(
+            affected_services, change_text
+        )
+        if not overlap and not matched_services:
+            continue
         similarity = len(overlap) / max(len(union), 1)
         similarity = min(
             1.0,
             similarity
             + _severity_bonus(candidate.get("severity", "unknown"))
-            + _recency_bonus(candidate.get("incident_date")),
+            + _recency_bonus(candidate.get("incident_date"))
+            + service_bonus,
         )
         if similarity < min_similarity:
             continue
+        rounded_similarity = round(similarity, 2)
+        matched_signals = _sorted_signals(overlap | set(matched_services))
+        confidence_label = _confidence_label(rounded_similarity)
+        prevention_notes = _extract_markdown_list_section(content, "Prevention notes")
+        label_prefix = f"{confidence_label.title()}-confidence"
         matches.append(
             IncidentMatch(
                 incident_id=candidate["id"],
@@ -391,23 +555,28 @@ def find_incident_matches(
                 severity=candidate["severity"],
                 source_file=candidate["source_file"],
                 incident_date=candidate.get("incident_date"),
-                similarity=round(similarity, 2),
-                confidence=round(similarity, 2),
+                similarity=rounded_similarity,
+                confidence=rounded_similarity,
+                confidence_label=confidence_label,
                 reason=(
                     "The current change shares deployment tokens with an "
-                    "organization-specific incident record."
+                    "organization-specific prior incident record."
                 ),
                 evidence=[
-                    f"overlap: {', '.join(sorted(overlap)[:8])}",
+                    f"matched signals: {', '.join(matched_signals)}",
                     f"incident source: {candidate['source_file']}",
                 ],
+                matched_signals=matched_signals,
+                affected_services=matched_services or affected_services,
+                prevention_notes=prevention_notes,
                 verification_guidance=[
                     "Compare the current change path against the prior incident timeline.",
                     "Confirm whether the same affected service, dependency, or rollback path applies.",
                 ],
                 summary=(
-                    f"Similar to prior incident '{candidate['title']}' "
-                    f"({candidate['severity']}) with {round(similarity * 100)}% token overlap."
+                    f"{label_prefix} organization-specific incident match: "
+                    f"'{candidate['title']}' ({candidate['severity']}) at "
+                    f"{round(similarity * 100)}% confidence."
                 ),
             )
         )

--- a/api/schemas.py
+++ b/api/schemas.py
@@ -955,17 +955,46 @@ class IncidentMatchData(BaseModel):
     confidence: float = Field(
         default=0.0, description="Confidence that this memory signal applies."
     )
+    confidence_label: Literal["high", "medium", "low"] = Field(
+        default="low", description="Human-readable confidence bucket."
+    )
     reason: str = Field(
         default="", description="Why the incident or public pattern matched."
     )
     evidence: list[str] = Field(
         default_factory=list, description="Concrete evidence supporting the match."
     )
+    matched_signals: list[str] = Field(
+        default_factory=list,
+        description="Specific tokens, services, or risk signals that matched.",
+    )
+    affected_services: list[str] = Field(
+        default_factory=list,
+        description="Services affected in the matched incident or pattern.",
+    )
+    prevention_notes: list[str] = Field(
+        default_factory=list,
+        description="Prevention guidance from the incident or public pattern.",
+    )
     verification_guidance: list[str] = Field(
         default_factory=list,
         description="Human verification steps before acting on the match.",
     )
     summary: str = Field(..., description="Short operational explanation")
+
+    @model_validator(mode="before")
+    @classmethod
+    def _derive_confidence_label(cls, value: Any) -> Any:
+        if not isinstance(value, dict) or value.get("confidence_label"):
+            return value
+        confidence = float(value.get("confidence") or 0.0)
+        if confidence >= 0.5:
+            label: Literal["high", "medium", "low"] = "high"
+        elif confidence >= 0.35:
+            label = "medium"
+        else:
+            label = "low"
+        return {**value, "confidence_label": label}
 
 
 class NarrativeData(BaseModel):

--- a/docs/schemas/report-v2.md
+++ b/docs/schemas/report-v2.md
@@ -349,9 +349,16 @@ without storing raw plan internals in a separate contract.
       "incident_date": null,
       "similarity": 0.86,
       "confidence": 0.86,
+      "confidence_label": "high",
       "reason": "The change appears to expose administrative or data-plane network access to the public internet.",
       "evidence": [
         "plan.json: aws_security_group.web (modify) - Terraform opened SSH ingress from 0.0.0.0/0 on port 22."
+      ],
+      "matched_signals": ["0.0.0.0/0", "ssh", "ingress"],
+      "affected_services": ["aws_security_group.web"],
+      "prevention_notes": [
+        "Use a trusted administrative access path instead of broad public ingress.",
+        "Time-bound any exception and verify compensating controls before deployment."
       ],
       "verification_guidance": [
         "Confirm whether the public CIDR is intentional and time-bound.",
@@ -389,8 +396,11 @@ Live API/CLI analysis responses and persisted report retrieval payloads include
 `incident_matches`. Matches from stored organization incident memory use
 `match_type: "organization_incident"`. Built-in day-zero risk patterns use
 `match_type: "public_risk_pattern"` and include `public_pattern_id`, `reason`,
-`evidence`, `confidence`, and `verification_guidance` so consumers can
-distinguish public guidance from a prior incident in their own environment.
+`evidence`, `confidence`, `confidence_label`, `matched_signals`,
+`affected_services`, `prevention_notes`, and `verification_guidance` so
+consumers can distinguish public guidance from a prior incident in their own
+environment. Public risk pattern matches are general failure-mode guidance and
+must not be presented as organization-specific incident history.
 
 ## Compatibility contract
 

--- a/tests/test_analysis/test_incident_matcher.py
+++ b/tests/test_analysis/test_incident_matcher.py
@@ -106,6 +106,229 @@ class IncidentMatcherTests(unittest.TestCase):
         self.assertGreaterEqual(matches[0].confidence, 0.8)
         self.assertTrue(matches[0].verification_guidance)
 
+    def test_organization_match_explains_signals_services_and_prevention(
+        self,
+    ) -> None:
+        incident_service_module.ingest_incident_document(
+            "checkout-ingress.md",
+            "\n".join(
+                [
+                    "# Checkout ingress exposure",
+                    "Date: 2026-04-20",
+                    "Severity: high",
+                    "The checkout-api and edge-router exposed administrative ingress.",
+                    "## Affected services",
+                    "- checkout-api",
+                    "- edge-router",
+                    "## Prevention notes",
+                    "- Require expiry checks before public ingress changes.",
+                    "- Restrict administrative access to trusted CIDRs.",
+                ]
+            ),
+            project_id=self.project.id,
+        )
+        changes = [
+            UnifiedChange(
+                source_file="plan.json",
+                tool="terraform",
+                resource_id="aws_security_group.checkout_admin",
+                action="modify",
+                summary=(
+                    "Terraform opens checkout-api administrative ingress on "
+                    "edge-router from 0.0.0.0/0 on port 22."
+                ),
+            )
+        ]
+
+        matches = incident_matcher_module.find_incident_matches(
+            changes,
+            project_id=self.project.id,
+        )
+
+        organization_match = next(
+            match for match in matches if match.match_type == "organization_incident"
+        )
+        self.assertEqual(organization_match.title, "Checkout ingress exposure")
+        self.assertIn("checkout-api", organization_match.matched_signals)
+        self.assertEqual(
+            organization_match.affected_services, ["checkout-api", "edge-router"]
+        )
+        self.assertIn(
+            "Require expiry checks before public ingress changes.",
+            organization_match.prevention_notes,
+        )
+        self.assertEqual(organization_match.confidence_label, "high")
+        self.assertIn("organization-specific", organization_match.reason)
+        self.assertTrue(
+            any(match.match_type == "public_risk_pattern" for match in matches)
+        )
+
+    def test_weak_organization_signal_is_labeled_low_confidence(self) -> None:
+        incident_service_module.ingest_incident_document(
+            "checkout-cache.md",
+            "\n".join(
+                [
+                    "# Checkout cache warmup",
+                    "Severity: low",
+                    "Checkout cache warmup created latency during a deploy.",
+                    "## Affected services",
+                    "- checkout-api",
+                    "## Prevention notes",
+                    "- Warm caches before checkout deploys.",
+                ]
+            ),
+            project_id=self.project.id,
+        )
+        changes = [
+            UnifiedChange(
+                source_file="plan.json",
+                tool="terraform",
+                resource_id="module.checkout.aws_appautoscaling_target.api",
+                action="modify",
+                summary="Checkout service capacity tuning for the next deploy.",
+            )
+        ]
+
+        matches = incident_matcher_module.find_incident_matches(
+            changes,
+            project_id=self.project.id,
+        )
+
+        self.assertEqual(len(matches), 1)
+        self.assertEqual(matches[0].match_type, "organization_incident")
+        self.assertEqual(matches[0].confidence_label, "low")
+        self.assertIn("Low-confidence", matches[0].summary)
+        self.assertIn("checkout", matches[0].matched_signals)
+
+    def test_incident_match_derives_legacy_confidence_label_from_numeric_string(
+        self,
+    ) -> None:
+        match = incident_matcher_module.IncidentMatch.model_validate(
+            {
+                "incident_id": 17,
+                "match_type": "organization_incident",
+                "title": "Checkout ingress exposure",
+                "severity": "high",
+                "source_file": "checkout-ingress.md",
+                "incident_date": None,
+                "similarity": 0.86,
+                "confidence": "0.86",
+                "reason": "Legacy persisted payload.",
+                "evidence": ["matched signals: checkout-api"],
+                "verification_guidance": ["Compare against prior incident."],
+                "summary": "Legacy organization incident match.",
+            }
+        )
+
+        self.assertEqual(match.confidence, 0.86)
+        self.assertEqual(match.confidence_label, "high")
+
+    def test_recent_high_severity_incident_without_signals_does_not_match(
+        self,
+    ) -> None:
+        incident_service_module.ingest_incident_document(
+            "database-outage.md",
+            "\n".join(
+                [
+                    "# Database outage",
+                    "Date: 2026-05-20",
+                    "Severity: high",
+                    "Postgres failover caused write loss during recovery.",
+                ]
+            ),
+            project_id=self.project.id,
+        )
+        changes = [
+            UnifiedChange(
+                source_file="plan.json",
+                tool="terraform",
+                resource_id="aws_security_group.docs",
+                action="modify",
+                summary="Open web documentation port for public preview.",
+            )
+        ]
+
+        matches = incident_matcher_module.find_incident_matches(
+            changes,
+            project_id=self.project.id,
+        )
+
+        self.assertEqual(matches, [])
+
+    def test_short_service_name_does_not_substring_match_resource_identifier(
+        self,
+    ) -> None:
+        incident_service_module.ingest_incident_document(
+            "api-incident.md",
+            "\n".join(
+                [
+                    "# API outage",
+                    "Severity: high",
+                    "A generic API failed during deployment.",
+                    "## Affected services",
+                    "- api",
+                    "## Prevention notes",
+                    "- Stage generic API rollouts.",
+                ]
+            ),
+            project_id=self.project.id,
+        )
+        changes = [
+            UnifiedChange(
+                source_file="plan.json",
+                tool="terraform",
+                resource_id="module.payments.aws_lambda_function.graphql_api",
+                action="modify",
+                summary="Tune GraphQL function memory for payments.",
+            )
+        ]
+
+        matches = incident_matcher_module.find_incident_matches(
+            changes,
+            project_id=self.project.id,
+        )
+
+        self.assertEqual(matches, [])
+
+    def test_organization_match_accepts_common_explanation_heading_variants(
+        self,
+    ) -> None:
+        incident_service_module.ingest_incident_document(
+            "checkout-variant.md",
+            "\n".join(
+                [
+                    "# Checkout deploy incident",
+                    "Severity: medium",
+                    "Checkout rollout missed canary checks.",
+                    "## Affected service:",
+                    "- checkout-api",
+                    "## Prevention notes:",
+                    "- Run canary checks before checkout rollout.",
+                ]
+            ),
+            project_id=self.project.id,
+        )
+        changes = [
+            UnifiedChange(
+                source_file="plan.json",
+                tool="terraform",
+                resource_id="module.checkout.aws_ecs_service.api",
+                action="modify",
+                summary="Checkout service rollout capacity change.",
+            )
+        ]
+
+        matches = incident_matcher_module.find_incident_matches(
+            changes,
+            project_id=self.project.id,
+        )
+
+        self.assertEqual(matches[0].affected_services, ["checkout-api"])
+        self.assertEqual(
+            matches[0].prevention_notes,
+            ["Run canary checks before checkout rollout."],
+        )
+
     def test_find_incident_matches_detects_structured_terraform_ingress(
         self,
     ) -> None:

--- a/tests/test_api/test_analyses.py
+++ b/tests/test_api/test_analyses.py
@@ -876,8 +876,12 @@ class AnalysesApiTests(unittest.TestCase):
             incident_date=None,
             similarity=0.86,
             confidence=0.86,
+            confidence_label="high",
             reason="The change exposes administrative ingress publicly.",
             evidence=["plan.json: aws_security_group.main (modify) - public SSH"],
+            matched_signals=["0.0.0.0/0", "ssh"],
+            affected_services=["aws_security_group.main"],
+            prevention_notes=["Use trusted administrative access."],
             verification_guidance=[
                 "Confirm public CIDR is intentional.",
                 "Restrict ingress to trusted networks.",
@@ -946,6 +950,22 @@ class AnalysesApiTests(unittest.TestCase):
             0.86,
         )
         self.assertEqual(
+            payload["data"]["incident_matches"][0]["confidence_label"],
+            "high",
+        )
+        self.assertEqual(
+            payload["data"]["incident_matches"][0]["matched_signals"],
+            ["0.0.0.0/0", "ssh"],
+        )
+        self.assertEqual(
+            payload["data"]["incident_matches"][0]["affected_services"],
+            ["aws_security_group.main"],
+        )
+        self.assertEqual(
+            payload["data"]["incident_matches"][0]["prevention_notes"],
+            ["Use trusted administrative access."],
+        )
+        self.assertEqual(
             payload["data"]["persisted_report"]["incident_matches"][0][
                 "public_pattern_id"
             ],
@@ -953,6 +973,30 @@ class AnalysesApiTests(unittest.TestCase):
         )
         self.assertTrue(
             payload["data"]["persisted_report"]["incident_matches"][0]["evidence"]
+        )
+        self.assertEqual(
+            payload["data"]["persisted_report"]["incident_matches"][0][
+                "confidence_label"
+            ],
+            "high",
+        )
+        self.assertEqual(
+            payload["data"]["persisted_report"]["incident_matches"][0][
+                "matched_signals"
+            ],
+            ["0.0.0.0/0", "ssh"],
+        )
+        self.assertEqual(
+            payload["data"]["persisted_report"]["incident_matches"][0][
+                "affected_services"
+            ],
+            ["aws_security_group.main"],
+        )
+        self.assertEqual(
+            payload["data"]["persisted_report"]["incident_matches"][0][
+                "prevention_notes"
+            ],
+            ["Use trusted administrative access."],
         )
         self.assertFalse(payload["data"]["persisted_report"]["narrative_degraded"])
         self.assertEqual(

--- a/tests/test_api/test_schemas.py
+++ b/tests/test_api/test_schemas.py
@@ -98,8 +98,12 @@ class ApiSchemaTests(unittest.TestCase):
                 "incident_date": None,
                 "similarity": 0.86,
                 "confidence": 0.86,
+                "confidence_label": "high",
                 "reason": "Public ingress matched a built-in failure mode.",
                 "evidence": ["plan.json: aws_security_group.ssh"],
+                "matched_signals": ["0.0.0.0/0", "ssh"],
+                "affected_services": ["aws_security_group.ssh"],
+                "prevention_notes": ["Use trusted administrative access."],
                 "verification_guidance": ["Restrict SSH ingress."],
                 "summary": "Public risk pattern match.",
             }
@@ -107,7 +111,32 @@ class ApiSchemaTests(unittest.TestCase):
 
         self.assertEqual(match.match_type, "public_risk_pattern")
         self.assertEqual(match.public_pattern_id, "public-ingress-wide-open")
+        self.assertEqual(match.confidence_label, "high")
+        self.assertEqual(match.matched_signals, ["0.0.0.0/0", "ssh"])
+        self.assertEqual(match.affected_services, ["aws_security_group.ssh"])
+        self.assertEqual(match.prevention_notes, ["Use trusted administrative access."])
         self.assertEqual(match.verification_guidance, ["Restrict SSH ingress."])
+
+    def test_incident_match_schema_derives_legacy_confidence_label(self) -> None:
+        match = IncidentMatchData.model_validate(
+            {
+                "incident_id": 0,
+                "match_type": "public_risk_pattern",
+                "public_pattern_id": "public-ingress-wide-open",
+                "title": "Wide-open administrative ingress",
+                "severity": "high",
+                "source_file": "plan.json",
+                "incident_date": None,
+                "similarity": 0.86,
+                "confidence": 0.86,
+                "reason": "Public ingress matched a built-in failure mode.",
+                "evidence": ["plan.json: aws_security_group.ssh"],
+                "verification_guidance": ["Restrict SSH ingress."],
+                "summary": "Public risk pattern match.",
+            }
+        )
+
+        self.assertEqual(match.confidence_label, "high")
 
 
 if __name__ == "__main__":

--- a/tests/test_services/test_report_service.py
+++ b/tests/test_services/test_report_service.py
@@ -3837,10 +3837,14 @@ class ReportServiceTests(unittest.TestCase):
                     incident_date=None,
                     similarity=0.86,
                     confidence=0.86,
+                    confidence_label="high",
                     reason="The change exposes administrative ingress publicly.",
                     evidence=[
                         "plan.json: aws_security_group.main (modify) - public SSH"
                     ],
+                    matched_signals=["0.0.0.0/0", "ssh"],
+                    affected_services=["aws_security_group.main"],
+                    prevention_notes=["Use trusted administrative access."],
                     verification_guidance=[
                         "Confirm public CIDR is intentional.",
                         "Restrict ingress to trusted networks.",
@@ -3896,6 +3900,19 @@ class ReportServiceTests(unittest.TestCase):
             "public-ingress-wide-open",
         )
         self.assertEqual(persisted["incident_matches"][0]["confidence"], 0.86)
+        self.assertEqual(persisted["incident_matches"][0]["confidence_label"], "high")
+        self.assertEqual(
+            persisted["incident_matches"][0]["matched_signals"],
+            ["0.0.0.0/0", "ssh"],
+        )
+        self.assertEqual(
+            persisted["incident_matches"][0]["affected_services"],
+            ["aws_security_group.main"],
+        )
+        self.assertEqual(
+            persisted["incident_matches"][0]["prevention_notes"],
+            ["Use trusted administrative access."],
+        )
         self.assertTrue(persisted["incident_matches"][0]["evidence"])
         self.assertEqual(
             persisted["rollback_plan"]["steps"][0]["estimated_minutes"], 15
@@ -3964,6 +3981,19 @@ class ReportServiceTests(unittest.TestCase):
                 "Confirm public CIDR is intentional.",
                 "Restrict ingress to trusted networks.",
             ],
+        )
+        self.assertEqual(fetched["incident_matches"][0]["confidence_label"], "high")
+        self.assertEqual(
+            fetched["incident_matches"][0]["matched_signals"],
+            ["0.0.0.0/0", "ssh"],
+        )
+        self.assertEqual(
+            fetched["incident_matches"][0]["affected_services"],
+            ["aws_security_group.main"],
+        )
+        self.assertEqual(
+            fetched["incident_matches"][0]["prevention_notes"],
+            ["Use trusted administrative access."],
         )
         self.assertEqual(
             fetched["rollback_plan"]["steps"][0]["title"],

--- a/tests/test_ui/test_incident_match_card.py
+++ b/tests/test_ui/test_incident_match_card.py
@@ -19,6 +19,26 @@ def incident_match_card_test_page() -> None:
     render_incident_matches(
         [
             IncidentMatch(
+                incident_id=17,
+                match_type="organization_incident",
+                title="Checkout ingress exposure",
+                severity="high",
+                source_file="checkout-ingress.md",
+                incident_date="2026-04-20",
+                similarity=0.78,
+                confidence=0.78,
+                confidence_label="high",
+                reason="The change shares organization-specific incident signals.",
+                evidence=["overlap: checkout-api, ingress"],
+                matched_signals=["checkout-api", "ingress"],
+                affected_services=["checkout-api", "edge-router"],
+                prevention_notes=["Restrict administrative access to trusted CIDRs."],
+                verification_guidance=[
+                    "Compare the current change path against the prior incident timeline."
+                ],
+                summary="High-confidence organization-specific incident match.",
+            ),
+            IncidentMatch(
                 incident_id=0,
                 match_type="public_risk_pattern",
                 public_pattern_id="public-ingress-wide-open",
@@ -30,12 +50,15 @@ def incident_match_card_test_page() -> None:
                 confidence=0.86,
                 reason="The change exposes administrative ingress publicly.",
                 evidence=["plan.json: aws_security_group.main (modify) - public SSH"],
+                matched_signals=["0.0.0.0/0", "ssh"],
+                affected_services=["aws_security_group.main"],
+                prevention_notes=["Use a trusted administrative access path."],
                 verification_guidance=[
                     "Confirm public CIDR is intentional.",
                     "Restrict ingress to trusted networks.",
                 ],
                 summary="Public risk pattern match: wide-open administrative ingress.",
-            )
+            ),
         ]
     )
 
@@ -43,6 +66,33 @@ def incident_match_card_test_page() -> None:
 @ui.page("/_test/incident-match-card-empty")
 def incident_match_card_empty_test_page() -> None:
     render_incident_matches([])
+
+
+@ui.page("/_test/incident-match-card-public-only")
+def incident_match_card_public_only_test_page() -> None:
+    render_incident_matches(
+        [
+            IncidentMatch(
+                incident_id=0,
+                match_type="public_risk_pattern",
+                public_pattern_id="public-ingress-wide-open",
+                title="Wide-open administrative ingress",
+                severity="high",
+                source_file="plan.json",
+                incident_date=None,
+                similarity=0.86,
+                confidence=0.86,
+                confidence_label="high",
+                reason="The change exposes administrative ingress publicly.",
+                evidence=["plan.json: aws_security_group.main (modify) - public SSH"],
+                matched_signals=["0.0.0.0/0", "ssh"],
+                affected_services=["aws_security_group.main"],
+                prevention_notes=["Use a trusted administrative access path."],
+                verification_guidance=["Confirm public CIDR is intentional."],
+                summary="Public risk pattern match: wide-open administrative ingress.",
+            )
+        ]
+    )
 
 
 @ui.page("/_test/report-detail-incident-matches")
@@ -100,7 +150,12 @@ class IncidentMatchCardRenderingTests(unittest.TestCase):
 
         self.assertEqual(response.status_code, 200)
         self.assertIn("Incident and risk pattern similarity", response.text)
+        self.assertIn("Organization incident", response.text)
         self.assertIn("Public risk pattern", response.text)
+        self.assertIn("Matched signals:", response.text)
+        self.assertIn("checkout-api", response.text)
+        self.assertIn("Affected services:", response.text)
+        self.assertIn("Prevention notes:", response.text)
         self.assertIn("86% confidence", response.text)
         self.assertIn("Evidence:", response.text)
         self.assertIn("aws_security_group.main", response.text)
@@ -112,7 +167,16 @@ class IncidentMatchCardRenderingTests(unittest.TestCase):
 
         self.assertEqual(response.status_code, 200)
         self.assertIn("Incident and risk pattern similarity", response.text)
-        self.assertIn("No similar incidents found.", response.text)
+        self.assertIn("No organization-specific incident match found.", response.text)
+
+    def test_public_only_card_does_not_claim_prior_incident(self) -> None:
+        response = self.client.get("/_test/incident-match-card-public-only")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("Public risk pattern", response.text)
+        self.assertIn("No organization-specific incident match found.", response.text)
+        self.assertIn("not prior incidents", response.text)
+        self.assertNotIn("Organization incident", response.text)
 
     def test_report_detail_renders_persisted_public_risk_pattern(self) -> None:
         response = self.client.get("/_test/report-detail-incident-matches")

--- a/ui/components/incident_match_card.py
+++ b/ui/components/incident_match_card.py
@@ -14,8 +14,17 @@ def render_incident_matches(matches: list[IncidentMatch]) -> None:
             "text-lg font-medium dw-text"
         )
         if not matches:
-            ui.label("No similar incidents found.").classes("text-sm dw-muted")
+            ui.label("No organization-specific incident match found.").classes(
+                "text-sm dw-muted"
+            )
             return
+        has_organization_match = any(
+            match.match_type == "organization_incident" for match in matches
+        )
+        if not has_organization_match:
+            ui.label(
+                "No organization-specific incident match found. Public risk patterns are general guidance, not prior incidents."
+            ).classes("text-sm dw-muted")
         with ui.column().classes("w-full gap-3"):
             for match in matches:
                 with ui.row().classes(
@@ -31,6 +40,10 @@ def render_incident_matches(matches: list[IncidentMatch]) -> None:
                         with ui.row().classes("items-center gap-2"):
                             ui.label(match.title).classes("text-sm font-medium dw-text")
                             render_risk_badge(match.severity, match.severity)
+                            if match.match_type == "organization_incident":
+                                ui.label("Organization incident").classes(
+                                    "text-xs dw-muted"
+                                )
                             if match.match_type == "public_risk_pattern":
                                 ui.label("Public risk pattern").classes(
                                     "text-xs dw-muted"
@@ -42,6 +55,20 @@ def render_incident_matches(matches: list[IncidentMatch]) -> None:
                         ui.label(match.summary).classes("text-sm dw-muted")
                         if match.reason:
                             ui.label(match.reason).classes("text-sm dw-muted")
+                        if match.matched_signals:
+                            ui.label(
+                                f"Matched signals: {', '.join(match.matched_signals)}"
+                            ).classes("text-xs dw-muted")
+                        if match.affected_services:
+                            ui.label(
+                                f"Affected services: {', '.join(match.affected_services)}"
+                            ).classes("text-xs dw-muted")
+                        if match.prevention_notes:
+                            ui.label("Prevention notes:").classes(
+                                "text-xs font-medium dw-text"
+                            )
+                            for note in match.prevention_notes:
+                                ui.label(note).classes("text-xs dw-muted")
                         for evidence in match.evidence:
                             ui.label(f"Evidence: {evidence}").classes(
                                 "text-xs dw-muted"


### PR DESCRIPTION
Story 4.4 adds explicit match explanation fields so reviewers can see confidence, matched signals, affected services, and prevention guidance while keeping public risk patterns distinct from organization incident memory. The matcher now requires real overlap or service evidence for organization incidents, uses token/path segment service matching, accepts common markdown heading variants, and preserves legacy confidence labels from numeric confidence.

Constraint: Story 4.4 requires weak or missing organization matches to avoid implying prior incidents when only public patterns apply
Rejected: Keep substring service matching | short service names could boost unrelated resources
Rejected: Drop weak organization matches entirely | AC2 allows low-confidence labeling for weak real signals
Confidence: high
Scope-risk: moderate
Directive: Do not present public_risk_pattern matches as organization incident history
Tested: ./.venv/bin/python -m unittest tests.test_analysis.test_incident_matcher tests.test_api.test_schemas tests.test_api.test_analyses tests.test_services.test_report_service tests.test_ui.test_incident_match_card -q
Tested: ./.venv/bin/python -m unittest discover -q
Tested: ./.venv/bin/ruff check .
Tested: ./.venv/bin/ruff format --check .
Tested: ./.venv/bin/bandit -q analysis/incident_matcher.py api/schemas.py ui/components/incident_match_card.py
Tested: APP_PORT=18080 npm run test:ui-review
Not-tested: Repo-wide Bandit still has pre-existing unrelated findings recorded in the story

## What does this PR do?

<!-- Brief description of changes -->

## Type of change
- [ ] Feature (new functionality)
- [ ] Bugfix (non-breaking fix)
- [ ] Release preparation
- [ ] Hotfix (critical production fix)
- [ ] Docs / refactor / chore

## Checklist
- [ ] I have followed the branch naming convention
- [ ] Tests pass locally (`pytest tests/ -v`)
- [ ] Linting passes (`ruff check .`)
- [ ] Docker build succeeds
- [ ] I have updated docs if needed
- [ ] No secrets or .env values committed

## Related issue
Closes #