### PR TITLE
Capture deployment outcomes for calibration learning

### DIFF
--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -87,7 +87,7 @@ development_status:
   4-3-incident-import-for-markdown-yaml-and-json: done
   4-4-incident-similarity-with-match-explanation: done
   4-5-reviewer-feedback-capture: done
-  4-6-deployment-outcome-capture: ready-for-dev
+  4-6-deployment-outcome-capture: review
   4-7-incident-ingestion-management-and-indexing: ready-for-dev
   epic-4-retrospective: optional
 

--- a/api/routes/deployments.py
+++ b/api/routes/deployments.py
@@ -294,6 +294,7 @@ def create_deployment_outcome_route(
             linked_incident_id=payload.linked_incident_id,
             environment=payload.environment,
             summary=payload.summary,
+            notes=payload.notes,
             project_id=payload.project_id,
             project_key=payload.project_key,
             workspace_id=payload.workspace_id,

--- a/api/schemas.py
+++ b/api/schemas.py
@@ -91,6 +91,7 @@ RiskSeverity = Literal["low", "medium", "high", "critical"]
 DeployRecommendation = Literal["go", "caution", "no-go"]
 RollbackComplexity = Literal["low", "medium", "high"]
 DeploymentOutcomeLabel = Literal["success", "failure", "rolled_back"]
+DeploymentOutcomeInputLabel = Literal["success", "failure", "rolled_back", "rollback"]
 
 
 class IntakeItem(BaseModel):
@@ -495,7 +496,7 @@ class WorkspaceResponse(BaseModel):
 
 class DeploymentOutcomeCreateRequest(BaseModel):
     analysis_id: int = Field(..., description="Analysis identifier for the deployment.")
-    outcome: DeploymentOutcomeLabel = Field(
+    outcome: DeploymentOutcomeInputLabel = Field(
         ..., description="Final deployment result for the analyzed change."
     )
     deployed_at: str = Field(..., description="Deployment completion timestamp.")
@@ -510,6 +511,10 @@ class DeploymentOutcomeCreateRequest(BaseModel):
     summary: str | None = Field(
         default=None,
         description="Optional operator summary for the deployment outcome.",
+    )
+    notes: str | None = Field(
+        default=None,
+        description="Optional operator notes for the deployment outcome.",
     )
     project_id: int | None = Field(
         default=None, description="Optional numeric project identifier."
@@ -547,6 +552,7 @@ class DeploymentOutcomeData(BaseModel):
         default=None, description="Optional environment label."
     )
     summary: str | None = Field(default=None, description="Optional operator summary.")
+    notes: str | None = Field(default=None, description="Optional operator notes.")
     created_at: str = Field(..., description="Outcome record creation timestamp.")
 
 

--- a/cli/analyze.py
+++ b/cli/analyze.py
@@ -237,7 +237,9 @@ def _run_skill_lint(path_arg: str) -> int:
             sys.stderr.write(f"- {issue}\n")
         return 2
 
-    assert document.manifest is not None
+    if document.manifest is None:
+        sys.stderr.write(f"{path}: missing skill manifest v1\n")
+        return 2
     print(
         f"{path}: valid skill manifest v1 "
         f"({document.manifest.name}@{document.manifest.version})"
@@ -644,6 +646,7 @@ def _run_outcome_record(args: argparse.Namespace) -> int:
             linked_incident_id=args.linked_incident_id,
             environment=args.environment,
             summary=args.summary,
+            notes=args.notes,
             project_id=args.project_id,
             project_key=args.project_key,
             workspace_id=args.workspace_id,
@@ -943,7 +946,7 @@ def build_parser() -> argparse.ArgumentParser:
     outcome_record_parser.add_argument(
         "--outcome",
         required=True,
-        help="Deployment result: success, failure, or rolled_back.",
+        help="Deployment result: success, failure, rolled_back, or rollback.",
     )
     outcome_record_parser.add_argument(
         "--deployed-at",
@@ -961,6 +964,10 @@ def build_parser() -> argparse.ArgumentParser:
     outcome_record_parser.add_argument(
         "--summary",
         help="Optional operator summary for the deployment outcome.",
+    )
+    outcome_record_parser.add_argument(
+        "--notes",
+        help="Optional operator notes for the deployment outcome.",
     )
     outcome_record_parser.add_argument(
         "--project",

--- a/docs/deployment-history.md
+++ b/docs/deployment-history.md
@@ -14,7 +14,8 @@ curl -X POST http://localhost:8080/api/v1/deployments/outcomes \
     "analysis_id": 42,
     "outcome": "success",
     "deployed_at": "2026-04-30T08:15:00Z",
-    "environment": "prod"
+    "environment": "prod",
+    "notes": "Deployment succeeded after review."
   }'
 ```
 
@@ -30,7 +31,8 @@ Project and workspace filters are also supported for scoped history views:
 curl "http://localhost:8080/api/v1/deployments/outcomes?project_key=payments&workspace_key=prod"
 ```
 
-Supported outcome values are `success`, `failure`, and `rolled_back`.
+Supported outcome values are `success`, `failure`, `rolled_back`, and `rollback`.
+`rollback` is accepted as an input alias and stored as the canonical `rolled_back` outcome.
 Set `DEPLOYWHISPER_OUTCOME_TOKEN` (or `APP_DEPLOYMENT_OUTCOME_TOKEN`) on the server before using the ingestion endpoint.
 
 ## CLI
@@ -44,7 +46,8 @@ deploywhisper outcome record \
   --deployed-at 2026-04-30T08:15:00Z \
   --project payments \
   --workspace prod \
-  --environment prod
+  --environment prod \
+  --notes "Deployment succeeded after review."
 ```
 
 `--deployed-at` is optional for the CLI path; when omitted, DeployWhisper records the current UTC timestamp.

--- a/migrations/versions/022_add_deployment_outcome_notes.py
+++ b/migrations/versions/022_add_deployment_outcome_notes.py
@@ -1,0 +1,28 @@
+"""Add independent deployment outcome notes.
+
+Revision ID: 022_add_deployment_outcome_notes
+Revises: 021_add_incident_matches_payload
+Create Date: 2026-05-22
+"""
+
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "022_add_deployment_outcome_notes"
+down_revision = "021_add_incident_matches_payload"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "deployment_outcomes",
+        sa.Column("notes", sa.Text(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("deployment_outcomes", "notes")

--- a/models/database.py
+++ b/models/database.py
@@ -51,6 +51,7 @@ _KNOWN_ALEMBIC_REVISIONS = {
     "019_add_finding_context_fields",
     "020_add_narrative_state_fields",
     "021_add_incident_matches_payload",
+    "022_add_deployment_outcome_notes",
 }
 _BASELINE_TABLES = {"analysis_reports", "app_settings"}
 _EVIDENCE_TABLES = {
@@ -608,6 +609,7 @@ def _bootstrap_brownfield_revision() -> None:
             has_incident_matches_payload
             and _analysis_report_incident_matches_complete(connection)
         )
+        has_deployment_outcome_notes = "notes" in deployment_outcome_columns
         if scoped_learning_columns_present and not has_complete_learning_context_scope:
             raise RuntimeError(
                 "Detected a partial learning/context scope schema without a complete "
@@ -663,6 +665,29 @@ def _bootstrap_brownfield_revision() -> None:
                 "Detected a partial incident matches payload schema without a complete "
                 "migration history. Manual recovery is required."
             )
+        if has_deployment_outcome_notes and not (
+            has_complete_learning_context_scope
+            and has_complete_submission_manifest_payload
+            and has_complete_evidence_identity_fields
+            and has_complete_finding_context_fields
+            and has_complete_narrative_state_fields
+            and has_complete_incident_matches_payload
+        ):
+            raise RuntimeError(
+                "Detected a partial deployment outcome notes schema without a complete "
+                "migration history. Manual recovery is required."
+            )
+        if (
+            has_complete_learning_context_scope
+            and has_complete_submission_manifest_payload
+            and has_complete_evidence_identity_fields
+            and has_complete_finding_context_fields
+            and has_complete_narrative_state_fields
+            and has_complete_incident_matches_payload
+            and has_deployment_outcome_notes
+        ):
+            _write_alembic_revision(connection, "022_add_deployment_outcome_notes")
+            return
         if (
             has_complete_learning_context_scope
             and has_complete_submission_manifest_payload

--- a/models/repositories/deployment_outcomes.py
+++ b/models/repositories/deployment_outcomes.py
@@ -28,6 +28,7 @@ def create_deployment_outcome(
     linked_incident_id: int | None = None,
     environment: str | None = None,
     summary: str | None = None,
+    notes: str | None = None,
 ) -> DeploymentOutcome:
     outcome = DeploymentOutcome(
         project_id=project_id,
@@ -38,6 +39,7 @@ def create_deployment_outcome(
         linked_incident_id=linked_incident_id,
         environment=environment,
         summary=summary,
+        notes=notes,
     )
     session.add(outcome)
     session.commit()

--- a/models/tables.py
+++ b/models/tables.py
@@ -508,6 +508,7 @@ if "DeploymentOutcome" not in globals():
         environment: Mapped[str | None] = mapped_column(String(80), nullable=True)
         outcome_label: Mapped[str] = mapped_column(String(40), default="unknown")
         summary: Mapped[str | None] = mapped_column(Text, nullable=True)
+        notes: Mapped[str | None] = mapped_column(Text, nullable=True)
         deployed_at: Mapped[datetime] = mapped_column(
             DateTime(timezone=True), default=lambda: datetime.now(UTC)
         )

--- a/services/deployment_outcome_service.py
+++ b/services/deployment_outcome_service.py
@@ -19,7 +19,12 @@ from services.backtesting_service import invalidate_backtesting_snapshot
 from services.project_service import ensure_default_project, normalize_project_key
 from services.project_service import resolve_workspace_reference
 
-ALLOWED_DEPLOYMENT_OUTCOMES = {"success", "failure", "rolled_back"}
+DEPLOYMENT_OUTCOME_ALIASES = {
+    "success": "success",
+    "failure": "failure",
+    "rolled_back": "rolled_back",
+    "rollback": "rolled_back",
+}
 
 
 class DeploymentOutcomeError(ValueError):
@@ -33,12 +38,13 @@ class DeploymentOutcomeError(ValueError):
 
 def _normalize_outcome(value: str) -> str:
     normalized = str(value or "").strip().lower().replace("-", "_")
-    if normalized not in ALLOWED_DEPLOYMENT_OUTCOMES:
+    try:
+        return DEPLOYMENT_OUTCOME_ALIASES[normalized]
+    except KeyError as exc:
         raise DeploymentOutcomeError(
             "invalid_deployment_outcome",
-            "Outcome must be one of: success, failure, rolled_back.",
-        )
-    return normalized
+            "Outcome must be one of: success, failure, rolled_back, rollback.",
+        ) from exc
 
 
 def _normalize_optional_text(value: str | None) -> str | None:
@@ -112,6 +118,7 @@ def _serialize_deployment_outcome(outcome) -> dict[str, Any]:
         "linked_incident_id": outcome.linked_incident_id,
         "environment": outcome.environment,
         "summary": outcome.summary,
+        "notes": outcome.notes,
         "created_at": _isoformat_utc(outcome.created_at),
     }
 
@@ -183,6 +190,7 @@ def record_deployment_outcome(
     linked_incident_id: int | None = None,
     environment: str | None = None,
     summary: str | None = None,
+    notes: str | None = None,
     project_id: int | None = None,
     project_key: str | None = None,
     workspace_id: int | None = None,
@@ -192,6 +200,8 @@ def record_deployment_outcome(
     del source_interface
     normalized_outcome = _normalize_outcome(outcome)
     normalized_timestamp = _coerce_timestamp(deployed_at)
+    normalized_summary = _normalize_optional_text(summary)
+    normalized_notes = _normalize_optional_text(notes)
     linked_project_id: int | None = None
 
     with SessionLocal() as session:
@@ -255,7 +265,8 @@ def record_deployment_outcome(
             deployed_at=normalized_timestamp,
             linked_incident_id=linked_incident_id,
             environment=_normalize_optional_text(environment),
-            summary=_normalize_optional_text(summary),
+            summary=normalized_summary,
+            notes=normalized_notes,
         )
         payload = _serialize_deployment_outcome(recorded)
     if linked_project_id is not None:

--- a/tests/test_api/test_deployments.py
+++ b/tests/test_api/test_deployments.py
@@ -18,6 +18,8 @@ from analysis.risk_scorer import RiskAssessment
 from app import create_app
 from fastapi.testclient import TestClient
 from llm.narrator import NarrativeResult
+from models.database import SessionLocal
+from models.repositories.incident_records import create_incident_record
 from parsers.base import ParseBatchResult, ParsedFileResult
 
 
@@ -78,31 +80,93 @@ class DeploymentOutcomesApiTests(unittest.TestCase):
         self.tempdir.cleanup()
 
     def test_webhook_endpoint_records_and_lists_deployment_outcomes(self) -> None:
+        workspace = project_service_module.create_workspace(
+            project_key=self.project.project_key,
+            workspace_key="prod",
+            display_name="Production",
+        )
+        scoped_report = report_service_module.persist_analysis_report(
+            ParseBatchResult(
+                files=[
+                    ParsedFileResult(
+                        file_name="payments-prod.tf",
+                        tool="terraform",
+                        status="parsed",
+                        changes=[],
+                    )
+                ]
+            ),
+            RiskAssessment(
+                score=52,
+                severity="medium",
+                recommendation="caution",
+                top_risk="Production outcome test report.",
+                contributors=[],
+                interaction_risks=[],
+                partial_context=False,
+                warnings=[],
+            ),
+            NarrativeResult(
+                opening_sentence="CAUTION: production outcome test report.",
+                explanation="Production outcome test report.",
+                guidance=[],
+                degraded=False,
+                warnings=[],
+            ),
+            project_id=self.project.id,
+            workspace_id=workspace.id,
+            audit_context={"source_interface": "api"},
+        )
+        with SessionLocal() as session:
+            incident = create_incident_record(
+                session,
+                title="Payments rollback",
+                severity="high",
+                source_file="payments-incident.md",
+                incident_date="2026-04-30",
+                project_id=self.project.id,
+                workspace_id=workspace.id,
+                content="Payments deploy rolled back after elevated errors.",
+            )
+
         response = self.client.post(
             "/api/v1/deployments/outcomes",
             headers={"X-DeployWhisper-Outcome-Token": "outcome-secret"},
             json={
-                "analysis_id": self.persisted_report["id"],
-                "outcome": "success",
+                "analysis_id": scoped_report["id"],
+                "outcome": "rollback",
                 "deployed_at": "2026-04-30T08:15:00Z",
+                "linked_incident_id": incident.id,
                 "environment": "prod",
+                "summary": "Rollback completed.",
+                "notes": "Rollback completed after checkout errors.",
             },
         )
 
         self.assertEqual(response.status_code, 200)
         payload = response.json()
-        self.assertEqual(payload["data"]["analysis_id"], self.persisted_report["id"])
+        self.assertEqual(payload["data"]["analysis_id"], scoped_report["id"])
         self.assertEqual(payload["data"]["project"]["project_key"], "payments")
-        self.assertEqual(payload["data"]["outcome"], "success")
+        self.assertEqual(payload["data"]["workspace"]["workspace_key"], "prod")
+        self.assertEqual(payload["data"]["outcome"], "rolled_back")
+        self.assertEqual(payload["data"]["linked_incident_id"], incident.id)
+        self.assertEqual(payload["data"]["summary"], "Rollback completed.")
+        self.assertEqual(
+            payload["data"]["notes"], "Rollback completed after checkout errors."
+        )
 
         list_response = self.client.get(
             "/api/v1/deployments/outcomes",
-            params={"analysis_id": self.persisted_report["id"]},
+            params={"analysis_id": scoped_report["id"]},
         )
         self.assertEqual(list_response.status_code, 200)
         list_payload = list_response.json()
         self.assertEqual(list_payload["meta"]["count"], 1)
-        self.assertEqual(list_payload["data"][0]["outcome"], "success")
+        self.assertEqual(list_payload["data"][0]["outcome"], "rolled_back")
+        self.assertEqual(
+            list_payload["data"][0]["notes"],
+            "Rollback completed after checkout errors.",
+        )
 
     def test_webhook_endpoint_returns_standard_error_for_unknown_analysis(self) -> None:
         response = self.client.post(

--- a/tests/test_cli/test_analyze.py
+++ b/tests/test_cli/test_analyze.py
@@ -1053,6 +1053,8 @@ class AnalyzeCliTests(unittest.TestCase):
                     "success",
                     "--deployed-at",
                     "2026-04-30T08:15:00Z",
+                    "--notes",
+                    "Deployment succeeded after review.",
                 ],
             ),
             redirect_stdout(output),
@@ -1066,6 +1068,8 @@ class AnalyzeCliTests(unittest.TestCase):
         self.assertEqual(payload["data"]["analysis_id"], persisted["id"])
         self.assertEqual(payload["data"]["project"]["project_key"], "payments")
         self.assertEqual(payload["data"]["outcome"], "success")
+        self.assertIsNone(payload["data"]["summary"])
+        self.assertEqual(payload["data"]["notes"], "Deployment succeeded after review.")
 
     def test_outcome_record_command_reports_unknown_analysis_with_structured_error(
         self,

--- a/tests/test_infra/test_container_contract.py
+++ b/tests/test_infra/test_container_contract.py
@@ -35,6 +35,7 @@ class ContainerContractTests(unittest.TestCase):
                 "019_add_finding_context_fields.py",
                 "020_add_narrative_state_fields.py",
                 "021_add_incident_matches_payload.py",
+                "022_add_deployment_outcome_notes.py",
             ],
         )
         baseline_content = migrations[0].read_text(encoding="utf-8")
@@ -55,6 +56,7 @@ class ContainerContractTests(unittest.TestCase):
         finding_context_content = migrations[15].read_text(encoding="utf-8")
         narrative_state_content = migrations[16].read_text(encoding="utf-8")
         incident_matches_content = migrations[17].read_text(encoding="utf-8")
+        deployment_notes_content = migrations[18].read_text(encoding="utf-8")
         self.assertIn("down_revision = None", baseline_content)
         self.assertIn('"app_settings"', baseline_content)
         self.assertIn(
@@ -146,6 +148,11 @@ class ContainerContractTests(unittest.TestCase):
             incident_matches_content,
         )
         self.assertIn('"incident_matches_json"', incident_matches_content)
+        self.assertIn(
+            'down_revision = "021_add_incident_matches_payload"',
+            deployment_notes_content,
+        )
+        self.assertIn('"notes"', deployment_notes_content)
 
     def test_dockerfile_exists(self) -> None:
         self.assertTrue(Path("Dockerfile").exists())

--- a/tests/test_infra/test_migrations.py
+++ b/tests/test_infra/test_migrations.py
@@ -193,6 +193,7 @@ class MigrationTests(unittest.TestCase):
         self.assertIn("payload_json", self._table_columns("topology_versions"))
         self.assertIn("deployed_at", self._table_columns("deployment_outcomes"))
         self.assertIn("linked_incident_id", self._table_columns("deployment_outcomes"))
+        self.assertIn("notes", self._table_columns("deployment_outcomes"))
         self.assertIn("finding_id", self._table_columns("feedback_events"))
         self.assertIn("false_positive_reason", self._table_columns("feedback_events"))
         self.assertIn("report_schema_version", self._table_columns("analysis_reports"))
@@ -977,7 +978,7 @@ class MigrationTests(unittest.TestCase):
         self.assertIn("evidence_items", tables)
         self.assertIn("projects", tables)
         self.assertIn("topology_versions", tables)
-        self.assertEqual(revision, "021_add_incident_matches_payload")
+        self.assertEqual(revision, "022_add_deployment_outcome_notes")
 
     def test_init_db_repairs_partial_evidence_schema_without_alembic_version(
         self,
@@ -1026,7 +1027,7 @@ class MigrationTests(unittest.TestCase):
         self.assertIn("findings", tables)
         self.assertIn("evidence_items", tables)
         self.assertIn("projects", tables)
-        self.assertEqual(revision, "021_add_incident_matches_payload")
+        self.assertEqual(revision, "022_add_deployment_outcome_notes")
 
     def test_init_db_repairs_current_schema_without_alembic_version(self) -> None:
         command.upgrade(self._config(), "head")
@@ -1052,7 +1053,7 @@ class MigrationTests(unittest.TestCase):
         finally:
             sqlite_conn.close()
 
-        self.assertEqual(revision, "021_add_incident_matches_payload")
+        self.assertEqual(revision, "022_add_deployment_outcome_notes")
         self.assertIn("report_schema_version", columns)
         self.assertIn("blast_radius_json", columns)
         self.assertIn("project_id", columns)
@@ -1076,7 +1077,7 @@ class MigrationTests(unittest.TestCase):
         finally:
             sqlite_conn.close()
 
-        self.assertEqual(revision, "021_add_incident_matches_payload")
+        self.assertEqual(revision, "022_add_deployment_outcome_notes")
 
     def test_init_db_rejects_partial_report_workspace_scope_schema(self) -> None:
         command.upgrade(self._config(), "014_add_project_workspace_records")
@@ -1213,6 +1214,23 @@ class MigrationTests(unittest.TestCase):
         ):
             database_module.init_db()
 
+    def test_init_db_rejects_partial_deployment_outcome_notes_schema(self) -> None:
+        command.upgrade(self._config(), "011_add_deployment_outcome_fields")
+        sqlite_conn = sqlite3.connect(self.db_path)
+        sqlite_conn.execute("ALTER TABLE deployment_outcomes ADD COLUMN notes TEXT")
+        sqlite_conn.execute("DROP TABLE alembic_version")
+        sqlite_conn.commit()
+        sqlite_conn.close()
+
+        reload(config_module)
+        reload(tables_module)
+        reload(database_module)
+
+        with self.assertRaisesRegex(
+            RuntimeError, "partial deployment outcome notes schema"
+        ):
+            database_module.init_db()
+
     def test_init_db_rejects_partial_project_workspace_schema(self) -> None:
         command.upgrade(self._config(), "013_add_incident_analysis_reference")
         sqlite_conn = sqlite3.connect(self.db_path)
@@ -1346,7 +1364,7 @@ class MigrationTests(unittest.TestCase):
         finally:
             sqlite_conn.close()
 
-        self.assertEqual(revision, "021_add_incident_matches_payload")
+        self.assertEqual(revision, "022_add_deployment_outcome_notes")
 
 
 if __name__ == "__main__":

--- a/tests/test_services/test_deployment_outcome_service.py
+++ b/tests/test_services/test_deployment_outcome_service.py
@@ -105,6 +105,7 @@ class DeploymentOutcomeServiceTests(unittest.TestCase):
             linked_incident_id=incident.id,
             environment="prod",
             summary="Rollback completed after checkout errors.",
+            notes="Operator notes captured during post-deploy review.",
             source_interface="api",
         )
 
@@ -117,7 +118,43 @@ class DeploymentOutcomeServiceTests(unittest.TestCase):
         self.assertEqual(
             recorded["summary"], "Rollback completed after checkout errors."
         )
+        self.assertEqual(
+            recorded["notes"], "Operator notes captured during post-deploy review."
+        )
         self.assertEqual(recorded["deployed_at"], "2026-04-30T08:15:00+00:00")
+
+    def test_record_deployment_outcome_accepts_notes_and_rollback_alias(
+        self,
+    ) -> None:
+        with SessionLocal() as session:
+            incident = create_incident_record(
+                session,
+                title="Payments rollback",
+                severity="high",
+                source_file="payments-incident.md",
+                incident_date="2026-04-30",
+                project_id=self.project.id,
+                workspace_id=self.workspace.id,
+                content="Payments deploy rolled back after elevated errors.",
+            )
+
+        recorded = deployment_outcome_service_module.record_deployment_outcome(
+            analysis_id=self.persisted_report["id"],
+            outcome="rollback",
+            deployed_at="2026-04-30T09:45:00Z",
+            linked_incident_id=incident.id,
+            environment="prod",
+            notes="Rollback captured from deployment review notes.",
+        )
+
+        self.assertEqual(recorded["outcome"], "rolled_back")
+        self.assertEqual(recorded["linked_incident_id"], incident.id)
+        self.assertEqual(recorded["project"]["project_key"], "payments")
+        self.assertEqual(recorded["workspace"]["workspace_key"], "prod")
+        self.assertIsNone(recorded["summary"])
+        self.assertEqual(
+            recorded["notes"], "Rollback captured from deployment review notes."
+        )
 
     def test_record_deployment_outcome_rejects_mismatched_project_reference(
         self,


### PR DESCRIPTION
Deployment outcomes need to preserve operator notes separately from summaries while still accepting rollback language at ingestion boundaries. The change keeps the persisted and response outcome contract canonical, adds the independent notes column through Alembic, and hardens brownfield bootstrap behavior so partial manual schemas fail clearly instead of colliding with the migration path.

Constraint: Preserve local-first advisory storage and existing API/CLI/service layering
Rejected: Store notes as summary alias | conflates two operator fields and breaks review finding intent
Rejected: Expose rollback as a response enum | response contract should remain canonical as rolled_back
Confidence: high
Scope-risk: moderate
Directive: Keep rollback as input-only alias unless API versioning explicitly changes the response contract
Tested: ./.venv/bin/ruff check .; ./.venv/bin/ruff format --check .; ./.venv/bin/python -m unittest tests.test_services.test_deployment_outcome_service tests.test_api.test_deployments tests.test_cli.test_analyze tests.test_infra.test_migrations tests.test_infra.test_container_contract -q; ./.venv/bin/python -m unittest discover -q; bash scripts/ci-local.sh
Not-tested: Browser UI validation, not applicable because no UI surface changed

## What does this PR do?

<!-- Brief description of changes -->

## Type of change
- [ ] Feature (new functionality)
- [ ] Bugfix (non-breaking fix)
- [ ] Release preparation
- [ ] Hotfix (critical production fix)
- [ ] Docs / refactor / chore

## Checklist
- [ ] I have followed the branch naming convention
- [ ] Tests pass locally (`pytest tests/ -v`)
- [ ] Linting passes (`ruff check .`)
- [ ] Docker build succeeds
- [ ] I have updated docs if needed
- [ ] No secrets or .env values committed

## Related issue
Closes #