### PR TITLE
Capture reviewer feedback for calibration

### DIFF
--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -1,5 +1,5 @@
 # generated: 2026-05-01
-# last_updated: 2026-05-21
+# last_updated: 2026-05-22
 # project: deploywhisper
 # project_key: NOKEY
 # tracking_system: file-system
@@ -35,7 +35,7 @@
 # - Dev moves story to review, then runs code-review
 
 generated: 2026-05-01
-last_updated: 2026-05-21
+last_updated: 2026-05-22
 project: deploywhisper
 project_key: NOKEY
 tracking_system: file-system
@@ -86,7 +86,7 @@ development_status:
   4-2-safe-sample-incident-pack: done
   4-3-incident-import-for-markdown-yaml-and-json: done
   4-4-incident-similarity-with-match-explanation: done
-  4-5-reviewer-feedback-capture: ready-for-dev
+  4-5-reviewer-feedback-capture: done
   4-6-deployment-outcome-capture: ready-for-dev
   4-7-incident-ingestion-management-and-indexing: ready-for-dev
   epic-4-retrospective: optional

--- a/docs/reviewer-feedback.md
+++ b/docs/reviewer-feedback.md
@@ -7,9 +7,10 @@ DeployWhisper now captures reviewer feedback for persisted analysis reports so t
 - Open a saved report in the main review UI.
 - Use the **Reviewer feedback** section to record:
   - `Thumbs up` when a finding was useful
-  - `Thumbs down` when a finding was not useful
+  - `Mark noisy` when a finding was not useful but was not a false positive
   - `Mark false positive` with an optional reason when the finding should not have been surfaced
-  - `Missed finding note` when the report failed to call out an important risk
+  - `Missed finding note` on the finding being reviewed when the report failed to call out an important risk
+  - `Report-level missed finding note` when a clean report has no findings but still missed an important risk
 
 The live dashboard review surface and the full history detail page both expose the same feedback controls.
 
@@ -20,14 +21,17 @@ The live dashboard review surface and the full history detail page both expose t
   - `finding_id`
   - `false_positive_reason`
 - Feedback stays project-scoped by deriving the owning workspace from the persisted `analysis_id`.
-- Finding feedback is validated against the findings stored on the target report before persistence.
+- Finding feedback and finding-level missed-risk notes are validated against the findings stored on the target report before persistence.
+- Clean reports with no findings can still store a report-scoped missed-risk note.
+- Feedback events are append-only calibration inputs; they do not rewrite the historical report verdict, severity, recommendation, or confidence.
 
 ## Admin Summary
 
 - The **Settings** page now shows a **Reviewer feedback summary** card for the active project.
+- The settings summary is an all-workspaces aggregate for the active project.
 - The summary reports:
   - useful findings
-  - not useful findings
+  - noisy findings
   - false positives
   - missed findings
   - recent reviewer notes

--- a/services/feedback_service.py
+++ b/services/feedback_service.py
@@ -108,6 +108,11 @@ def record_finding_feedback(
             "invalid_feedback_request",
             "False positive reason requires false_positive_flag=True.",
         )
+    if false_positive_flag and useful:
+        raise FeedbackError(
+            "invalid_feedback_request",
+            "False positive feedback requires useful=False.",
+        )
     with SessionLocal() as session:
         report = get_analysis_report(session, analysis_id, include_evidence=False)
         if report is None:
@@ -122,11 +127,7 @@ def record_finding_feedback(
                 f"Finding not found on analysis report {analysis_id}: {normalized_finding_id}.",
             )
         outcome_label = (
-            "false_positive"
-            if false_positive_flag
-            else "useful"
-            if useful
-            else "not_useful"
+            "false_positive" if false_positive_flag else "useful" if useful else "noisy"
         )
         event = create_feedback_event(
             session,
@@ -147,9 +148,11 @@ def record_finding_feedback(
 def record_false_negative_feedback(
     *,
     analysis_id: int,
+    finding_id: str | None = None,
     note: str,
     reviewer_role: str = "reviewer",
 ) -> dict[str, Any]:
+    normalized_finding_id = str(finding_id or "").strip()
     normalized_note = _normalize_optional_text(note)
     if normalized_note is None:
         raise FeedbackError(
@@ -163,11 +166,27 @@ def record_false_negative_feedback(
                 "analysis_not_found",
                 f"Analysis report not found: {analysis_id}.",
             )
+        finding_ids = {finding.finding_id for finding in report.findings}
+        if normalized_finding_id:
+            if normalized_finding_id not in finding_ids:
+                raise FeedbackError(
+                    "finding_not_found",
+                    f"Finding not found on analysis report {analysis_id}: {normalized_finding_id}.",
+                )
+            stored_finding_id: str | None = normalized_finding_id
+        elif finding_ids:
+            raise FeedbackError(
+                "invalid_feedback_request",
+                "finding_id is required when a report has findings.",
+            )
+        else:
+            stored_finding_id = None
         event = create_feedback_event(
             session,
             project_id=report.project_id,
             workspace_id=report.workspace_id,
             analysis_id=analysis_id,
+            finding_id=stored_finding_id,
             reviewer_role=reviewer_role,
             false_negative_note=normalized_note,
             outcome_label="missed",
@@ -185,15 +204,26 @@ def fetch_report_feedback_state(analysis_id: int) -> dict[str, Any]:
             )
         events = list_feedback_events(session, analysis_id=analysis_id)
     finding_feedback: dict[str, dict[str, Any]] = {}
+    false_negative_by_finding: dict[str, dict[str, Any]] = {}
     false_negative_notes: list[dict[str, Any]] = []
     for event in events:
         serialized = _serialize_event(event)
-        if event.finding_id is not None and event.finding_id not in finding_feedback:
+        if (
+            event.finding_id is not None
+            and event.false_negative_note is None
+            and event.finding_id not in finding_feedback
+        ):
             finding_feedback[event.finding_id] = serialized
         if event.false_negative_note:
             false_negative_notes.append(serialized)
+            if (
+                event.finding_id is not None
+                and event.finding_id not in false_negative_by_finding
+            ):
+                false_negative_by_finding[event.finding_id] = serialized
     return {
         "finding_feedback": finding_feedback,
+        "false_negative_by_finding": false_negative_by_finding,
         "false_negative_notes": false_negative_notes,
     }
 
@@ -219,10 +249,10 @@ def fetch_feedback_summary(
         )
 
     latest_finding_feedback: dict[tuple[int | None, str], Any] = {}
-    latest_false_negative_by_report: dict[int | None, Any] = {}
+    latest_false_negative_by_scope: dict[tuple[int | None, str | None], Any] = {}
     recent_notes: list[dict[str, Any]] = []
     for event in events:
-        if event.finding_id is not None:
+        if event.finding_id is not None and event.false_negative_note is None:
             latest_finding_feedback.setdefault(
                 (event.analysis_id, event.finding_id), event
             )
@@ -237,7 +267,9 @@ def fetch_feedback_summary(
                     }
                 )
         if event.false_negative_note:
-            latest_false_negative_by_report.setdefault(event.analysis_id, event)
+            latest_false_negative_by_scope.setdefault(
+                (event.analysis_id, event.finding_id), event
+            )
             recent_notes.append(
                 {
                     "type": "missed_finding",
@@ -250,7 +282,12 @@ def fetch_feedback_summary(
 
     latest_events = list(latest_finding_feedback.values())
     useful_count = sum(1 for event in latest_events if event.useful is True)
-    not_useful_count = sum(1 for event in latest_events if event.useful is False)
+    noisy_count = sum(
+        1
+        for event in latest_events
+        if event.useful is False and not bool(event.false_positive_flag)
+    )
+    not_useful_count = noisy_count
     false_positive_count = sum(
         1 for event in latest_events if bool(event.false_positive_flag)
     )
@@ -260,9 +297,10 @@ def fetch_feedback_summary(
         "project": build_project_payload(project),
         "current_state": {
             "useful_count": useful_count,
+            "noisy_count": noisy_count,
             "not_useful_count": not_useful_count,
             "false_positive_count": false_positive_count,
-            "missed_finding_count": len(latest_false_negative_by_report),
+            "missed_finding_count": len(latest_false_negative_by_scope),
         },
         "totals": {
             "events_recorded": len(events),

--- a/tests/test_services/test_feedback_service.py
+++ b/tests/test_services/test_feedback_service.py
@@ -98,6 +98,41 @@ class FeedbackServiceTests(unittest.TestCase):
         os.environ.pop("DATABASE_URL", None)
         self.tempdir.cleanup()
 
+    def _persist_clean_report(self) -> dict:
+        return report_service_module.persist_analysis_report(
+            ParseBatchResult(
+                files=[
+                    ParsedFileResult(
+                        file_name="payments-clean.tf",
+                        tool="terraform",
+                        status="parsed",
+                        changes=[],
+                    )
+                ]
+            ),
+            RiskAssessment(
+                score=12,
+                severity="low",
+                recommendation="go",
+                top_risk="No findings detected.",
+                contributors=[],
+                interaction_risks=[],
+                partial_context=False,
+                warnings=[],
+            ),
+            NarrativeResult(
+                opening_sentence="GO: no findings detected.",
+                explanation="Clean feedback test report.",
+                guidance=[],
+                degraded=False,
+                warnings=[],
+            ),
+            findings=[],
+            project_id=self.project.id,
+            workspace_id=self.workspace.id,
+            audit_context={"source_interface": "ui"},
+        )
+
     def test_record_finding_feedback_persists_useful_and_false_positive_reason(
         self,
     ) -> None:
@@ -120,21 +155,126 @@ class FeedbackServiceTests(unittest.TestCase):
             "Known compensating control already covers this.",
         )
 
-    def test_record_false_negative_feedback_persists_report_level_note(self) -> None:
+    def test_record_finding_feedback_persists_noisy_outcome_without_changing_report(
+        self,
+    ) -> None:
+        before = report_service_module.fetch_analysis_report(self.report["id"])
+
+        event = feedback_service_module.record_finding_feedback(
+            analysis_id=self.report["id"],
+            finding_id=self.finding_id,
+            useful=False,
+        )
+        after = report_service_module.fetch_analysis_report(self.report["id"])
+
+        self.assertEqual(event["analysis_id"], self.report["id"])
+        self.assertEqual(event["project_id"], self.project.id)
+        self.assertEqual(event["workspace_id"], self.workspace.id)
+        self.assertEqual(event["finding_id"], self.finding_id)
+        self.assertFalse(event["useful"])
+        self.assertEqual(event["outcome_label"], "noisy")
+        self.assertIsNotNone(before)
+        self.assertIsNotNone(after)
+        if before is None or after is None:
+            self.fail("Expected persisted report before and after feedback.")
+        self.assertEqual(after["risk_score"], before["risk_score"])
+        self.assertEqual(after["severity"], before["severity"])
+        self.assertEqual(after["recommendation"], before["recommendation"])
+        self.assertEqual(after["confidence"], before["confidence"])
+        summary = feedback_service_module.fetch_feedback_summary(
+            project_id=self.project.id,
+            workspace_id=self.workspace.id,
+        )
+        self.assertEqual(summary["current_state"]["noisy_count"], 1)
+        self.assertEqual(summary["current_state"]["not_useful_count"], 1)
+        self.assertEqual(summary["current_state"]["false_positive_count"], 0)
+
+    def test_record_finding_feedback_rejects_useful_false_positive(self) -> None:
+        with self.assertRaises(feedback_service_module.FeedbackError) as context:
+            feedback_service_module.record_finding_feedback(
+                analysis_id=self.report["id"],
+                finding_id=self.finding_id,
+                useful=True,
+                false_positive_flag=True,
+            )
+
+        self.assertEqual(context.exception.code, "invalid_feedback_request")
+
+    def test_record_false_negative_feedback_persists_finding_level_note(self) -> None:
         event = feedback_service_module.record_false_negative_feedback(
             analysis_id=self.report["id"],
+            finding_id=self.finding_id,
             note="Missed the lack of rollback alarms on the payments API.",
         )
 
         self.assertEqual(event["analysis_id"], self.report["id"])
         self.assertEqual(event["project_id"], self.project.id)
         self.assertEqual(event["workspace_id"], self.workspace.id)
-        self.assertIsNone(event["finding_id"])
+        self.assertEqual(event["finding_id"], self.finding_id)
         self.assertEqual(
             event["false_negative_note"],
             "Missed the lack of rollback alarms on the payments API.",
         )
         self.assertEqual(event["outcome_label"], "missed")
+        state = feedback_service_module.fetch_report_feedback_state(self.report["id"])
+        self.assertEqual(
+            state["false_negative_by_finding"][self.finding_id]["false_negative_note"],
+            "Missed the lack of rollback alarms on the payments API.",
+        )
+
+    def test_report_feedback_state_uses_latest_finding_level_missed_note(self) -> None:
+        feedback_service_module.record_false_negative_feedback(
+            analysis_id=self.report["id"],
+            finding_id=self.finding_id,
+            note="Older missed rollback note.",
+        )
+        feedback_service_module.record_false_negative_feedback(
+            analysis_id=self.report["id"],
+            finding_id=self.finding_id,
+            note="Latest missed rollback note.",
+        )
+
+        state = feedback_service_module.fetch_report_feedback_state(self.report["id"])
+
+        self.assertEqual(
+            state["false_negative_by_finding"][self.finding_id]["false_negative_note"],
+            "Latest missed rollback note.",
+        )
+
+    def test_record_false_negative_feedback_persists_report_level_note_for_clean_report(
+        self,
+    ) -> None:
+        clean_report = self._persist_clean_report()
+
+        event = feedback_service_module.record_false_negative_feedback(
+            analysis_id=clean_report["id"],
+            note="Missed a cross-service rollback dependency.",
+        )
+
+        self.assertEqual(event["analysis_id"], clean_report["id"])
+        self.assertEqual(event["project_id"], self.project.id)
+        self.assertEqual(event["workspace_id"], self.workspace.id)
+        self.assertIsNone(event["finding_id"])
+        self.assertEqual(
+            event["false_negative_note"],
+            "Missed a cross-service rollback dependency.",
+        )
+        summary = feedback_service_module.fetch_feedback_summary(
+            project_id=self.project.id,
+            workspace_id=self.workspace.id,
+        )
+        self.assertEqual(summary["current_state"]["missed_finding_count"], 1)
+
+    def test_record_false_negative_feedback_requires_finding_when_report_has_findings(
+        self,
+    ) -> None:
+        with self.assertRaises(feedback_service_module.FeedbackError) as ctx:
+            feedback_service_module.record_false_negative_feedback(
+                analysis_id=self.report["id"],
+                note="Missed a rollback dependency.",
+            )
+
+        self.assertEqual(ctx.exception.code, "invalid_feedback_request")
 
     def test_feedback_summary_uses_latest_finding_feedback_state(self) -> None:
         feedback_service_module.record_finding_feedback(
@@ -151,6 +291,7 @@ class FeedbackServiceTests(unittest.TestCase):
         )
         feedback_service_module.record_false_negative_feedback(
             analysis_id=self.report["id"],
+            finding_id=self.finding_id,
             note="Missed a payments failover prerequisite.",
         )
 
@@ -161,13 +302,38 @@ class FeedbackServiceTests(unittest.TestCase):
 
         self.assertEqual(summary["project"]["project_key"], "payments")
         self.assertEqual(summary["current_state"]["useful_count"], 0)
-        self.assertEqual(summary["current_state"]["not_useful_count"], 1)
+        self.assertEqual(summary["current_state"]["not_useful_count"], 0)
+        self.assertEqual(summary["current_state"]["noisy_count"], 0)
         self.assertEqual(summary["current_state"]["false_positive_count"], 1)
         self.assertEqual(summary["current_state"]["missed_finding_count"], 1)
         self.assertEqual(summary["totals"]["events_recorded"], 3)
         self.assertIn(
             "payments failover prerequisite", summary["recent_notes"][0]["text"]
         )
+
+    def test_feedback_summary_counts_legacy_not_useful_events_as_noisy(self) -> None:
+        with database_module.SessionLocal() as session:
+            session.add(
+                tables_module.FeedbackEvent(
+                    project_id=self.project.id,
+                    workspace_id=self.workspace.id,
+                    analysis_id=self.report["id"],
+                    finding_id=self.finding_id,
+                    useful=False,
+                    correctness_rating=0,
+                    outcome_label="not_useful",
+                )
+            )
+            session.commit()
+
+        summary = feedback_service_module.fetch_feedback_summary(
+            project_id=self.project.id,
+            workspace_id=self.workspace.id,
+        )
+
+        self.assertEqual(summary["current_state"]["noisy_count"], 1)
+        self.assertEqual(summary["current_state"]["not_useful_count"], 1)
+        self.assertEqual(summary["current_state"]["false_positive_count"], 0)
 
     def test_feedback_summary_filters_by_workspace(self) -> None:
         staging_workspace = project_service_module.create_workspace(
@@ -241,6 +407,7 @@ class FeedbackServiceTests(unittest.TestCase):
         self.assertEqual(summary["totals"]["events_recorded"], 1)
         self.assertEqual(summary["current_state"]["useful_count"], 1)
         self.assertEqual(summary["current_state"]["not_useful_count"], 0)
+        self.assertEqual(summary["current_state"]["noisy_count"], 0)
 
     def test_record_finding_feedback_rejects_unknown_finding(self) -> None:
         with self.assertRaises(feedback_service_module.FeedbackError) as ctx:
@@ -248,6 +415,16 @@ class FeedbackServiceTests(unittest.TestCase):
                 analysis_id=self.report["id"],
                 finding_id="missing-finding",
                 useful=True,
+            )
+
+        self.assertEqual(ctx.exception.code, "finding_not_found")
+
+    def test_record_false_negative_feedback_rejects_unknown_finding(self) -> None:
+        with self.assertRaises(feedback_service_module.FeedbackError) as ctx:
+            feedback_service_module.record_false_negative_feedback(
+                analysis_id=self.report["id"],
+                finding_id="missing-finding",
+                note="Missed a rollback dependency.",
             )
 
         self.assertEqual(ctx.exception.code, "finding_not_found")

--- a/tests/test_ui/test_app_shell.py
+++ b/tests/test_ui/test_app_shell.py
@@ -413,7 +413,7 @@ class DashboardShellTests(unittest.TestCase):
         self.assertIn("Findings table", response.text)
         self.assertIn("Reviewer feedback", response.text)
         self.assertIn("Thumbs up", response.text)
-        self.assertIn("Thumbs down", response.text)
+        self.assertIn("Mark noisy", response.text)
         self.assertIn("Missed finding note", response.text)
         self.assertIn("Severity", response.text)
         self.assertIn("Evidence", response.text)

--- a/tests/test_ui/test_history_page.py
+++ b/tests/test_ui/test_history_page.py
@@ -15,6 +15,7 @@ import models.database as database_module
 import models.repositories.analysis_reports as analysis_reports_repository_module
 import models.tables as tables_module
 import services.deployment_outcome_service as deployment_outcome_service_module
+import services.feedback_service as feedback_service_module
 import services.report_service as report_service_module
 import services.project_service as project_service_module
 import ui.components.report_detail_page as report_detail_page_module
@@ -940,6 +941,8 @@ class HistoryPageRenderingTests(unittest.TestCase):
         reload(analysis_reports_repository_module)
         reload(project_service_module)
         reload(report_service_module)
+        reload(feedback_service_module)
+        reload(report_detail_page_module)
         reload(history_module)
         reload(app_module)
         database_module.init_db()
@@ -968,6 +971,7 @@ class HistoryPageRenderingTests(unittest.TestCase):
         workspace_id: int | None = None,
         tool: str = "terraform",
         incident_matches: list[IncidentMatch] | None = None,
+        include_finding: bool = True,
     ) -> dict:
         source_file = "plan.json" if tool == "terraform" else f"{tool}-review.yaml"
         parse_batch = ParseBatchResult(
@@ -1033,6 +1037,45 @@ class HistoryPageRenderingTests(unittest.TestCase):
             local_mode=True,
             skills_applied=["git", "terraform"],
         )
+        findings = (
+            [
+                Finding(
+                    finding_id="finding-001",
+                    analysis_id=0,
+                    title=f"{severity.upper()}: aws_security_group.main",
+                    description=finding_description,
+                    severity=severity,
+                    category="networking/ingress",
+                    deterministic=True,
+                    confidence=finding_confidence,
+                    uncertainty_note=None,
+                    evidence_refs=["ev-001"],
+                    skill_id=None,
+                )
+            ]
+            if include_finding
+            else []
+        )
+        evidence_items = (
+            [
+                EvidenceItem(
+                    evidence_id="ev-001",
+                    analysis_id=0,
+                    finding_id="pending:change-1",
+                    source_type="artifact",
+                    source_ref=(
+                        "terraform://plan.json#aws_security_group.main?action=modify"
+                    ),
+                    summary="Terraform changed a security group.",
+                    severity_hint=severity,
+                    deterministic=True,
+                    confidence=1.0,
+                    related_change_ids=["change-1"],
+                )
+            ]
+            if include_finding
+            else []
+        )
         return report_service_module.persist_analysis_report(
             parse_batch,
             assessment,
@@ -1054,37 +1097,8 @@ class HistoryPageRenderingTests(unittest.TestCase):
                 ),
                 warning=None,
             ),
-            findings=[
-                Finding(
-                    finding_id="finding-001",
-                    analysis_id=0,
-                    title=f"{severity.upper()}: aws_security_group.main",
-                    description=finding_description,
-                    severity=severity,
-                    category="networking/ingress",
-                    deterministic=True,
-                    confidence=finding_confidence,
-                    uncertainty_note=None,
-                    evidence_refs=["ev-001"],
-                    skill_id=None,
-                )
-            ],
-            evidence_items=[
-                EvidenceItem(
-                    evidence_id="ev-001",
-                    analysis_id=0,
-                    finding_id="pending:change-1",
-                    source_type="artifact",
-                    source_ref=(
-                        "terraform://plan.json#aws_security_group.main?action=modify"
-                    ),
-                    summary="Terraform changed a security group.",
-                    severity_hint=severity,
-                    deterministic=True,
-                    confidence=1.0,
-                    related_change_ids=["change-1"],
-                )
-            ],
+            findings=findings,
+            evidence_items=evidence_items,
             audit_context={"source_interface": "ui"},
             project_id=project_id,
             workspace_id=workspace_id,
@@ -1353,7 +1367,7 @@ class HistoryPageRenderingTests(unittest.TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertIn("Reviewer feedback", response.text)
         self.assertIn("Thumbs up", response.text)
-        self.assertIn("Thumbs down", response.text)
+        self.assertIn("Mark noisy", response.text)
         self.assertIn("False positive reason", response.text)
         self.assertIn("Missed finding note", response.text)
         self.assertIn("Why is it risky?", response.text)
@@ -1365,6 +1379,90 @@ class HistoryPageRenderingTests(unittest.TestCase):
         self.assertIn(
             "Review the security group change before deployment.", response.text
         )
+
+    def test_history_detail_route_labels_false_positive_without_noisy_status(
+        self,
+    ) -> None:
+        report = self._persist_report()
+        feedback_service_module.record_finding_feedback(
+            analysis_id=report["id"],
+            finding_id=report["findings"][0]["finding_id"],
+            useful=False,
+            false_positive_flag=True,
+            false_positive_reason="Compensating control already approved.",
+        )
+
+        response = self.client.get(f"/history/{report['id']}")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("Latest vote: false positive", response.text)
+        self.assertNotIn("Latest vote: noisy", response.text)
+
+    def test_history_detail_route_shows_finding_scoped_missed_note(self) -> None:
+        report = self._persist_report()
+        feedback_service_module.record_false_negative_feedback(
+            analysis_id=report["id"],
+            finding_id=report["findings"][0]["finding_id"],
+            note="Missed rollback alarm dependency.",
+        )
+
+        response = self.client.get(f"/history/{report['id']}")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("Latest note: Missed rollback alarm dependency.", response.text)
+
+    def test_history_detail_route_shows_legacy_report_level_missed_note(self) -> None:
+        report = self._persist_report()
+        with database_module.SessionLocal() as session:
+            session.add(
+                tables_module.FeedbackEvent(
+                    project_id=report["project"]["id"],
+                    workspace_id=(
+                        report["workspace"]["id"]
+                        if report.get("workspace") is not None
+                        else None
+                    ),
+                    analysis_id=report["id"],
+                    false_negative_note="Legacy report-level missed rollback dependency.",
+                    outcome_label="missed",
+                )
+            )
+            session.commit()
+
+        response = self.client.get(f"/history/{report['id']}")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("Report-level missed finding notes", response.text)
+        self.assertIn(
+            "Legacy note: Legacy report-level missed rollback dependency.",
+            response.text,
+        )
+
+    def test_history_detail_route_shows_report_level_missed_note_for_clean_report(
+        self,
+    ) -> None:
+        report = self._persist_report(
+            severity="low",
+            recommendation="go",
+            top_risk="No findings detected.",
+            opening_sentence="GO: no findings detected.",
+            include_finding=False,
+        )
+        feedback_service_module.record_false_negative_feedback(
+            analysis_id=report["id"],
+            note="Missed cross-service rollback dependency.",
+        )
+
+        response = self.client.get(f"/history/{report['id']}")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("Report-level missed finding note", response.text)
+        self.assertIn("Missed finding note", response.text)
+        self.assertIn(
+            "Latest note: Missed cross-service rollback dependency.",
+            response.text,
+        )
+        self.assertIn("Save missed finding note", response.text)
 
     def test_history_detail_route_hides_report_from_other_active_project(self) -> None:
         self._persist_report()

--- a/tests/test_ui/test_settings_page.py
+++ b/tests/test_ui/test_settings_page.py
@@ -68,6 +68,8 @@ class SettingsPageTests(unittest.TestCase):
         self.assertIn("Drift check cadence", response.text)
         self.assertIn("Topology drift", response.text)
         self.assertIn("Reviewer feedback summary", response.text)
+        self.assertIn("all-workspaces summary", response.text)
+        self.assertIn("Noisy", response.text)
 
     def test_settings_page_lists_drift_resource_names(self) -> None:
         project = project_service_module.create_project(

--- a/ui/components/report_detail_page.py
+++ b/ui/components/report_detail_page.py
@@ -599,11 +599,14 @@ def render_reviewer_feedback_panel(
 ) -> None:
     feedback_state = fetch_report_feedback_state(int(report["id"]))
     latest_finding_feedback = feedback_state["finding_feedback"]
-    latest_false_negative = (
-        feedback_state["false_negative_notes"][0]
-        if feedback_state["false_negative_notes"]
-        else None
+    latest_false_negative_by_finding = feedback_state.get(
+        "false_negative_by_finding", {}
     )
+    legacy_false_negative_notes = [
+        note
+        for note in feedback_state.get("false_negative_notes", [])
+        if note.get("finding_id") is None
+    ]
 
     def submit_finding_feedback(
         *,
@@ -629,10 +632,11 @@ def render_reviewer_feedback_panel(
         if on_feedback_change is not None:
             on_feedback_change()
 
-    def submit_false_negative(note_input) -> None:
+    def submit_false_negative(*, finding_id: str | None = None, note_input) -> None:
         try:
             record_false_negative_feedback(
                 analysis_id=int(report["id"]),
+                finding_id=finding_id,
                 note=note_input.value,
             )
         except FeedbackError as exc:
@@ -657,6 +661,9 @@ def render_reviewer_feedback_panel(
             for finding in report.get("findings", []):
                 finding_id = str(finding["finding_id"])
                 current_feedback = latest_finding_feedback.get(finding_id)
+                current_missed_feedback = latest_false_negative_by_finding.get(
+                    finding_id
+                )
                 with ui.card().classes("w-full dw-panel-soft shadow-none"):
                     with ui.column().classes("gap-3 p-4"):
                         ui.label(finding["title"]).classes(
@@ -664,12 +671,12 @@ def render_reviewer_feedback_panel(
                         )
                         if current_feedback is not None:
                             status_bits = []
-                            if current_feedback.get("useful") is True:
+                            if current_feedback.get("false_positive_flag"):
+                                status_bits.append("Latest vote: false positive")
+                            elif current_feedback.get("useful") is True:
                                 status_bits.append("Latest vote: useful")
                             elif current_feedback.get("useful") is False:
-                                status_bits.append("Latest vote: not useful")
-                            if current_feedback.get("false_positive_flag"):
-                                status_bits.append("Marked false positive")
+                                status_bits.append("Latest vote: noisy")
                             ui.label(" · ".join(status_bits)).classes(
                                 "text-xs dw-muted"
                             )
@@ -682,7 +689,7 @@ def render_reviewer_feedback_panel(
                                 ),
                             ).props("outline no-caps").classes("dw-theme-button")
                             ui.button(
-                                "Thumbs down",
+                                "Mark noisy",
                                 on_click=lambda fid=finding_id: submit_finding_feedback(
                                     finding_id=fid,
                                     useful=False,
@@ -711,34 +718,88 @@ def render_reviewer_feedback_panel(
                                 )
                             ),
                         ).props("outline no-caps").classes("dw-danger-button")
-            with ui.card().classes("w-full dw-panel-soft shadow-none"):
-                with ui.column().classes("gap-3 p-4"):
-                    ui.label("Missed finding note").classes(
-                        "text-sm font-semibold dw-text"
-                    )
-                    if latest_false_negative is not None:
-                        ui.label(
-                            "Latest note: "
-                            + str(latest_false_negative["false_negative_note"])
-                        ).classes("text-xs dw-muted")
-                    missed_note = (
-                        ui.textarea(
-                            label="Missed finding note",
-                            value=(
-                                latest_false_negative.get("false_negative_note")
-                                if latest_false_negative is not None
-                                else ""
-                            ),
+                        ui.label("Missed finding note").classes(
+                            "text-sm font-semibold dw-text"
                         )
-                        .props("outlined autogrow")
-                        .classes("w-full")
-                    )
-                    ui.button(
-                        "Save missed finding note",
-                        on_click=lambda note_input=missed_note: submit_false_negative(
-                            note_input
-                        ),
-                    ).props("outline no-caps").classes("dw-theme-button")
+                        if current_missed_feedback is not None:
+                            ui.label(
+                                "Latest note: "
+                                + str(current_missed_feedback["false_negative_note"])
+                            ).classes("text-xs dw-muted")
+                        missed_note = (
+                            ui.textarea(
+                                label="Missed finding note",
+                                value=(
+                                    current_missed_feedback.get("false_negative_note")
+                                    if current_missed_feedback is not None
+                                    else ""
+                                ),
+                            )
+                            .props("outlined autogrow")
+                            .classes("w-full")
+                        )
+                        ui.button(
+                            "Save missed finding note",
+                            on_click=lambda fid=finding_id, note_input=missed_note: (
+                                submit_false_negative(
+                                    finding_id=fid,
+                                    note_input=note_input,
+                                )
+                            ),
+                        ).props("outline no-caps").classes("dw-theme-button")
+            if not report.get("findings"):
+                current_report_missed_feedback = (
+                    legacy_false_negative_notes[0]
+                    if legacy_false_negative_notes
+                    else None
+                )
+                with ui.card().classes("w-full dw-panel-soft shadow-none"):
+                    with ui.column().classes("gap-3 p-4"):
+                        ui.label("Report-level missed finding note").classes(
+                            "text-sm font-semibold dw-text"
+                        )
+                        ui.label(
+                            "Record an important risk that this report did not surface."
+                        ).classes("text-sm dw-muted")
+                        if current_report_missed_feedback is not None:
+                            ui.label(
+                                "Latest note: "
+                                + str(
+                                    current_report_missed_feedback[
+                                        "false_negative_note"
+                                    ]
+                                )
+                            ).classes("text-xs dw-muted")
+                        report_missed_note = (
+                            ui.textarea(
+                                label="Missed finding note",
+                                value=(
+                                    current_report_missed_feedback.get(
+                                        "false_negative_note"
+                                    )
+                                    if current_report_missed_feedback is not None
+                                    else ""
+                                ),
+                            )
+                            .props("outlined autogrow")
+                            .classes("w-full")
+                        )
+                        ui.button(
+                            "Save missed finding note",
+                            on_click=lambda note_input=report_missed_note: (
+                                submit_false_negative(note_input=note_input)
+                            ),
+                        ).props("outline no-caps").classes("dw-theme-button")
+            if legacy_false_negative_notes and report.get("findings"):
+                with ui.card().classes("w-full dw-panel-soft shadow-none"):
+                    with ui.column().classes("gap-3 p-4"):
+                        ui.label("Report-level missed finding notes").classes(
+                            "text-sm font-semibold dw-text"
+                        )
+                        for note in legacy_false_negative_notes:
+                            ui.label(
+                                "Legacy note: " + str(note["false_negative_note"])
+                            ).classes("text-xs dw-muted leading-5")
 
 
 def render_report_detail_page(

--- a/ui/routes/settings.py
+++ b/ui/routes/settings.py
@@ -35,6 +35,7 @@ def _empty_feedback_summary() -> dict[str, Any]:
     return {
         "current_state": {
             "useful_count": 0,
+            "noisy_count": 0,
             "not_useful_count": 0,
             "false_positive_count": 0,
             "missed_finding_count": 0,
@@ -616,14 +617,17 @@ def build_settings_page() -> None:
                     "text-lg font-medium dw-text"
                 )
                 ui.label(
-                    "Admin-facing summary of the latest reviewer feedback state for the active project."
+                    "Admin-facing all-workspaces summary of the latest reviewer feedback state for the active project."
                 ).classes("text-sm dw-muted")
                 with ui.row().classes("w-full items-stretch gap-2 flex-wrap mt-3"):
                     metrics = [
                         ("Useful", feedback_summary["current_state"]["useful_count"]),
                         (
-                            "Not useful",
-                            feedback_summary["current_state"]["not_useful_count"],
+                            "Noisy",
+                            feedback_summary["current_state"].get(
+                                "noisy_count",
+                                feedback_summary["current_state"]["not_useful_count"],
+                            ),
                         ),
                         (
                             "False positives",


### PR DESCRIPTION
Story 4.5 needs reviewer feedback to be useful calibration input without rewriting historical report verdicts. This change keeps feedback append-only, distinguishes noisy feedback from false positives, links missed-risk notes to findings where possible, and preserves a clean-report report-level path for missed risks when no finding exists.

Constraint: Feedback must remain project/workspace scoped and advisory-first.

Constraint: Historical report verdicts, severity, recommendation, and confidence must not be silently mutated.

Rejected: Keep missed-risk notes only report-level | violates displayed-finding linkage in Story 4.5.

Rejected: Treat all useful=false feedback as noisy | overlaps false-positive and noisy calibration buckets.

Confidence: high

Scope-risk: moderate

Directive: Do not collapse noisy, false-positive, and missed feedback into one negative bucket without updating summary semantics and regressions.

Tested: ./.venv/bin/python -m unittest tests.test_services.test_feedback_service tests.test_ui.test_history_page tests.test_ui.test_app_shell tests.test_ui.test_settings_page -q

Tested: ./.venv/bin/ruff check .

Tested: ./.venv/bin/ruff format --check .

Tested: ./.venv/bin/bandit -q services/feedback_service.py ui/components/report_detail_page.py ui/routes/settings.py

Tested: ./.venv/bin/python -m unittest discover -q

Tested: APP_PORT=18080 npm run test:ui-review

Tested: bash scripts/ci-local.sh

Not-tested: VoiceOver-specific UI review was not rerun for this story.

## What does this PR do?

<!-- Brief description of changes -->

## Type of change
- [ ] Feature (new functionality)
- [ ] Bugfix (non-breaking fix)
- [ ] Release preparation
- [ ] Hotfix (critical production fix)
- [ ] Docs / refactor / chore

## Checklist
- [ ] I have followed the branch naming convention
- [ ] Tests pass locally (`pytest tests/ -v`)
- [ ] Linting passes (`ruff check .`)
- [ ] Docker build succeeds
- [ ] I have updated docs if needed
- [ ] No secrets or .env values committed

## Related issue
Closes #