### PR TITLE
Stabilize integrations on the v1 report contract

### DIFF
--- a/_bmad-output/implementation-artifacts/5-1-versioned-api-report-contract.md
+++ b/_bmad-output/implementation-artifacts/5-1-versioned-api-report-contract.md
@@ -1,0 +1,266 @@
+# Story 5.1: Versioned API Report Contract
+
+Status: done
+
+<!-- Generated from updated PRD/architecture/epics plus implementation-readiness-report-2026-05-01.md. -->
+
+## Story
+
+As a DeployWhisper user,
+I want stable `/api/v1` report and analysis endpoints,
+So that integrations can rely on machine-readable advisory output.
+
+## Acceptance Criteria
+
+1. Given an API client submits or retrieves analysis, When the API responds, Then it returns versioned report schema, project/workspace scope, evidence, findings, context, narrative status, and advisory recommendation. And errors use the existing API error envelope.
+
+### Requirement Traceability
+
+- Primary PRD requirements: Epic 5 coverage: WRK-01..10, REV-05..08, ADM-07, DOC-08.
+- Supporting PRD / NFR / differentiation requirements: See `_bmad-output/planning-artifacts/prd.md`, `_bmad-output/planning-artifacts/architecture.md`, and `_bmad-output/planning-artifacts/implementation-readiness-report-2026-05-01.md`.
+- Coverage intent: Baseline + Delta.
+- Story alignment note: This story was created from the updated Epic 5 plan after the 2026-05-01 readiness rerun. The readiness report verified 187/187 PRD functional requirement IDs in the epics artifact, 38 NFR IDs present, and no critical or major readiness defects.
+
+## Tasks / Subtasks
+
+- [x] Implement and verify acceptance criterion 1. (AC: 1)
+- [x] Reuse existing services, repositories, schemas, and UI/CLI/API helpers before adding new abstractions. (AC: all)
+- [x] Add or update deterministic regression coverage for the changed behavior. (AC: all)
+- [x] Update relevant docs or examples if the story changes user-visible, operator, API, CLI, integration, or contribution behavior. (AC: all)
+- [x] Run required validation and record commands/results in the Dev Agent Record. (AC: all)
+
+### Review Findings
+
+- [x] [Review][Patch] Persisted report advisory semantics can diverge from the canonical submit-response advisory contract [services/report_service.py:3387]
+- [x] [Review][Patch] Add regression coverage for persisted advisory parity and nested advisory top-risk redaction [tests/test_api/test_analyses.py:1079]
+- [x] [Review][Patch] Persisted advisory still misclassifies built-in assessment warnings as narrative warnings [services/report_service.py:3401]
+- [x] [Review][Patch] Submit advisory and persisted_report advisory can diverge on synthesized context_todos [services/report_service.py:3417]
+- [x] [Review][Patch] List retrieval still omits evidence despite the Story 5.1 submit/list/detail contract [services/report_service.py:4185]
+- [x] [Review][Patch] Add submit/list regression coverage for go advisory with narrative-only warnings [tests/test_api/test_analyses.py:146]
+- [x] [Review][Patch] Document required advisory.top_risk in the report v2 advisory example [docs/schemas/report-v2.md:125]
+- [x] [Review][Patch] Lock meta.api_version in report schema documentation tests [tests/test_docs/test_report_schema_documentation.py:32]
+- [x] [Review][Patch] Advisory `partial_context` conflates evidence extraction gaps with parser partial context [services/report_service.py:3376]
+- [x] [Review][Patch] History list pagination hydrates full evidence for the entire unpaginated scope [services/report_service.py:4180]
+- [x] [Review][Patch] Normalize persisted advisory severity before strict API schema validation [services/report_service.py:3457]
+- [x] [Review][Patch] Persisted advisory partial_context ignores per-artifact manifest partial signals [services/report_service.py:3368]
+- [x] [Review][Patch] Partial-context derivation misses fallback manifest branches [services/report_service.py:3368]
+- [x] [Review][Patch] Persisted advisory normalization can diverge from top-level severity/recommendation on legacy rows [services/report_service.py:3648]
+- [x] [Review][Patch] Persisted advisory drops explicit partial_context signal when manifest/context signals look clean [services/report_service.py:3380]
+- [x] [Review][Patch] Persisted JSON boolean-like strings can incorrectly mark advisory output as partial context [services/report_service.py:3267]
+- [x] [Review][Patch] Submit response can bypass the API error envelope when persisted advisory is missing or invalid [api/routes/analyses.py:588]
+- [x] [Review][Patch] Share summary ignores stored partial_context while advisory flags it [services/analysis_service.py:650]
+- [x] [Review][Patch] Submit advisory fallback can diverge from persisted report advisory derivation [api/routes/analyses.py:76]
+- [x] [Review][Patch] Legacy or recovered reports can disagree on partial_context between context_completeness and advisory [services/report_service.py:3283]
+- [x] [Review][Patch] Advisory rebuild treats false-like string booleans as attention signals [services/report_service.py:3450]
+- [x] [Review][Patch] OpenAPI docs omit runtime error envelopes for list/detail analysis endpoints [api/routes/analyses.py:396]
+- [x] [Review][Patch] Share summary still treats false-like persisted booleans as attention signals [services/analysis_service.py:748]
+- [x] [Review][Patch] Submit response can return a stale schema-valid advisory instead of rebuilding from persisted report fields [api/routes/analyses.py:76]
+- [x] [Review][Patch] Submit response advisory and share summary can disagree on partial-context signals [api/routes/analyses.py:630]
+- [x] [Review][Patch] Add create-response regression coverage for `meta.api_version` and report schema version [tests/test_api/test_analyses.py:1382]
+- [x] [Review][Patch] Malformed persisted report context can bypass the submit-contract API error envelope [api/routes/analyses.py:87]
+- [x] [Review][Patch] Non-finite legacy boolean values are normalized as truthy attention signals [services/report_service.py:3194]
+- [x] [Review][Patch] Share summary still requires attention for narrative-only warnings while advisory does not [services/analysis_service.py:916]
+- [x] [Review][Patch] Submit response still exposes transient findings/evidence/context instead of persisted contract values [api/schemas.py:1367]
+- [x] [Review][Defer] List endpoint masks forbidden/conflicting scoped reads as empty success instead of an error envelope [api/routes/analyses.py:425] — deferred, pre-existing
+
+## Dev Notes
+
+### Epic Context
+
+- Epic: 5. Workflow-Native Delivery
+- Epic goal: Deliver the report in real review workflows without duplicating analysis logic.
+- Epic coverage: WRK-01..10, REV-05..08, ADM-07, DOC-08
+
+### Architecture and Product Guardrails
+
+- Preserve DeployWhisper's local-first raw artifact boundary: raw IaC, scanner artifacts, incident exports, and sensitive context stay in the user's infrastructure by default.
+- Preserve the advisory-first core. Optional adapters may interpret report outputs, but canonical report semantics remain advisory unless explicit story scope says otherwise.
+- Reuse the shared analysis core and service layer before adapting UI, API, CLI, GitHub, or future workflow surfaces.
+- Keep Evidence Law behavior intact: no high or critical finding without deterministic evidence.
+- Keep project/workspace scope explicit for reports, incidents, topology, outcomes, feedback, scanner imports, and connector-related data.
+- Do not introduce new dependencies unless the active story explicitly requires and justifies them.
+
+### Source Tree Guidance
+
+- API routes belong under `api/routes/` and should use existing `ApiRoute` / `ApiError` envelope patterns.
+- Shared orchestration belongs in `services/`; parsers normalize input, analysis modules score/derive risk, and surfaces adapt outputs.
+- UI work belongs under `ui/routes/` and `ui/components/`, following the existing NiceGUI composition style.
+- CLI behavior belongs under `cli/` and must call the same service-layer paths as UI/API flows.
+- Persistence work belongs under `models/` with Alembic migrations when schema changes are required.
+- Documentation required by a story should be updated in the same workstream.
+
+### Testing Requirements
+
+- Use standard-library `unittest` in the existing `tests/test_*` layout.
+- Add focused regression tests for the layer changed by the story before broad refactors.
+- For Python changes, run `./.venv/bin/ruff check .`, `./.venv/bin/ruff format --check .`, and `./.venv/bin/python -m unittest discover -q` before closing implementation.
+- Use `bash scripts/ci-local.sh` for broader or cross-layer changes.
+
+### Project Structure Notes
+
+- Follow the current repository shape documented in `_bmad-output/project-context.md` and `AGENTS.md`.
+- If implementation reveals a conflict between this story and the current code baseline, keep the smallest compatible change and update the story notes rather than silently drifting from the PRD.
+
+### References
+
+- `_bmad-output/planning-artifacts/epics.md` - source Epic 5 / Story 5.1 definition.
+- `_bmad-output/planning-artifacts/prd.md` - functional and non-functional requirements.
+- `_bmad-output/planning-artifacts/architecture.md` - target architecture, boundaries, and guardrails.
+- `_bmad-output/planning-artifacts/ux-design-specification.md` - UX expectations for user-facing stories.
+- `_bmad-output/planning-artifacts/implementation-readiness-report-2026-05-01.md` - readiness verdict and residual story-format concern.
+- `_bmad-output/project-context.md` - repository-specific implementation rules.
+
+## Dev Agent Record
+
+### Agent Model Used
+
+Codex (GPT-5)
+
+### Debug Log References
+
+- Red phase: `./.venv/bin/python -m unittest tests.test_api.test_analyses.AnalysesApiTests.test_list_analyses_returns_persisted_reports tests.test_api.test_analyses.AnalysesApiTests.test_get_analysis_returns_single_report tests.test_api.test_analyses.AnalysesApiTests.test_create_analysis_returns_structured_result -q` failed before implementation on missing `meta.api_version` and `persisted_report.advisory`.
+- Focused API regression: `./.venv/bin/python -m unittest tests.test_api.test_analyses.AnalysesApiTests.test_list_analyses_returns_persisted_reports tests.test_api.test_analyses.AnalysesApiTests.test_get_analysis_returns_single_report tests.test_api.test_analyses.AnalysesApiTests.test_create_analysis_returns_structured_result -q` passed after implementation.
+- Affected suite: `./.venv/bin/python -m unittest tests.test_api.test_analyses tests.test_docs.test_report_schema_documentation -q` passed, 59 tests.
+- Schema fixture regression: `./.venv/bin/python -m unittest tests.test_api.test_schemas -q` passed, 7 tests.
+- Lint/format: `./.venv/bin/ruff check .` passed; `./.venv/bin/ruff format --check .` passed.
+- Full suite: `./.venv/bin/python -m unittest discover -q` passed, 429 tests, 1 skipped.
+- Local CI: `bash scripts/ci-local.sh` passed, including Ruff, format check, pip check, Bandit, compileall, parser scenarios, and unittest discovery.
+- UI validation not applicable: no UI route, NiceGUI component, rendered report/history/dashboard surface, browser interaction, keyboard behavior, or accessibility semantics changed.
+- Review fix targeted regressions: `./.venv/bin/python -m unittest tests.test_api.test_analyses.AnalysesApiTests.test_get_analysis_preserves_go_advisory_with_narrative_warning tests.test_services.test_report_service.ReportServiceTests.test_shared_report_redaction_prefers_longest_overlapping_filename -q` passed, 2 tests.
+- Review fix affected suite: `./.venv/bin/python -m unittest tests.test_api.test_analyses tests.test_services.test_report_service -q` passed, 193 tests.
+- Review fix lint/format: `./.venv/bin/ruff check services/report_service.py tests/test_api/test_analyses.py tests/test_services/test_report_service.py` passed; `./.venv/bin/ruff format --check services/report_service.py tests/test_api/test_analyses.py tests/test_services/test_report_service.py` passed.
+- Review fix full validation: `./.venv/bin/ruff check .` passed; `./.venv/bin/ruff format --check .` passed; `./.venv/bin/python -m unittest discover -q` passed, 430 tests, 1 skipped; `bash scripts/ci-local.sh` passed.
+- Re-review fix targeted regressions: `./.venv/bin/python -m unittest tests.test_api.test_analyses.AnalysesApiTests.test_create_analysis_returns_structured_result tests.test_api.test_analyses.AnalysesApiTests.test_get_analysis_flags_insufficient_context_as_assessment_warning tests.test_api.test_analyses.AnalysesApiTests.test_get_analysis_preserves_go_advisory_with_narrative_warning -q` passed, 3 tests.
+- Re-review fix affected suites: `./.venv/bin/python -m unittest tests.test_api.test_analyses tests.test_services.test_report_service -q` passed, 194 tests; `./.venv/bin/python -m unittest tests.test_api.test_schemas tests.test_docs.test_report_schema_documentation -q` passed, 9 tests.
+- Re-review fix lint/format: `./.venv/bin/ruff check api/routes/analyses.py services/report_service.py tests/test_api/test_analyses.py` passed; `./.venv/bin/ruff format --check api/routes/analyses.py services/report_service.py tests/test_api/test_analyses.py` passed.
+- Re-review fix full validation: `./.venv/bin/ruff check .` passed; `./.venv/bin/ruff format --check .` passed; `./.venv/bin/python -m unittest discover -q` passed, 431 tests, 1 skipped; `bash scripts/ci-local.sh` passed.
+- Re-review evidence/list targeted regressions: `./.venv/bin/python -m unittest tests.test_api.test_analyses.AnalysesApiTests.test_list_analyses_preserves_go_advisory_with_narrative_warning tests.test_api.test_analyses.AnalysesApiTests.test_create_analysis_preserves_go_advisory_with_narrative_warning tests.test_services.test_report_service.ReportServiceTests.test_fetch_filtered_history_page_includes_evidence_payloads tests.test_docs.test_report_schema_documentation.ReportSchemaDocumentationTests.test_report_v2_guide_covers_machine_consumers_and_contract_fields -q` passed, 4 tests.
+- Re-review evidence/list affected suites: `./.venv/bin/python -m unittest tests.test_api.test_analyses tests.test_services.test_report_service tests.test_docs.test_report_schema_documentation -q` passed, 198 tests.
+- Re-review evidence/list lint/format: `./.venv/bin/ruff check services/report_service.py tests/test_api/test_analyses.py tests/test_services/test_report_service.py tests/test_docs/test_report_schema_documentation.py` passed; `./.venv/bin/ruff format --check services/report_service.py tests/test_api/test_analyses.py tests/test_services/test_report_service.py tests/test_docs/test_report_schema_documentation.py` passed.
+- Re-review evidence/list full validation: `./.venv/bin/ruff check .` passed; `./.venv/bin/ruff format --check .` passed; `./.venv/bin/python -m unittest discover -q` passed, 433 tests, 1 skipped; `bash scripts/ci-local.sh` passed, including Ruff, format check, pip check, Bandit, compileall, parser scenarios, and unittest discovery.
+- Re-review advisory/scope targeted regressions: `./.venv/bin/python -m unittest tests.test_services.test_report_service.ReportServiceTests.test_fetch_filtered_history_page_uses_lightweight_scope_for_diff_candidates tests.test_services.test_report_service.ReportServiceTests.test_persisted_advisory_keeps_evidence_gap_separate_from_partial_context tests.test_services.test_report_service.ReportServiceTests.test_persisted_advisory_normalizes_legacy_severity_values tests.test_services.test_report_service.ReportServiceTests.test_fetch_filtered_history_page_includes_evidence_payloads -q` passed, 4 tests.
+- Re-review advisory/scope affected suites: `./.venv/bin/python -m unittest tests.test_api.test_analyses tests.test_services.test_report_service tests.test_docs.test_report_schema_documentation tests.test_api.test_schemas -q` passed, 208 tests.
+- Re-review advisory/scope lint/format: `./.venv/bin/ruff check services/report_service.py tests/test_services/test_report_service.py` passed; `./.venv/bin/ruff format services/report_service.py tests/test_services/test_report_service.py` formatted 1 file; `./.venv/bin/ruff check .` passed; `./.venv/bin/ruff format --check .` passed.
+- Re-review advisory/scope full validation: `./.venv/bin/python -m unittest discover -q` passed, 433 tests, 1 skipped; `bash scripts/ci-local.sh` passed, including Ruff, format check, pip check, Bandit, compileall, parser scenarios, and unittest discovery.
+- UI validation not applicable: no UI route, NiceGUI component, rendered report/history/dashboard surface, browser interaction, keyboard behavior, or accessibility semantics changed.
+- Latest re-review red phase: `./.venv/bin/python -m unittest tests.test_services.test_report_service.ReportServiceTests.test_persisted_advisory_honors_manifest_item_partial_context -q` failed before implementation on missing manifest-item partial context detection.
+- Latest re-review targeted regressions: `./.venv/bin/python -m unittest tests.test_services.test_report_service.ReportServiceTests.test_persisted_advisory_honors_manifest_item_partial_context tests.test_services.test_report_service.ReportServiceTests.test_persisted_advisory_keeps_evidence_gap_separate_from_partial_context tests.test_services.test_report_service.ReportServiceTests.test_persisted_advisory_normalizes_legacy_severity_values tests.test_services.test_report_service.ReportServiceTests.test_fetch_filtered_history_page_uses_lightweight_scope_for_diff_candidates -q` passed, 4 tests.
+- Latest re-review lint/format: `./.venv/bin/ruff check services/report_service.py tests/test_services/test_report_service.py` passed; `./.venv/bin/ruff format --check services/report_service.py tests/test_services/test_report_service.py` passed.
+- Latest re-review affected suites: `./.venv/bin/python -m unittest tests.test_api.test_analyses tests.test_services.test_report_service tests.test_docs.test_report_schema_documentation tests.test_api.test_schemas -q` passed, 209 tests.
+- Latest re-review full validation: `./.venv/bin/ruff check .` passed; `./.venv/bin/ruff format --check .` passed; `./.venv/bin/python -m unittest discover -q` passed, 433 tests, 1 skipped; `bash scripts/ci-local.sh` passed, including Ruff, format check, pip check, Bandit, compileall, parser scenarios, and unittest discovery.
+- UI validation not applicable: no UI route, NiceGUI component, rendered report/history/dashboard surface, browser interaction, keyboard behavior, or accessibility semantics changed.
+- Final re-review red phase: `./.venv/bin/python -m unittest tests.test_services.test_report_service.ReportServiceTests.test_fetch_report_degrades_on_malformed_submission_manifest_json tests.test_services.test_report_service.ReportServiceTests.test_persisted_advisory_normalizes_legacy_severity_values -q` failed before implementation on fallback manifest partial-context and top-level legacy normalization assertions.
+- Final re-review targeted regressions: `./.venv/bin/python -m unittest tests.test_services.test_report_service.ReportServiceTests.test_fetch_report_degrades_on_malformed_submission_manifest_json tests.test_services.test_report_service.ReportServiceTests.test_persisted_advisory_normalizes_legacy_severity_values -q` passed, 2 tests.
+- Final re-review lint/format: `./.venv/bin/ruff check services/report_service.py tests/test_services/test_report_service.py` passed; `./.venv/bin/ruff format --check services/report_service.py tests/test_services/test_report_service.py` passed.
+- Final re-review affected suites: `./.venv/bin/python -m unittest tests.test_api.test_analyses tests.test_services.test_report_service tests.test_docs.test_report_schema_documentation tests.test_api.test_schemas -q` passed, 209 tests.
+- Final re-review full validation: `./.venv/bin/ruff check .` passed; `./.venv/bin/ruff format --check .` passed; `./.venv/bin/python -m unittest discover -q` passed, 433 tests, 1 skipped; `bash scripts/ci-local.sh` passed, including Ruff, format check, pip check, Bandit, compileall, parser scenarios, and unittest discovery.
+- UI validation not applicable: no UI route, NiceGUI component, rendered report/history/dashboard surface, browser interaction, keyboard behavior, or accessibility semantics changed.
+- Stored partial-context red phase: `./.venv/bin/python -m unittest tests.test_services.test_report_service.ReportServiceTests.test_persisted_advisory_honors_stored_partial_context_signal -q` failed before implementation on missing `context_completeness.partial_context`.
+- Stored partial-context targeted regressions: `./.venv/bin/python -m unittest tests.test_services.test_report_service.ReportServiceTests.test_persisted_advisory_honors_stored_partial_context_signal tests.test_services.test_report_service.ReportServiceTests.test_persisted_advisory_honors_manifest_item_partial_context tests.test_services.test_report_service.ReportServiceTests.test_persisted_advisory_keeps_evidence_gap_separate_from_partial_context tests.test_models.test_evidence_models.EvidenceModelTests.test_context_completeness_constructs_and_serializes -q` passed, 4 tests.
+- Stored partial-context affected suites: `./.venv/bin/python -m unittest tests.test_models.test_evidence_models tests.test_services.test_report_service tests.test_api.test_schemas tests.test_docs.test_report_schema_documentation -q` passed, 165 tests; `./.venv/bin/python -m unittest tests.test_api.test_analyses -q` passed, 61 tests.
+- Stored partial-context lint/format: `./.venv/bin/ruff check .` passed; `./.venv/bin/ruff format --check .` passed.
+- Stored partial-context full validation: `./.venv/bin/python -m unittest discover -q` passed, 433 tests, 1 skipped; `bash scripts/ci-local.sh` passed, including Ruff, format check, pip check, Bandit, compileall, parser scenarios, and unittest discovery.
+- UI validation not applicable: no UI route, NiceGUI component, rendered report/history/dashboard surface, browser interaction, keyboard behavior, or accessibility semantics changed.
+- Reviewer findings red phase: `./.venv/bin/python -m unittest tests.test_services.test_report_service.ReportServiceTests.test_persisted_advisory_treats_false_like_strings_as_false tests.test_services.test_analysis_service.AnalysisServiceTests.test_build_share_summary_requires_attention_for_stored_partial_context tests.test_api.test_analyses.AnalysesApiTests.test_create_analysis_falls_back_when_persisted_advisory_is_invalid -q` failed before implementation on boolean-like persisted partial-context flags, stored share-summary partial-context parity, and invalid persisted advisory fallback.
+- Reviewer findings targeted regressions: `./.venv/bin/python -m unittest tests.test_services.test_report_service.ReportServiceTests.test_persisted_advisory_treats_false_like_strings_as_false tests.test_services.test_analysis_service.AnalysisServiceTests.test_build_share_summary_requires_attention_for_stored_partial_context tests.test_api.test_analyses.AnalysesApiTests.test_create_analysis_falls_back_when_persisted_advisory_is_invalid -q` passed, 3 tests.
+- Reviewer findings affected suites: `./.venv/bin/python -m unittest tests.test_api.test_analyses tests.test_services.test_report_service tests.test_services.test_analysis_service -q` passed, 239 tests.
+- Reviewer findings lint/format: `./.venv/bin/ruff format api/routes/analyses.py services/report_service.py services/analysis_service.py tests/test_api/test_analyses.py tests/test_services/test_report_service.py tests/test_services/test_analysis_service.py` formatted 2 files; `./.venv/bin/ruff check api/routes/analyses.py services/report_service.py services/analysis_service.py tests/test_api/test_analyses.py tests/test_services/test_report_service.py tests/test_services/test_analysis_service.py` passed; `./.venv/bin/ruff check .` passed; `./.venv/bin/ruff format --check .` passed.
+- Reviewer findings full validation: `./.venv/bin/python -m unittest discover -q` passed, 434 tests, 1 skipped; `bash scripts/ci-local.sh` passed, including Ruff, format check, pip check, Bandit, compileall, parser scenarios, and unittest discovery.
+- UI validation not applicable: no UI route, NiceGUI component, rendered report/history/dashboard surface, browser interaction, keyboard behavior, or accessibility semantics changed.
+- Submit advisory fallback parity red phase: `./.venv/bin/python -m unittest tests.test_api.test_analyses.AnalysesApiTests.test_create_analysis_falls_back_when_persisted_advisory_is_invalid -q` failed before implementation on missing persisted-report evidence-gap advisory derivation.
+- Submit advisory fallback parity targeted regression: `./.venv/bin/python -m unittest tests.test_api.test_analyses.AnalysesApiTests.test_create_analysis_falls_back_when_persisted_advisory_is_invalid -q` passed, 1 test.
+- Submit advisory fallback parity affected suite: `./.venv/bin/python -m unittest tests.test_api.test_analyses tests.test_services.test_report_service tests.test_services.test_analysis_service -q` passed, 239 tests.
+- Submit advisory fallback parity lint/format: `./.venv/bin/ruff format api/routes/analyses.py services/report_service.py tests/test_api/test_analyses.py` left 3 files unchanged; `./.venv/bin/ruff check api/routes/analyses.py services/report_service.py tests/test_api/test_analyses.py` passed; `./.venv/bin/ruff check .` passed; `./.venv/bin/ruff format --check .` passed.
+- Submit advisory fallback parity full validation: `./.venv/bin/python -m unittest discover -q` passed, 434 tests, 1 skipped; `bash scripts/ci-local.sh` passed, including Ruff, format check, pip check, Bandit, compileall, parser scenarios, and unittest discovery.
+- UI validation not applicable: no UI route, NiceGUI component, rendered report/history/dashboard surface, browser interaction, keyboard behavior, or accessibility semantics changed.
+- Reviewer follow-up red phase: `./.venv/bin/python -m unittest tests.test_services.test_report_service.ReportServiceTests.test_fetch_report_degrades_on_malformed_submission_manifest_json tests.test_services.test_report_service.ReportServiceTests.test_report_advisory_builder_normalizes_false_like_boolean_strings tests.test_services.test_report_service.ReportServiceTests.test_legacy_context_partial_context_matches_recovered_manifest_signal tests.test_api.test_analyses.AnalysesApiTests.test_openapi_documents_analysis_submission_contract -q` failed before implementation on OpenAPI runtime error docs, false-like advisory boolean handling, and context/advisory partial_context parity.
+- Reviewer follow-up targeted regressions: `./.venv/bin/python -m unittest tests.test_services.test_report_service.ReportServiceTests.test_fetch_report_degrades_on_malformed_submission_manifest_json tests.test_services.test_report_service.ReportServiceTests.test_report_advisory_builder_normalizes_false_like_boolean_strings tests.test_services.test_report_service.ReportServiceTests.test_legacy_context_partial_context_matches_recovered_manifest_signal tests.test_api.test_analyses.AnalysesApiTests.test_openapi_documents_analysis_submission_contract -q` passed, 4 tests.
+- Reviewer follow-up affected suite: `./.venv/bin/python -m unittest tests.test_api.test_analyses tests.test_services.test_report_service tests.test_docs.test_report_schema_documentation tests.test_api.test_schemas -q` passed, 214 tests.
+- Reviewer follow-up lint/format: `./.venv/bin/ruff format api/routes/analyses.py services/report_service.py tests/test_api/test_analyses.py tests/test_services/test_report_service.py` left 4 files unchanged; `./.venv/bin/ruff check api/routes/analyses.py services/report_service.py tests/test_api/test_analyses.py tests/test_services/test_report_service.py` passed; `./.venv/bin/ruff check .` passed; `./.venv/bin/ruff format --check .` passed.
+- Reviewer follow-up full validation: `./.venv/bin/python -m unittest discover -q` passed, 434 tests, 1 skipped; `bash scripts/ci-local.sh` passed, including Ruff, format check, pip check, Bandit, compileall, parser scenarios, and unittest discovery.
+- UI validation not applicable: no UI route, NiceGUI component, rendered report/history/dashboard surface, browser interaction, keyboard behavior, or accessibility semantics changed.
+- Share-summary boolean red phase: `./.venv/bin/python -m unittest tests.test_services.test_analysis_service.AnalysisServiceTests.test_build_share_summary_normalizes_false_like_context_booleans tests.test_services.test_analysis_service.AnalysisServiceTests.test_build_share_summary_normalizes_false_like_narrative_availability -q` failed before implementation on false-like context and narrative availability string handling.
+- Share-summary boolean targeted regressions: `./.venv/bin/python -m unittest tests.test_services.test_analysis_service.AnalysisServiceTests.test_build_share_summary_normalizes_false_like_context_booleans tests.test_services.test_analysis_service.AnalysisServiceTests.test_build_share_summary_normalizes_false_like_narrative_availability -q` passed, 2 tests.
+- Share-summary boolean affected suite: `./.venv/bin/python -m unittest tests.test_services.test_analysis_service tests.test_api.test_analyses tests.test_services.test_report_service tests.test_docs.test_report_schema_documentation tests.test_api.test_schemas -q` passed, 252 tests.
+- Share-summary boolean lint/format: `./.venv/bin/ruff format services/analysis_service.py tests/test_services/test_analysis_service.py` reformatted 1 file; `./.venv/bin/ruff check .` passed; `./.venv/bin/ruff format --check .` passed.
+- Share-summary boolean full validation: `./.venv/bin/python -m unittest discover -q` passed, 434 tests, 1 skipped; `bash scripts/ci-local.sh` passed, including Ruff, format check, pip check, Bandit, compileall, parser scenarios, and unittest discovery.
+- UI validation not applicable: no UI route, NiceGUI component, rendered report/history/dashboard surface, browser interaction, keyboard behavior, or accessibility semantics changed.
+- Current reviewer findings red phase: `./.venv/bin/python -m unittest tests.test_api.test_analyses.AnalysesApiTests.test_create_analysis_rebuilds_stale_valid_persisted_advisory tests.test_api.test_analyses.AnalysesApiTests.test_create_analysis_share_summary_matches_advisory_partial_context tests.test_api.test_analyses.AnalysesApiTests.test_create_analysis_invalid_advisory_context_uses_error_envelope tests.test_api.test_analyses.AnalysesApiTests.test_create_analysis_preserves_go_advisory_with_narrative_warning tests.test_services.test_analysis_service.AnalysisServiceTests.test_build_share_summary_ignores_non_finite_boolean_signals tests.test_services.test_report_service.ReportServiceTests.test_report_advisory_builder_ignores_non_finite_boolean_signals -q` failed before implementation on stale submit advisory, share-summary partial-context parity, malformed-context API envelope, and non-finite boolean normalization.
+- Current reviewer findings targeted regressions: `./.venv/bin/python -m unittest tests.test_api.test_analyses.AnalysesApiTests.test_create_analysis_rebuilds_stale_valid_persisted_advisory tests.test_api.test_analyses.AnalysesApiTests.test_create_analysis_share_summary_matches_advisory_partial_context tests.test_api.test_analyses.AnalysesApiTests.test_create_analysis_invalid_advisory_context_uses_error_envelope tests.test_api.test_analyses.AnalysesApiTests.test_create_analysis_preserves_go_advisory_with_narrative_warning tests.test_services.test_analysis_service.AnalysisServiceTests.test_build_share_summary_ignores_non_finite_boolean_signals tests.test_services.test_report_service.ReportServiceTests.test_report_advisory_builder_ignores_non_finite_boolean_signals -q` passed, 6 tests.
+- Current reviewer findings affected suites: `./.venv/bin/python -m unittest tests.test_api.test_analyses tests.test_services.test_analysis_service tests.test_services.test_report_service -q` passed, 248 tests.
+- Current reviewer findings lint/format: `./.venv/bin/ruff check .` passed; `./.venv/bin/ruff format --check .` passed.
+- Current reviewer findings full validation: `./.venv/bin/python -m unittest discover -q` passed, 437 tests, 1 skipped; `bash scripts/ci-local.sh` passed, including Ruff, format check, pip check, Bandit, compileall, parser scenarios, and unittest discovery.
+- UI validation not applicable: no UI route, NiceGUI component, rendered report/history/dashboard surface, browser interaction, keyboard behavior, or accessibility semantics changed.
+- Latest patch reviewer red phase: `./.venv/bin/python -m unittest tests.test_api.test_analyses.AnalysesApiTests.test_create_analysis_preserves_go_advisory_with_narrative_warning tests.test_api.test_analyses.AnalysesApiTests.test_create_analysis_returns_structured_result -q` failed before implementation on create-response transient findings/evidence/context values instead of persisted-report contract values.
+- Latest patch reviewer targeted regressions: `./.venv/bin/python -m unittest tests.test_api.test_analyses.AnalysesApiTests.test_create_analysis_preserves_go_advisory_with_narrative_warning tests.test_api.test_analyses.AnalysesApiTests.test_create_analysis_returns_structured_result -q` passed, 2 tests.
+- Latest patch reviewer affected suites: `./.venv/bin/python -m unittest tests.test_api.test_analyses tests.test_services.test_analysis_service tests.test_services.test_report_service -q` passed, 248 tests.
+- Latest patch reviewer lint/format: `./.venv/bin/ruff check api/schemas.py services/analysis_service.py tests/test_api/test_analyses.py` passed; `./.venv/bin/ruff format --check api/schemas.py services/analysis_service.py tests/test_api/test_analyses.py` passed.
+- Latest patch reviewer full validation: `./.venv/bin/ruff check .` passed; `./.venv/bin/ruff format --check .` passed; `./.venv/bin/python -m unittest discover -q` passed, 437 tests, 1 skipped; `bash scripts/ci-local.sh` passed, including Ruff, format check, pip check, Bandit, compileall, parser scenarios, and unittest discovery.
+- UI validation not applicable: no UI route, NiceGUI component, rendered report/history/dashboard surface, browser interaction, keyboard behavior, or accessibility semantics changed.
+- Clean re-review validation: `./.venv/bin/ruff check .` passed; `./.venv/bin/ruff format --check .` passed; `./.venv/bin/python -m unittest tests.test_api.test_analyses tests.test_services.test_analysis_service tests.test_services.test_report_service tests.test_api.test_schemas tests.test_docs.test_report_schema_documentation -q` passed, 257 tests; `./.venv/bin/python -m unittest discover -q` passed, 437 tests, 1 skipped.
+- Clean re-review result: no new decision-needed, patch, or defer findings; moved story to done.
+
+### Completion Notes List
+
+- Added `meta.api_version: "v1"` to report-bearing API metadata helpers and response meta models.
+- Added a persisted-report `advisory` payload for analysis submit/list/detail responses, derived from durable report state and preserving `advisory_only=true` / `should_block=false`.
+- Resolved reviewer findings by distinguishing attention-worthy persisted warnings from narrative-only warnings, preserving `go` advisory semantics for clean low-risk reports with narrative provider warnings.
+- Added regression coverage for persisted advisory parity and nested advisory top-risk redaction.
+- Resolved re-review findings by deriving submit-response `data.advisory` from the persisted advisory payload, keeping synthesized `context_todos` and nested advisory flags identical between `advisory` and `persisted_report.advisory`.
+- Tightened persisted warning classification so only warnings prefixed as narrative warnings are treated as narrative-only; built-in assessment and persistence warnings still require advisory attention.
+- Resolved re-review evidence/list findings by including persisted evidence payloads in history/list serialization for Story 5.1 submit/list/detail contract parity.
+- Added submit and list regressions proving clean `go` advisory semantics survive narrative-only provider warnings without assessment warnings or attention flags.
+- Locked required report contract documentation fields for `meta.api_version` and `advisory.top_risk`.
+- Kept the implementation in the existing API schema and report serialization layer; no new dependencies or persistence migrations were needed.
+- Updated report schema and project workspace documentation for the `/api/v1` contract.
+- Resolved latest re-review findings by keeping evidence extraction gaps separate from parser `partial_context`, while still surfacing `evidence_gaps` in persisted advisory uncertainty and attention signals.
+- Kept history page evidence payloads for paginated list items while making the previous-scan comparison scope lightweight and evidence-free.
+- Normalized persisted advisory severity values before strict schema validation so legacy casing or unknown stored values do not break `/api/v1` response serialization.
+- Resolved the latest reviewer finding by deriving persisted advisory `partial_context` from per-artifact manifest item partial/status/parse-status signals, not only top-level manifest partial analysis.
+- Preserved evidence-gap separation from parser partial context while still surfacing evidence gaps through advisory uncertainty and attention signals.
+- Resolved final re-review findings by applying the same manifest item partial/status/parse-status rules to fallback manifest items when canonical manifest JSON is unavailable.
+- Normalized top-level persisted report severity and recommendation during serialization so legacy stored values match the advisory payload contract.
+- Resolved stored partial-context review finding by persisting the upstream `RiskAssessment.partial_context` signal into context completeness, honoring it during persisted advisory derivation, and documenting the report schema field.
+- Resolved reviewer findings by applying strict persisted boolean normalization to partial-context flags, falling back to the canonical advisory builder when persisted submit advisory data is invalid, and making share summaries honor stored `partial_context`.
+- Resolved submit advisory fallback parity by deriving invalid or missing submit-response advisory data from the canonical persisted-report advisory builder, preserving evidence gaps and manifest/context signals.
+- Resolved reviewer follow-ups by aligning recovered/legacy context `partial_context` with advisory `partial_context`, normalizing false-like advisory booleans, and documenting list/detail/submit runtime error envelopes in OpenAPI.
+- Resolved share-summary boolean review finding by normalizing false-like persisted `insufficient_context`, `narrative_available`, and `narrative_degraded` values before computing context labels and human-attention copy.
+- Resolved current reviewer findings by always rebuilding submit-response advisory from canonical persisted-report fields, routing malformed persisted advisory context through the API error envelope, aligning share-summary partial-context detection with advisory manifest semantics, adding create-response contract regressions for API/report schema versions, and ignoring non-finite legacy boolean values.
+- Resolved latest patch reviewer findings by making share summaries use advisory attention semantics instead of treating narrative-only warnings as attention-worthy, and by serializing submit-response findings, evidence, context, blast radius, rollback plan, and incident matches from the persisted report contract.
+
+### File List
+
+- `api/schemas.py`
+- `api/routes/analyses.py`
+- `evidence/models.py`
+- `services/report_service.py`
+- `services/analysis_service.py`
+- `tests/test_api/test_analyses.py`
+- `tests/test_api/test_schemas.py`
+- `tests/test_docs/test_report_schema_documentation.py`
+- `tests/test_models/test_evidence_models.py`
+- `tests/test_services/test_report_service.py`
+- `tests/test_services/test_analysis_service.py`
+- `docs/schemas/report-v2.md`
+- `docs/project-workspaces.md`
+- `_bmad-output/implementation-artifacts/5-1-versioned-api-report-contract.md`
+- `_bmad-output/implementation-artifacts/sprint-status.yaml`
+
+## Change Log
+
+- 2026-05-01: Story created/aligned from updated PRD, architecture, epics, sprint status, and readiness report.
+- 2026-05-25: Implemented `/api/v1` versioned report contract metadata and persisted advisory payload coverage; moved story to review.
+- 2026-05-25: Resolved code review findings for persisted advisory parity and nested advisory redaction coverage; moved story to done.
+- 2026-05-25: Resolved re-review findings for warning classification and submit/persisted advisory parity; kept story done.
+- 2026-05-25: Resolved re-review findings for evidence payload list retrieval, narrative-only go advisory submit/list coverage, and report schema documentation locks; kept story done.
+- 2026-05-25: Resolved re-review findings for advisory partial-context semantics, lightweight history pagination scope, and persisted advisory severity normalization; kept story done.
+- 2026-05-25: Resolved latest re-review finding for per-artifact manifest partial-context advisory detection; kept story done.
+- 2026-05-25: Resolved final re-review findings for fallback manifest partial-context detection and top-level/advisory normalization parity; kept story done.
+- 2026-05-25: Resolved stored partial-context advisory review finding; moved story to review.
+- 2026-05-25: Resolved reviewer findings for persisted boolean normalization, submit advisory fallback, and share-summary partial-context parity; moved story to review.
+- 2026-05-25: Resolved submit fallback advisory parity review finding; moved story to review.
+- 2026-05-25: Resolved reviewer follow-ups for partial-context parity, advisory boolean normalization, and OpenAPI error envelopes; moved story to review.
+- 2026-05-25: Resolved share-summary false-like persisted boolean review finding; moved story to review.
+- 2026-05-25: Resolved current reviewer findings for stale submit advisory rebuild, share-summary/advisory partial-context parity, create-response version coverage, malformed-context error envelopes, and non-finite boolean normalization; moved story to review.
+- 2026-05-25: Resolved latest patch reviewer findings for narrative-only share-summary attention semantics and persisted create-response contract parity; moved story to review.
+- 2026-05-25: Re-ran BMad code review cleanly with full validation; moved story to done.

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -1,5 +1,5 @@
 # generated: 2026-05-01
-# last_updated: 2026-05-22
+# last_updated: 2026-05-25
 # project: deploywhisper
 # project_key: NOKEY
 # tracking_system: file-system
@@ -35,7 +35,7 @@
 # - Dev moves story to review, then runs code-review
 
 generated: 2026-05-01
-last_updated: 2026-05-22
+last_updated: 2026-05-25
 project: deploywhisper
 project_key: NOKEY
 tracking_system: file-system
@@ -92,7 +92,7 @@ development_status:
   epic-4-retrospective: optional
 
   epic-5: in-progress
-  5-1-versioned-api-report-contract: ready-for-dev
+  5-1-versioned-api-report-contract: done
   5-2-cli-project-aware-advisory-output: ready-for-dev
   5-3-github-action-integration-contract: ready-for-dev
   5-4-pr-comment-formatter: ready-for-dev

--- a/api/routes/analyses.py
+++ b/api/routes/analyses.py
@@ -8,6 +8,7 @@ from datetime import UTC, datetime
 from typing import Annotated
 
 from fastapi import APIRouter, Depends, File, Form, Header, Query, UploadFile
+from pydantic import ValidationError
 
 from api.errors import ApiError, ApiRoute
 from api.schemas import (
@@ -15,6 +16,7 @@ from api.schemas import (
     AnalysisListResponse,
     AnalysisReportData,
     AnalysisRunResponse,
+    AdvisorySummaryData,
     AnalysisShareConfigData,
     AnalysisShareConfigRequest,
     AnalysisShareConfigResponse,
@@ -26,7 +28,6 @@ from config import settings
 from services.analysis_service import (
     AnalysisPersistenceError,
     analyze_uploaded_files,
-    build_advisory_summary,
     build_share_summary,
     resolve_analysis_project_scope,
 )
@@ -36,6 +37,7 @@ from services.intake_service import (
     uniquify_artifact_names,
 )
 from services.report_service import REPORT_SCHEMA_VERSION
+from services.report_service import build_report_advisory_payload
 from services.report_service import configure_report_share
 from services.report_service import fetch_analysis_report
 from services.report_service import fetch_filtered_analysis_history_page
@@ -69,6 +71,33 @@ def _list_report_schema_meta(reports: list[dict]) -> dict[str, object]:
         else REPORT_SCHEMA_VERSION,
         "report_schema_versions": versions,
     }
+
+
+def _analysis_run_advisory(result) -> AdvisorySummaryData:
+    persisted_report = result.persisted_report
+    try:
+        fallback_payload = (
+            build_report_advisory_payload(persisted_report)
+            if isinstance(persisted_report, dict)
+            else {}
+        )
+    except (TypeError, ValueError) as exc:
+        raise ApiError(
+            status_code=500,
+            code="analysis_advisory_contract_invalid",
+            message="Analysis advisory contract validation failed.",
+        ) from exc
+    try:
+        advisory = AdvisorySummaryData.model_validate(fallback_payload)
+    except ValidationError as exc:
+        raise ApiError(
+            status_code=500,
+            code="analysis_advisory_contract_invalid",
+            message="Analysis advisory contract validation failed.",
+        ) from exc
+    if isinstance(persisted_report, dict):
+        persisted_report["advisory"] = advisory.model_dump(mode="json")
+    return advisory
 
 
 def _project_api_error(exc: ValueError) -> ApiError:
@@ -362,7 +391,17 @@ async def _read_upload_files_with_limit(
     return uniquify_artifact_names(buffered)
 
 
-@router.get("", response_model=AnalysisListResponse)
+@router.get(
+    "",
+    response_model=AnalysisListResponse,
+    responses={
+        400: {"model": ErrorResponse},
+        403: {"model": ErrorResponse},
+        405: {"model": ErrorResponse},
+        422: {"model": ErrorResponse},
+        500: {"model": ErrorResponse},
+    },
+)
 def list_analyses(
     project_id: int | None = Query(default=None),
     project_key: str | None = Query(default=None),
@@ -459,6 +498,7 @@ def list_analyses(
     response_model=AnalysisRunResponse,
     responses={
         400: {"model": ErrorResponse},
+        403: {"model": ErrorResponse},
         404: {"model": ErrorResponse},
         413: {"model": ErrorResponse},
         405: {"model": ErrorResponse},
@@ -585,7 +625,7 @@ async def create_analysis(
         ) from exc
     except ValueError as exc:
         raise _project_api_error(exc) from exc
-    advisory = build_advisory_summary(result.assessment, result.narrative)
+    advisory = _analysis_run_advisory(result)
     share_summary = build_share_summary(result.persisted_report)
     return AnalysisRunResponse(
         data=build_analysis_run_data(
@@ -608,6 +648,8 @@ async def create_analysis(
     "/{report_id}",
     response_model=AnalysisDetailResponse,
     responses={
+        400: {"model": ErrorResponse},
+        403: {"model": ErrorResponse},
         404: {"model": ErrorResponse},
         405: {"model": ErrorResponse},
         422: {"model": ErrorResponse},

--- a/api/schemas.py
+++ b/api/schemas.py
@@ -26,6 +26,7 @@ def build_meta(**extra: Any) -> dict[str, Any]:
 
 def build_report_meta(*, report_schema_version: str, **extra: Any) -> dict[str, Any]:
     """Build metadata for report-bearing API responses."""
+    extra.setdefault("api_version", "v1")
     return build_meta(report_schema_version=report_schema_version, **extra)
 
 
@@ -111,6 +112,9 @@ class PendingAnalysis(BaseModel):
 
 
 class CountMetaPayload(MetaPayload):
+    api_version: str = Field(
+        default="v1", description="Versioned API contract identifier"
+    )
     report_schema_version: str = Field(
         ...,
         description=(
@@ -131,6 +135,9 @@ class CountMetaPayload(MetaPayload):
 
 
 class ResourceMetaPayload(MetaPayload):
+    api_version: str = Field(
+        default="v1", description="Versioned API contract identifier"
+    )
     report_schema_version: str = Field(
         ..., description="Report schema version used by the returned payload"
     )
@@ -396,6 +403,9 @@ class PersistedReportData(BaseModel):
     narrative_provider: str | None = Field(default=None)
     narrative_model: str | None = Field(default=None)
     narrative_local_mode: bool | None = Field(default=None)
+    advisory: "AdvisorySummaryData" = Field(
+        ..., description="Stable advisory recommendation contract for automation"
+    )
     skills_applied: list[str] = Field(default_factory=list)
     created_at: str
     warnings: list[str] = Field(default_factory=list)
@@ -850,6 +860,10 @@ class ContextCompletenessData(BaseModel):
     insufficient_context: bool = Field(
         default=False,
         description="Whether context is too weak for a confident low-risk verdict",
+    )
+    partial_context: bool = Field(
+        default=False,
+        description="Whether analysis context was explicitly marked partial upstream",
     )
 
 
@@ -1343,6 +1357,16 @@ def _copy_model(model: BaseModel, schema_type: type[BaseModel]) -> BaseModel:
     return schema_type.model_validate(model.model_dump())
 
 
+def _copy_payload(payload: Any, schema_type: type[BaseModel]) -> BaseModel:
+    return schema_type.model_validate(payload)
+
+
+def _copy_payload_list(items: Any, schema_type: type[BaseModel]) -> list[BaseModel]:
+    if not isinstance(items, list):
+        return []
+    return [_copy_payload(item, schema_type) for item in items]
+
+
 def build_analysis_run_data(
     *,
     intake: PendingAnalysis,
@@ -1352,13 +1376,13 @@ def build_analysis_run_data(
 ) -> AnalysisRunData:
     parse_batch = result.parse_batch
     assessment = result.assessment
-    findings = result.findings
-    evidence_items = result.evidence_items
     blast_radius = result.blast_radius
     rollback_plan = result.rollback_plan
-    incident_matches = result.incident_matches
     narrative = result.narrative
     persisted_report = result.persisted_report
+    persisted_context = ContextCompletenessData.model_validate(
+        persisted_report.get("context_completeness", {})
+    )
 
     return AnalysisRunData(
         intake=PendingAnalysis.model_validate(intake.model_dump()),
@@ -1380,19 +1404,23 @@ def build_analysis_run_data(
             ]
         ),
         assessment=AssessmentData(
-            score=assessment.score,
-            severity=assessment.severity,
-            recommendation=assessment.recommendation,
-            confidence=assessment.confidence,
-            top_risk=assessment.top_risk,
-            top_risk_contributors=list(assessment.top_risk_contributors),
-            context_completeness=_copy_model(
-                assessment.context_completeness, ContextCompletenessData
+            score=int(persisted_report.get("risk_score", assessment.score)),
+            severity=persisted_report.get("severity", assessment.severity),
+            recommendation=persisted_report.get(
+                "recommendation", assessment.recommendation
             ),
-            contributors=[
-                _copy_model(contributor, RiskContributorData)
-                for contributor in assessment.contributors
-            ],
+            confidence=float(persisted_report.get("confidence", assessment.confidence)),
+            top_risk=str(persisted_report.get("top_risk", assessment.top_risk)),
+            top_risk_contributors=list(
+                persisted_report.get(
+                    "top_risk_contributors", assessment.top_risk_contributors
+                )
+                or []
+            ),
+            context_completeness=persisted_context,
+            contributors=_copy_payload_list(
+                persisted_report.get("contributors"), RiskContributorData
+            ),
             confidence_ledger=ConfidenceLedgerData.model_validate(
                 persisted_report.get("confidence_ledger", {})
             ),
@@ -1400,34 +1428,43 @@ def build_analysis_run_data(
                 _copy_model(interaction_risk, InteractionRiskData)
                 for interaction_risk in assessment.interaction_risks
             ],
-            partial_context=assessment.partial_context,
-            warnings=list(assessment.warnings),
-            source=assessment.source,
+            partial_context=persisted_context.partial_context,
+            warnings=list(persisted_report.get("warnings") or []),
+            source=persisted_report.get("assessment_source") or assessment.source,
         ),
-        findings=[_copy_model(finding, FindingData) for finding in findings],
-        evidence_items=[
-            _copy_model(evidence_item, EvidenceItemData)
-            for evidence_item in evidence_items
-        ],
-        blast_radius=BlastRadiusData(
-            affected=[
-                _copy_model(node, ImpactNodeData) for node in blast_radius.affected
-            ],
-            direct_count=blast_radius.direct_count,
-            transitive_count=blast_radius.transitive_count,
-            warning=blast_radius.warning,
-            unmatched_resources=list(blast_radius.unmatched_resources),
+        findings=_copy_payload_list(persisted_report.get("findings"), FindingData),
+        evidence_items=_copy_payload_list(
+            persisted_report.get("evidence_items"), EvidenceItemData
         ),
-        rollback_plan=RollbackPlanData(
-            steps=[_copy_model(step, RollbackStepData) for step in rollback_plan.steps],
-            complexity=rollback_plan.complexity,
-            complexity_score=rollback_plan.complexity_score,
-            complexity_explanation=rollback_plan.complexity_explanation,
-            warning=rollback_plan.warning,
+        blast_radius=BlastRadiusData.model_validate(
+            persisted_report.get("blast_radius")
+            or {
+                "affected": [
+                    _copy_model(node, ImpactNodeData).model_dump()
+                    for node in blast_radius.affected
+                ],
+                "direct_count": blast_radius.direct_count,
+                "transitive_count": blast_radius.transitive_count,
+                "warning": blast_radius.warning,
+                "unmatched_resources": list(blast_radius.unmatched_resources),
+            }
         ),
-        incident_matches=[
-            _copy_model(match, IncidentMatchData) for match in incident_matches
-        ],
+        rollback_plan=RollbackPlanData.model_validate(
+            persisted_report.get("rollback_plan")
+            or {
+                "steps": [
+                    _copy_model(step, RollbackStepData).model_dump()
+                    for step in rollback_plan.steps
+                ],
+                "complexity": rollback_plan.complexity,
+                "complexity_score": rollback_plan.complexity_score,
+                "complexity_explanation": rollback_plan.complexity_explanation,
+                "warning": rollback_plan.warning,
+            }
+        ),
+        incident_matches=_copy_payload_list(
+            persisted_report.get("incident_matches"), IncidentMatchData
+        ),
         narrative=_copy_model(narrative, NarrativeData),
         advisory=_copy_model(advisory, AdvisorySummaryData),
         share_summary=_copy_model(share_summary, ShareSummaryData),

--- a/cli/analyze.py
+++ b/cli/analyze.py
@@ -10,7 +10,7 @@ import os
 import sys
 from pathlib import Path
 from api.errors import build_error
-from api.schemas import build_analysis_run_data, build_meta
+from api.schemas import AdvisorySummaryData, build_analysis_run_data, build_meta
 from integrations.github.init_service import (
     GitHubInitError,
     collect_github_init_options,
@@ -34,7 +34,6 @@ from services.skill_test_harness_service import iter_built_in_skill_ids
 from services.analysis_service import (
     AnalysisPersistenceError,
     analyze_uploaded_files,
-    build_advisory_summary,
     build_share_summary,
     resolve_analysis_project_scope,
 )
@@ -51,13 +50,30 @@ from services.intake_service import (
     build_pending_analysis,
     uniquify_artifact_names,
 )
-from services.report_service import REPORT_SCHEMA_VERSION, fetch_analysis_report
+from services.report_service import (
+    REPORT_SCHEMA_VERSION,
+    build_report_advisory_payload,
+    fetch_analysis_report,
+)
 from services.topology_service import get_topology_status, import_topology_source
 
 
 def _emit_json(payload: dict, *, stream) -> None:
     stream.write(json.dumps(payload))
     stream.write("\n")
+
+
+def _analysis_run_advisory(result) -> AdvisorySummaryData:
+    persisted_report = result.persisted_report
+    fallback_payload = (
+        build_report_advisory_payload(persisted_report)
+        if isinstance(persisted_report, dict)
+        else {}
+    )
+    advisory = AdvisorySummaryData.model_validate(fallback_payload)
+    if isinstance(persisted_report, dict):
+        persisted_report["advisory"] = advisory.model_dump(mode="json")
+    return advisory
 
 
 def _split_env_project_keys(value: str | None) -> list[str] | None:
@@ -510,7 +526,7 @@ def _run_analyze(
         "data": build_analysis_run_data(
             intake=pending_analysis,
             result=result,
-            advisory=build_advisory_summary(result.assessment, result.narrative),
+            advisory=_analysis_run_advisory(result),
             share_summary=build_share_summary(result.persisted_report),
         ).model_dump(),
         "meta": build_meta(

--- a/docs/project-workspaces.md
+++ b/docs/project-workspaces.md
@@ -28,6 +28,7 @@ For setup-specific modeling guidance, see the [Project Model Guide](./concepts/p
   - `POST /api/v1/analyses` also accepts optional `workspace_key` or `workspace_id` to attach a run to a project-local workspace/environment
   - `GET /api/v1/analyses?project_key=<key>&workspace_key=<workspace>` lists reports for one workspace
   - `GET /api/v1/analyses/<id>?project_key=<key>&workspace_key=<workspace>` returns a report only when the requested scope matches
+  - Analysis submit/list/detail responses expose `meta.api_version`, `meta.report_schema_version`, project/workspace scope, evidence, findings, context completeness, narrative status, and the advisory recommendation contract.
   - `GET /api/v1/context/topology?project_key=<key>` reads project-scoped topology status
   - `POST /api/v1/context/topology` stores project-scoped topology JSON with `project_key` or `project_id`
   - Project, analysis, report, topology context, and deployment outcome routes accept `X-DeployWhisper-Project-Role` and `X-DeployWhisper-Project-Keys` as the lightweight actor contract. Omitting both preserves local self-hosted admin behavior.

--- a/docs/schemas/report-v2.md
+++ b/docs/schemas/report-v2.md
@@ -15,11 +15,13 @@ This schema version applies to:
 
 1. Every persisted report stores `report_schema_version`.
 2. API and CLI envelopes include `report_schema_version` in `meta`.
-3. Machine-friendly share-summary payloads include `report_schema_version`
+3. Report-bearing `/api/v1` analysis envelopes include `api_version: "v1"`
+   in `meta` alongside the report schema version.
+4. Machine-friendly share-summary payloads include `report_schema_version`
    alongside their own share payload `version`.
-4. Stored reports remain readable across upgrades by version-aware readers.
-5. Newer readers are expected to read older schemas when the older schema major version is less than or equal to the reader version.
-6. Successful analysis responses include a persisted report identifier and
+5. Stored reports remain readable across upgrades by version-aware readers.
+6. Newer readers are expected to read older schemas when the older schema major version is less than or equal to the reader version.
+7. Successful analysis responses include a persisted report identifier and
    audit metadata derived from durable report state. Persistence failures use an
    explicit `report_persistence_failed` error/status instead of returning
    success, with sanitized remediation text rather than raw storage-driver
@@ -100,7 +102,10 @@ the audit actor can still be recovered if manifest JSON is malformed.
 ### Advisory and share-summary shape
 
 API and CLI analysis responses include advisory fields for automation and PR
-comment consumers. `data.advisory.should_block` remains `false`; downstream
+comment consumers. API report list/detail payloads also include
+`data[*].advisory` / `data.advisory` derived from persisted report state, so
+retrieval clients do not have to reconstruct DeployWhisper's advisory posture
+from lower-level report fields. `should_block` remains `false`; downstream
 systems may use `requires_attention` and `uncertainty_flags` to decide whether
 to notify humans, but DeployWhisper's canonical contract remains advisory-first.
 
@@ -123,6 +128,7 @@ full-report contract.
     "requires_attention": true,
     "severity": "high",
     "recommendation": "no-go",
+    "top_risk": "Security group exposure risk",
     "partial_context": true,
     "narrative_degraded": true,
     "uncertainty_flags": ["partial_context", "narrative_degraded"]
@@ -221,7 +227,8 @@ without storing raw plan internals in a separate contract.
       "Review evidence extraction gaps for supported artifacts.",
       "Review parser errors and resubmit supported artifacts."
     ],
-    "insufficient_context": true
+    "insufficient_context": true,
+    "partial_context": true
   },
   "rollback_plan": {
     "complexity": "medium",

--- a/evidence/models.py
+++ b/evidence/models.py
@@ -85,6 +85,7 @@ class ContextCompleteness(BaseModel):
     uncertainty: str | None = Field(default=None, min_length=1)
     context_todos: list[str] = Field(default_factory=list)
     insufficient_context: bool = Field(default=False)
+    partial_context: bool = Field(default=False)
 
     @field_validator("parser_success_by_tool")
     @classmethod

--- a/services/analysis_service.py
+++ b/services/analysis_service.py
@@ -647,12 +647,62 @@ def _report_link(report_id: int | None) -> str | None:
     return build_share_report_link(report_id)
 
 
-def _has_partial_context_signal(report: dict) -> bool:
-    manifest = report.get("submission_manifest")
-    if isinstance(manifest, dict) and manifest.get("partial_analysis"):
+def _truthy_bool_signal(value: object) -> bool:
+    if isinstance(value, bool):
+        return value
+    if value is None:
+        return False
+    if isinstance(value, int | float):
+        if not math.isfinite(float(value)):
+            return False
+        return bool(value)
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        if normalized in {"true", "1", "yes", "y", "on"}:
+            return True
+        if normalized in {"false", "0", "no", "n", "off", ""}:
+            return False
+    return False
+
+
+def _mapping_or_empty(value: object) -> dict:
+    return dict(value) if isinstance(value, dict) else {}
+
+
+def _manifest_item_has_partial_context_signal(item: object) -> bool:
+    if not isinstance(item, dict):
+        return False
+    if _truthy_bool_signal(item.get("partial")):
         return True
-    context = dict(report.get("context_completeness") or {})
-    if bool(context.get("insufficient_context")):
+    status = str(item.get("status") or "").strip().lower()
+    if status in {"failed", "excluded", "sensitive"}:
+        return True
+    parse_status = str(item.get("parse_status") or "").strip().lower()
+    return bool(parse_status and parse_status != "parsed")
+
+
+def _has_partial_context_signal(report: dict) -> bool:
+    if _truthy_bool_signal(report.get("partial_context")):
+        return True
+    advisory = report.get("advisory")
+    if isinstance(advisory, dict) and _truthy_bool_signal(
+        advisory.get("partial_context")
+    ):
+        return True
+    manifest = report.get("submission_manifest")
+    if isinstance(manifest, dict):
+        if _truthy_bool_signal(manifest.get("partial_analysis")):
+            return True
+        for item in manifest.get("items") or []:
+            if _manifest_item_has_partial_context_signal(item):
+                return True
+    for item in report.get("submission_manifest_fallback") or []:
+        if _manifest_item_has_partial_context_signal(item):
+            return True
+    context = _mapping_or_empty(report.get("context_completeness"))
+    if _truthy_bool_signal(context.get("partial_context")):
+        return True
+    if _truthy_bool_signal(context.get("insufficient_context")):
         return True
     if str(context.get("uncertainty") or "").strip():
         return True
@@ -663,15 +713,58 @@ def _has_partial_context_signal(report: dict) -> bool:
             return True
     except (TypeError, ValueError):
         pass
-    try:
-        if float(context.get("evidence_success_rate", 1.0)) < 1.0:
-            return True
-    except (TypeError, ValueError):
-        pass
     warnings = [str(warning).lower() for warning in (report.get("warnings") or [])]
     return any(
         "partial context" in warning or "failed to parse" in warning
         for warning in warnings
+    )
+
+
+def _has_context_attention_signal(report: dict) -> bool:
+    if _has_partial_context_signal(report):
+        return True
+    context = _mapping_or_empty(report.get("context_completeness"))
+    try:
+        return float(context.get("evidence_success_rate", 1.0)) < 1.0
+    except (TypeError, ValueError):
+        return False
+
+
+def _advisory_requires_attention_signal(report: dict) -> bool | None:
+    advisory = report.get("advisory")
+    if not isinstance(advisory, dict) or "requires_attention" not in advisory:
+        return None
+    return _truthy_bool_signal(advisory.get("requires_attention"))
+
+
+def _warning_requires_attention_signal(warning: object) -> bool:
+    normalized = str(warning or "").strip().lower()
+    return bool(normalized and not normalized.startswith("narrative"))
+
+
+def _has_warning_attention_signal(report: dict) -> bool:
+    return any(
+        _warning_requires_attention_signal(warning)
+        for warning in (report.get("warnings") or [])
+    )
+
+
+def _context_summary_from_report(report: dict) -> ShareSummaryContext:
+    context = _mapping_or_empty(report.get("context_completeness"))
+    context_summary = _context_summary(context)
+    if (
+        not _has_partial_context_signal(report)
+        or context_summary.label == "LIMITED CONTEXT"
+    ):
+        return context_summary
+    uncertainty = str(context.get("uncertainty") or "").strip()
+    return ShareSummaryContext(
+        score=context_summary.score,
+        label="LIMITED CONTEXT",
+        summary=(
+            f"LIMITED CONTEXT ({context_summary.score:.2f}) - "
+            + (uncertainty or "one or more submitted artifacts were not analyzed.")
+        ),
     )
 
 
@@ -721,7 +814,7 @@ def _context_summary(context: dict) -> ShareSummaryContext:
     partial_evidence = (
         _context_number(context, "evidence_success_rate", missing_default=1.0) < 1.0
     )
-    insufficient_context = bool(context.get("insufficient_context"))
+    insufficient_context = _truthy_bool_signal(context.get("insufficient_context"))
     uncertainty = str(context.get("uncertainty") or "").strip()
     context_todos = bool(_context_todo_items(context.get("context_todos")))
     label = (
@@ -832,30 +925,26 @@ def build_share_summary(report: dict) -> ShareSummary:
     evidence_count = len(report.get("evidence_items") or [])
     blast_radius_summary = _blast_radius_summary(report)
     rollback_summary = _rollback_summary(report)
-    context_summary = _context_summary(dict(report.get("context_completeness") or {}))
+    context_summary = _context_summary_from_report(report)
     report_id = int(report["id"]) if report.get("id") is not None else None
     report_link = _report_link(report_id)
     rollback_link = report_link
-    partial_context = _has_partial_context_signal(report)
-    if partial_context and context_summary.label != "LIMITED CONTEXT":
-        uncertainty = str(
-            dict(report.get("context_completeness") or {}).get("uncertainty") or ""
-        ).strip()
-        context_summary = ShareSummaryContext(
-            score=context_summary.score,
-            label="LIMITED CONTEXT",
-            summary=(
-                f"LIMITED CONTEXT ({context_summary.score:.2f}) - "
-                + (uncertainty or "one or more submitted artifacts were not analyzed.")
-            ),
-        )
+    partial_context = _has_context_attention_signal(report)
+    narrative_available = _truthy_bool_signal(report.get("narrative_available", True))
+    narrative_degraded = _truthy_bool_signal(report.get("narrative_degraded"))
+    advisory_requires_attention = _advisory_requires_attention_signal(report)
     requires_attention = (
-        recommendation != "go"
-        or context_summary.score < 0.7
-        or partial_context
-        or context_summary.label == "LIMITED CONTEXT"
-        or not bool(report.get("narrative_available", True))
-        or bool(report.get("warnings"))
+        advisory_requires_attention
+        if advisory_requires_attention is not None
+        else (
+            recommendation != "go"
+            or context_summary.score < 0.7
+            or partial_context
+            or context_summary.label == "LIMITED CONTEXT"
+            or not narrative_available
+            or narrative_degraded
+            or _has_warning_attention_signal(report)
+        )
     )
     uncertainty_summary = (
         "This result requires additional human review before release."

--- a/services/report_service.py
+++ b/services/report_service.py
@@ -430,6 +430,12 @@ def _redact_report_file_names(report: dict[str, Any]) -> dict[str, Any]:
             pairs,
         ),
     }
+    advisory = report.get("advisory")
+    if isinstance(advisory, dict):
+        redacted["advisory"] = {
+            **advisory,
+            "top_risk": _redact_text_value(advisory.get("top_risk"), pairs),
+        }
     return redacted
 
 
@@ -3095,7 +3101,7 @@ def _load_submission_manifest_fallback_payload(
                 if item.get("parse_status") is not None
                 else None
             ),
-            "partial": bool(item.get("partial", False)),
+            "partial": _persisted_bool_value(item.get("partial")),
         }
         if "redaction_status" in item:
             fallback_item["redaction_status"] = normalize_manifest_redaction_status(
@@ -3185,6 +3191,30 @@ def _context_todo_items(value: object) -> list[str]:
     return [str(item) for item in value if str(item).strip()]
 
 
+def _persisted_bool_value(value: object, *, default: bool = False) -> bool:
+    if isinstance(value, bool):
+        return value
+    if value is None:
+        return default
+    if isinstance(value, int | float):
+        if not math.isfinite(float(value)):
+            return default
+        return bool(value)
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        if normalized in {"true", "1", "yes", "y", "on"}:
+            return True
+        if normalized in {"false", "0", "no", "n", "off", ""}:
+            return False
+    return default
+
+
+def _require_mapping(value: object, *, field_name: str) -> dict:
+    if not isinstance(value, dict):
+        raise ValueError(f"{field_name} must be an object")
+    return dict(value)
+
+
 def _normalize_context_completeness_payload(decoded: dict) -> dict:
     context_score = _context_float_value(decoded, "context_score", missing_default=1.0)
     parser_success_rate = _context_float_value(
@@ -3258,6 +3288,9 @@ def _normalize_context_completeness_payload(decoded: dict) -> dict:
     if insufficient_context and not todos:
         todos.append(_CONTEXT_UNAVAILABLE_TODO)
     normalized["context_todos"] = todos
+    normalized["partial_context"] = _persisted_bool_value(
+        normalized.get("partial_context")
+    )
 
     uncertainty = str(normalized.get("uncertainty") or "").strip()
     if insufficient_context and not uncertainty:
@@ -3359,6 +3392,170 @@ def _context_with_incident_index_freshness(report, context_completeness: dict) -
     return context_completeness
 
 
+def _context_with_partial_context_signal(
+    context_completeness: dict,
+    *,
+    submission_manifest: dict | None,
+    submission_manifest_fallback: list[dict[str, Any]] | None,
+    warnings: list[str],
+) -> dict:
+    partial_context = _report_has_partial_context_signal(
+        {
+            "context_completeness": context_completeness,
+            "submission_manifest": submission_manifest,
+            "submission_manifest_fallback": submission_manifest_fallback or [],
+            "warnings": warnings,
+        }
+    )
+    if partial_context == _persisted_bool_value(
+        context_completeness.get("partial_context")
+    ):
+        return context_completeness
+    updated = dict(context_completeness)
+    updated["partial_context"] = partial_context
+    return updated
+
+
+def _manifest_item_has_partial_context_signal(item: object) -> bool:
+    if not isinstance(item, dict):
+        return False
+    if _persisted_bool_value(item.get("partial")):
+        return True
+    status = str(item.get("status") or "").strip().lower()
+    if status in {"failed", "excluded", "sensitive"}:
+        return True
+    parse_status = str(item.get("parse_status") or "").strip().lower()
+    return bool(parse_status and parse_status != "parsed")
+
+
+def _report_has_partial_context_signal(report: dict[str, Any]) -> bool:
+    if _persisted_bool_value(report.get("partial_context")):
+        return True
+    manifest = report.get("submission_manifest")
+    if isinstance(manifest, dict):
+        if _persisted_bool_value(manifest.get("partial_analysis")):
+            return True
+        for item in manifest.get("items") or []:
+            if _manifest_item_has_partial_context_signal(item):
+                return True
+    for item in report.get("submission_manifest_fallback") or []:
+        if _manifest_item_has_partial_context_signal(item):
+            return True
+    context = dict(report.get("context_completeness") or {})
+    if _persisted_bool_value(context.get("partial_context")):
+        return True
+    if _context_float_value(context, "parser_success_rate", missing_default=1.0) < 1.0:
+        return True
+    warnings = [str(warning).lower() for warning in (report.get("warnings") or [])]
+    return any(
+        "partial context" in warning or "failed to parse" in warning
+        for warning in warnings
+    )
+
+
+def _report_warning_requires_advisory_attention(warning: object) -> bool:
+    normalized = str(warning or "").strip().lower()
+    if not normalized:
+        return False
+    return not normalized.startswith("narrative")
+
+
+def _normalized_advisory_recommendation(value: object) -> str:
+    normalized = str(value or "caution").strip().lower()
+    if normalized not in {"go", "caution", "no-go"}:
+        return "caution"
+    return normalized
+
+
+def _normalized_advisory_severity(value: object) -> str:
+    normalized = str(value or "medium").strip().lower()
+    if normalized not in {"low", "medium", "high", "critical"}:
+        return "medium"
+    return normalized
+
+
+def _build_report_advisory_payload(report: dict[str, Any]) -> dict[str, Any]:
+    context = _require_mapping(
+        report.get("context_completeness") or {},
+        field_name="context_completeness",
+    )
+    context_score = _context_float_value(context, "context_score", missing_default=1.0)
+    context_uncertainty = bool(str(context.get("uncertainty") or "").strip())
+    context_todos = bool(_context_todo_items(context.get("context_todos")))
+    insufficient_context = _persisted_bool_value(context.get("insufficient_context"))
+    partial_context = _report_has_partial_context_signal(report)
+    evidence_gap = (
+        _context_float_value(context, "evidence_success_rate", missing_default=1.0)
+        < 1.0
+    )
+    warnings = [
+        warning for warning in (report.get("warnings") or []) if str(warning).strip()
+    ]
+    attention_warnings = [
+        warning
+        for warning in warnings
+        if _report_warning_requires_advisory_attention(warning)
+    ]
+    narrative_warnings = [
+        warning
+        for warning in warnings
+        if not _report_warning_requires_advisory_attention(warning)
+    ]
+    narrative_degraded = _persisted_bool_value(
+        report.get("narrative_degraded")
+    ) or not _persisted_bool_value(
+        report.get("narrative_available"),
+        default=True,
+    )
+    recommendation = _normalized_advisory_recommendation(report.get("recommendation"))
+
+    uncertainty_flags: list[str] = []
+    if partial_context:
+        uncertainty_flags.append("partial_context")
+    if context_score < 0.7:
+        uncertainty_flags.append("low_context_completeness")
+    if insufficient_context:
+        uncertainty_flags.append("insufficient_context")
+    if context_uncertainty:
+        uncertainty_flags.append("context_uncertainty")
+    if context_todos:
+        uncertainty_flags.append("context_todos")
+    if evidence_gap:
+        uncertainty_flags.append("evidence_gaps")
+    if attention_warnings:
+        uncertainty_flags.append("assessment_warnings")
+    if narrative_degraded:
+        uncertainty_flags.append("narrative_degraded")
+    if narrative_warnings:
+        uncertainty_flags.append("narrative_warnings")
+
+    return {
+        "advisory_only": True,
+        "should_block": False,
+        "requires_attention": (
+            recommendation != "go"
+            or partial_context
+            or context_score < 0.7
+            or insufficient_context
+            or context_uncertainty
+            or context_todos
+            or evidence_gap
+            or bool(attention_warnings)
+            or narrative_degraded
+        ),
+        "severity": _normalized_advisory_severity(report.get("severity")),
+        "recommendation": recommendation,
+        "top_risk": str(report.get("top_risk") or ""),
+        "partial_context": partial_context,
+        "narrative_degraded": narrative_degraded,
+        "uncertainty_flags": uncertainty_flags,
+    }
+
+
+def build_report_advisory_payload(report: dict[str, Any]) -> dict[str, Any]:
+    return _build_report_advisory_payload(report)
+
+
 def _serialize_report(report, *, include_evidence: bool = True) -> dict:
     created_at = report.created_at
     if created_at.tzinfo is None:
@@ -3435,6 +3632,12 @@ def _serialize_report(report, *, include_evidence: bool = True) -> dict:
     )
     if context_warning is not None and context_warning not in warnings:
         warnings.append(context_warning)
+    context_completeness = _context_with_partial_context_signal(
+        context_completeness,
+        submission_manifest=submission_manifest,
+        submission_manifest_fallback=submission_manifest_fallback,
+        warnings=warnings,
+    )
     confidence = _clamp_confidence_to_context(confidence, context_completeness)
     evidence_items: list[dict[str, Any]] = []
     if include_evidence:
@@ -3521,8 +3724,8 @@ def _serialize_report(report, *, include_evidence: bool = True) -> dict:
             else None
         ),
         "risk_score": report.risk_score,
-        "severity": report.severity,
-        "recommendation": report.recommendation,
+        "severity": _normalized_advisory_severity(report.severity),
+        "recommendation": _normalized_advisory_recommendation(report.recommendation),
         "top_risk": report.top_risk,
         "report_schema_version": readable_report_schema_version(
             getattr(report, "report_schema_version", None)
@@ -3602,6 +3805,7 @@ def _serialize_report(report, *, include_evidence: bool = True) -> dict:
         ),
         "audit": audit,
     }
+    payload["advisory"] = _build_report_advisory_payload(payload)
     payload["confidence_ledger"] = build_confidence_ledger(
         payload,
         evidence_detail_available=include_evidence,
@@ -3811,7 +4015,10 @@ def persist_analysis_report(
                         assessment.top_risk_contributors
                     ),
                     context_completeness_json=json.dumps(
-                        assessment.context_completeness.model_dump(mode="json")
+                        {
+                            **assessment.context_completeness.model_dump(mode="json"),
+                            "partial_context": assessment.partial_context,
+                        }
                     ),
                     findings_payload=[
                         finding.model_dump(mode="json") for finding in (findings or [])
@@ -4094,10 +4301,10 @@ def fetch_filtered_analysis_history_page(
                     report_schema_versions=readable_schema_versions,
                     limit=page_size,
                     offset=offset,
-                    include_evidence=False,
+                    include_evidence=True,
                 )
                 serialized_reports = [
-                    _serialize_report(report, include_evidence=False)
+                    _serialize_report(report, include_evidence=True)
                     for report in reports
                 ]
                 serialized_all_reports = [
@@ -4131,10 +4338,10 @@ def fetch_filtered_analysis_history_page(
                     created_to=created_to,
                     limit=page_size,
                     offset=offset,
-                    include_evidence=False,
+                    include_evidence=True,
                 )
                 serialized_reports = [
-                    _serialize_report(report, include_evidence=False)
+                    _serialize_report(report, include_evidence=True)
                     for report in reports
                 ]
                 serialized_all_reports = [

--- a/tests/test_api/test_analyses.py
+++ b/tests/test_api/test_analyses.py
@@ -17,11 +17,18 @@ import models.repositories.analysis_reports as analysis_reports_repository_modul
 import models.tables as tables_module
 import services.project_service as project_service_module
 import services.report_service as report_service_module
+from analysis.blast_radius import BlastRadiusResult
 from services.analysis_service import AnalysisPersistenceError
+from services.analysis_service import AnalysisRunResult
+from analysis.rollback_planner import RollbackPlan
 from analysis.incident_matcher import IncidentMatch
-from analysis.risk_scorer import RiskAssessment, RiskContributor
+from analysis.risk_scorer import (
+    INSUFFICIENT_CONTEXT_WARNING,
+    RiskAssessment,
+    RiskContributor,
+)
 from app import create_app
-from evidence.models import EvidenceItem
+from evidence.models import ContextCompleteness, EvidenceItem
 from fastapi.testclient import TestClient
 from llm.narrator import NarrativeResult
 from parsers.base import ParseBatchResult, ParsedFileResult, UnifiedChange
@@ -76,6 +83,13 @@ class AnalysesApiTests(unittest.TestCase):
                 )
             ],
             interaction_risks=[],
+            context_completeness=ContextCompleteness(
+                topology_freshness_days=0,
+                topology_last_imported_at="2026-05-25T00:00:00Z",
+                incident_index_size=1,
+                incident_index_version="incidents:unknown",
+                incident_index_freshness_status="current",
+            ),
             partial_context=False,
             warnings=[],
         )
@@ -131,16 +145,77 @@ class AnalysesApiTests(unittest.TestCase):
         os.environ.pop("DEPLOYWHISPER_SHARE_TOKEN", None)
         self.tempdir.cleanup()
 
+    def _analysis_result_with_persisted_report(
+        self,
+        persisted_report: dict,
+        *,
+        assessment: RiskAssessment | None = None,
+        narrative: NarrativeResult | None = None,
+    ) -> AnalysisRunResult:
+        parse_batch = ParseBatchResult(
+            files=[
+                ParsedFileResult(
+                    file_name="plan.json",
+                    tool="terraform",
+                    status="parsed",
+                    changes=[
+                        UnifiedChange(
+                            source_file="plan.json",
+                            tool="terraform",
+                            resource_id="aws_security_group.main",
+                            action="modify",
+                            summary="Terraform changed a security group.",
+                        )
+                    ],
+                )
+            ]
+        )
+        return AnalysisRunResult(
+            parse_batch=parse_batch,
+            evidence_items=[],
+            findings=[],
+            assessment=assessment
+            or self._analysis_assessment(
+                severity="low",
+                recommendation="go",
+                top_risk="Low risk metadata-only update.",
+            ),
+            blast_radius=BlastRadiusResult(
+                affected=[],
+                direct_count=0,
+                transitive_count=0,
+            ),
+            rollback_plan=RollbackPlan(
+                steps=[],
+                complexity="low",
+                complexity_score=1,
+            ),
+            incident_matches=[],
+            narrative=narrative
+            or NarrativeResult(
+                opening_sentence="GO: low risk metadata-only update.",
+                explanation="Review can follow the standard approval flow.",
+                guidance=[],
+                degraded=False,
+                warnings=[],
+            ),
+            persisted_report=persisted_report,
+        )
+
     def test_list_analyses_returns_persisted_reports(self) -> None:
         response = self.client.get("/api/v1/analyses")
         self.assertEqual(response.status_code, 200)
         payload = response.json()
+        self.assertEqual(payload["meta"]["api_version"], "v1")
         self.assertEqual(payload["meta"]["report_schema_version"], "v2")
         self.assertEqual(payload["meta"]["report_schema_versions"], ["v2"])
         self.assertEqual(payload["meta"]["count"], 1)
         self.assertEqual(payload["meta"]["total_count"], 1)
         self.assertEqual(payload["meta"]["page"], 1)
         self.assertEqual(payload["meta"]["page_size"], 50)
+        self.assertEqual(payload["data"][0]["advisory"]["advisory_only"], True)
+        self.assertFalse(payload["data"][0]["advisory"]["should_block"])
+        self.assertEqual(payload["data"][0]["advisory"]["recommendation"], "caution")
 
     def test_list_analyses_meta_matches_legacy_report_schema(self) -> None:
         with sqlite3.connect(self.db_path) as conn:
@@ -267,10 +342,220 @@ class AnalysesApiTests(unittest.TestCase):
         self.assertEqual(response.status_code, 200)
         payload = response.json()
         self.assertEqual(payload["data"]["id"], self.persisted["id"])
+        self.assertEqual(payload["meta"]["api_version"], "v1")
         self.assertEqual(payload["meta"]["report_schema_version"], "v2")
         self.assertEqual(payload["data"]["report_schema_version"], "v2")
+        self.assertEqual(payload["data"]["advisory"]["advisory_only"], True)
+        self.assertFalse(payload["data"]["advisory"]["should_block"])
+        self.assertTrue(payload["data"]["advisory"]["requires_attention"])
+        self.assertEqual(payload["data"]["advisory"]["recommendation"], "caution")
         self.assertEqual(payload["data"]["audit"]["llm_provider"], "ollama")
         self.assertEqual(payload["data"]["blast_radius"]["direct_count"], 0)
+
+    def test_get_analysis_preserves_go_advisory_with_narrative_warning(self) -> None:
+        parse_batch = ParseBatchResult(
+            files=[
+                ParsedFileResult(
+                    file_name="low-risk-plan.json",
+                    tool="terraform",
+                    status="parsed",
+                    changes=[
+                        UnifiedChange(
+                            source_file="low-risk-plan.json",
+                            tool="terraform",
+                            resource_id="aws_s3_bucket.logs",
+                            action="modify",
+                            summary="Terraform adjusted log bucket tags.",
+                        )
+                    ],
+                )
+            ]
+        )
+        assessment = RiskAssessment(
+            score=12,
+            severity="low",
+            recommendation="go",
+            top_risk="Low risk tag update.",
+            contributors=[
+                RiskContributor(
+                    source_file="low-risk-plan.json",
+                    tool="terraform",
+                    resource_id="aws_s3_bucket.logs",
+                    action="modify",
+                    contribution=12,
+                    summary="Terraform adjusted log bucket tags.",
+                    severity="low",
+                    reasoning="Low risk tag update.",
+                )
+            ],
+            interaction_risks=[],
+            context_completeness=ContextCompleteness(
+                topology_freshness_days=0,
+                topology_last_imported_at="2026-05-25T00:00:00Z",
+                incident_index_size=1,
+                incident_index_version="incidents:unknown",
+                incident_index_freshness_status="current",
+            ),
+            partial_context=False,
+            warnings=[],
+        )
+        narrative = NarrativeResult(
+            opening_sentence="GO: low risk tag update.",
+            explanation="Review can follow the standard approval flow.",
+            guidance=[],
+            degraded=False,
+            warnings=["Narrative provider warning."],
+            source="llm",
+        )
+        persisted = report_service_module.persist_analysis_report(
+            parse_batch,
+            assessment,
+            narrative,
+            submitted_artifacts=[("low-risk-plan.json", b"{}")],
+        )
+
+        response = self.client.get(f"/api/v1/analyses/{persisted['id']}")
+
+        self.assertEqual(response.status_code, 200)
+        advisory = response.json()["data"]["advisory"]
+        self.assertEqual(advisory["recommendation"], "go")
+        self.assertFalse(advisory["should_block"])
+        self.assertFalse(advisory["requires_attention"])
+        self.assertNotIn("assessment_warnings", advisory["uncertainty_flags"])
+        self.assertIn("narrative_warnings", advisory["uncertainty_flags"])
+
+    def test_list_analyses_preserves_go_advisory_with_narrative_warning(self) -> None:
+        persisted = report_service_module.persist_analysis_report(
+            ParseBatchResult(
+                files=[
+                    ParsedFileResult(
+                        file_name="low-risk-list-plan.json",
+                        tool="terraform",
+                        status="parsed",
+                        changes=[
+                            UnifiedChange(
+                                source_file="low-risk-list-plan.json",
+                                tool="terraform",
+                                resource_id="aws_s3_bucket.logs",
+                                action="modify",
+                                summary="Terraform adjusted log bucket tags.",
+                            )
+                        ],
+                    )
+                ]
+            ),
+            RiskAssessment(
+                score=12,
+                severity="low",
+                recommendation="go",
+                top_risk="Low risk tag update.",
+                contributors=[],
+                interaction_risks=[],
+                context_completeness=ContextCompleteness(
+                    topology_freshness_days=0,
+                    topology_last_imported_at="2026-05-25T00:00:00Z",
+                    incident_index_size=1,
+                    incident_index_version="incidents:unknown",
+                    incident_index_freshness_status="current",
+                ),
+                partial_context=False,
+                warnings=[],
+            ),
+            NarrativeResult(
+                opening_sentence="GO: low risk tag update.",
+                explanation="Review can follow the standard approval flow.",
+                guidance=[],
+                degraded=False,
+                warnings=["Narrative provider warning."],
+                source="llm",
+            ),
+            submitted_artifacts=[("low-risk-list-plan.json", b"{}")],
+        )
+
+        response = self.client.get("/api/v1/analyses")
+
+        self.assertEqual(response.status_code, 200)
+        reports = response.json()["data"]
+        report = next(item for item in reports if item["id"] == persisted["id"])
+        advisory = report["advisory"]
+        self.assertEqual(advisory["recommendation"], "go")
+        self.assertFalse(advisory["requires_attention"])
+        self.assertNotIn("assessment_warnings", advisory["uncertainty_flags"])
+        self.assertIn("narrative_warnings", advisory["uncertainty_flags"])
+
+    def test_get_analysis_flags_insufficient_context_as_assessment_warning(
+        self,
+    ) -> None:
+        parse_batch = ParseBatchResult(
+            files=[
+                ParsedFileResult(
+                    file_name="low-context-plan.json",
+                    tool="terraform",
+                    status="parsed",
+                    changes=[
+                        UnifiedChange(
+                            source_file="low-context-plan.json",
+                            tool="terraform",
+                            resource_id="aws_s3_bucket.logs",
+                            action="modify",
+                            summary="Terraform adjusted log bucket tags.",
+                        )
+                    ],
+                )
+            ]
+        )
+        assessment = RiskAssessment(
+            score=12,
+            severity="low",
+            recommendation="go",
+            top_risk="Low risk tag update.",
+            contributors=[
+                RiskContributor(
+                    source_file="low-context-plan.json",
+                    tool="terraform",
+                    resource_id="aws_s3_bucket.logs",
+                    action="modify",
+                    contribution=12,
+                    summary="Terraform adjusted log bucket tags.",
+                    severity="low",
+                    reasoning="Low risk tag update.",
+                )
+            ],
+            interaction_risks=[],
+            context_completeness=ContextCompleteness(
+                context_score=0.4,
+                confidence_level="low",
+                insufficient_context=True,
+            ),
+            partial_context=False,
+            warnings=[INSUFFICIENT_CONTEXT_WARNING],
+        )
+        narrative = NarrativeResult(
+            opening_sentence="GO: low risk tag update.",
+            explanation="Review can follow the standard approval flow.",
+            guidance=[],
+            degraded=False,
+            warnings=[],
+            source="llm",
+        )
+        persisted = report_service_module.persist_analysis_report(
+            parse_batch,
+            assessment,
+            narrative,
+            submitted_artifacts=[("low-context-plan.json", b"{}")],
+        )
+
+        response = self.client.get(f"/api/v1/analyses/{persisted['id']}")
+
+        self.assertEqual(response.status_code, 200)
+        advisory = response.json()["data"]["advisory"]
+        self.assertTrue(advisory["requires_attention"])
+        self.assertIn("assessment_warnings", advisory["uncertainty_flags"])
+        self.assertNotIn(
+            "narrative_warnings",
+            advisory["uncertainty_flags"],
+            response.json()["data"]["warnings"],
+        )
 
     def test_get_analysis_meta_matches_legacy_report_schema(self) -> None:
         with sqlite3.connect(self.db_path) as conn:
@@ -932,7 +1217,8 @@ class AnalysesApiTests(unittest.TestCase):
             payload["data"]["assessment"]["context_completeness"]["context_todos"]
         )
         self.assertEqual(
-            payload["data"]["assessment"]["top_risk_contributors"], ["ev-001"]
+            payload["data"]["assessment"]["top_risk_contributors"],
+            payload["data"]["persisted_report"]["top_risk_contributors"],
         )
         self.assertEqual(
             payload["data"]["persisted_report"]["project"]["project_key"], "payments"
@@ -1000,17 +1286,36 @@ class AnalysesApiTests(unittest.TestCase):
         )
         self.assertFalse(payload["data"]["persisted_report"]["narrative_degraded"])
         self.assertEqual(
-            payload["data"]["assessment"]["contributors"][0]["evidence_id"], "ev-001"
+            payload["data"]["assessment"]["contributors"],
+            payload["data"]["persisted_report"]["contributors"],
         )
         self.assertTrue(payload["data"]["findings"])
         self.assertTrue(payload["data"]["evidence_items"])
-        self.assertEqual(payload["data"]["evidence_items"][0]["analysis_id"], 0)
+        self.assertEqual(
+            payload["data"]["findings"],
+            payload["data"]["persisted_report"]["findings"],
+        )
+        self.assertEqual(
+            payload["data"]["evidence_items"],
+            payload["data"]["persisted_report"]["evidence_items"],
+        )
+        self.assertEqual(
+            payload["data"]["assessment"]["context_completeness"],
+            payload["data"]["persisted_report"]["context_completeness"],
+        )
+        self.assertEqual(
+            payload["data"]["evidence_items"][0]["analysis_id"],
+            payload["data"]["persisted_report"]["id"],
+        )
         self.assertEqual(payload["data"]["findings"][0]["confidence"], 1.0)
         self.assertEqual(
             payload["data"]["findings"][0]["evidence_classification"],
             "deterministic",
         )
-        self.assertEqual(payload["data"]["findings"][0]["evidence_refs"], ["ev-001"])
+        self.assertEqual(
+            payload["data"]["findings"][0]["evidence_refs"],
+            payload["data"]["persisted_report"]["findings"][0]["evidence_refs"],
+        )
         self.assertEqual(
             payload["data"]["findings"][0]["explanation"],
             "Security group exposure risk",
@@ -1021,6 +1326,14 @@ class AnalysesApiTests(unittest.TestCase):
         self.assertTrue(payload["data"]["narrative"]["skills_applied"])
         self.assertFalse(payload["data"]["advisory"]["should_block"])
         self.assertTrue(payload["data"]["advisory"]["requires_attention"])
+        self.assertEqual(
+            payload["data"]["advisory"],
+            payload["data"]["persisted_report"]["advisory"],
+        )
+        self.assertIn("context_todos", payload["data"]["advisory"]["uncertainty_flags"])
+        self.assertIn(
+            "assessment_warnings", payload["data"]["advisory"]["uncertainty_flags"]
+        )
         self.assertIn("Advisory only", payload["data"]["share_summary"]["markdown"])
         self.assertEqual(payload["data"]["share_summary"]["recommendation"], "no-go")
         self.assertLessEqual(len(payload["data"]["share_summary"]["markdown"]), 1500)
@@ -1066,6 +1379,17 @@ class AnalysesApiTests(unittest.TestCase):
         self.assertEqual(
             payload["data"]["persisted_report"]["report_schema_version"], "v2"
         )
+        self.assertEqual(
+            payload["data"]["persisted_report"]["advisory"]["advisory_only"],
+            True,
+        )
+        self.assertFalse(
+            payload["data"]["persisted_report"]["advisory"]["should_block"]
+        )
+        self.assertEqual(
+            payload["data"]["persisted_report"]["advisory"]["recommendation"],
+            payload["data"]["advisory"]["recommendation"],
+        )
         self.assertIn("blast_radius", payload["data"]["persisted_report"])
         self.assertTrue(payload["data"]["persisted_report"]["findings"])
         self.assertTrue(payload["data"]["persisted_report"]["evidence_items"])
@@ -1074,6 +1398,233 @@ class AnalysesApiTests(unittest.TestCase):
             persisted_evidence_id,
         )
         self.assertEqual(payload["data"]["persisted_report"]["id"], 2)
+
+    def test_create_analysis_preserves_go_advisory_with_narrative_warning(
+        self,
+    ) -> None:
+        project_service_module.create_project(
+            project_key="safe-change",
+            display_name="Safe Change",
+        )
+        narrative = NarrativeResult(
+            opening_sentence="GO: low risk tag update.",
+            explanation="Review can follow the standard approval flow.",
+            guidance=[],
+            degraded=False,
+            warnings=["Narrative provider warning."],
+            source="llm",
+        )
+        evidence_items = [
+            EvidenceItem(
+                evidence_id="ev-001",
+                analysis_id=0,
+                finding_id="pending:change-001",
+                source_type="artifact",
+                source_ref="terraform://low-risk-plan.json#aws_s3_bucket.logs?action=modify",
+                summary="Terraform adjusted log bucket tags.",
+                severity_hint="low",
+                deterministic=True,
+                confidence=1.0,
+                related_change_ids=["change-001"],
+            )
+        ]
+
+        with (
+            patch(
+                "services.analysis_service.evaluate_parse_batch",
+                return_value=RiskAssessment(
+                    score=12,
+                    severity="low",
+                    recommendation="go",
+                    top_risk="Low risk tag update.",
+                    top_risk_contributors=["ev-001"],
+                    contributors=[
+                        RiskContributor(
+                            evidence_id="ev-001",
+                            source_file="low-risk-plan.json",
+                            tool="terraform",
+                            resource_id="aws_s3_bucket.logs",
+                            action="modify",
+                            contribution=12,
+                            summary="Terraform adjusted log bucket tags.",
+                            severity="low",
+                            reasoning="Low risk tag update.",
+                        )
+                    ],
+                    interaction_risks=[],
+                    context_completeness=ContextCompleteness(
+                        topology_freshness_days=0,
+                        topology_last_imported_at="2026-05-25T00:00:00Z",
+                        incident_index_size=1,
+                        incident_index_version="incidents:unknown",
+                        incident_index_freshness_status="current",
+                    ),
+                    partial_context=False,
+                    warnings=[],
+                    source="heuristic+llm",
+                ),
+            ),
+            patch(
+                "services.analysis_service.extract_batch_evidence",
+                return_value=evidence_items,
+            ),
+            patch(
+                "services.analysis_service._build_context_completeness",
+                return_value=ContextCompleteness(
+                    topology_freshness_days=0,
+                    topology_last_imported_at="2026-05-25T00:00:00Z",
+                    incident_index_size=1,
+                    incident_index_version="incidents:unknown",
+                    incident_index_freshness_status="current",
+                ),
+            ),
+            patch(
+                "services.analysis_service.generate_narrative", return_value=narrative
+            ),
+            patch("services.analysis_service.find_incident_matches", return_value=[]),
+        ):
+            response = self.client.post(
+                "/api/v1/analyses",
+                files=[
+                    (
+                        "files",
+                        (
+                            "low-risk-plan.json",
+                            b'{"resource_changes": []}',
+                            "application/json",
+                        ),
+                    )
+                ],
+                data={"project_key": "safe-change"},
+            )
+
+        self.assertEqual(response.status_code, 200)
+        payload = response.json()
+        self.assertEqual(payload["meta"]["api_version"], "v1")
+        self.assertEqual(payload["meta"]["report_schema_version"], "v2")
+        advisory = payload["data"]["advisory"]
+        self.assertEqual(advisory, payload["data"]["persisted_report"]["advisory"])
+        self.assertEqual(advisory["recommendation"], "go")
+        self.assertFalse(advisory["requires_attention"])
+        self.assertNotIn("assessment_warnings", advisory["uncertainty_flags"])
+        self.assertIn("narrative_warnings", advisory["uncertainty_flags"])
+        self.assertEqual(
+            payload["data"]["share_summary"]["json_payload"]["advisory_summary"],
+            "Standard approval flow is sufficient.",
+        )
+        self.assertNotIn(
+            "requires additional human review",
+            payload["data"]["share_summary"]["plain_text"].lower(),
+        )
+
+    def test_create_analysis_rebuilds_stale_valid_persisted_advisory(self) -> None:
+        project_service_module.create_project(
+            project_key="payments-stale-advisory",
+            display_name="Payments Stale Advisory",
+        )
+        persisted_report = dict(self.persisted)
+        persisted_report["severity"] = "low"
+        persisted_report["recommendation"] = "go"
+        persisted_report["top_risk"] = "Low risk metadata-only update."
+        persisted_report["warnings"] = []
+        persisted_report["narrative_available"] = True
+        persisted_report["narrative_degraded"] = False
+        persisted_report["context_completeness"] = {
+            **dict(persisted_report["context_completeness"]),
+            "context_score": 0.95,
+            "parser_success_rate": 1.0,
+            "evidence_success_rate": 1.0,
+            "insufficient_context": False,
+            "partial_context": False,
+        }
+        persisted_report["advisory"] = {
+            "advisory_only": True,
+            "should_block": False,
+            "requires_attention": True,
+            "severity": "high",
+            "recommendation": "no-go",
+            "top_risk": "Stale advisory from an older report state.",
+            "partial_context": True,
+            "narrative_degraded": False,
+            "uncertainty_flags": ["partial_context"],
+        }
+
+        with patch(
+            "api.routes.analyses.analyze_uploaded_files",
+            return_value=self._analysis_result_with_persisted_report(persisted_report),
+        ):
+            response = self.client.post(
+                "/api/v1/analyses",
+                files={"files": ("plan.json", b'{"resource_changes": []}')},
+                data={"project_key": "payments-stale-advisory"},
+            )
+
+        self.assertEqual(response.status_code, 200)
+        payload = response.json()
+        advisory = payload["data"]["advisory"]
+        self.assertEqual(advisory["severity"], "low")
+        self.assertEqual(advisory["recommendation"], "go")
+        self.assertFalse(advisory["requires_attention"])
+        self.assertFalse(advisory["partial_context"])
+        self.assertEqual(payload["data"]["persisted_report"]["advisory"], advisory)
+
+    def test_create_analysis_share_summary_matches_advisory_partial_context(
+        self,
+    ) -> None:
+        project_service_module.create_project(
+            project_key="payments-partial-summary",
+            display_name="Payments Partial Summary",
+        )
+        persisted_report = dict(self.persisted)
+        persisted_report["severity"] = "low"
+        persisted_report["recommendation"] = "go"
+        persisted_report["top_risk"] = "Low risk metadata-only update."
+        persisted_report["warnings"] = []
+        persisted_report["narrative_available"] = True
+        persisted_report["narrative_degraded"] = False
+        persisted_report["context_completeness"] = {
+            **dict(persisted_report["context_completeness"]),
+            "context_score": 0.95,
+            "parser_success_rate": 1.0,
+            "evidence_success_rate": 1.0,
+            "insufficient_context": False,
+            "partial_context": False,
+        }
+        persisted_report["submission_manifest_fallback"] = [
+            {
+                "name": "plan.json",
+                "tool": "terraform",
+                "status": "accepted",
+                "intake_status": "accepted",
+                "parse_status": "failed",
+                "partial": False,
+                "redaction_status": "none",
+            }
+        ]
+
+        with patch(
+            "api.routes.analyses.analyze_uploaded_files",
+            return_value=self._analysis_result_with_persisted_report(persisted_report),
+        ):
+            response = self.client.post(
+                "/api/v1/analyses",
+                files={"files": ("plan.json", b'{"resource_changes": []}')},
+                data={"project_key": "payments-partial-summary"},
+            )
+
+        self.assertEqual(response.status_code, 200)
+        payload = response.json()
+        self.assertTrue(payload["data"]["advisory"]["partial_context"])
+        self.assertEqual(
+            payload["data"]["share_summary"]["json_payload"]["context_completeness"][
+                "label"
+            ],
+            "LIMITED CONTEXT",
+        )
+        self.assertIn(
+            "submitted artifacts were not analyzed",
+            payload["data"]["share_summary"]["plain_text"],
+        )
 
     def test_create_analysis_returns_degraded_narrative_provider_metadata(
         self,
@@ -2271,12 +2822,104 @@ class AnalysesApiTests(unittest.TestCase):
         )
         self.assertNotIn("database is read-only", response.text)
 
+    def test_create_analysis_falls_back_when_persisted_advisory_is_invalid(
+        self,
+    ) -> None:
+        project_service_module.create_project(
+            project_key="payments-invalid-advisory",
+            display_name="Payments Invalid Advisory",
+        )
+        persisted_report = dict(self.persisted)
+        persisted_report["severity"] = "low"
+        persisted_report["recommendation"] = "go"
+        persisted_report["top_risk"] = "Low risk metadata-only update."
+        persisted_report["context_completeness"] = {
+            **dict(persisted_report["context_completeness"]),
+            "context_score": 0.92,
+            "parser_success_rate": 1.0,
+            "evidence_success_rate": 0.5,
+            "insufficient_context": False,
+            "partial_context": False,
+        }
+        persisted_report["advisory"] = {
+            "advisory_only": True,
+            "should_block": False,
+            "requires_attention": False,
+            "severity": "minor",
+            "recommendation": "ship",
+            "top_risk": "Invalid legacy advisory.",
+            "partial_context": False,
+            "narrative_degraded": False,
+            "uncertainty_flags": [],
+        }
+        client = TestClient(create_app(), raise_server_exceptions=False)
+
+        with patch(
+            "api.routes.analyses.analyze_uploaded_files",
+            return_value=self._analysis_result_with_persisted_report(persisted_report),
+        ):
+            response = client.post(
+                "/api/v1/analyses",
+                files={"files": ("plan.json", b'{"resource_changes": []}')},
+                data={"project_key": "payments-invalid-advisory"},
+            )
+
+        self.assertEqual(response.status_code, 200)
+        payload = response.json()
+        self.assertEqual(payload["data"]["advisory"]["severity"], "low")
+        self.assertEqual(payload["data"]["advisory"]["recommendation"], "go")
+        self.assertTrue(payload["data"]["advisory"]["requires_attention"])
+        self.assertFalse(payload["data"]["advisory"]["partial_context"])
+        self.assertIn("evidence_gaps", payload["data"]["advisory"]["uncertainty_flags"])
+        self.assertEqual(
+            payload["data"]["persisted_report"]["advisory"],
+            payload["data"]["advisory"],
+        )
+
+    def test_create_analysis_invalid_advisory_context_uses_error_envelope(
+        self,
+    ) -> None:
+        project_service_module.create_project(
+            project_key="payments-invalid-advisory-context",
+            display_name="Payments Invalid Advisory Context",
+        )
+        persisted_report = dict(self.persisted)
+        persisted_report["context_completeness"] = ["bad"]
+        persisted_report["advisory"] = {
+            "advisory_only": True,
+            "should_block": False,
+            "requires_attention": False,
+            "severity": "minor",
+            "recommendation": "ship",
+            "top_risk": "Invalid legacy advisory.",
+            "partial_context": False,
+            "narrative_degraded": False,
+            "uncertainty_flags": [],
+        }
+        client = TestClient(create_app(), raise_server_exceptions=False)
+
+        with patch(
+            "api.routes.analyses.analyze_uploaded_files",
+            return_value=self._analysis_result_with_persisted_report(persisted_report),
+        ):
+            response = client.post(
+                "/api/v1/analyses",
+                files={"files": ("plan.json", b'{"resource_changes": []}')},
+                data={"project_key": "payments-invalid-advisory-context"},
+            )
+
+        self.assertEqual(response.status_code, 500)
+        payload = response.json()
+        self.assertEqual(payload["error"]["code"], "analysis_advisory_contract_invalid")
+
     def test_openapi_documents_analysis_submission_contract(self) -> None:
         response = self.client.get("/openapi.json")
 
         self.assertEqual(response.status_code, 200)
         schema = response.json()
+        analyses_get = schema["paths"]["/api/v1/analyses"]["get"]
         analyses_post = schema["paths"]["/api/v1/analyses"]["post"]
+        analyses_detail = schema["paths"]["/api/v1/analyses/{report_id}"]["get"]
         request_body_schema = analyses_post["requestBody"]["content"][
             "multipart/form-data"
         ]["schema"]
@@ -2287,6 +2930,16 @@ class AnalysesApiTests(unittest.TestCase):
         )
         self.assertIn("AnalysisRunResponse", str(analyses_post["responses"]["200"]))
         self.assertIn("ErrorResponse", str(analyses_post["responses"]["400"]))
+        for responses in (
+            analyses_get["responses"],
+            analyses_post["responses"],
+            analyses_detail["responses"],
+        ):
+            with self.subTest(responses=responses):
+                self.assertIn("ErrorResponse", str(responses["400"]))
+                self.assertIn("ErrorResponse", str(responses["403"]))
+                self.assertIn("ErrorResponse", str(responses["422"]))
+                self.assertIn("ErrorResponse", str(responses["500"]))
         self.assertNotIn("ParseBatchResult", schema["components"]["schemas"])
         self.assertNotIn("RiskAssessment", schema["components"]["schemas"])
 

--- a/tests/test_api/test_schemas.py
+++ b/tests/test_api/test_schemas.py
@@ -28,6 +28,17 @@ class ApiSchemaTests(unittest.TestCase):
             "parse_summary": "Parsed 1 file.",
             "narrative_opening": "CAUTION: review the security group update.",
             "narrative_degraded": False,
+            "advisory": {
+                "advisory_only": True,
+                "should_block": False,
+                "requires_attention": True,
+                "severity": "medium",
+                "recommendation": "caution",
+                "top_risk": "Terraform changed a security group.",
+                "partial_context": False,
+                "narrative_degraded": False,
+                "uncertainty_flags": [],
+            },
             "created_at": "2026-05-11T00:00:00Z",
             "audit": {"files_analyzed": ["plan.json"]},
         }

--- a/tests/test_cli/test_analyze.py
+++ b/tests/test_cli/test_analyze.py
@@ -2414,6 +2414,8 @@ class AnalyzeCliTests(unittest.TestCase):
                     action="delete",
                     contribution=24,
                     summary="Terraform changed a security group.",
+                    normalized_action="destroy",
+                    severity="critical",
                 )
             ],
             interaction_risks=[],

--- a/tests/test_docs/test_report_schema_documentation.py
+++ b/tests/test_docs/test_report_schema_documentation.py
@@ -30,6 +30,7 @@ class ReportSchemaDocumentationTests(unittest.TestCase):
                 self.assertIn(consumer, content)
 
         for field in (
+            '"api_version"',
             '"report_schema_version"',
             '"findings"',
             '"evidence_items"',
@@ -40,6 +41,7 @@ class ReportSchemaDocumentationTests(unittest.TestCase):
             '"narrative_failure_notice"',
             '"advisory_only"',
             '"should_block"',
+            '"top_risk"',
         ):
             with self.subTest(field=field):
                 self.assertIn(field, content)

--- a/tests/test_models/test_evidence_models.py
+++ b/tests/test_models/test_evidence_models.py
@@ -48,6 +48,7 @@ class EvidenceModelTests(unittest.TestCase):
                 "uncertainty": "Kubernetes parser coverage was partial.",
                 "context_todos": ["Refresh Kubernetes context."],
                 "insufficient_context": False,
+                "partial_context": False,
             },
         )
 

--- a/tests/test_services/test_analysis_service.py
+++ b/tests/test_services/test_analysis_service.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import math
 import unittest
 from types import SimpleNamespace
 from unittest.mock import patch
@@ -1549,6 +1550,100 @@ class AnalysisServiceTests(unittest.TestCase):
             summary.json_payload.context_completeness.label, "LIMITED CONTEXT"
         )
         self.assertIn("submitted artifacts were not analyzed", summary.plain_text)
+
+    def test_build_share_summary_requires_attention_for_stored_partial_context(
+        self,
+    ) -> None:
+        report = self._share_report_payload()
+        report["severity"] = "low"
+        report["recommendation"] = "go"
+        report["context_completeness"] = {
+            "context_score": 0.94,
+            "parser_success_rate": 1.0,
+            "evidence_success_rate": 1.0,
+            "insufficient_context": False,
+            "partial_context": True,
+        }
+
+        summary = build_share_summary(report)
+
+        self.assertEqual(
+            summary.json_payload.context_completeness.label, "LIMITED CONTEXT"
+        )
+        self.assertIn("submitted artifacts were not analyzed", summary.plain_text)
+        self.assertIn("requires additional human review", summary.plain_text.lower())
+
+    def test_build_share_summary_normalizes_false_like_context_booleans(
+        self,
+    ) -> None:
+        report = self._share_report_payload()
+        report["severity"] = "low"
+        report["recommendation"] = "go"
+        report["narrative_available"] = "true"
+        report["narrative_degraded"] = "false"
+        report["context_completeness"] = {
+            "context_score": 0.94,
+            "parser_success_rate": 1.0,
+            "evidence_success_rate": 1.0,
+            "insufficient_context": "false",
+            "partial_context": "false",
+        }
+
+        summary = build_share_summary(report)
+
+        self.assertEqual(
+            summary.json_payload.context_completeness.label, "STRONG CONTEXT"
+        )
+        self.assertNotIn("requires additional human review", summary.plain_text.lower())
+        self.assertIn("Standard approval flow is sufficient", summary.plain_text)
+
+    def test_build_share_summary_normalizes_false_like_narrative_availability(
+        self,
+    ) -> None:
+        report = self._share_report_payload()
+        report["severity"] = "low"
+        report["recommendation"] = "go"
+        report["narrative_available"] = "false"
+        report["narrative_degraded"] = "false"
+        report["warnings"] = []
+        report["context_completeness"] = {
+            "context_score": 0.94,
+            "parser_success_rate": 1.0,
+            "evidence_success_rate": 1.0,
+            "insufficient_context": "false",
+            "partial_context": "false",
+        }
+
+        summary = build_share_summary(report)
+
+        self.assertEqual(
+            summary.json_payload.context_completeness.label, "STRONG CONTEXT"
+        )
+        self.assertIn("requires additional human review", summary.plain_text.lower())
+
+    def test_build_share_summary_ignores_non_finite_boolean_signals(
+        self,
+    ) -> None:
+        report = self._share_report_payload()
+        report["severity"] = "low"
+        report["recommendation"] = "go"
+        report["narrative_available"] = "true"
+        report["narrative_degraded"] = math.nan
+        report["context_completeness"] = {
+            "context_score": 0.94,
+            "parser_success_rate": 1.0,
+            "evidence_success_rate": 1.0,
+            "insufficient_context": math.inf,
+            "partial_context": math.nan,
+        }
+
+        summary = build_share_summary(report)
+
+        self.assertEqual(
+            summary.json_payload.context_completeness.label, "STRONG CONTEXT"
+        )
+        self.assertNotIn("requires additional human review", summary.plain_text.lower())
+        self.assertIn("Standard approval flow is sufficient", summary.plain_text)
 
     def test_build_share_summary_falls_back_to_local_report_link_without_public_base_url(
         self,

--- a/tests/test_services/test_report_service.py
+++ b/tests/test_services/test_report_service.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import math
 import os
 import sqlite3
 import tempfile
@@ -5376,6 +5377,10 @@ class ReportServiceTests(unittest.TestCase):
         self.assertNotIn("plan.json", serialized)
         self.assertNotIn(".bak", serialized)
         self.assertIn("Artifact 2 changed after Artifact 1", shared_report["top_risk"])
+        self.assertIn(
+            "Artifact 2 changed after Artifact 1",
+            shared_report["advisory"]["top_risk"],
+        )
 
     def test_persist_manifest_uses_submitted_artifacts_without_raw_snapshots(
         self,
@@ -5771,6 +5776,9 @@ class ReportServiceTests(unittest.TestCase):
         self.assertEqual(fallback_by_name["broken.tf"]["status"], "failed")
         self.assertEqual(fallback_by_name[".env"]["status"], "sensitive")
         self.assertEqual(fallback_by_name["notes.txt"]["status"], "excluded")
+        self.assertTrue(fetched["context_completeness"]["partial_context"])
+        self.assertTrue(fetched["advisory"]["partial_context"])
+        self.assertIn("partial_context", fetched["advisory"]["uncertainty_flags"])
         self.assertEqual(fetched["audit"]["redaction_status"], "sensitive_blocked")
         self.assertEqual(
             fetched["audit"]["redaction"],
@@ -9033,7 +9041,7 @@ class ReportServiceTests(unittest.TestCase):
             report["contributors"][0]["evidence_id"], persisted_evidence_id
         )
 
-    def test_fetch_filtered_history_page_omits_evidence_payloads(self) -> None:
+    def test_fetch_filtered_history_page_includes_evidence_payloads(self) -> None:
         parse_batch = ParseBatchResult(
             files=[
                 ParsedFileResult(
@@ -9118,7 +9126,474 @@ class ReportServiceTests(unittest.TestCase):
             page=1, page_size=5
         )
 
-        self.assertEqual(page["items"][0]["evidence_items"], [])
+        self.assertEqual(
+            page["items"][0]["evidence_items"][0]["source_ref"],
+            "terraform://plan.json#aws_security_group.main?action=modify",
+        )
+
+    def test_fetch_filtered_history_page_uses_lightweight_scope_for_diff_candidates(
+        self,
+    ) -> None:
+        scope_report = object()
+        page_report = object()
+
+        def serialize(report: object, *, include_evidence: bool = True) -> dict:
+            evidence_items = [{"evidence_id": "page-ev"}] if include_evidence else []
+            return {
+                "id": 2 if report is page_report else 1,
+                "project": {"id": 1, "project_key": "unassigned"},
+                "workspace": None,
+                "risk_score": 12,
+                "severity": "low",
+                "recommendation": "go",
+                "created_at": "2026-05-25T00:00:00+00:00",
+                "audit": {
+                    "files_analyzed": ["plan.json"],
+                    "source_interface": "api",
+                    "trigger_type": "api_request",
+                    "trigger_id": "review-fix",
+                },
+                "submission_manifest": {
+                    "items": [
+                        {
+                            "name": "plan.json",
+                            "tool": "terraform",
+                            "status": "accepted",
+                            "intake_status": "ready",
+                            "parse_status": "parsed",
+                            "partial": False,
+                        }
+                    ]
+                },
+                "evidence_items": evidence_items,
+            }
+
+        with (
+            patch.object(
+                report_service_module,
+                "list_analysis_reports",
+                side_effect=[[scope_report], [page_report]],
+            ) as list_reports,
+            patch.object(
+                report_service_module,
+                "_serialize_report",
+                side_effect=serialize,
+            ) as serialize_report,
+            patch.object(
+                report_service_module,
+                "count_analysis_reports",
+                return_value=1,
+            ),
+        ):
+            page = report_service_module.fetch_filtered_analysis_history_page(
+                page=1, page_size=1
+            )
+
+        self.assertEqual(
+            page["items"][0]["evidence_items"], [{"evidence_id": "page-ev"}]
+        )
+        self.assertFalse(list_reports.call_args_list[0].kwargs["include_evidence"])
+        self.assertTrue(list_reports.call_args_list[1].kwargs["include_evidence"])
+        self.assertTrue(serialize_report.call_args_list[0].kwargs["include_evidence"])
+        self.assertFalse(serialize_report.call_args_list[1].kwargs["include_evidence"])
+
+    def test_persisted_advisory_keeps_evidence_gap_separate_from_partial_context(
+        self,
+    ) -> None:
+        report = report_service_module.persist_analysis_report(
+            ParseBatchResult(
+                files=[
+                    ParsedFileResult(
+                        file_name="plan.json",
+                        tool="terraform",
+                        status="parsed",
+                        changes=[
+                            UnifiedChange(
+                                source_file="plan.json",
+                                tool="terraform",
+                                resource_id="aws_s3_bucket.logs",
+                                action="modify",
+                                summary="Terraform adjusted log bucket tags.",
+                            )
+                        ],
+                    )
+                ]
+            ),
+            RiskAssessment(
+                score=12,
+                severity="low",
+                recommendation="go",
+                top_risk="Low risk tag update.",
+                contributors=[],
+                interaction_risks=[],
+                context_completeness=ContextCompleteness(
+                    context_score=0.8,
+                    parser_success_rate=1.0,
+                    evidence_success_rate=0.5,
+                ),
+                partial_context=False,
+                warnings=[],
+            ),
+            NarrativeResult(
+                opening_sentence="GO: low risk tag update.",
+                explanation="Review can follow the standard approval flow.",
+                guidance=[],
+                degraded=False,
+                warnings=[],
+            ),
+        )
+
+        advisory = report_service_module.fetch_analysis_report(report["id"])["advisory"]
+
+        self.assertFalse(advisory["partial_context"])
+        self.assertNotIn("partial_context", advisory["uncertainty_flags"])
+        self.assertIn("evidence_gaps", advisory["uncertainty_flags"])
+        self.assertTrue(advisory["requires_attention"])
+
+    def test_persisted_advisory_honors_manifest_item_partial_context(
+        self,
+    ) -> None:
+        report = report_service_module.persist_analysis_report(
+            ParseBatchResult(
+                files=[
+                    ParsedFileResult(
+                        file_name="plan.json",
+                        tool="terraform",
+                        status="parsed",
+                        changes=[
+                            UnifiedChange(
+                                source_file="plan.json",
+                                tool="terraform",
+                                resource_id="aws_s3_bucket.logs",
+                                action="modify",
+                                summary="Terraform adjusted log bucket tags.",
+                            )
+                        ],
+                    )
+                ]
+            ),
+            RiskAssessment(
+                score=12,
+                severity="low",
+                recommendation="go",
+                top_risk="Low risk tag update.",
+                contributors=[],
+                interaction_risks=[],
+                context_completeness=ContextCompleteness(
+                    context_score=1.0,
+                    parser_success_rate=1.0,
+                    evidence_success_rate=1.0,
+                ),
+                partial_context=False,
+                warnings=[],
+            ),
+            NarrativeResult(
+                opening_sentence="GO: low risk tag update.",
+                explanation="Review can follow the standard approval flow.",
+                guidance=[],
+                degraded=False,
+                warnings=[],
+            ),
+        )
+        manifest = dict(report["submission_manifest"])
+        manifest["partial_analysis"] = False
+        manifest["items"][0]["partial"] = True
+        with sqlite3.connect(self.db_path) as conn:
+            conn.execute(
+                "UPDATE analysis_reports SET submission_manifest_json = ? WHERE id = ?",
+                (json.dumps(manifest), report["id"]),
+            )
+
+        advisory = report_service_module.fetch_analysis_report(report["id"])["advisory"]
+
+        self.assertTrue(advisory["partial_context"])
+        self.assertIn("partial_context", advisory["uncertainty_flags"])
+        self.assertTrue(advisory["requires_attention"])
+
+    def test_persisted_advisory_honors_stored_partial_context_signal(self) -> None:
+        report = report_service_module.persist_analysis_report(
+            ParseBatchResult(
+                files=[
+                    ParsedFileResult(
+                        file_name="plan.json",
+                        tool="terraform",
+                        status="parsed",
+                        changes=[
+                            UnifiedChange(
+                                source_file="plan.json",
+                                tool="terraform",
+                                resource_id="aws_s3_bucket.logs",
+                                action="modify",
+                                summary="Terraform adjusted log bucket tags.",
+                            )
+                        ],
+                    )
+                ]
+            ),
+            RiskAssessment(
+                score=12,
+                severity="low",
+                recommendation="go",
+                top_risk="Low risk tag update.",
+                contributors=[],
+                interaction_risks=[],
+                context_completeness=ContextCompleteness(
+                    context_score=1.0,
+                    parser_success_rate=1.0,
+                    evidence_success_rate=1.0,
+                ),
+                partial_context=True,
+                warnings=[],
+            ),
+            NarrativeResult(
+                opening_sentence="GO: low risk tag update.",
+                explanation="Review can follow the standard approval flow.",
+                guidance=[],
+                degraded=False,
+                warnings=[],
+            ),
+        )
+
+        fetched = report_service_module.fetch_analysis_report(report["id"])
+        advisory = fetched["advisory"]
+
+        self.assertTrue(fetched["context_completeness"]["partial_context"])
+        self.assertTrue(advisory["partial_context"])
+        self.assertIn("partial_context", advisory["uncertainty_flags"])
+        self.assertTrue(advisory["requires_attention"])
+
+    def test_persisted_advisory_treats_false_like_strings_as_false(self) -> None:
+        report = report_service_module.persist_analysis_report(
+            ParseBatchResult(
+                files=[
+                    ParsedFileResult(
+                        file_name="plan.json",
+                        tool="terraform",
+                        status="parsed",
+                        changes=[],
+                    )
+                ]
+            ),
+            RiskAssessment(
+                score=12,
+                severity="low",
+                recommendation="go",
+                top_risk="Low risk metadata-only update.",
+                contributors=[],
+                interaction_risks=[],
+                context_completeness=ContextCompleteness(
+                    context_score=1.0,
+                    parser_success_rate=1.0,
+                    evidence_success_rate=1.0,
+                ),
+                partial_context=False,
+                warnings=[],
+            ),
+            NarrativeResult(
+                opening_sentence="GO: low risk metadata-only update.",
+                explanation="Review can follow the standard approval flow.",
+                guidance=[],
+                degraded=False,
+                warnings=[],
+            ),
+        )
+        context = dict(report["context_completeness"])
+        context["partial_context"] = "false"
+        fallback_items = [
+            {
+                "name": "plan.json",
+                "tool": "terraform",
+                "status": "accepted",
+                "intake_status": "accepted",
+                "parse_status": "parsed",
+                "partial": "0",
+            }
+        ]
+        with sqlite3.connect(self.db_path) as conn:
+            conn.execute(
+                "UPDATE risk_assessments SET context_completeness_json = ? "
+                "WHERE analysis_id = ?",
+                (json.dumps(context), report["id"]),
+            )
+            conn.execute(
+                "UPDATE analysis_reports "
+                "SET submission_manifest_json = ?, submission_manifest_fallback_json = ? "
+                "WHERE id = ?",
+                ("{not-valid-json", json.dumps(fallback_items), report["id"]),
+            )
+
+        fetched = report_service_module.fetch_analysis_report(report["id"])
+        advisory = fetched["advisory"]
+
+        self.assertFalse(fetched["context_completeness"]["partial_context"])
+        self.assertFalse(fetched["submission_manifest_fallback"][0]["partial"])
+        self.assertFalse(advisory["partial_context"])
+        self.assertNotIn("partial_context", advisory["uncertainty_flags"])
+
+    def test_report_advisory_builder_normalizes_false_like_boolean_strings(
+        self,
+    ) -> None:
+        advisory = report_service_module.build_report_advisory_payload(
+            {
+                "severity": "low",
+                "recommendation": "go",
+                "top_risk": "Low risk metadata-only update.",
+                "context_completeness": {
+                    "context_score": 1.0,
+                    "parser_success_rate": 1.0,
+                    "evidence_success_rate": 1.0,
+                    "insufficient_context": "false",
+                    "partial_context": "false",
+                },
+                "narrative_available": "true",
+                "narrative_degraded": "false",
+                "warnings": [],
+            }
+        )
+
+        self.assertFalse(advisory["requires_attention"])
+        self.assertFalse(advisory["narrative_degraded"])
+        self.assertNotIn("insufficient_context", advisory["uncertainty_flags"])
+        self.assertNotIn("narrative_degraded", advisory["uncertainty_flags"])
+
+    def test_report_advisory_builder_ignores_non_finite_boolean_signals(
+        self,
+    ) -> None:
+        advisory = report_service_module.build_report_advisory_payload(
+            {
+                "severity": "low",
+                "recommendation": "go",
+                "top_risk": "Low risk metadata-only update.",
+                "context_completeness": {
+                    "context_score": 1.0,
+                    "parser_success_rate": 1.0,
+                    "evidence_success_rate": 1.0,
+                    "insufficient_context": math.inf,
+                    "partial_context": math.nan,
+                },
+                "narrative_available": "true",
+                "narrative_degraded": math.nan,
+                "warnings": [],
+            }
+        )
+
+        self.assertFalse(advisory["requires_attention"])
+        self.assertFalse(advisory["partial_context"])
+        self.assertFalse(advisory["narrative_degraded"])
+        self.assertNotIn("insufficient_context", advisory["uncertainty_flags"])
+        self.assertNotIn("partial_context", advisory["uncertainty_flags"])
+        self.assertNotIn("narrative_degraded", advisory["uncertainty_flags"])
+
+    def test_legacy_context_partial_context_matches_recovered_manifest_signal(
+        self,
+    ) -> None:
+        report = report_service_module.persist_analysis_report(
+            ParseBatchResult(
+                files=[
+                    ParsedFileResult(
+                        file_name="plan.json",
+                        tool="terraform",
+                        status="parsed",
+                        changes=[],
+                    )
+                ]
+            ),
+            RiskAssessment(
+                score=12,
+                severity="low",
+                recommendation="go",
+                top_risk="Low risk metadata-only update.",
+                contributors=[],
+                interaction_risks=[],
+                context_completeness=ContextCompleteness(
+                    context_score=1.0,
+                    parser_success_rate=1.0,
+                    evidence_success_rate=1.0,
+                ),
+                partial_context=False,
+                warnings=[],
+            ),
+            NarrativeResult(
+                opening_sentence="GO: low risk metadata-only update.",
+                explanation="Review can follow the standard approval flow.",
+                guidance=[],
+                degraded=False,
+                warnings=[],
+            ),
+        )
+        context = dict(report["context_completeness"])
+        context.pop("partial_context", None)
+        fallback_items = [
+            {
+                "name": "broken.tf",
+                "tool": "terraform",
+                "status": "failed",
+                "intake_status": "accepted",
+                "parse_status": "failed",
+            }
+        ]
+        with sqlite3.connect(self.db_path) as conn:
+            conn.execute(
+                "UPDATE risk_assessments SET context_completeness_json = ? "
+                "WHERE analysis_id = ?",
+                (json.dumps(context), report["id"]),
+            )
+            conn.execute(
+                "UPDATE analysis_reports "
+                "SET submission_manifest_json = ?, submission_manifest_fallback_json = ? "
+                "WHERE id = ?",
+                ("{not-valid-json", json.dumps(fallback_items), report["id"]),
+            )
+
+        fetched = report_service_module.fetch_analysis_report(report["id"])
+
+        self.assertTrue(fetched["context_completeness"]["partial_context"])
+        self.assertTrue(fetched["advisory"]["partial_context"])
+        self.assertIn("partial_context", fetched["advisory"]["uncertainty_flags"])
+
+    def test_persisted_advisory_normalizes_legacy_severity_values(self) -> None:
+        report = report_service_module.persist_analysis_report(
+            ParseBatchResult(
+                files=[
+                    ParsedFileResult(
+                        file_name="plan.json",
+                        tool="terraform",
+                        status="parsed",
+                        changes=[],
+                    )
+                ]
+            ),
+            RiskAssessment(
+                score=75,
+                severity="high",
+                recommendation="no-go",
+                top_risk="Security group exposure.",
+                contributors=[],
+                interaction_risks=[],
+                partial_context=False,
+                warnings=[],
+            ),
+            NarrativeResult(
+                opening_sentence="NO-GO: security group exposure.",
+                explanation="Review before deployment.",
+                guidance=[],
+                degraded=False,
+                warnings=[],
+            ),
+        )
+        with sqlite3.connect(self.db_path) as conn:
+            conn.execute(
+                "UPDATE analysis_reports SET severity = ?, recommendation = ? WHERE id = ?",
+                ("HIGH", "NO-GO", report["id"]),
+            )
+
+        fetched = report_service_module.fetch_analysis_report(report["id"])
+        advisory = fetched["advisory"]
+
+        self.assertEqual(fetched["severity"], "high")
+        self.assertEqual(fetched["recommendation"], "no-go")
+        self.assertEqual(advisory["severity"], "high")
+        self.assertEqual(advisory["recommendation"], "no-go")
 
     def test_persist_analysis_report_raises_when_evidence_cannot_attach_to_finding(
         self,


### PR DESCRIPTION
Story 5.1 needed submit, list, and detail analysis responses to agree on one durable machine-readable advisory/report contract. The implementation derives API metadata and advisory state from persisted report payloads, aligns share-summary attention semantics with the advisory contract, and closes the story after a clean BMad re-review.

Constraint: Preserve local-first advisory-only behavior and reuse the existing API/service schema boundary
Rejected: Trust stored submit advisory blobs as-is | stale or malformed legacy payloads can diverge from durable report fields
Confidence: high
Scope-risk: moderate
Directive: Keep submit/list/detail response contract fields derived from persisted report state before adapting new integration surfaces
Tested: ./.venv/bin/ruff check .; ./.venv/bin/ruff format --check .; ./.venv/bin/python -m unittest tests.test_api.test_analyses tests.test_services.test_analysis_service tests.test_services.test_report_service tests.test_api.test_schemas tests.test_docs.test_report_schema_documentation -q; ./.venv/bin/python -m unittest discover -q
Not-tested: Browser UI validation, not applicable because no UI surface changed

## What does this PR do?

<!-- Brief description of changes -->

## Type of change
- [ ] Feature (new functionality)
- [ ] Bugfix (non-breaking fix)
- [ ] Release preparation
- [ ] Hotfix (critical production fix)
- [ ] Docs / refactor / chore

## Checklist
- [ ] I have followed the branch naming convention
- [ ] Tests pass locally (`pytest tests/ -v`)
- [ ] Linting passes (`ruff check .`)
- [ ] Docker build succeeds
- [ ] I have updated docs if needed
- [ ] No secrets or .env values committed

## Related issue
Closes #