### PR TITLE
Story 5.6 future adapter output contract

### DIFF
--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -1,5 +1,5 @@
 # generated: 2026-05-01
-# last_updated: 2026-05-26
+# last_updated: 2026-05-29
 # project: deploywhisper
 # project_key: NOKEY
 # tracking_system: file-system
@@ -35,7 +35,7 @@
 # - Dev moves story to review, then runs code-review
 
 generated: 2026-05-01
-last_updated: 2026-05-26
+last_updated: 2026-05-29
 project: deploywhisper
 project_key: NOKEY
 tracking_system: file-system
@@ -97,7 +97,7 @@ development_status:
   5-3-github-action-integration-contract: done
   5-4-pr-comment-formatter: done
   5-5-rerun-on-commit-and-report-comparison: ready-for-dev
-  5-6-future-adapter-output-contract: ready-for-dev
+  5-6-future-adapter-output-contract: done
   epic-5-retrospective: optional
 
   epic-6: in-progress

--- a/docs/ci-advisory-consumption.md
+++ b/docs/ci-advisory-consumption.md
@@ -13,6 +13,7 @@ DeployWhisper remains advisory in automation contexts.
 - The share-configuration API is disabled unless `DEPLOYWHISPER_SHARE_TOKEN` is set; callers must send that value in `X-DeployWhisper-Share-Token`
 - CLI and API responses preserve `severity`, `recommendation`, `partial_context`, and `narrative_degraded` for machine-readable uncertainty handling
 - High-risk or degraded analyses still return success payloads; non-zero CLI exit codes are reserved for operational failures such as unreadable files, missing project scope, or shared-analysis crashes
+- Future workflow adapters should wrap `data.share_summary` with adapter identity through the shared [workflow adapter output contract](./workflow-adapter-output-contract.md) instead of redefining severity, recommendation, or Evidence Law fields.
 
 ## CLI Example
 

--- a/docs/workflow-adapter-output-contract.md
+++ b/docs/workflow-adapter-output-contract.md
@@ -25,12 +25,17 @@ The service helper returns an `AdapterOutputContract` with three parts:
 `adapter_payload` and `adapter_metadata.extra` must not shadow canonical fields
 such as severity, recommendation, Evidence Law status, Evidence Law detail,
 advisory posture, blocking decision, markdown, plain text, JSON payload, or
-report schema version.
+report schema version. Adapter-owned payload and metadata values must remain
+JSON-safe; non-finite numeric values such as NaN and infinity are rejected.
+
+The envelope `contract_version` is fixed to `v1` until a future migration story
+introduces and documents a new adapter contract version.
 
 Project scope is mandatory for adapter output. Provide exactly one of
-`project_key` or `project_id`. Workspace scope is optional; provide exactly one
-of `workspace_key` or `workspace_id` when the adapter output targets a specific
-environment or deployment lane.
+`project_key` or `project_id`. Numeric IDs must be strict positive integers,
+not coerced booleans, strings, or floats. Workspace scope is optional; provide
+exactly one of `workspace_key` or `workspace_id` when the adapter output targets
+a specific environment or deployment lane.
 
 ## Adapter Implementation Pattern
 

--- a/docs/workflow-adapter-output-contract.md
+++ b/docs/workflow-adapter-output-contract.md
@@ -27,10 +27,10 @@ such as severity, recommendation, Evidence Law status, Evidence Law detail,
 advisory posture, blocking decision, markdown, plain text, JSON payload, or
 report schema version.
 
-Project scope is mandatory for adapter output. Provide either `project_key` or
-`project_id`. Workspace scope is optional; provide either `workspace_key` or
-`workspace_id` when the adapter output targets a specific environment or
-deployment lane.
+Project scope is mandatory for adapter output. Provide exactly one of
+`project_key` or `project_id`. Workspace scope is optional; provide exactly one
+of `workspace_key` or `workspace_id` when the adapter output targets a specific
+environment or deployment lane.
 
 ## Adapter Implementation Pattern
 

--- a/docs/workflow-adapter-output-contract.md
+++ b/docs/workflow-adapter-output-contract.md
@@ -1,0 +1,87 @@
+# Workflow Adapter Output Contract
+
+DeployWhisper workflow adapters must consume one canonical report-output
+contract. GitLab, Jenkins, Atlantis, Argo CD, Flux, chat, and policy adapters
+should start from the shared `ShareSummary` produced by the analysis service,
+then wrap it with adapter identity and delivery metadata by calling
+`build_adapter_output_contract`.
+
+## Contract Shape
+
+The service helper returns an `AdapterOutputContract` with three parts:
+
+- `canonical_summary`: immutable DeployWhisper report summary fields derived from
+  `data.share_summary`, including `canonical_summary.severity`,
+  `canonical_summary.recommendation`,
+  `canonical_summary.json_payload.evidence_law_status`, markdown, plain text,
+  and typed JSON payload fields.
+- `adapter_metadata`: an `AdapterMetadata` object that names the adapter,
+  destination format, version, required project scope, optional workspace scope,
+  invocation ID, delivery target, and safe extra metadata.
+- `adapter_payload`: adapter-specific rendering or delivery details, such as a
+  GitLab discussion key, Jenkins build annotation identifier, Atlantis plan
+  comment marker, or chat thread ID.
+
+`adapter_payload` and `adapter_metadata.extra` must not shadow canonical fields
+such as severity, recommendation, Evidence Law status, Evidence Law detail,
+advisory posture, blocking decision, markdown, plain text, JSON payload, or
+report schema version.
+
+Project scope is mandatory for adapter output. Provide either `project_key` or
+`project_id`. Workspace scope is optional; provide either `workspace_key` or
+`workspace_id` when the adapter output targets a specific environment or
+deployment lane.
+
+## Adapter Implementation Pattern
+
+```python
+from services.adapter_output_contract import (
+    AdapterMetadata,
+    build_adapter_output_contract,
+)
+from services.analysis_service import build_share_summary
+
+share_summary = build_share_summary(persisted_report)
+contract = build_adapter_output_contract(
+    share_summary,
+    AdapterMetadata(
+        adapter="gitlab",
+        format="merge_request_note",
+        version="v1",
+        project_key="payments",
+        workspace_key="prod",
+        extra={"merge_request_iid": 42},
+    ),
+    adapter_payload={
+        "thread_key": "deploywhisper:17",
+        "rendered_markdown": "Adapter wrapper around canonical markdown",
+    },
+)
+```
+
+Adapters may change layout, comments, issue labels, chat blocks, or delivery
+metadata. They must not rewrite canonical severity or Evidence Law status. If a
+workflow needs blocking or policy behavior, add that as a separate configured
+interpretation of the canonical summary; do not mutate the report contract.
+
+## Canonical Field Ownership
+
+DeployWhisper core owns:
+
+- severity and recommendation
+- Evidence Law status and detail
+- advisory-only and should-block posture
+- report schema version
+- share-summary markdown, plain text, and typed JSON payload
+
+Adapters own:
+
+- required project identity and optional workspace identity
+- workflow destination metadata
+- output markers used for idempotent updates
+- rendered wrappers around canonical markdown or plain text
+- external IDs such as merge request, build, plan, sync, or chat-thread IDs
+
+This keeps future workflow integrations independent without letting adapter
+formatting drift from the report object users inspect in API, CLI, UI, and
+shared report views.

--- a/services/adapter_output_contract.py
+++ b/services/adapter_output_contract.py
@@ -1,0 +1,227 @@
+"""Canonical output contracts for workflow adapters."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+
+from services.analysis_service import (
+    ShareSummary,
+    ShareSummaryContext,
+    ShareSummaryFinding,
+    ShareSummaryJsonPayload,
+)
+
+AdapterMetadataValue = str | int | float | bool | None
+
+
+class AdapterOutputContractError(ValueError):
+    """Raised when adapter-specific output attempts to shadow canonical fields."""
+
+
+class FrozenDict(dict):
+    """JSON-serializable immutable dict used for adapter-owned maps."""
+
+    def _immutable(self, *args: Any, **kwargs: Any) -> None:
+        raise TypeError("FrozenDict is immutable.")
+
+    __setitem__ = _immutable
+    __delitem__ = _immutable
+    clear = _immutable
+    pop = _immutable
+    popitem = _immutable
+    setdefault = _immutable
+    update = _immutable
+
+    def __ior__(self, other: object) -> FrozenDict:
+        self._immutable()
+        return self
+
+
+def _freeze_value(value: Any) -> Any:
+    if isinstance(value, FrozenDict):
+        return value
+    if isinstance(value, dict):
+        return FrozenDict({key: _freeze_value(item) for key, item in value.items()})
+    if isinstance(value, list):
+        return tuple(_freeze_value(item) for item in value)
+    return value
+
+
+class AdapterMetadata(BaseModel):
+    """Workflow adapter identity and delivery context."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    adapter: str = Field(..., description="Adapter family, such as gitlab or jenkins")
+    format: str = Field(..., description="Adapter output format or destination type")
+    version: str | None = Field(default=None, description="Adapter contract version")
+    project_key: str | None = Field(default=None, description="Project key in scope")
+    project_id: int | None = Field(default=None, description="Project ID in scope")
+    workspace_key: str | None = Field(
+        default=None, description="Workspace key in scope"
+    )
+    workspace_id: int | None = Field(default=None, description="Workspace ID in scope")
+    invocation_id: str | None = Field(
+        default=None, description="Adapter invocation or workflow run identifier"
+    )
+    delivery_target: str | None = Field(
+        default=None, description="Adapter-specific delivery target"
+    )
+    extra: dict[str, AdapterMetadataValue] = Field(
+        default_factory=dict,
+        description="Adapter-specific metadata that does not shadow canonical fields",
+    )
+
+    @field_validator("adapter", "format")
+    @classmethod
+    def _normalize_required_label(cls, value: str) -> str:
+        normalized = value.strip()
+        if not normalized:
+            raise ValueError("Adapter metadata labels must not be blank.")
+        return normalized
+
+    @field_validator(
+        "version",
+        "project_key",
+        "workspace_key",
+        "invocation_id",
+        "delivery_target",
+    )
+    @classmethod
+    def _normalize_optional_label(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
+        normalized = value.strip()
+        if not normalized:
+            raise ValueError("Adapter metadata labels must not be blank.")
+        return normalized
+
+    @field_validator("project_id", "workspace_id")
+    @classmethod
+    def _validate_positive_id(cls, value: int | None) -> int | None:
+        if value is not None and value <= 0:
+            raise ValueError("Adapter metadata IDs must be positive.")
+        return value
+
+    @model_validator(mode="after")
+    def _validate_scope_and_extra_keys(self) -> AdapterMetadata:
+        if self.project_key is None and self.project_id is None:
+            raise ValueError("Adapter metadata requires project_key or project_id.")
+        shadowed = sorted(
+            key for key in self.extra if key in _reserved_adapter_fields()
+        )
+        if shadowed:
+            joined = ", ".join(shadowed)
+            raise ValueError(
+                f"Adapter metadata extra cannot shadow canonical field(s): {joined}."
+            )
+        return self
+
+    def model_post_init(self, __context: Any) -> None:
+        object.__setattr__(self, "extra", _freeze_value(dict(self.extra)))
+
+
+class FrozenShareSummaryFinding(ShareSummaryFinding):
+    """Immutable share-summary finding for adapter contracts."""
+
+    model_config = ConfigDict(frozen=True)
+
+
+class FrozenShareSummaryContext(ShareSummaryContext):
+    """Immutable context summary for adapter contracts."""
+
+    model_config = ConfigDict(frozen=True)
+
+
+class FrozenShareSummaryJsonPayload(ShareSummaryJsonPayload):
+    """Immutable machine-friendly share-summary payload for adapter contracts."""
+
+    model_config = ConfigDict(frozen=True)
+
+    top_findings: tuple[FrozenShareSummaryFinding, ...] = Field(
+        default_factory=tuple, description="Top findings to surface"
+    )
+    context_completeness: FrozenShareSummaryContext = Field(
+        ..., description="Context completeness summary"
+    )
+
+
+class AdapterCanonicalSummary(ShareSummary):
+    """Immutable canonical report summary consumed by all workflow adapters."""
+
+    model_config = ConfigDict(frozen=True)
+
+    json_payload: FrozenShareSummaryJsonPayload = Field(
+        ..., description="Machine-friendly share-summary payload"
+    )
+
+
+class AdapterOutputContract(BaseModel):
+    """One report-output envelope for future delivery adapters."""
+
+    model_config = ConfigDict(frozen=True)
+
+    contract_version: str = Field(default="v1", description="Adapter contract version")
+    adapter_metadata: AdapterMetadata = Field(..., description="Adapter metadata")
+    canonical_summary: AdapterCanonicalSummary = Field(
+        ..., description="Immutable canonical summary"
+    )
+    adapter_payload: dict[str, Any] = Field(
+        default_factory=dict,
+        description="Adapter-specific formatting and delivery fields",
+    )
+
+    @model_validator(mode="after")
+    def _reject_payload_canonical_keys(self) -> AdapterOutputContract:
+        _validate_adapter_payload(self.adapter_payload)
+        return self
+
+    def model_post_init(self, __context: Any) -> None:
+        object.__setattr__(
+            self, "adapter_payload", _freeze_value(dict(self.adapter_payload))
+        )
+
+
+def build_adapter_output_contract(
+    share_summary: ShareSummary,
+    adapter_metadata: AdapterMetadata | dict[str, Any],
+    *,
+    adapter_payload: dict[str, Any] | None = None,
+) -> AdapterOutputContract:
+    """Return a canonical adapter envelope without letting adapters rewrite core fields."""
+    metadata = AdapterMetadata.model_validate(adapter_metadata)
+    payload = dict(adapter_payload or {})
+    _validate_adapter_payload(payload)
+
+    canonical_summary = AdapterCanonicalSummary.model_validate(
+        share_summary.model_dump()
+    )
+    return AdapterOutputContract(
+        adapter_metadata=metadata,
+        canonical_summary=canonical_summary,
+        adapter_payload=payload,
+    )
+
+
+def _reserved_adapter_fields() -> frozenset[str]:
+    return frozenset(
+        {
+            *AdapterCanonicalSummary.model_fields,
+            *FrozenShareSummaryJsonPayload.model_fields,
+            "adapter_metadata",
+            "adapter_payload",
+            "canonical_summary",
+            "contract_version",
+        }
+    )
+
+
+def _validate_adapter_payload(payload: dict[str, Any]) -> None:
+    shadowed = sorted(key for key in payload if key in _reserved_adapter_fields())
+    if shadowed:
+        joined = ", ".join(shadowed)
+        raise AdapterOutputContractError(
+            f"Adapter payload cannot shadow canonical field(s): {joined}."
+        )

--- a/services/adapter_output_contract.py
+++ b/services/adapter_output_contract.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import math
 from typing import Any
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
@@ -45,6 +46,8 @@ def _freeze_value(value: Any) -> Any:
     if isinstance(value, dict):
         return FrozenDict({key: _freeze_value(item) for key, item in value.items()})
     if isinstance(value, list):
+        return tuple(_freeze_value(item) for item in value)
+    if isinstance(value, tuple):
         return tuple(_freeze_value(item) for item in value)
     return value
 
@@ -109,6 +112,14 @@ class AdapterMetadata(BaseModel):
     def _validate_scope_and_extra_keys(self) -> AdapterMetadata:
         if self.project_key is None and self.project_id is None:
             raise ValueError("Adapter metadata requires project_key or project_id.")
+        if self.project_key is not None and self.project_id is not None:
+            raise ValueError(
+                "Adapter metadata must use either project_key or project_id, not both."
+            )
+        if self.workspace_key is not None and self.workspace_id is not None:
+            raise ValueError(
+                "Adapter metadata must use either workspace_key or workspace_id, not both."
+            )
         shadowed = sorted(
             key for key in self.extra if key in _reserved_adapter_fields()
         )
@@ -219,9 +230,40 @@ def _reserved_adapter_fields() -> frozenset[str]:
 
 
 def _validate_adapter_payload(payload: dict[str, Any]) -> None:
-    shadowed = sorted(key for key in payload if key in _reserved_adapter_fields())
-    if shadowed:
-        joined = ", ".join(shadowed)
+    _validate_json_payload_value(payload, "adapter_payload")
+
+
+def _validate_json_payload_value(value: Any, path: str) -> None:
+    if isinstance(value, dict):
+        for key, item in value.items():
+            if not isinstance(key, str):
+                raise AdapterOutputContractError(
+                    f"Adapter payload keys must be strings at {path}."
+                )
+            child_path = f"{path}.{key}"
+            if key in _reserved_adapter_fields():
+                raise AdapterOutputContractError(
+                    f"Adapter payload cannot shadow canonical field at {child_path}."
+                )
+            _validate_json_payload_value(item, child_path)
+        return
+
+    if isinstance(value, list | tuple):
+        for index, item in enumerate(value):
+            _validate_json_payload_value(item, f"{path}[{index}]")
+        return
+
+    if value is None or isinstance(value, str | bool | int):
+        return
+
+    if isinstance(value, float) and math.isfinite(value):
+        return
+
+    if isinstance(value, float):
         raise AdapterOutputContractError(
-            f"Adapter payload cannot shadow canonical field(s): {joined}."
+            f"Adapter payload numbers must be finite at {path}."
         )
+
+    raise AdapterOutputContractError(
+        f"Adapter payload values must be JSON-serializable at {path}."
+    )

--- a/services/adapter_output_contract.py
+++ b/services/adapter_output_contract.py
@@ -5,7 +5,15 @@ from __future__ import annotations
 import math
 from typing import Any
 
-from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    StrictInt,
+    StrictStr,
+    field_validator,
+    model_validator,
+)
 
 from services.analysis_service import (
     ShareSummary,
@@ -61,11 +69,15 @@ class AdapterMetadata(BaseModel):
     format: str = Field(..., description="Adapter output format or destination type")
     version: str | None = Field(default=None, description="Adapter contract version")
     project_key: str | None = Field(default=None, description="Project key in scope")
-    project_id: int | None = Field(default=None, description="Project ID in scope")
+    project_id: StrictInt | None = Field(
+        default=None, description="Project ID in scope"
+    )
     workspace_key: str | None = Field(
         default=None, description="Workspace key in scope"
     )
-    workspace_id: int | None = Field(default=None, description="Workspace ID in scope")
+    workspace_id: StrictInt | None = Field(
+        default=None, description="Workspace ID in scope"
+    )
     invocation_id: str | None = Field(
         default=None, description="Adapter invocation or workflow run identifier"
     )
@@ -128,6 +140,16 @@ class AdapterMetadata(BaseModel):
             raise ValueError(
                 f"Adapter metadata extra cannot shadow canonical field(s): {joined}."
             )
+        non_finite_numbers = sorted(
+            key
+            for key, value in self.extra.items()
+            if isinstance(value, float) and not math.isfinite(value)
+        )
+        if non_finite_numbers:
+            joined = ", ".join(non_finite_numbers)
+            raise ValueError(
+                f"Adapter metadata extra numbers must be finite: {joined}."
+            )
         return self
 
     def model_post_init(self, __context: Any) -> None:
@@ -174,7 +196,9 @@ class AdapterOutputContract(BaseModel):
 
     model_config = ConfigDict(frozen=True)
 
-    contract_version: str = Field(default="v1", description="Adapter contract version")
+    contract_version: StrictStr = Field(
+        default="v1", description="Adapter contract version"
+    )
     adapter_metadata: AdapterMetadata = Field(..., description="Adapter metadata")
     canonical_summary: AdapterCanonicalSummary = Field(
         ..., description="Immutable canonical summary"
@@ -183,6 +207,13 @@ class AdapterOutputContract(BaseModel):
         default_factory=dict,
         description="Adapter-specific formatting and delivery fields",
     )
+
+    @field_validator("contract_version")
+    @classmethod
+    def _validate_contract_version(cls, value: str) -> str:
+        if value != "v1":
+            raise ValueError("Adapter contract version must be v1.")
+        return value
 
     @model_validator(mode="after")
     def _reject_payload_canonical_keys(self) -> AdapterOutputContract:
@@ -221,6 +252,8 @@ def _reserved_adapter_fields() -> frozenset[str]:
         {
             *AdapterCanonicalSummary.model_fields,
             *FrozenShareSummaryJsonPayload.model_fields,
+            *FrozenShareSummaryFinding.model_fields,
+            *FrozenShareSummaryContext.model_fields,
             "adapter_metadata",
             "adapter_payload",
             "canonical_summary",

--- a/tests/test_docs/test_workflow_adapter_output_contract.py
+++ b/tests/test_docs/test_workflow_adapter_output_contract.py
@@ -1,0 +1,39 @@
+"""Documentation checks for workflow adapter output contracts."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import unittest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+CONTRACT_GUIDE = REPO_ROOT / "docs" / "workflow-adapter-output-contract.md"
+CI_GUIDE = REPO_ROOT / "docs" / "ci-advisory-consumption.md"
+
+
+class WorkflowAdapterOutputContractDocumentationTests(unittest.TestCase):
+    def test_contract_guide_documents_canonical_summary_and_adapter_metadata(
+        self,
+    ) -> None:
+        content = CONTRACT_GUIDE.read_text(encoding="utf-8")
+
+        expected_clauses = (
+            "AdapterMetadata",
+            "build_adapter_output_contract",
+            "GitLab, Jenkins, Atlantis, Argo CD, Flux, chat, and policy adapters",
+            "`canonical_summary.severity`",
+            "`canonical_summary.json_payload.evidence_law_status`",
+            "`adapter_metadata`",
+            "`adapter_payload`",
+            "Project scope is mandatory",
+            "must not shadow canonical fields",
+        )
+        for expected in expected_clauses:
+            with self.subTest(expected=expected):
+                self.assertIn(expected, content)
+
+    def test_ci_guide_links_to_future_adapter_contract(self) -> None:
+        content = CI_GUIDE.read_text(encoding="utf-8")
+
+        self.assertIn("workflow-adapter-output-contract.md", content)
+        self.assertTrue(CONTRACT_GUIDE.exists())

--- a/tests/test_services/test_adapter_output_contract.py
+++ b/tests/test_services/test_adapter_output_contract.py
@@ -74,6 +74,56 @@ class AdapterOutputContractTests(unittest.TestCase):
                         adapter_payload=forbidden_payload,
                     )
 
+    def test_adapter_payload_cannot_shadow_canonical_fields_nested(self) -> None:
+        summary = build_share_summary(_report_payload())
+
+        for forbidden_payload in (
+            {"thread": {"severity": "low"}},
+            {"blocks": [{"evidence_law_status": "Needs review"}]},
+        ):
+            with self.subTest(forbidden_payload=forbidden_payload):
+                with self.assertRaises(AdapterOutputContractError):
+                    build_adapter_output_contract(
+                        summary,
+                        AdapterMetadata(
+                            adapter="gitlab",
+                            format="merge_request_note",
+                            project_key="payments",
+                        ),
+                        adapter_payload=forbidden_payload,
+                    )
+
+    def test_adapter_payload_requires_json_native_values(self) -> None:
+        summary = build_share_summary(_report_payload())
+        metadata = AdapterMetadata(
+            adapter="gitlab",
+            format="merge_request_note",
+            project_key="payments",
+        )
+
+        for forbidden_payload in (
+            {"items": {"one", "two"}},
+            {"bad": object()},
+            {"ratio": float("nan")},
+        ):
+            with self.subTest(forbidden_payload=forbidden_payload):
+                with self.assertRaises(AdapterOutputContractError):
+                    build_adapter_output_contract(
+                        summary,
+                        metadata,
+                        adapter_payload=forbidden_payload,
+                    )
+
+        canonical_summary = build_adapter_output_contract(
+            summary, metadata
+        ).canonical_summary
+        with self.assertRaises(ValidationError):
+            AdapterOutputContract(
+                adapter_metadata=metadata,
+                canonical_summary=canonical_summary,
+                adapter_payload={"bad": object()},
+            )
+
     def test_adapter_metadata_extra_cannot_shadow_canonical_fields(self) -> None:
         with self.assertRaises(ValidationError):
             AdapterMetadata(
@@ -112,6 +162,23 @@ class AdapterOutputContractTests(unittest.TestCase):
         self.assertEqual(by_id.project_id, 12)
         self.assertEqual(by_id.workspace_id, 7)
 
+    def test_adapter_metadata_rejects_conflicting_scope_identifiers(self) -> None:
+        for kwargs in (
+            {"project_key": "payments", "project_id": 12},
+            {
+                "project_key": "payments",
+                "workspace_key": "prod",
+                "workspace_id": 7,
+            },
+        ):
+            with self.subTest(kwargs=kwargs):
+                with self.assertRaises(ValidationError):
+                    AdapterMetadata(
+                        adapter="chat",
+                        format="message",
+                        **kwargs,
+                    )
+
     def test_adapter_metadata_rejects_unknown_top_level_fields(self) -> None:
         with self.assertRaises(ValidationError):
             AdapterMetadata(
@@ -125,15 +192,19 @@ class AdapterOutputContractTests(unittest.TestCase):
         self,
     ) -> None:
         summary = build_share_summary(_report_payload())
+        metadata = AdapterMetadata(
+            adapter="jenkins",
+            format="build_comment",
+            project_key="payments",
+        )
+        canonical_summary = build_adapter_output_contract(
+            summary, metadata
+        ).canonical_summary
 
         with self.assertRaises(ValidationError):
             AdapterOutputContract(
-                adapter_metadata=AdapterMetadata(
-                    adapter="jenkins",
-                    format="build_comment",
-                    project_key="payments",
-                ),
-                canonical_summary=summary,
+                adapter_metadata=metadata,
+                canonical_summary=canonical_summary,
                 adapter_payload={"evidence_law_status": "Needs review"},
             )
 
@@ -170,6 +241,21 @@ class AdapterOutputContractTests(unittest.TestCase):
             contract.adapter_payload["thread"]["evidence_law_status"] = "Needs review"
         with self.assertRaises(TypeError):
             contract.adapter_metadata.extra["evidence_law_status"] = "Needs review"
+
+    def test_tuple_wrapped_adapter_maps_are_immutable_after_validation(self) -> None:
+        contract = build_adapter_output_contract(
+            build_share_summary(_report_payload()),
+            AdapterMetadata(
+                adapter="gitlab",
+                format="merge_request_note",
+                project_key="payments",
+            ),
+            adapter_payload={"items": ({"id": "deploywhisper:17"},)},
+        )
+
+        self.assertIsInstance(contract.adapter_payload["items"], tuple)
+        with self.assertRaises(TypeError):
+            contract.adapter_payload["items"][0]["severity"] = "low"
 
 
 def _report_payload() -> dict:

--- a/tests/test_services/test_adapter_output_contract.py
+++ b/tests/test_services/test_adapter_output_contract.py
@@ -80,6 +80,9 @@ class AdapterOutputContractTests(unittest.TestCase):
         for forbidden_payload in (
             {"thread": {"severity": "low"}},
             {"blocks": [{"evidence_law_status": "Needs review"}]},
+            {"thread": {"confidence": 0.2}},
+            {"thread": {"score": 0.1}},
+            {"blocks": [{"label": "Partial context"}]},
         ):
             with self.subTest(forbidden_payload=forbidden_payload):
                 with self.assertRaises(AdapterOutputContractError):
@@ -140,6 +143,17 @@ class AdapterOutputContractTests(unittest.TestCase):
                 extra={"headline": "Adapter headline"},
             )
 
+    def test_adapter_metadata_extra_requires_finite_numbers(self) -> None:
+        for value in (float("nan"), float("inf"), -float("inf")):
+            with self.subTest(value=value):
+                with self.assertRaises(ValidationError):
+                    AdapterMetadata(
+                        adapter="chat",
+                        format="message",
+                        project_key="payments",
+                        extra={"ratio": value},
+                    )
+
     def test_adapter_metadata_requires_project_key_or_id(self) -> None:
         with self.assertRaises(ValidationError):
             AdapterMetadata(adapter="chat", format="message")
@@ -161,6 +175,23 @@ class AdapterOutputContractTests(unittest.TestCase):
         self.assertEqual(by_key.workspace_key, "prod")
         self.assertEqual(by_id.project_id, 12)
         self.assertEqual(by_id.workspace_id, 7)
+
+    def test_adapter_metadata_rejects_coerced_scope_ids(self) -> None:
+        for kwargs in (
+            {"project_id": True},
+            {"project_id": "12"},
+            {"project_id": 12.0},
+            {"project_key": "payments", "workspace_id": True},
+            {"project_key": "payments", "workspace_id": "7"},
+            {"project_key": "payments", "workspace_id": 7.0},
+        ):
+            with self.subTest(kwargs=kwargs):
+                with self.assertRaises(ValidationError):
+                    AdapterMetadata(
+                        adapter="chat",
+                        format="message",
+                        **kwargs,
+                    )
 
     def test_adapter_metadata_rejects_conflicting_scope_identifiers(self) -> None:
         for kwargs in (
@@ -207,6 +238,33 @@ class AdapterOutputContractTests(unittest.TestCase):
                 canonical_summary=canonical_summary,
                 adapter_payload={"evidence_law_status": "Needs review"},
             )
+
+    def test_contract_version_is_fixed_to_v1(self) -> None:
+        summary = build_share_summary(_report_payload())
+        metadata = AdapterMetadata(
+            adapter="jenkins",
+            format="build_comment",
+            project_key="payments",
+        )
+        canonical_summary = build_adapter_output_contract(
+            summary, metadata
+        ).canonical_summary
+
+        contract = AdapterOutputContract(
+            contract_version="v1",
+            adapter_metadata=metadata,
+            canonical_summary=canonical_summary,
+        )
+        self.assertEqual(contract.contract_version, "v1")
+
+        for contract_version in ("", " ", "v2"):
+            with self.subTest(contract_version=contract_version):
+                with self.assertRaises(ValidationError):
+                    AdapterOutputContract(
+                        contract_version=contract_version,
+                        adapter_metadata=metadata,
+                        canonical_summary=canonical_summary,
+                    )
 
     def test_canonical_summary_is_immutable_for_adapter_formatters(self) -> None:
         contract = build_adapter_output_contract(

--- a/tests/test_services/test_adapter_output_contract.py
+++ b/tests/test_services/test_adapter_output_contract.py
@@ -1,0 +1,215 @@
+"""Tests for future workflow adapter output contracts."""
+
+from __future__ import annotations
+
+import unittest
+
+from pydantic import ValidationError
+
+from services.adapter_output_contract import (
+    AdapterMetadata,
+    AdapterOutputContract,
+    AdapterOutputContractError,
+    build_adapter_output_contract,
+)
+from services.analysis_service import build_share_summary
+
+
+class AdapterOutputContractTests(unittest.TestCase):
+    def test_contract_combines_canonical_summary_and_adapter_metadata(self) -> None:
+        summary = build_share_summary(_report_payload())
+
+        contract = build_adapter_output_contract(
+            summary,
+            AdapterMetadata(
+                adapter="gitlab",
+                format="merge_request_note",
+                version="v1",
+                project_key="payments",
+                workspace_key="prod",
+                extra={"merge_request_iid": 42},
+            ),
+            adapter_payload={
+                "thread_key": "deploywhisper:17",
+                "rendered_markdown": "GitLab-specific wrapper",
+            },
+        )
+
+        self.assertEqual(contract.contract_version, "v1")
+        self.assertEqual(contract.adapter_metadata.adapter, "gitlab")
+        self.assertEqual(contract.adapter_metadata.extra["merge_request_iid"], 42)
+        self.assertEqual(contract.canonical_summary.severity, "high")
+        self.assertEqual(contract.canonical_summary.recommendation, "caution")
+        self.assertEqual(
+            contract.canonical_summary.json_payload.evidence_law_status, "Satisfied"
+        )
+        self.assertFalse(contract.canonical_summary.should_block)
+        self.assertIn("Evidence Law", contract.canonical_summary.markdown)
+        self.assertEqual(contract.adapter_payload["thread_key"], "deploywhisper:17")
+
+        share_payload = contract.canonical_summary.json_payload
+        self.assertEqual(share_payload.report_schema_version, "v2")
+        self.assertEqual(share_payload.evidence_law_status, "Satisfied")
+        self.assertEqual(share_payload.top_findings[0].severity, "high")
+        self.assertIn("evidence_law_status", contract.model_dump_json())
+
+    def test_adapter_payload_cannot_override_canonical_fields(self) -> None:
+        summary = build_share_summary(_report_payload())
+
+        for forbidden_payload in (
+            {"severity": "low"},
+            {"headline": "Adapter rewrite"},
+            {"evidence_law_status": "Needs review"},
+            {"evidence_law_detail": "Adapter-specific rewrite"},
+        ):
+            with self.subTest(forbidden_payload=forbidden_payload):
+                with self.assertRaises(AdapterOutputContractError):
+                    build_adapter_output_contract(
+                        summary,
+                        AdapterMetadata(
+                            adapter="jenkins",
+                            format="build_comment",
+                            project_key="payments",
+                        ),
+                        adapter_payload=forbidden_payload,
+                    )
+
+    def test_adapter_metadata_extra_cannot_shadow_canonical_fields(self) -> None:
+        with self.assertRaises(ValidationError):
+            AdapterMetadata(
+                adapter="chat",
+                format="message",
+                project_key="payments",
+                extra={"severity": "low"},
+            )
+        with self.assertRaises(ValidationError):
+            AdapterMetadata(
+                adapter="chat",
+                format="message",
+                project_key="payments",
+                extra={"headline": "Adapter headline"},
+            )
+
+    def test_adapter_metadata_requires_project_key_or_id(self) -> None:
+        with self.assertRaises(ValidationError):
+            AdapterMetadata(adapter="chat", format="message")
+
+        by_key = AdapterMetadata(
+            adapter="chat",
+            format="message",
+            project_key="payments",
+            workspace_key="prod",
+        )
+        by_id = AdapterMetadata(
+            adapter="chat",
+            format="message",
+            project_id=12,
+            workspace_id=7,
+        )
+
+        self.assertEqual(by_key.project_key, "payments")
+        self.assertEqual(by_key.workspace_key, "prod")
+        self.assertEqual(by_id.project_id, 12)
+        self.assertEqual(by_id.workspace_id, 7)
+
+    def test_adapter_metadata_rejects_unknown_top_level_fields(self) -> None:
+        with self.assertRaises(ValidationError):
+            AdapterMetadata(
+                adapter="chat",
+                format="message",
+                project_key="payments",
+                severity="low",
+            )
+
+    def test_adapter_payload_rejects_direct_model_construction_shadowing(
+        self,
+    ) -> None:
+        summary = build_share_summary(_report_payload())
+
+        with self.assertRaises(ValidationError):
+            AdapterOutputContract(
+                adapter_metadata=AdapterMetadata(
+                    adapter="jenkins",
+                    format="build_comment",
+                    project_key="payments",
+                ),
+                canonical_summary=summary,
+                adapter_payload={"evidence_law_status": "Needs review"},
+            )
+
+    def test_canonical_summary_is_immutable_for_adapter_formatters(self) -> None:
+        contract = build_adapter_output_contract(
+            build_share_summary(_report_payload()),
+            AdapterMetadata(
+                adapter="atlantis",
+                format="plan_comment",
+                project_key="payments",
+            ),
+        )
+
+        with self.assertRaises(ValidationError):
+            contract.canonical_summary.severity = "low"
+        with self.assertRaises(ValidationError):
+            contract.canonical_summary.json_payload.evidence_law_status = "Needs review"
+
+    def test_adapter_owned_maps_are_immutable_after_validation(self) -> None:
+        contract = build_adapter_output_contract(
+            build_share_summary(_report_payload()),
+            AdapterMetadata(
+                adapter="gitlab",
+                format="merge_request_note",
+                project_key="payments",
+                extra={"merge_request_iid": 42},
+            ),
+            adapter_payload={"thread": {"id": "deploywhisper:17"}},
+        )
+
+        with self.assertRaises(TypeError):
+            contract.adapter_payload["severity"] = "low"
+        with self.assertRaises(TypeError):
+            contract.adapter_payload["thread"]["evidence_law_status"] = "Needs review"
+        with self.assertRaises(TypeError):
+            contract.adapter_metadata.extra["evidence_law_status"] = "Needs review"
+
+
+def _report_payload() -> dict:
+    return {
+        "id": 17,
+        "report_schema_version": "v2",
+        "severity": "high",
+        "recommendation": "caution",
+        "top_risk": "Terraform opened database ingress.",
+        "narrative_opening": "CAUTION: review database ingress.",
+        "narrative_available": True,
+        "warnings": [],
+        "findings": [
+            {
+                "finding_id": "finding-001",
+                "title": "HIGH: aws_security_group.db",
+                "severity": "high",
+                "confidence": 0.91,
+                "evidence_refs": ["ev-001"],
+            }
+        ],
+        "evidence_items": [
+            {
+                "evidence_id": "ev-001",
+                "finding_id": "finding-001",
+                "deterministic": True,
+                "determinism_level": "deterministic",
+            }
+        ],
+        "blast_radius": {
+            "affected": [{"label": "Primary Database"}],
+            "direct_count": 1,
+            "transitive_count": 0,
+            "warning": None,
+        },
+        "rollback_plan": {
+            "steps": [{"title": "Revert ingress rule"}],
+            "complexity": "low",
+            "complexity_score": 1,
+            "warning": None,
+        },
+        "context_completeness": {"context_score": 0.9},
+    }


### PR DESCRIPTION
## Summary
- Add a service-layer adapter output contract that wraps the existing typed ShareSummary instead of copying canonical fields
- Require adapter project scope via project_key or project_id while keeping workspace_key/workspace_id optional
- Forbid adapter payload/metadata shadowing of canonical fields and deep-freeze adapter-owned maps after validation
- Document the future workflow adapter contract and link it from CI advisory consumption guidance

## Validation
- ./.venv/bin/python -m unittest tests.test_services.test_adapter_output_contract tests.test_docs.test_workflow_adapter_output_contract -q
- ./.venv/bin/ruff check .
- ./.venv/bin/ruff format --check .
- ./.venv/bin/python -m unittest discover -q
- bash scripts/ci-local.sh

## Notes
- Story 5.6 BMad markdown was updated locally, but implementation story files are ignored by this repository; tracked sprint status is updated to done.