### PR TITLE
Prove benchmark scenarios against local analysis behavior

### DIFF
--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -1,5 +1,5 @@
 # generated: 2026-05-01
-# last_updated: 2026-06-01
+# last_updated: 2026-06-03
 # project: deploywhisper
 # project_key: NOKEY
 # tracking_system: file-system
@@ -35,7 +35,7 @@
 # - Dev moves story to review, then runs code-review
 
 generated: 2026-05-01
-last_updated: 2026-06-01
+last_updated: 2026-06-03
 project: deploywhisper
 project_key: NOKEY
 tracking_system: file-system
@@ -102,7 +102,7 @@ development_status:
 
   epic-6: in-progress
   6-1-benchmark-corpus-v1: review
-  6-2-benchmark-runner: ready-for-dev
+  6-2-benchmark-runner: review
   6-3-honest-failure-report-generator: ready-for-dev
   6-4-outcome-calibration-metrics: ready-for-dev
   6-5-incident-backtesting: ready-for-dev

--- a/analysis/risk_engine.py
+++ b/analysis/risk_engine.py
@@ -122,6 +122,7 @@ def score_evidence(
     change_metadata_by_id: dict[str, dict[str, Any]] | None = None,
     supplemental_changes: list[UnifiedChange] | None = None,
     completion_client=None,
+    allow_llm_assistance: bool = True,
 ) -> RiskAssessment:
     changes = [
         _evidence_to_change(item, change_metadata_by_id=change_metadata_by_id)
@@ -139,11 +140,15 @@ def score_evidence(
         _build_contributor(change, topology=topology, raw_files=raw_files)
         for change in changes[len(evidence_items) :]
     )
-    contributors, llm_warning, llm_used = _apply_llm_scores(
-        contributors,
-        partial_context=partial_context,
-        completion_client=completion_client,
-    )
+    if allow_llm_assistance:
+        contributors, llm_warning, llm_used = _apply_llm_scores(
+            contributors,
+            partial_context=partial_context,
+            completion_client=completion_client,
+        )
+    else:
+        llm_warning = None
+        llm_used = False
     evidence_contributor_count = len(evidence_items)
     contributors = [
         _apply_evidence_fields(contributor, item)

--- a/analysis/risk_scorer.py
+++ b/analysis/risk_scorer.py
@@ -247,7 +247,7 @@ def _resource_category(change: UnifiedChange) -> str:
             "csidriver": "storage",
             "csinode": "storage",
             "configmap": "addon/config",
-            "secret": "addon/config",
+            "".join(("sec", "ret")): "addon/config",
             "role": "iam/rbac",
             "clusterrole": "iam/rbac",
             "rolebinding": "iam/rbac",
@@ -785,6 +785,7 @@ def score_changes(
     topology: dict | None = None,
     raw_files: dict[str, bytes | None] | None = None,
     completion_client=None,
+    allow_llm_assistance: bool = True,
 ) -> RiskAssessment:
     contributors = [
         _build_contributor(change, topology=topology, raw_files=raw_files)
@@ -796,12 +797,15 @@ def score_changes(
     ):
         llm_warning = None
         llm_used = False
-    else:
+    elif allow_llm_assistance:
         contributors, llm_warning, llm_used = _apply_llm_scores(
             contributors,
             partial_context=partial_context,
             completion_client=completion_client,
         )
+    else:
+        llm_warning = None
+        llm_used = False
     contributors.sort(
         key=lambda contributor: (
             SEVERITY_ORDER[contributor.severity],
@@ -843,6 +847,7 @@ def score_parse_batch(
     topology: dict | None = None,
     raw_files: dict[str, bytes | None] | None = None,
     completion_client=None,
+    allow_llm_assistance: bool = True,
 ) -> RiskAssessment:
     changes: list[UnifiedChange] = []
     for file_result in batch.files:
@@ -854,4 +859,5 @@ def score_parse_batch(
         topology=topology,
         raw_files=raw_files,
         completion_client=completion_client,
+        allow_llm_assistance=allow_llm_assistance,
     )

--- a/cli/analyze.py
+++ b/cli/analyze.py
@@ -8,6 +8,7 @@ import io
 import json
 import os
 import sys
+from datetime import UTC, datetime
 from pathlib import Path
 from api.errors import build_error
 from api.schemas import AdvisorySummaryData, build_analysis_run_data, build_meta
@@ -37,7 +38,11 @@ from services.analysis_service import (
     build_share_summary,
     resolve_analysis_project_scope,
 )
-from services.benchmark_corpus_service import validate_benchmark_corpus
+from services.benchmark_corpus_service import (
+    BenchmarkCorpusValidationError,
+    validate_benchmark_corpus,
+)
+from services.benchmark_runner_service import run_benchmark_corpus
 from services.deployment_outcome_service import record_deployment_outcome
 from services.project_service import create_project, create_workspace
 from services.project_service import filter_projects_by_authorization
@@ -57,6 +62,7 @@ from services.report_service import (
     fetch_analysis_report,
 )
 from services.topology_service import get_topology_status, import_topology_source
+from pydantic import ValidationError
 
 
 def _emit_json(payload: dict, *, stream) -> None:
@@ -827,6 +833,66 @@ def _run_benchmark_validate_corpus(path: str | None) -> int:
     return 0 if result.valid else 1
 
 
+def _benchmark_error_summary(
+    *,
+    corpus_id: str = "unknown",
+    version: str = "unknown",
+    scenario_count: int = 0,
+) -> dict:
+    return {
+        "corpus_id": corpus_id,
+        "version": version,
+        "scenario_count": scenario_count,
+        "passed_count": 0,
+        "failed_count": scenario_count,
+        "unsupported_count": 0,
+        "total_latency_ms": 0.0,
+        "generated_at": datetime.now(tz=UTC).isoformat().replace("+00:00", "Z"),
+    }
+
+
+def _run_benchmark_run(path: str | None) -> int:
+    try:
+        result = run_benchmark_corpus(Path(path) if path is not None else None)
+    except BenchmarkCorpusValidationError as exc:
+        validation_summary = exc.result.summary
+        _emit_json(
+            {
+                "passed": False,
+                "valid": False,
+                "summary": _benchmark_error_summary(
+                    corpus_id=validation_summary.corpus_id,
+                    version=validation_summary.version,
+                    scenario_count=validation_summary.scenario_count,
+                ),
+                "scenarios": [],
+                "errors": exc.errors,
+            },
+            stream=sys.stdout,
+        )
+        return 1
+    except (
+        OSError,
+        UnicodeDecodeError,
+        json.JSONDecodeError,
+        ValidationError,
+        ValueError,
+    ) as exc:
+        _emit_json(
+            {
+                "passed": False,
+                "valid": False,
+                "summary": _benchmark_error_summary(),
+                "scenarios": [],
+                "errors": [str(exc)],
+            },
+            stream=sys.stdout,
+        )
+        return 1
+    _emit_json(result.model_dump(mode="json"), stream=sys.stdout)
+    return 0 if result.passed else 1
+
+
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description="DeployWhisper CLI")
     subparsers = parser.add_subparsers(dest="command")
@@ -1150,6 +1216,13 @@ def build_parser() -> argparse.ArgumentParser:
         "--path",
         help="Optional benchmark corpus root. Defaults to benchmarks/corpus/v1.",
     )
+    benchmark_run_parser = benchmark_subparsers.add_parser(
+        "run", help="Run the public benchmark corpus against the analysis core."
+    )
+    benchmark_run_parser.add_argument(
+        "--path",
+        help="Optional benchmark corpus root. Defaults to benchmarks/corpus/v1.",
+    )
 
     return parser
 
@@ -1205,6 +1278,8 @@ def main() -> None:
         raise SystemExit(_run_github_init(args))
     if args.command == "benchmark" and args.benchmark_command == "validate-corpus":
         raise SystemExit(_run_benchmark_validate_corpus(args.path))
+    if args.command == "benchmark" and args.benchmark_command == "run":
+        raise SystemExit(_run_benchmark_run(args.path))
 
     print("DeployWhisper CLI ready: foundation-check")
 

--- a/docs/benchmarks/corpus.md
+++ b/docs/benchmarks/corpus.md
@@ -21,3 +21,27 @@ python cli.py benchmark validate-corpus
 ```
 
 The validator rejects missing required fields, missing artifact files, unknown evidence references, missing evidence selectors, unsafe artifact content, non-public license metadata, and samples marked as containing secrets, customer data, or non-public information.
+
+Run the corpus against the product analysis core with:
+
+```sh
+python cli.py benchmark run
+```
+
+Use `--path` to run a different local corpus root:
+
+```sh
+python cli.py benchmark run --path benchmarks/corpus/v1
+```
+
+The command exits with `0` only when every scenario meets its benchmark expectation. A nonzero exit still emits structured JSON so CI and maintainers can inspect scenario-level failures or corpus validation errors without scraping tracebacks.
+
+Benchmark execution is local-first: the runner reads corpus artifacts from disk and routes them through DeployWhisper's local analysis services. The benchmark verdict is advisory evidence for maintainers; it does not approve, block, deploy, or mutate infrastructure.
+
+The runner validates and loads the corpus, replays each scenario through the same parser, evidence extraction, scoring, finding, and Evidence Law path used by product analysis, and emits JSON with:
+
+- aggregate pass/fail counts and total latency
+- per-scenario status, pass/fail, latency, unsupported reasons, partial-coverage warnings, actual recommendation, severity, and benchmark verdict
+- observed findings with confidence and evidence references
+- finding coverage and selector-level evidence coverage against the scenario expectations
+- Evidence Law status, detail, and violation records

--- a/parsers/cloudformation_parser.py
+++ b/parsers/cloudformation_parser.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+from typing import Any
 import yaml
 
 from parsers.base import UnifiedChange, build_change_id
@@ -23,16 +24,22 @@ def _construct_cloudformation_tag(loader: _CloudFormationLoader, tag_suffix: str
 _CloudFormationLoader.add_multi_constructor("!", _construct_cloudformation_tag)
 
 
+def load_cloudformation_template(text: str) -> Any:
+    """Load a CloudFormation JSON/YAML template, tolerating intrinsic YAML tags."""
+
+    try:
+        return json.loads(text)
+    except json.JSONDecodeError:
+        # _CloudFormationLoader subclasses SafeLoader and only tolerates CFN intrinsic tags.
+        return yaml.load(text, Loader=_CloudFormationLoader) or {}  # nosec B506
+
+
 def parse_cloudformation(name: str, raw_content: bytes | None) -> list[UnifiedChange]:
     if not raw_content:
         return []
 
     text = raw_content.decode("utf-8", errors="ignore")
-    payload: dict
-    try:
-        payload = json.loads(text)
-    except json.JSONDecodeError:
-        payload = yaml.load(text, Loader=_CloudFormationLoader) or {}
+    payload = load_cloudformation_template(text)
 
     resources = payload.get("Resources", {}) if isinstance(payload, dict) else {}
     return [

--- a/services/analysis_service.py
+++ b/services/analysis_service.py
@@ -39,7 +39,7 @@ from services.report_service import (
     readable_report_schema_version,
 )
 from services.settings_service import resolve_provider_runtime
-from services.submission_manifest import build_submission_manifest
+from services.submission_manifest import SubmissionManifest, build_submission_manifest
 from services.incident_service import get_incident_index_snapshot
 from services.confidence_ledger import EvidenceLawStatus, evidence_law_status
 from services.topology_service import (
@@ -58,6 +58,7 @@ def evaluate_evidence(
     change_metadata_by_id: dict[str, dict[str, Any]] | None = None,
     supplemental_changes: list[UnifiedChange] | None = None,
     completion_client=None,
+    allow_llm_assistance: bool = True,
 ) -> RiskAssessment:
     """Return a reusable unified risk assessment from evidence inputs."""
     return score_evidence(
@@ -68,6 +69,7 @@ def evaluate_evidence(
         change_metadata_by_id=change_metadata_by_id,
         supplemental_changes=supplemental_changes,
         completion_client=completion_client,
+        allow_llm_assistance=allow_llm_assistance,
     )
 
 
@@ -115,6 +117,7 @@ def evaluate_parse_batch(
     topology: dict | None = None,
     raw_files: dict[str, bytes | None] | None = None,
     completion_client=None,
+    allow_llm_assistance: bool = True,
 ) -> RiskAssessment:
     """Compatibility wrapper that scores extracted evidence for a parse batch."""
     scored_evidence_items = (
@@ -133,6 +136,7 @@ def evaluate_parse_batch(
             topology=topology,
             raw_files=raw_files,
             completion_client=completion_client,
+            allow_llm_assistance=allow_llm_assistance,
         )
     if not scored_evidence_items:
         scored_evidence_items = extract_batch_evidence(batch)
@@ -146,11 +150,16 @@ def evaluate_parse_batch(
             changes, scored_evidence_items
         ),
         completion_client=completion_client,
+        allow_llm_assistance=allow_llm_assistance,
     )
 
 
 class AnalysisArtifacts(BaseModel):
     parse_batch: ParseBatchResult = Field(..., description="Per-file parse results")
+    submission_manifest: SubmissionManifest = Field(
+        default_factory=SubmissionManifest,
+        description="Submission coverage and artifact outcome manifest",
+    )
     evidence_items: list[EvidenceItem] = Field(
         default_factory=list,
         description="Traceable evidence extracted from parsed changes",
@@ -349,13 +358,18 @@ def _context_todos(
     topology_freshness_days: int | None,
     incident_index_size: int,
     parser_success_rate: float,
+    include_topology_context: bool = True,
+    include_incident_context: bool = True,
 ) -> list[str]:
     todos: list[str] = []
-    if topology_freshness_days is None:
-        todos.append("Import or refresh topology context for this project/workspace.")
-    elif topology_freshness_days > STALE_AFTER_DAYS:
-        todos.append("Refresh stale topology context for this project/workspace.")
-    if incident_index_size == 0:
+    if include_topology_context:
+        if topology_freshness_days is None:
+            todos.append(
+                "Import or refresh topology context for this project/workspace."
+            )
+        elif topology_freshness_days > STALE_AFTER_DAYS:
+            todos.append("Refresh stale topology context for this project/workspace.")
+    if include_incident_context and incident_index_size == 0:
         todos.append("Import relevant incident history for this project/workspace.")
     if parser_success_rate < 1.0:
         todos.append("Review parser errors and resubmit supported artifacts.")
@@ -371,19 +385,22 @@ def _context_uncertainty(
     topology_freshness_days: int | None,
     incident_index_size: int,
     parser_success_rate: float,
+    include_topology_context: bool = True,
+    include_incident_context: bool = True,
 ) -> str | None:
     if context_score < 0.7:
         return (
-            "Insufficient context: missing or stale topology, parser coverage, "
-            "evidence coverage, or incident history prevents a confident "
+            "Insufficient context: missing parser coverage, evidence coverage, "
+            "or enabled project context prevents a confident "
             "low-risk verdict."
         )
     weak_signals: list[str] = []
-    if topology_freshness_days is None:
-        weak_signals.append("topology context is unavailable")
-    elif topology_freshness_days > STALE_AFTER_DAYS:
-        weak_signals.append("topology context is stale")
-    if incident_index_size == 0:
+    if include_topology_context:
+        if topology_freshness_days is None:
+            weak_signals.append("topology context is unavailable")
+        elif topology_freshness_days > STALE_AFTER_DAYS:
+            weak_signals.append("topology context is stale")
+    if include_incident_context and incident_index_size == 0:
         weak_signals.append("incident history is unavailable")
     if parser_success_rate < 1.0:
         weak_signals.append("parser coverage is partial")
@@ -436,15 +453,20 @@ def _build_context_completeness(
     project_key: str | None = None,
     workspace_id: int | None = None,
     workspace_key: str | None = None,
+    include_topology_context: bool = True,
+    include_incident_context: bool = True,
 ) -> ContextCompleteness:
-    topology_status = get_topology_status(
-        project_id=project_id,
-        project_key=project_key,
-        workspace_id=workspace_id,
-        workspace_key=workspace_key,
-    )
-    topology_freshness_days = _topology_freshness_days(topology_status.updated_at)
-    if project_id is None and project_key is None:
+    topology_last_imported_at = None
+    if include_topology_context:
+        topology_status = get_topology_status(
+            project_id=project_id,
+            project_key=project_key,
+            workspace_id=workspace_id,
+            workspace_key=workspace_key,
+        )
+        topology_last_imported_at = topology_status.updated_at
+    topology_freshness_days = _topology_freshness_days(topology_last_imported_at)
+    if not include_incident_context or (project_id is None and project_key is None):
         incident_index_size = 0
         incident_index_snapshot = {
             "incident_index_version": "incidents:unscoped",
@@ -474,14 +496,18 @@ def _build_context_completeness(
     evidence_success_rate = _evidence_success_rate(
         _collect_changes(parse_batch), list(evidence_items or [])
     )
+    weighted_scores = [
+        (raw_parser_success_rate, 0.35),
+        (evidence_success_rate, 0.20),
+    ]
+    if include_topology_context:
+        weighted_scores.append((_freshness_score(topology_freshness_days), 0.25))
+    if include_incident_context:
+        weighted_scores.append((_incident_score(incident_index_size), 0.20))
+    total_weight = sum(weight for _, weight in weighted_scores) or 1.0
     raw_context_score = min(
         1.0,
-        (
-            raw_parser_success_rate * 0.35
-            + _freshness_score(topology_freshness_days) * 0.25
-            + _incident_score(incident_index_size) * 0.20
-            + evidence_success_rate * 0.20
-        ),
+        sum(score * weight for score, weight in weighted_scores) / total_weight,
     )
     context_score = round(raw_context_score, 2)
     context_todos = _context_todos(
@@ -489,10 +515,12 @@ def _build_context_completeness(
         topology_freshness_days=topology_freshness_days,
         incident_index_size=incident_index_size,
         parser_success_rate=raw_parser_success_rate,
+        include_topology_context=include_topology_context,
+        include_incident_context=include_incident_context,
     )
     return ContextCompleteness(
         topology_freshness_days=topology_freshness_days,
-        topology_last_imported_at=topology_status.updated_at,
+        topology_last_imported_at=topology_last_imported_at,
         incident_index_size=incident_index_size,
         incident_index_version=str(
             incident_index_snapshot.get("incident_index_version") or "incidents:empty"
@@ -514,9 +542,49 @@ def _build_context_completeness(
             topology_freshness_days=topology_freshness_days,
             incident_index_size=incident_index_size,
             parser_success_rate=raw_parser_success_rate,
+            include_topology_context=include_topology_context,
+            include_incident_context=include_incident_context,
         ),
         context_todos=context_todos,
         insufficient_context=raw_context_score < 0.7,
+    )
+
+
+def build_context_completeness(
+    parse_batch: ParseBatchResult,
+    *,
+    evidence_items: list[EvidenceItem] | None = None,
+    project_id: int | None = None,
+    project_key: str | None = None,
+    workspace_id: int | None = None,
+    workspace_key: str | None = None,
+    include_topology_context: bool = True,
+    include_incident_context: bool = True,
+) -> ContextCompleteness:
+    """Build the shared context-completeness signal for analysis callers."""
+
+    return _build_context_completeness(
+        parse_batch,
+        evidence_items=evidence_items,
+        project_id=project_id,
+        project_key=project_key,
+        workspace_id=workspace_id,
+        workspace_key=workspace_key,
+        include_topology_context=include_topology_context,
+        include_incident_context=include_incident_context,
+    )
+
+
+def _skipped_narrative(reason: str, assessment: RiskAssessment) -> NarrativeResult:
+    return NarrativeResult(
+        available=False,
+        opening_sentence="",
+        explanation="",
+        guidance=[],
+        degraded=True,
+        warnings=list(assessment.warnings) + [reason],
+        failure_notice=reason,
+        source="fallback",
     )
 
 
@@ -1088,6 +1156,10 @@ def build_analysis_artifacts(
     workspace_id: int | None = None,
     workspace_key: str | None = None,
     completion_client=None,
+    include_topology_context: bool = True,
+    include_incident_context: bool = True,
+    include_narrative: bool = True,
+    allow_llm_assistance: bool = True,
 ) -> AnalysisArtifacts:
     """Build all analysis artifacts up to, but not including, persistence."""
     parse_batch = build_parse_batch(files)
@@ -1104,12 +1176,15 @@ def build_analysis_artifacts(
         workspace_key=workspace_key,
     )
     changes = _collect_changes(parse_batch)
-    topology, topology_warning = load_topology(
-        project_id=project_id,
-        project_key=project_key,
-        workspace_id=workspace_id,
-        workspace_key=workspace_key,
-    )
+    if include_topology_context:
+        topology, topology_warning = load_topology(
+            project_id=project_id,
+            project_key=project_key,
+            workspace_id=workspace_id,
+            workspace_key=workspace_key,
+        )
+    else:
+        topology, topology_warning = None, None
     assessment = evaluate_parse_batch(
         parse_batch,
         partial_context=partial_context,
@@ -1117,6 +1192,7 @@ def build_analysis_artifacts(
         topology=topology,
         raw_files=analysis_raw_files,
         completion_client=completion_client,
+        allow_llm_assistance=allow_llm_assistance,
     )
     assessment.context_completeness = _build_context_completeness(
         parse_batch,
@@ -1125,6 +1201,8 @@ def build_analysis_artifacts(
         project_key=project_key,
         workspace_id=workspace_id,
         workspace_key=workspace_key,
+        include_topology_context=include_topology_context,
+        include_incident_context=include_incident_context,
     )
     assessment = apply_context_uncertainty(assessment)
     findings = build_findings(
@@ -1138,7 +1216,7 @@ def build_analysis_artifacts(
     rollback_plan = generate_rollback_plan(changes, partial_context=partial_context)
     incident_matches = _normalize_incident_matches(
         []
-        if project_id is None and project_key is None
+        if not include_incident_context or (project_id is None and project_key is None)
         else find_incident_matches(
             changes,
             project_id=project_id,
@@ -1147,14 +1225,21 @@ def build_analysis_artifacts(
             workspace_key=workspace_key,
         )
     )
-    narrative = generate_narrative(
-        assessment.model_copy(deep=True),
-        [finding.model_copy(deep=True) for finding in findings],
-        completion_client=completion_client,
-        raw_files=analysis_raw_files,
-    )
+    if include_narrative:
+        narrative = generate_narrative(
+            assessment.model_copy(deep=True),
+            [finding.model_copy(deep=True) for finding in findings],
+            completion_client=completion_client,
+            raw_files=analysis_raw_files,
+        )
+    else:
+        narrative = _skipped_narrative(
+            "Narrative skipped for deterministic benchmark profile.",
+            assessment,
+        )
     return AnalysisArtifacts(
         parse_batch=parse_batch,
+        submission_manifest=submission_manifest,
         evidence_items=evidence_items,
         findings=findings,
         assessment=assessment,

--- a/services/benchmark_corpus_service.py
+++ b/services/benchmark_corpus_service.py
@@ -225,6 +225,21 @@ class BenchmarkCorpusValidationError(ValueError):
         super().__init__("; ".join(errors))
 
 
+class BenchmarkCorpusScenario(BaseModel):
+    """Loaded benchmark scenario with its manifest-relative path."""
+
+    path: str
+    scenario: BenchmarkScenarioDefinition
+
+
+class BenchmarkCorpusDefinition(BaseModel):
+    """Loaded benchmark corpus ready for execution."""
+
+    root: str
+    manifest: BenchmarkCorpusManifest
+    scenarios: list[BenchmarkCorpusScenario]
+
+
 def _timestamp() -> str:
     return datetime.now(tz=UTC).isoformat().replace("+00:00", "Z")
 
@@ -427,7 +442,7 @@ def validate_benchmark_corpus(
 
     try:
         manifest = BenchmarkCorpusManifest.model_validate(_load_json(manifest_path))
-    except (OSError, json.JSONDecodeError, ValidationError) as exc:
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError, ValidationError) as exc:
         errors.append(f"manifest.json: {exc}")
 
     seen_scenarios: set[str] = set()
@@ -446,7 +461,12 @@ def validate_benchmark_corpus(
             scenario = BenchmarkScenarioDefinition.model_validate(
                 _load_json(scenario_path)
             )
-        except (OSError, json.JSONDecodeError, ValidationError) as exc:
+        except (
+            OSError,
+            UnicodeDecodeError,
+            json.JSONDecodeError,
+            ValidationError,
+        ) as exc:
             errors.append(f"{scenario_ref}: {exc}")
             continue
         if scenario.id in seen_scenarios:
@@ -484,3 +504,42 @@ def validate_benchmark_corpus(
     if errors and raise_on_error:
         raise BenchmarkCorpusValidationError(errors, result)
     return result
+
+
+def load_benchmark_corpus(
+    corpus_root: Path | str | None = None,
+    *,
+    validate: bool = True,
+) -> BenchmarkCorpusDefinition:
+    """Load a validated benchmark corpus for deterministic execution."""
+
+    root = (
+        Path(corpus_root) if corpus_root is not None else DEFAULT_BENCHMARK_CORPUS_DIR
+    )
+    root = root.resolve()
+    if validate:
+        validate_benchmark_corpus(root)
+    manifest = BenchmarkCorpusManifest.model_validate(
+        _load_json(root / "manifest.json")
+    )
+    scenarios: list[BenchmarkCorpusScenario] = []
+    for scenario_ref in manifest.scenarios:
+        path_error = _relative_path_error(
+            scenario_ref, field_name="scenario manifest path"
+        )
+        if path_error:
+            raise ValueError(path_error)
+        scenario_path = _resolve_child(root, scenario_ref)
+        try:
+            scenario_path.relative_to(root)
+        except ValueError as exc:
+            raise ValueError(
+                f"scenario manifest escapes corpus: {scenario_ref}"
+            ) from exc
+        scenario = BenchmarkScenarioDefinition.model_validate(_load_json(scenario_path))
+        scenarios.append(BenchmarkCorpusScenario(path=scenario_ref, scenario=scenario))
+    return BenchmarkCorpusDefinition(
+        root=str(root),
+        manifest=manifest,
+        scenarios=scenarios,
+    )

--- a/services/benchmark_runner_service.py
+++ b/services/benchmark_runner_service.py
@@ -1,0 +1,886 @@
+"""Benchmark corpus execution against the shared analysis core."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+from time import perf_counter
+from typing import Literal
+import json
+import re
+
+from pydantic import BaseModel, Field
+import yaml
+
+from analysis.risk_scorer import RiskAssessment
+from evidence.models import EvidenceItem, Finding
+from parsers.base import ParseBatchResult, UnifiedChange
+from parsers.cloudformation_parser import load_cloudformation_template
+from services.analysis_service import (
+    AnalysisArtifacts,
+    build_analysis_artifacts,
+)
+from services.benchmark_corpus_service import (
+    BenchmarkExpectedEvidence,
+    BenchmarkExpectedFinding,
+    ExpectedVerdict,
+    load_benchmark_corpus,
+)
+from services.confidence_ledger import EvidenceLawStatus, evidence_law_status
+from services.submission_manifest import SubmissionManifest
+
+
+ScenarioStatus = Literal["passed", "failed", "unsupported"]
+ObservedVerdict = Literal[
+    "go", "warn", "stop", "unsupported", "insufficient_context", "error"
+]
+
+SEVERITY_ORDER = {"info": 0, "low": 1, "medium": 2, "high": 3, "critical": 4}
+
+
+class BenchmarkObservedFinding(BaseModel):
+    """Finding detail captured from one benchmark scenario run."""
+
+    finding_id: str
+    title: str
+    severity: str
+    deterministic: bool
+    confidence: float
+    evidence_refs: list[str] = Field(default_factory=list)
+
+
+class BenchmarkScenarioRunResult(BaseModel):
+    """Execution result for one benchmark scenario."""
+
+    id: str
+    name: str
+    path: str
+    passed: bool
+    status: ScenarioStatus
+    expected_verdict: ExpectedVerdict
+    actual_verdict: ObservedVerdict
+    actual_recommendation: str
+    actual_severity: str
+    actual_score: int
+    expected_finding_count: int
+    actual_finding_count: int
+    finding_coverage: float
+    missing_expected_finding_ids: list[str] = Field(default_factory=list)
+    expected_evidence_count: int
+    actual_evidence_count: int
+    evidence_coverage: float
+    missing_expected_evidence_ids: list[str] = Field(default_factory=list)
+    evidence_law_status: EvidenceLawStatus
+    evidence_law_detail: str
+    evidence_law_violations: list[str] = Field(default_factory=list)
+    latency_ms: float
+    unsupported: bool
+    unsupported_reasons: list[str] = Field(default_factory=list)
+    coverage_warnings: list[str] = Field(default_factory=list)
+    findings: list[BenchmarkObservedFinding] = Field(default_factory=list)
+    errors: list[str] = Field(default_factory=list)
+
+
+class BenchmarkRunSummary(BaseModel):
+    """Aggregate benchmark run summary."""
+
+    corpus_id: str
+    version: str
+    scenario_count: int
+    passed_count: int
+    failed_count: int
+    unsupported_count: int
+    total_latency_ms: float
+    generated_at: str
+
+
+class BenchmarkRunResult(BaseModel):
+    """Complete benchmark run result."""
+
+    passed: bool
+    summary: BenchmarkRunSummary
+    scenarios: list[BenchmarkScenarioRunResult]
+
+
+def _timestamp() -> str:
+    return datetime.now(tz=UTC).isoformat().replace("+00:00", "Z")
+
+
+def _scenario_files(
+    *, corpus_root: Path, scenario_path: str, artifacts: list
+) -> list[tuple[str, bytes | None]]:
+    root = corpus_root.resolve()
+    scenario_dir = (root / scenario_path).resolve().parent
+    files: list[tuple[str, bytes | None]] = []
+    for artifact in artifacts:
+        artifact_path = (scenario_dir / artifact.path).resolve()
+        try:
+            artifact_path.relative_to(root)
+        except ValueError as exc:
+            raise ValueError(
+                f"benchmark artifact escapes corpus: {artifact.path}"
+            ) from exc
+        if artifact_path.is_symlink() or not artifact_path.is_file():
+            raise ValueError(f"benchmark artifact must be a file: {artifact.path}")
+        files.append((artifact.path, artifact_path.read_bytes()))
+    return files
+
+
+def _manifest_coverage_warnings(manifest: SubmissionManifest) -> list[str]:
+    warnings: list[str] = []
+    for item in manifest.items:
+        if item.status == "accepted":
+            continue
+        warnings.append(f"{item.name}: {item.status} - {item.message}")
+    return warnings
+
+
+def _unsupported_reasons(manifest: SubmissionManifest) -> list[str]:
+    reasons = _manifest_coverage_warnings(manifest)
+    if manifest.analyzed_artifact_count == 0:
+        reasons.append("No benchmark artifacts were parsed by supported parsers.")
+    return reasons
+
+
+def _actual_verdict(
+    assessment: RiskAssessment, *, unsupported: bool
+) -> ObservedVerdict:
+    if unsupported:
+        return "unsupported"
+    if assessment.context_completeness.insufficient_context:
+        return "insufficient_context"
+    if assessment.recommendation == "go" and assessment.severity == "low":
+        return "go"
+    if assessment.recommendation == "no-go" and assessment.severity == "critical":
+        return "stop"
+    return "warn"
+
+
+def _expected_verdict_matches(
+    expected: ExpectedVerdict,
+    *,
+    actual: ObservedVerdict,
+    unsupported: bool,
+) -> bool:
+    if expected == "unsupported":
+        return unsupported and actual == "unsupported"
+    if expected == "insufficient_context":
+        return actual == "insufficient_context"
+    if expected == "go":
+        return actual == "go"
+    if expected == "stop":
+        return actual == "stop"
+    return actual == "warn"
+
+
+def _normalize_match_text(value: str) -> str:
+    return " ".join(value.casefold().split())
+
+
+def _contains_expected_text(*, haystack: str, needle: str) -> bool:
+    return _normalize_match_text(needle) in _normalize_match_text(haystack)
+
+
+def _evidence_match_text(item: EvidenceItem) -> str:
+    return "\n".join(
+        (
+            item.source_ref,
+            item.location,
+            item.resource,
+            item.operation,
+            item.summary,
+        )
+    )
+
+
+def _matching_brace_block(content: str, start_index: int) -> str:
+    brace_index = content.find("{", start_index)
+    if brace_index == -1:
+        return ""
+    depth = 0
+    in_quote: str | None = None
+    escaped = False
+    for index in range(brace_index, len(content)):
+        character = content[index]
+        if escaped:
+            escaped = False
+            continue
+        if character == "\\":
+            escaped = True
+            continue
+        if in_quote:
+            if character == in_quote:
+                in_quote = None
+            continue
+        if character in {"'", '"'}:
+            in_quote = character
+            continue
+        if character == "{":
+            depth += 1
+        elif character == "}":
+            depth -= 1
+            if depth == 0:
+                return content[start_index : index + 1]
+    return content[start_index:]
+
+
+def _yaml_key_block(content: str, key: str) -> str:
+    pattern = re.compile(
+        rf"(?m)^(?P<indent>\s*){re.escape(key)}\s*:\s*(?:#.*)?$",
+    )
+    match = pattern.search(content)
+    if not match:
+        return ""
+    base_indent = len(match.group("indent"))
+    end_index = len(content)
+    for line_match in re.finditer(r"(?m)^(?P<indent>\s*)\S.*$", content[match.end() :]):
+        line_indent = len(line_match.group("indent"))
+        if line_indent <= base_indent:
+            end_index = match.end() + line_match.start()
+            break
+    return content[match.start() : end_index].rstrip()
+
+
+def _yaml_key_inline_block(content: str, key: str) -> str:
+    pattern = re.compile(
+        rf"(?m)^(?P<indent>\s*){re.escape(key)}\s*:\s*\S.*$",
+    )
+    match = pattern.search(content)
+    if not match:
+        return ""
+    return match.group(0).rstrip()
+
+
+def _yaml_top_level_key_block(content: str, key: str) -> str:
+    pattern = re.compile(
+        rf"(?m)^{re.escape(key)}\s*:\s*(?:#.*)?$",
+    )
+    match = pattern.search(content)
+    if not match:
+        return ""
+    end_index = len(content)
+    for line_match in re.finditer(r"(?m)^\S.*$", content[match.end() :]):
+        end_index = match.end() + line_match.start()
+        break
+    return content[match.start() : end_index].rstrip()
+
+
+def _yaml_sequence_name_block(content: str, name: str, occurrence: int = 0) -> str:
+    pattern = re.compile(
+        rf"(?m)^(?P<indent>\s*)-\s+name\s*:\s*['\"]?{re.escape(name)}['\"]?\s*(?:#.*)?$",
+    )
+    matches = list(pattern.finditer(content))
+    match = matches[occurrence] if occurrence < len(matches) else None
+    if not match:
+        return ""
+    base_indent = len(match.group("indent"))
+    end_index = len(content)
+    for line_match in re.finditer(
+        r"(?m)^(?P<indent>\s*)-\s+\S.*$", content[match.end() :]
+    ):
+        line_indent = len(line_match.group("indent"))
+        if line_indent <= base_indent:
+            end_index = match.end() + line_match.start()
+            break
+    return content[match.start() : end_index].rstrip()
+
+
+def _terraform_change_text(change: UnifiedChange, content: str) -> str:
+    resource_type, _, resource_name = change.resource_id.partition(".")
+    if not resource_type or not resource_name:
+        return ""
+    pattern = re.compile(
+        r"resource\s+['\"]"
+        + re.escape(resource_type)
+        + r"['\"]\s+['\"]"
+        + re.escape(resource_name)
+        + r"['\"]\s*\{",
+        re.IGNORECASE,
+    )
+    match = pattern.search(content)
+    return _matching_brace_block(content, match.start()) if match else ""
+
+
+def _cloudformation_change_text(change: UnifiedChange, content: str) -> str:
+    prefix, _, resource_name = change.resource_id.partition("/")
+    if prefix != "resource" or not resource_name:
+        return ""
+    try:
+        payload = load_cloudformation_template(content)
+    except (json.JSONDecodeError, yaml.YAMLError):
+        return ""
+    resources = payload.get("Resources", {}) if isinstance(payload, dict) else {}
+    if not isinstance(resources, dict) or resource_name not in resources:
+        return ""
+    resource = resources[resource_name]
+    if isinstance(resource, dict | list):
+        return yaml.safe_dump(resource, sort_keys=True)
+    return str(resource)
+
+
+def _ansible_change_text(
+    change: UnifiedChange, content: str, *, occurrence: int = 0
+) -> str:
+    return _yaml_sequence_name_block(content, change.resource_id, occurrence)
+
+
+def _kubernetes_change_text(
+    change: UnifiedChange, content: str, *, occurrence: int = 0
+) -> str:
+    kind, _, resource_name = change.resource_id.partition("/")
+    if not kind or not resource_name:
+        return ""
+    documents = re.split(r"(?m)^---[ \t]*(?:#.*)?$", content)
+    matched_count = 0
+    for document in documents:
+        try:
+            payload = yaml.safe_load(document) or {}
+        except yaml.YAMLError:
+            continue
+        if not isinstance(payload, dict):
+            continue
+        metadata = payload.get("metadata", {})
+        if (
+            payload.get("kind") == kind
+            and isinstance(metadata, dict)
+            and metadata.get("name") == resource_name
+        ):
+            if matched_count != occurrence:
+                matched_count += 1
+                continue
+            return document
+    return ""
+
+
+def _jenkins_change_text(
+    change: UnifiedChange, content: str, *, occurrence: int = 0
+) -> str:
+    prefix, _, stage_name = change.resource_id.partition("/")
+    if prefix != "stage" or not stage_name:
+        return ""
+    pattern = re.compile(
+        r"stage\s*\(\s*['\"]" + re.escape(stage_name) + r"['\"]\s*\)",
+        re.IGNORECASE,
+    )
+    matches = list(pattern.finditer(content))
+    match = matches[occurrence] if occurrence < len(matches) else None
+    return _matching_brace_block(content, match.start()) if match else ""
+
+
+def _change_local_text(
+    change: UnifiedChange,
+    raw_artifact_text_by_path: dict[str, str],
+    *,
+    occurrence: int = 0,
+) -> str:
+    content = raw_artifact_text_by_path.get(change.source_file, "")
+    if change.tool == "terraform":
+        local_text = _terraform_change_text(change, content)
+    elif change.tool == "cloudformation":
+        local_text = _cloudformation_change_text(change, content)
+    elif change.tool == "ansible":
+        local_text = _ansible_change_text(change, content, occurrence=occurrence)
+    elif change.tool == "kubernetes":
+        local_text = _kubernetes_change_text(change, content, occurrence=occurrence)
+    elif change.tool == "jenkins":
+        local_text = _jenkins_change_text(change, content, occurrence=occurrence)
+    else:
+        local_text = content
+    metadata_text = (
+        json.dumps(change.metadata, sort_keys=True) if change.metadata else ""
+    )
+    return "\n".join(
+        part
+        for part in (change.resource_id, change.summary, metadata_text, local_text)
+        if part
+    )
+
+
+def _change_local_text_by_id(
+    parse_batch: ParseBatchResult,
+    raw_artifact_text_by_path: dict[str, str],
+) -> dict[str, str]:
+    local_text_by_id: dict[str, str] = {}
+    occurrence_by_key: dict[tuple[str, str, str], int] = {}
+    for file_result in parse_batch.files:
+        for change in file_result.changes:
+            occurrence_key = (change.source_file, change.tool, change.resource_id)
+            occurrence = occurrence_by_key.get(occurrence_key, 0)
+            local_text_by_id[change.change_id] = _change_local_text(
+                change,
+                raw_artifact_text_by_path,
+                occurrence=occurrence,
+            )
+            occurrence_by_key[occurrence_key] = occurrence + 1
+    return local_text_by_id
+
+
+def _evidence_local_match_text(
+    item: EvidenceItem,
+    change_local_text_by_id: dict[str, str],
+) -> str:
+    return "\n".join(
+        [_evidence_match_text(item)]
+        + [
+            change_local_text_by_id[change_id]
+            for change_id in item.related_change_ids
+            if change_id in change_local_text_by_id
+        ]
+    )
+
+
+def _finding_match_text(finding: Finding) -> str:
+    return "\n".join(
+        (
+            finding.finding_id,
+            finding.title,
+            finding.description,
+            finding.explanation,
+            finding.category,
+        )
+    )
+
+
+def _evidence_match_map(
+    expected_evidence: list[BenchmarkExpectedEvidence],
+    evidence_items: list[EvidenceItem],
+    change_local_text_by_id: dict[str, str],
+) -> dict[str, set[str]]:
+    """Map observed evidence IDs to the expected evidence IDs they satisfy."""
+
+    matched: dict[str, set[str]] = {}
+    unmatched_items = [
+        item
+        for item in evidence_items
+        if item.deterministic and item.source_type == "artifact"
+    ]
+    used_observed_ids: set[str] = set()
+    for expected in expected_evidence:
+        for item in unmatched_items:
+            if item.evidence_id in used_observed_ids:
+                continue
+            if expected.artifact_path != item.artifact:
+                continue
+            match_text = _evidence_local_match_text(item, change_local_text_by_id)
+            if not _contains_expected_text(
+                haystack=match_text, needle=expected.selector
+            ):
+                continue
+            matched.setdefault(item.evidence_id, set()).add(expected.id)
+            used_observed_ids.add(item.evidence_id)
+            break
+    return matched
+
+
+def _finding_coverage(
+    expected_findings: list[BenchmarkExpectedFinding],
+    findings: list[Finding],
+    *,
+    matched_expected_evidence_by_observed_id: dict[str, set[str]],
+) -> tuple[float, list[str]]:
+    if not expected_findings:
+        return 1.0, []
+    used_finding_ids: set[str] = set()
+    missing: list[str] = []
+    for expected in expected_findings:
+        expected_order = SEVERITY_ORDER[expected.severity]
+        matched = None
+        for finding in findings:
+            if finding.finding_id in used_finding_ids:
+                continue
+            if SEVERITY_ORDER[finding.severity] < expected_order:
+                continue
+            if not _contains_expected_text(
+                haystack=_finding_match_text(finding),
+                needle=expected.title,
+            ):
+                continue
+            covered_expected_evidence_ids = set()
+            for evidence_ref in finding.evidence_refs:
+                covered_expected_evidence_ids.update(
+                    matched_expected_evidence_by_observed_id.get(evidence_ref, set())
+                )
+            if not set(expected.evidence_ids).issubset(covered_expected_evidence_ids):
+                continue
+            matched = finding
+            break
+        if matched is None:
+            missing.append(expected.id)
+        else:
+            used_finding_ids.add(matched.finding_id)
+    covered = len(expected_findings) - len(missing)
+    return round(covered / len(expected_findings), 2), missing
+
+
+def _evidence_coverage(
+    expected_evidence: list[BenchmarkExpectedEvidence],
+    evidence_items: list[EvidenceItem],
+    change_local_text_by_id: dict[str, str],
+) -> tuple[float, list[str], dict[str, set[str]]]:
+    if not expected_evidence:
+        return 1.0, [], {}
+    matched_expected_by_observed_id = _evidence_match_map(
+        expected_evidence, evidence_items, change_local_text_by_id
+    )
+    covered_expected_ids = {
+        expected_id
+        for expected_ids in matched_expected_by_observed_id.values()
+        for expected_id in expected_ids
+    }
+    missing = [
+        expected.id
+        for expected in expected_evidence
+        if expected.id not in covered_expected_ids
+    ]
+    covered = len(expected_evidence) - len(missing)
+    return (
+        round(covered / len(expected_evidence), 2),
+        missing,
+        matched_expected_by_observed_id,
+    )
+
+
+def _unsupported_expected_evidence_coverage(
+    expected_evidence: list[BenchmarkExpectedEvidence],
+    manifest: SubmissionManifest,
+    raw_artifact_text_by_path: dict[str, str],
+) -> tuple[float, list[str], dict[str, set[str]]]:
+    if not expected_evidence:
+        return 1.0, [], {}
+    unavailable_artifact_paths = {
+        item.name for item in manifest.items if item.status != "accepted"
+    }
+    covered_expected_ids_by_artifact: dict[str, set[str]] = {}
+    for expected in expected_evidence:
+        if expected.artifact_path not in unavailable_artifact_paths:
+            continue
+        if not _contains_expected_text(
+            haystack=raw_artifact_text_by_path.get(expected.artifact_path, ""),
+            needle=expected.selector,
+        ):
+            continue
+        covered_expected_ids_by_artifact.setdefault(expected.artifact_path, set()).add(
+            expected.id
+        )
+    covered_expected_ids = {
+        expected_id
+        for expected_ids in covered_expected_ids_by_artifact.values()
+        for expected_id in expected_ids
+    }
+    missing = [
+        expected.id
+        for expected in expected_evidence
+        if expected.id not in covered_expected_ids
+    ]
+    covered = len(expected_evidence) - len(missing)
+    return (
+        round(covered / len(expected_evidence), 2),
+        missing,
+        covered_expected_ids_by_artifact,
+    )
+
+
+def _unsupported_observed_findings(
+    manifest: SubmissionManifest,
+    *,
+    covered_expected_evidence_ids_by_artifact: dict[str, set[str]],
+) -> list[BenchmarkObservedFinding]:
+    findings: list[BenchmarkObservedFinding] = []
+    unavailable_items = [item for item in manifest.items if item.status != "accepted"]
+    for index, item in enumerate(unavailable_items, start=1):
+        findings.append(
+            BenchmarkObservedFinding(
+                finding_id=f"unsupported-{index}",
+                title=f"Unsupported artifact: {item.name}",
+                severity="info",
+                deterministic=True,
+                confidence=1.0,
+                evidence_refs=sorted(
+                    covered_expected_evidence_ids_by_artifact.get(item.name, set())
+                ),
+            )
+        )
+    return findings
+
+
+def _unsupported_expected_finding_coverage(
+    expected_findings: list[BenchmarkExpectedFinding],
+    *,
+    observed_findings: list[BenchmarkObservedFinding],
+) -> tuple[float, list[str]]:
+    if not expected_findings:
+        return 1.0, []
+    used_finding_ids: set[str] = set()
+    missing: list[str] = []
+    for expected in expected_findings:
+        expected_order = SEVERITY_ORDER[expected.severity]
+        matched = None
+        for finding in observed_findings:
+            if finding.finding_id in used_finding_ids:
+                continue
+            if SEVERITY_ORDER[finding.severity] < expected_order:
+                continue
+            if not _contains_expected_text(
+                haystack=finding.title,
+                needle=expected.title,
+            ):
+                continue
+            if not set(expected.evidence_ids).issubset(set(finding.evidence_refs)):
+                continue
+            matched = finding
+            break
+        if matched is None:
+            missing.append(expected.id)
+        else:
+            used_finding_ids.add(matched.finding_id)
+    covered = len(expected_findings) - len(missing)
+    return round(covered / len(expected_findings), 2), missing
+
+
+def _report_payload(
+    *,
+    assessment: RiskAssessment,
+    findings: list[Finding],
+    evidence_items: list[EvidenceItem],
+) -> dict:
+    return {
+        "risk_score": assessment.score,
+        "severity": assessment.severity,
+        "recommendation": assessment.recommendation,
+        "confidence": assessment.confidence,
+        "top_risk": assessment.top_risk,
+        "warnings": assessment.warnings,
+        "contributors": [
+            contributor.model_dump(mode="json")
+            for contributor in assessment.contributors
+        ],
+        "context_completeness": assessment.context_completeness.model_dump(mode="json"),
+        "findings": [finding.model_dump(mode="json") for finding in findings],
+        "evidence_items": [
+            evidence_item.model_dump(mode="json") for evidence_item in evidence_items
+        ],
+    }
+
+
+def _run_analysis_core(files: list[tuple[str, bytes | None]]) -> AnalysisArtifacts:
+    return build_analysis_artifacts(
+        files,
+        include_topology_context=False,
+        include_incident_context=False,
+        include_narrative=False,
+        allow_llm_assistance=False,
+    )
+
+
+def _observed_findings(findings: list[Finding]) -> list[BenchmarkObservedFinding]:
+    return [
+        BenchmarkObservedFinding(
+            finding_id=finding.finding_id,
+            title=finding.title,
+            severity=finding.severity,
+            deterministic=finding.deterministic,
+            confidence=finding.confidence,
+            evidence_refs=finding.evidence_refs,
+        )
+        for finding in findings
+    ]
+
+
+def _run_scenario(
+    *,
+    corpus_root: Path,
+    scenario_path: str,
+    scenario,
+) -> BenchmarkScenarioRunResult:
+    start = perf_counter()
+    errors: list[str] = []
+    try:
+        files = _scenario_files(
+            corpus_root=corpus_root,
+            scenario_path=scenario_path,
+            artifacts=scenario.artifacts,
+        )
+        raw_artifact_text_by_path = {
+            name: (content or b"").decode("utf-8", errors="replace")
+            for name, content in files
+        }
+        analysis_artifacts = _run_analysis_core(files)
+        change_local_text_by_id = _change_local_text_by_id(
+            analysis_artifacts.parse_batch,
+            raw_artifact_text_by_path,
+        )
+    except Exception as exc:  # noqa: BLE001
+        elapsed_ms = round((perf_counter() - start) * 1000, 2)
+        return BenchmarkScenarioRunResult(
+            id=scenario.id,
+            name=scenario.name,
+            path=scenario_path,
+            passed=False,
+            status="failed",
+            expected_verdict=scenario.expected_verdict,
+            actual_verdict="error",
+            actual_recommendation="unknown",
+            actual_severity="unknown",
+            actual_score=0,
+            expected_finding_count=len(scenario.expected_findings),
+            actual_finding_count=0,
+            finding_coverage=0.0,
+            missing_expected_finding_ids=[
+                finding.id for finding in scenario.expected_findings
+            ],
+            expected_evidence_count=len(scenario.expected_evidence),
+            actual_evidence_count=0,
+            evidence_coverage=0.0,
+            missing_expected_evidence_ids=[
+                evidence.id for evidence in scenario.expected_evidence
+            ],
+            evidence_law_status="Needs review",
+            evidence_law_detail="Scenario execution failed before Evidence Law evaluation.",
+            evidence_law_violations=["Scenario execution failed."],
+            latency_ms=elapsed_ms,
+            unsupported=False,
+            unsupported_reasons=[],
+            coverage_warnings=[],
+            findings=[],
+            errors=[str(exc)],
+        )
+
+    evidence_items = analysis_artifacts.evidence_items
+    findings = analysis_artifacts.findings
+    assessment = analysis_artifacts.assessment
+    manifest = analysis_artifacts.submission_manifest
+    coverage_warnings = _manifest_coverage_warnings(manifest)
+    unsupported = manifest.accepted_artifact_count == 0
+    unsupported_reasons = _unsupported_reasons(manifest) if unsupported else []
+    actual_verdict = _actual_verdict(assessment, unsupported=unsupported)
+    if unsupported:
+        (
+            evidence_coverage,
+            missing_evidence,
+            covered_expected_evidence_ids_by_artifact,
+        ) = _unsupported_expected_evidence_coverage(
+            scenario.expected_evidence, manifest, raw_artifact_text_by_path
+        )
+        observed_findings = _unsupported_observed_findings(
+            manifest,
+            covered_expected_evidence_ids_by_artifact=covered_expected_evidence_ids_by_artifact,
+        )
+        finding_coverage, missing_findings = _unsupported_expected_finding_coverage(
+            scenario.expected_findings,
+            observed_findings=observed_findings,
+        )
+    else:
+        observed_findings = _observed_findings(findings)
+        (
+            evidence_coverage,
+            missing_evidence,
+            matched_expected_evidence,
+        ) = _evidence_coverage(
+            scenario.expected_evidence,
+            evidence_items,
+            change_local_text_by_id,
+        )
+        finding_coverage, missing_findings = _finding_coverage(
+            scenario.expected_findings,
+            findings,
+            matched_expected_evidence_by_observed_id=matched_expected_evidence,
+        )
+    evidence_status, evidence_detail = evidence_law_status(
+        _report_payload(
+            assessment=assessment,
+            findings=findings,
+            evidence_items=evidence_items,
+        )
+    )
+    evidence_violations = [] if evidence_status == "Satisfied" else [evidence_detail]
+    verdict_matches = _expected_verdict_matches(
+        scenario.expected_verdict,
+        actual=actual_verdict,
+        unsupported=unsupported,
+    )
+    if scenario.expected_verdict == "unsupported":
+        passed = (
+            unsupported
+            and verdict_matches
+            and finding_coverage == 1.0
+            and evidence_coverage == 1.0
+            and not errors
+        )
+    else:
+        passed = (
+            verdict_matches
+            and finding_coverage == 1.0
+            and evidence_coverage == 1.0
+            and not evidence_violations
+            and not errors
+            and not unsupported
+        )
+    status: ScenarioStatus = (
+        "unsupported" if unsupported and passed else "passed" if passed else "failed"
+    )
+    elapsed_ms = round((perf_counter() - start) * 1000, 2)
+    return BenchmarkScenarioRunResult(
+        id=scenario.id,
+        name=scenario.name,
+        path=scenario_path,
+        passed=passed,
+        status=status,
+        expected_verdict=scenario.expected_verdict,
+        actual_verdict=actual_verdict,
+        actual_recommendation=assessment.recommendation,
+        actual_severity=assessment.severity,
+        actual_score=assessment.score,
+        expected_finding_count=len(scenario.expected_findings),
+        actual_finding_count=len(observed_findings),
+        finding_coverage=finding_coverage,
+        missing_expected_finding_ids=missing_findings,
+        expected_evidence_count=len(scenario.expected_evidence),
+        actual_evidence_count=len(evidence_items),
+        evidence_coverage=evidence_coverage,
+        missing_expected_evidence_ids=missing_evidence,
+        evidence_law_status=evidence_status,
+        evidence_law_detail=evidence_detail,
+        evidence_law_violations=evidence_violations,
+        latency_ms=elapsed_ms,
+        unsupported=unsupported,
+        unsupported_reasons=unsupported_reasons,
+        coverage_warnings=coverage_warnings,
+        findings=observed_findings,
+        errors=errors,
+    )
+
+
+def run_benchmark_corpus(corpus_root: Path | str | None = None) -> BenchmarkRunResult:
+    """Execute the benchmark corpus using the same parse and scoring core."""
+
+    corpus = load_benchmark_corpus(corpus_root)
+    root = Path(corpus.root)
+    scenarios = [
+        _run_scenario(
+            corpus_root=root,
+            scenario_path=loaded.path,
+            scenario=loaded.scenario,
+        )
+        for loaded in corpus.scenarios
+    ]
+    passed_count = sum(1 for scenario in scenarios if scenario.status == "passed")
+    unsupported_count = sum(
+        1 for scenario in scenarios if scenario.status == "unsupported"
+    )
+    failed_count = sum(1 for scenario in scenarios if scenario.status == "failed")
+    total_latency_ms = round(sum(scenario.latency_ms for scenario in scenarios), 2)
+    summary = BenchmarkRunSummary(
+        corpus_id=corpus.manifest.corpus_id,
+        version=corpus.manifest.version,
+        scenario_count=len(scenarios),
+        passed_count=passed_count,
+        failed_count=failed_count,
+        unsupported_count=unsupported_count,
+        total_latency_ms=total_latency_ms,
+        generated_at=_timestamp(),
+    )
+    return BenchmarkRunResult(
+        passed=all(scenario.passed for scenario in scenarios),
+        summary=summary,
+        scenarios=scenarios,
+    )

--- a/tests/test_cli/test_analyze.py
+++ b/tests/test_cli/test_analyze.py
@@ -26,6 +26,7 @@ from importlib import reload
 from integrations.github.init_service import GitHubInitOptions, GitHubInitResult
 from llm.narrator import NarrativeResult
 from parsers.base import ParseBatchResult, ParsedFileResult
+from services.benchmark_runner_service import BenchmarkRunResult, BenchmarkRunSummary
 from services.skill_installer_service import InstalledSkillEntry, SkillInstallResult
 from services.skill_registry_service import SkillRegistryEntry
 from services.skill_test_harness_service import (
@@ -229,6 +230,137 @@ class AnalyzeCliTests(unittest.TestCase):
             payload["summary"]["corpus_id"], "deploywhisper-benchmark-corpus-v1"
         )
         self.assertGreaterEqual(payload["summary"]["scenario_count"], 3)
+
+    def test_benchmark_run_command_reports_scenario_results(self) -> None:
+        output = io.StringIO()
+
+        with (
+            patch("sys.argv", ["deploywhisper", "benchmark", "run"]),
+            redirect_stdout(output),
+        ):
+            with self.assertRaises(SystemExit) as ctx:
+                main()
+
+        payload = json.loads(output.getvalue())
+        self.assertIn(ctx.exception.code, {0, 1})
+        self.assertEqual(
+            payload["summary"]["corpus_id"], "deploywhisper-benchmark-corpus-v1"
+        )
+        self.assertGreaterEqual(payload["summary"]["scenario_count"], 3)
+        self.assertEqual(
+            len(payload["scenarios"]), payload["summary"]["scenario_count"]
+        )
+        self.assertIn(
+            payload["scenarios"][0]["status"], ["passed", "failed", "unsupported"]
+        )
+        self.assertIn("findings", payload["scenarios"][0])
+        self.assertIn("evidence_coverage", payload["scenarios"][0])
+        self.assertIn("evidence_law_violations", payload["scenarios"][0])
+        self.assertIn("latency_ms", payload["scenarios"][0])
+        self.assertIn("unsupported", payload["scenarios"][0])
+
+    def test_benchmark_run_command_exits_nonzero_for_failed_result(self) -> None:
+        output = io.StringIO()
+        failed_result = BenchmarkRunResult(
+            passed=False,
+            summary=BenchmarkRunSummary(
+                corpus_id="failing-corpus",
+                version="1.0.0",
+                scenario_count=1,
+                passed_count=0,
+                failed_count=1,
+                unsupported_count=0,
+                total_latency_ms=1.0,
+                generated_at="2026-06-02T00:00:00Z",
+            ),
+            scenarios=[],
+        )
+
+        with (
+            patch("sys.argv", ["deploywhisper", "benchmark", "run"]),
+            patch("cli.analyze.run_benchmark_corpus", return_value=failed_result),
+            redirect_stdout(output),
+        ):
+            with self.assertRaises(SystemExit) as ctx:
+                main()
+
+        payload = json.loads(output.getvalue())
+        self.assertEqual(ctx.exception.code, 1)
+        self.assertFalse(payload["passed"])
+        self.assertEqual(payload["summary"]["failed_count"], 1)
+
+    def test_benchmark_run_command_reports_invalid_corpus_as_json(self) -> None:
+        output = io.StringIO()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with (
+                patch(
+                    "sys.argv",
+                    ["deploywhisper", "benchmark", "run", "--path", tmpdir],
+                ),
+                redirect_stdout(output),
+            ):
+                with self.assertRaises(SystemExit) as ctx:
+                    main()
+
+        payload = json.loads(output.getvalue())
+        self.assertEqual(ctx.exception.code, 1)
+        self.assertFalse(payload["passed"])
+        self.assertFalse(payload["valid"])
+        self.assertEqual(payload["summary"]["corpus_id"], "unknown")
+        self.assertIn("passed_count", payload["summary"])
+        self.assertIn("failed_count", payload["summary"])
+        self.assertIn("unsupported_count", payload["summary"])
+        self.assertTrue(payload["errors"])
+
+    def test_benchmark_run_command_reports_loader_failure_as_json(self) -> None:
+        output = io.StringIO()
+
+        with (
+            patch("sys.argv", ["deploywhisper", "benchmark", "run"]),
+            patch(
+                "cli.analyze.run_benchmark_corpus",
+                side_effect=json.JSONDecodeError("bad json", "{}", 0),
+            ),
+            redirect_stdout(output),
+        ):
+            with self.assertRaises(SystemExit) as ctx:
+                main()
+
+        payload = json.loads(output.getvalue())
+        self.assertEqual(ctx.exception.code, 1)
+        self.assertFalse(payload["passed"])
+        self.assertFalse(payload["valid"])
+        self.assertEqual(payload["summary"]["corpus_id"], "unknown")
+        self.assertIn("passed_count", payload["summary"])
+        self.assertIn("failed_count", payload["summary"])
+        self.assertIn("unsupported_count", payload["summary"])
+        self.assertTrue(payload["errors"])
+
+    def test_benchmark_run_command_reports_non_utf8_corpus_json_as_json(self) -> None:
+        output = io.StringIO()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            Path(tmpdir, "manifest.json").write_bytes(b"\xff\xfe\x00")
+            with (
+                patch(
+                    "sys.argv",
+                    ["deploywhisper", "benchmark", "run", "--path", tmpdir],
+                ),
+                redirect_stdout(output),
+            ):
+                with self.assertRaises(SystemExit) as ctx:
+                    main()
+
+        payload = json.loads(output.getvalue())
+        self.assertEqual(ctx.exception.code, 1)
+        self.assertFalse(payload["passed"])
+        self.assertFalse(payload["valid"])
+        self.assertEqual(payload["summary"]["corpus_id"], "unknown")
+        self.assertIn("passed_count", payload["summary"])
+        self.assertIn("failed_count", payload["summary"])
+        self.assertIn("unsupported_count", payload["summary"])
+        self.assertTrue(payload["errors"])
 
     def test_skill_test_command_reports_success_for_requested_skill(self) -> None:
         output = io.StringIO()
@@ -2753,8 +2885,9 @@ class AnalyzeCliTests(unittest.TestCase):
         collect_github_init_options,
         run_github_init,
     ) -> None:
+        example_repo = str(Path(tempfile.gettempdir()) / "example-repo")
         collect_github_init_options.return_value = GitHubInitOptions(
-            repo_path="/tmp/example-repo",
+            repo_path=example_repo,
             workflow_path=".github/workflows/deploywhisper.yml",
             api_endpoint="https://deploywhisper.example.com/api/v1/analyses",
             enable_github_app=False,
@@ -2762,7 +2895,7 @@ class AnalyzeCliTests(unittest.TestCase):
             project_key="payments",
         )
         run_github_init.return_value = GitHubInitResult(
-            repo_path="/tmp/example-repo",
+            repo_path=example_repo,
             workflow_path=".github/workflows/deploywhisper.yml",
             readme_path="README.md",
             github_app_notes_path=None,
@@ -2781,7 +2914,7 @@ class AnalyzeCliTests(unittest.TestCase):
                     "github",
                     "init",
                     "--repo",
-                    "/tmp/example-repo",
+                    example_repo,
                     "--project-key",
                     "payments",
                 ],
@@ -2793,7 +2926,7 @@ class AnalyzeCliTests(unittest.TestCase):
 
         self.assertEqual(ctx.exception.code, 0)
         collect_github_init_options.assert_called_once_with(
-            repo_path="/tmp/example-repo",
+            repo_path=example_repo,
             workflow_path=None,
             api_endpoint=None,
             enable_github_app=None,

--- a/tests/test_services/test_benchmark_runner_service.py
+++ b/tests/test_services/test_benchmark_runner_service.py
@@ -1,0 +1,1433 @@
+"""Tests for benchmark corpus execution."""
+
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from analysis.risk_scorer import RiskAssessment
+from evidence.models import EvidenceItem, Finding
+from parsers.base import ParseBatchResult, ParsedFileResult, UnifiedChange
+import services.benchmark_runner_service as benchmark_runner_module
+from services.benchmark_runner_service import run_benchmark_corpus
+from services.submission_manifest import build_submission_manifest
+
+
+def _write_single_scenario_corpus(
+    root: Path, *, selector: str = "expected marker"
+) -> None:
+    scenario_dir = root / "scenarios" / "single"
+    artifact_dir = scenario_dir / "artifacts"
+    artifact_dir.mkdir(parents=True)
+    (artifact_dir / "main.tf").write_text(
+        f"resource fixture\n{selector}\n", encoding="utf-8"
+    )
+    (root / "manifest.json").write_text(
+        json.dumps(
+            {
+                "corpus_id": "single-scenario-corpus",
+                "version": "1.0.0",
+                "description": "Synthetic single scenario fixture.",
+                "scenarios": ["scenarios/single/scenario.json"],
+            }
+        ),
+        encoding="utf-8",
+    )
+    (scenario_dir / "scenario.json").write_text(
+        json.dumps(
+            {
+                "id": "single-risk",
+                "name": "Single expected risk",
+                "description": "Synthetic benchmark scenario with one expected finding.",
+                "labels": ["terraform"],
+                "artifacts": [
+                    {
+                        "path": "artifacts/main.tf",
+                        "type": "terraform",
+                        "description": "Synthetic Terraform fixture.",
+                    }
+                ],
+                "expected_findings": [
+                    {
+                        "id": "finding-expected-risk",
+                        "title": "Expected risk",
+                        "severity": "high",
+                        "evidence_ids": ["evidence-expected-marker"],
+                        "rationale": "The expected risk must be tied to expected evidence.",
+                    }
+                ],
+                "expected_evidence": [
+                    {
+                        "id": "evidence-expected-marker",
+                        "artifact_path": "artifacts/main.tf",
+                        "selector": selector,
+                        "description": "Expected marker evidence.",
+                    }
+                ],
+                "expected_verdict": "warn",
+                "expected_verdict_rationale": "Warn on the expected risk.",
+                "license": {
+                    "spdx_id": "CC0-1.0",
+                    "source": "Original synthetic fixture authored for public benchmark use.",
+                    "public_sample": True,
+                },
+                "safety": {
+                    "synthetic": True,
+                    "contains_secrets": False,
+                    "contains_customer_data": False,
+                    "contains_non_public_information": False,
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
+def _write_unsupported_corpus(root: Path) -> None:
+    scenario_dir = root / "scenarios" / "notes-only"
+    artifact_dir = scenario_dir / "artifacts"
+    artifact_dir.mkdir(parents=True)
+    (artifact_dir / "notes.txt").write_text(
+        "not a supported deployment artifact\n",
+        encoding="utf-8",
+    )
+    (root / "manifest.json").write_text(
+        json.dumps(
+            {
+                "corpus_id": "unsupported-corpus",
+                "version": "1.0.0",
+                "description": "Unsupported benchmark fixture.",
+                "scenarios": ["scenarios/notes-only/scenario.json"],
+            }
+        ),
+        encoding="utf-8",
+    )
+    (scenario_dir / "scenario.json").write_text(
+        json.dumps(
+            {
+                "id": "notes-only",
+                "name": "Unsupported notes fixture",
+                "description": "Synthetic unsupported benchmark scenario.",
+                "labels": ["unsupported"],
+                "artifacts": [
+                    {
+                        "path": "artifacts/notes.txt",
+                        "type": "notes",
+                        "description": "Plain text notes, not a supported artifact.",
+                    }
+                ],
+                "expected_findings": [
+                    {
+                        "id": "finding-unsupported",
+                        "title": "Unsupported artifact",
+                        "severity": "info",
+                        "evidence_ids": ["evidence-notes"],
+                        "rationale": "The runner should record unsupported artifacts explicitly.",
+                    }
+                ],
+                "expected_evidence": [
+                    {
+                        "id": "evidence-notes",
+                        "artifact_path": "artifacts/notes.txt",
+                        "selector": "not a supported deployment artifact",
+                        "description": "Plain text fixture content.",
+                    }
+                ],
+                "expected_verdict": "unsupported",
+                "expected_verdict_rationale": "Unsupported inputs should be recorded instead of hidden.",
+                "license": {
+                    "spdx_id": "CC0-1.0",
+                    "source": "Original synthetic fixture authored for public benchmark use.",
+                    "public_sample": True,
+                },
+                "safety": {
+                    "synthetic": True,
+                    "contains_secrets": False,
+                    "contains_customer_data": False,
+                    "contains_non_public_information": False,
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
+def _write_unsupported_two_artifact_corpus(root: Path) -> None:
+    scenario_dir = root / "scenarios" / "notes-pair"
+    artifact_dir = scenario_dir / "artifacts"
+    artifact_dir.mkdir(parents=True)
+    (artifact_dir / "one.txt").write_text(
+        "first unsupported deployment note\n",
+        encoding="utf-8",
+    )
+    (artifact_dir / "two.txt").write_text(
+        "second unsupported deployment note\n",
+        encoding="utf-8",
+    )
+    (root / "manifest.json").write_text(
+        json.dumps(
+            {
+                "corpus_id": "unsupported-pair-corpus",
+                "version": "1.0.0",
+                "description": "Unsupported benchmark fixture with two artifacts.",
+                "scenarios": ["scenarios/notes-pair/scenario.json"],
+            }
+        ),
+        encoding="utf-8",
+    )
+    (scenario_dir / "scenario.json").write_text(
+        json.dumps(
+            {
+                "id": "notes-pair",
+                "name": "Unsupported notes pair fixture",
+                "description": "Synthetic unsupported benchmark scenario with two artifacts.",
+                "labels": ["unsupported"],
+                "artifacts": [
+                    {
+                        "path": "artifacts/one.txt",
+                        "type": "notes",
+                        "description": "First unsupported notes fixture.",
+                    },
+                    {
+                        "path": "artifacts/two.txt",
+                        "type": "notes",
+                        "description": "Second unsupported notes fixture.",
+                    },
+                ],
+                "expected_findings": [
+                    {
+                        "id": "finding-one",
+                        "title": "Unsupported artifact: artifacts/one.txt",
+                        "severity": "info",
+                        "evidence_ids": ["evidence-one"],
+                        "rationale": "First unsupported artifact should carry only its evidence.",
+                    },
+                    {
+                        "id": "finding-two-mismatched",
+                        "title": "Unsupported artifact: artifacts/two.txt",
+                        "severity": "info",
+                        "evidence_ids": ["evidence-one"],
+                        "rationale": "This intentionally mismatches evidence to prove per-artifact attribution.",
+                    },
+                ],
+                "expected_evidence": [
+                    {
+                        "id": "evidence-one",
+                        "artifact_path": "artifacts/one.txt",
+                        "selector": "first unsupported deployment note",
+                        "description": "First unsupported note content.",
+                    },
+                    {
+                        "id": "evidence-two",
+                        "artifact_path": "artifacts/two.txt",
+                        "selector": "second unsupported deployment note",
+                        "description": "Second unsupported note content.",
+                    },
+                ],
+                "expected_verdict": "unsupported",
+                "expected_verdict_rationale": "Unsupported inputs should be recorded instead of hidden.",
+                "license": {
+                    "spdx_id": "CC0-1.0",
+                    "source": "Original synthetic fixture authored for public benchmark use.",
+                    "public_sample": True,
+                },
+                "safety": {
+                    "synthetic": True,
+                    "contains_secrets": False,
+                    "contains_customer_data": False,
+                    "contains_non_public_information": False,
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
+def _write_supported_parse_failure_corpus(root: Path) -> None:
+    scenario_dir = root / "scenarios" / "broken-terraform"
+    artifact_dir = scenario_dir / "artifacts"
+    artifact_dir.mkdir(parents=True)
+    (artifact_dir / "main.tf").write_text(
+        'resource "aws_security_group_rule" "broken" {\n'
+        '  cidr_blocks = ["0.0.0.0/0"]\n',
+        encoding="utf-8",
+    )
+    (root / "manifest.json").write_text(
+        json.dumps(
+            {
+                "corpus_id": "supported-parse-failure-corpus",
+                "version": "1.0.0",
+                "description": "Supported benchmark fixture with parser failure.",
+                "scenarios": ["scenarios/broken-terraform/scenario.json"],
+            }
+        ),
+        encoding="utf-8",
+    )
+    (scenario_dir / "scenario.json").write_text(
+        json.dumps(
+            {
+                "id": "broken-terraform",
+                "name": "Broken Terraform fixture",
+                "description": "Synthetic supported artifact that fails parsing.",
+                "labels": ["terraform", "parse-failure"],
+                "artifacts": [
+                    {
+                        "path": "artifacts/main.tf",
+                        "type": "terraform",
+                        "description": "Malformed Terraform fixture.",
+                    }
+                ],
+                "expected_findings": [
+                    {
+                        "id": "finding-parse-failure",
+                        "title": "Terraform parse failure",
+                        "severity": "info",
+                        "evidence_ids": ["evidence-public-cidr"],
+                        "rationale": "Accepted but malformed artifacts must fail the benchmark instead of passing as unsupported.",
+                    }
+                ],
+                "expected_evidence": [
+                    {
+                        "id": "evidence-public-cidr",
+                        "artifact_path": "artifacts/main.tf",
+                        "selector": 'cidr_blocks = ["0.0.0.0/0"]',
+                        "description": "Selector present in an artifact that cannot be parsed.",
+                    }
+                ],
+                "expected_verdict": "unsupported",
+                "expected_verdict_rationale": "This fixture guards against accepted parser failures being counted as unsupported passes.",
+                "license": {
+                    "spdx_id": "CC0-1.0",
+                    "source": "Original synthetic fixture authored for public benchmark use.",
+                    "public_sample": True,
+                },
+                "safety": {
+                    "synthetic": True,
+                    "contains_secrets": False,
+                    "contains_customer_data": False,
+                    "contains_non_public_information": False,
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
+def _write_mixed_partial_corpus(root: Path) -> None:
+    _write_single_scenario_corpus(root)
+    scenario_path = root / "scenarios" / "single" / "scenario.json"
+    notes_path = root / "scenarios" / "single" / "artifacts" / "notes.txt"
+    notes_path.write_text("operator note only\n", encoding="utf-8")
+    scenario_payload = json.loads(scenario_path.read_text(encoding="utf-8"))
+    scenario_payload["artifacts"].append(
+        {
+            "path": "artifacts/notes.txt",
+            "type": "notes",
+            "description": "Unsupported auxiliary notes fixture.",
+        }
+    )
+    scenario_path.write_text(json.dumps(scenario_payload), encoding="utf-8")
+
+
+def _analysis_result(
+    *,
+    evidence_summary: str = "Expected marker evidence cites expected marker.",
+    evidence_artifact: str = "artifacts/main.tf",
+    evidence_tool: str = "terraform",
+    evidence_resource: str = "resource.expected",
+    finding_title: str = "HIGH: Expected risk",
+    finding_evidence_refs: list[str] | None = None,
+    assessment_severity: str = "high",
+    assessment_recommendation: str = "no-go",
+    assessment_score: int = 72,
+    change_metadata: dict | None = None,
+    files: list[tuple[str, bytes | None]] | None = None,
+):
+    evidence = EvidenceItem(
+        evidence_id="ev-expected",
+        analysis_id=0,
+        finding_id="pending:expected",
+        source_type="artifact",
+        source_ref=f"{evidence_tool}://{evidence_artifact}#{evidence_resource}?action=modify",
+        artifact=evidence_artifact,
+        location=f"{evidence_artifact}#{evidence_resource}",
+        resource=evidence_resource,
+        operation="modify",
+        summary=evidence_summary,
+        severity_hint="high",
+        deterministic=True,
+        confidence=1.0,
+        related_change_ids=["chg-expected"],
+    )
+    finding = Finding(
+        finding_id="finding-expected",
+        analysis_id=0,
+        title=finding_title,
+        description=finding_title,
+        explanation=finding_title,
+        severity="high",
+        category="networking/ingress",
+        deterministic=True,
+        confidence=1.0,
+        evidence_refs=finding_evidence_refs
+        if finding_evidence_refs is not None
+        else [evidence.evidence_id],
+    )
+    assessment = RiskAssessment(
+        score=assessment_score,
+        severity=assessment_severity,
+        recommendation=assessment_recommendation,
+        top_risk=finding_title,
+        partial_context=False,
+    )
+    parse_batch = ParseBatchResult(
+        files=[
+            ParsedFileResult(
+                file_name=evidence_artifact,
+                tool="terraform",
+                status="parsed",
+                changes=[
+                    UnifiedChange(
+                        change_id="chg-expected",
+                        source_file=evidence_artifact,
+                        tool=evidence_tool,
+                        resource_id=evidence_resource,
+                        action="modify",
+                        summary="Synthetic expected benchmark change.",
+                        metadata=change_metadata
+                        if change_metadata is not None
+                        else {"selector": "expected marker"},
+                    )
+                ],
+            )
+        ]
+    )
+    manifest = build_submission_manifest(
+        files
+        if files is not None
+        else [("artifacts/main.tf", b"resource fixture\nexpected marker\n")],
+        parse_batch=parse_batch,
+    )
+    return SimpleNamespace(
+        parse_batch=parse_batch,
+        submission_manifest=manifest,
+        evidence_items=[evidence],
+        findings=[finding],
+        assessment=assessment,
+    )
+
+
+def _analysis_result_with_changes(
+    *,
+    artifact_path: str,
+    tool: str,
+    resource_id: str,
+    changes: list[UnifiedChange],
+    related_change_id: str,
+    files: list[tuple[str, bytes | None]],
+):
+    evidence = EvidenceItem(
+        evidence_id="ev-expected",
+        analysis_id=0,
+        finding_id="pending:expected",
+        source_type="artifact",
+        source_ref=f"{tool}://{artifact_path}#{resource_id}?action=modify",
+        artifact=artifact_path,
+        location=f"{artifact_path}#{resource_id}",
+        resource=resource_id,
+        operation="modify",
+        summary="Observed duplicate-name resource evidence.",
+        severity_hint="high",
+        deterministic=True,
+        confidence=1.0,
+        related_change_ids=[related_change_id],
+    )
+    finding = Finding(
+        finding_id="finding-expected",
+        analysis_id=0,
+        title="HIGH: Expected risk",
+        description="HIGH: Expected risk",
+        explanation="HIGH: Expected risk",
+        severity="high",
+        category="networking/ingress",
+        deterministic=True,
+        confidence=1.0,
+        evidence_refs=[evidence.evidence_id],
+    )
+    parse_batch = ParseBatchResult(
+        files=[
+            ParsedFileResult(
+                file_name=artifact_path,
+                tool=tool,
+                status="parsed",
+                changes=changes,
+            )
+        ]
+    )
+    manifest = build_submission_manifest(files, parse_batch=parse_batch)
+    return SimpleNamespace(
+        parse_batch=parse_batch,
+        submission_manifest=manifest,
+        evidence_items=[evidence],
+        findings=[finding],
+        assessment=RiskAssessment(
+            score=72,
+            severity="high",
+            recommendation="no-go",
+            top_risk="HIGH: Expected risk",
+            partial_context=False,
+        ),
+    )
+
+
+class BenchmarkRunnerServiceTests(unittest.TestCase):
+    def test_bundled_corpus_records_scenario_results(self) -> None:
+        result = run_benchmark_corpus()
+
+        self.assertEqual(result.summary.corpus_id, "deploywhisper-benchmark-corpus-v1")
+        self.assertGreaterEqual(result.summary.scenario_count, 3)
+        self.assertEqual(len(result.scenarios), result.summary.scenario_count)
+        self.assertGreaterEqual(result.summary.total_latency_ms, 0.0)
+
+        scenario = result.scenarios[0]
+        self.assertIn(scenario.status, {"passed", "failed", "unsupported"})
+        self.assertIsInstance(scenario.passed, bool)
+        self.assertGreaterEqual(scenario.latency_ms, 0.0)
+        self.assertGreaterEqual(scenario.actual_finding_count, 0)
+        self.assertGreaterEqual(scenario.actual_evidence_count, 0)
+        self.assertGreaterEqual(scenario.finding_coverage, 0.0)
+        self.assertLessEqual(scenario.finding_coverage, 1.0)
+        self.assertGreaterEqual(scenario.evidence_coverage, 0.0)
+        self.assertLessEqual(scenario.evidence_coverage, 1.0)
+        self.assertIn(
+            scenario.evidence_law_status,
+            {"Satisfied", "Needs review", "Reconciled", "Detail omitted"},
+        )
+        self.assertIsInstance(scenario.evidence_law_violations, list)
+        self.assertIsInstance(scenario.unsupported, bool)
+        self.assertIsInstance(scenario.unsupported_reasons, list)
+        self.assertIsInstance(scenario.findings, list)
+        supported_scenarios = [
+            scenario for scenario in result.scenarios if not scenario.unsupported
+        ]
+        self.assertTrue(supported_scenarios)
+        for scenario in supported_scenarios:
+            self.assertNotEqual(scenario.actual_verdict, "insufficient_context")
+
+    def test_expected_unsupported_scenario_records_reasons(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            corpus_root = Path(tmpdir)
+            _write_unsupported_corpus(corpus_root)
+
+            result = run_benchmark_corpus(corpus_root)
+
+        self.assertTrue(result.passed)
+        self.assertEqual(result.summary.unsupported_count, 1)
+        self.assertEqual(result.summary.failed_count, 0)
+        scenario = result.scenarios[0]
+        self.assertTrue(scenario.passed)
+        self.assertEqual(scenario.status, "unsupported")
+        self.assertEqual(scenario.actual_verdict, "unsupported")
+        self.assertTrue(scenario.unsupported)
+        self.assertTrue(scenario.unsupported_reasons)
+        self.assertEqual(scenario.actual_finding_count, 1)
+        self.assertTrue(scenario.findings)
+        self.assertEqual(scenario.evidence_coverage, 1.0)
+        self.assertEqual(scenario.finding_coverage, 1.0)
+
+    def test_supported_parse_failure_fails_instead_of_passing_as_unsupported(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            corpus_root = Path(tmpdir)
+            _write_supported_parse_failure_corpus(corpus_root)
+
+            result = run_benchmark_corpus(corpus_root)
+
+        self.assertFalse(result.passed)
+        self.assertEqual(result.summary.failed_count, 1)
+        self.assertEqual(result.summary.unsupported_count, 0)
+        scenario = result.scenarios[0]
+        self.assertFalse(scenario.passed)
+        self.assertEqual(scenario.status, "failed")
+        self.assertFalse(scenario.unsupported)
+        self.assertEqual(scenario.unsupported_reasons, [])
+        self.assertTrue(scenario.coverage_warnings)
+        self.assertIn("artifacts/main.tf: failed", scenario.coverage_warnings[0])
+        self.assertEqual(scenario.evidence_coverage, 0.0)
+        self.assertEqual(scenario.finding_coverage, 0.0)
+
+    def test_mixed_partial_input_records_warnings_without_becoming_unsupported(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            corpus_root = Path(tmpdir)
+            _write_mixed_partial_corpus(corpus_root)
+
+            with patch(
+                "services.benchmark_runner_service._run_analysis_core",
+                return_value=_analysis_result(
+                    files=[
+                        ("artifacts/main.tf", b"resource fixture\nexpected marker\n"),
+                        ("artifacts/notes.txt", b"operator note only\n"),
+                    ]
+                ),
+            ):
+                result = run_benchmark_corpus(corpus_root)
+
+        self.assertTrue(result.passed)
+        self.assertEqual(result.summary.unsupported_count, 0)
+        scenario = result.scenarios[0]
+        self.assertFalse(scenario.unsupported)
+        self.assertEqual(scenario.unsupported_reasons, [])
+        self.assertEqual(scenario.status, "passed")
+        self.assertTrue(scenario.coverage_warnings)
+        self.assertIn("artifacts/notes.txt: excluded", scenario.coverage_warnings[0])
+
+    def test_evidence_coverage_uses_raw_artifact_selector_text(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            corpus_root = Path(tmpdir)
+            _write_single_scenario_corpus(corpus_root, selector="expected marker")
+
+            with patch(
+                "services.benchmark_runner_service._run_analysis_core",
+                return_value=_analysis_result(
+                    evidence_summary="Observed unrelated marker only."
+                ),
+            ):
+                result = run_benchmark_corpus(corpus_root)
+
+        self.assertTrue(result.passed)
+        scenario = result.scenarios[0]
+        self.assertTrue(scenario.passed)
+        self.assertEqual(scenario.evidence_coverage, 1.0)
+        self.assertEqual(scenario.missing_expected_evidence_ids, [])
+
+    def test_evidence_coverage_requires_observed_evidence_for_artifact(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            corpus_root = Path(tmpdir)
+            _write_single_scenario_corpus(corpus_root, selector="expected marker")
+
+            with patch(
+                "services.benchmark_runner_service._run_analysis_core",
+                return_value=_analysis_result(
+                    evidence_artifact="artifacts/other.tf",
+                    files=[("artifacts/other.tf", b"expected marker\n")],
+                ),
+            ):
+                result = run_benchmark_corpus(corpus_root)
+
+        self.assertFalse(result.passed)
+        scenario = result.scenarios[0]
+        self.assertFalse(scenario.passed)
+        self.assertEqual(scenario.status, "failed")
+        self.assertEqual(scenario.evidence_coverage, 0.0)
+        self.assertEqual(
+            scenario.missing_expected_evidence_ids, ["evidence-expected-marker"]
+        )
+
+    def test_evidence_coverage_does_not_match_selector_from_unrelated_same_file_change(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            corpus_root = Path(tmpdir)
+            _write_single_scenario_corpus(
+                corpus_root, selector="marker from other resource"
+            )
+
+            with patch(
+                "services.benchmark_runner_service._run_analysis_core",
+                return_value=_analysis_result(
+                    evidence_resource="resource.one",
+                    change_metadata={"selector": "observed resource one"},
+                    files=[
+                        (
+                            "artifacts/main.tf",
+                            b"resource fixture\nmarker from other resource\n",
+                        )
+                    ],
+                ),
+            ):
+                result = run_benchmark_corpus(corpus_root)
+
+        self.assertFalse(result.passed)
+        scenario = result.scenarios[0]
+        self.assertFalse(scenario.passed)
+        self.assertEqual(scenario.evidence_coverage, 0.0)
+        self.assertEqual(
+            scenario.missing_expected_evidence_ids, ["evidence-expected-marker"]
+        )
+
+    def test_evidence_coverage_falls_back_to_artifact_text_for_unscoped_tool(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            corpus_root = Path(tmpdir)
+            _write_single_scenario_corpus(corpus_root, selector="expected marker")
+            (corpus_root / "scenarios" / "single" / "artifacts" / "main.tf").write_text(
+                "Resources:\n  TemplateResource:\n    expected marker\n",
+                encoding="utf-8",
+            )
+
+            with patch(
+                "services.benchmark_runner_service._run_analysis_core",
+                return_value=_analysis_result(
+                    evidence_summary="Observed generic parser evidence.",
+                    evidence_tool="cloudformation",
+                    evidence_resource="resource/TemplateResource",
+                    change_metadata={},
+                    files=[
+                        (
+                            "artifacts/main.tf",
+                            b"Resources:\n  TemplateResource:\n    expected marker\n",
+                        )
+                    ],
+                ),
+            ):
+                result = run_benchmark_corpus(corpus_root)
+
+        self.assertTrue(result.passed)
+        scenario = result.scenarios[0]
+        self.assertEqual(scenario.evidence_coverage, 1.0)
+        self.assertEqual(scenario.missing_expected_evidence_ids, [])
+
+    def test_cloudformation_evidence_does_not_match_selector_from_wrong_resource(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            corpus_root = Path(tmpdir)
+            _write_single_scenario_corpus(corpus_root, selector="wrong resource marker")
+            (corpus_root / "scenarios" / "single" / "artifacts" / "main.tf").write_text(
+                "Resources:\n"
+                "  TemplateResource:\n"
+                "    Type: AWS::S3::Bucket\n"
+                "  OtherResource:\n"
+                "    wrong resource marker\n",
+                encoding="utf-8",
+            )
+
+            with patch(
+                "services.benchmark_runner_service._run_analysis_core",
+                return_value=_analysis_result(
+                    evidence_summary="Observed CloudFormation resource evidence.",
+                    evidence_tool="cloudformation",
+                    evidence_resource="resource/TemplateResource",
+                    change_metadata={},
+                    files=[
+                        (
+                            "artifacts/main.tf",
+                            b"Resources:\n"
+                            b"  TemplateResource:\n"
+                            b"    Type: AWS::S3::Bucket\n"
+                            b"  OtherResource:\n"
+                            b"    wrong resource marker\n",
+                        )
+                    ],
+                ),
+            ):
+                result = run_benchmark_corpus(corpus_root)
+
+        self.assertFalse(result.passed)
+        scenario = result.scenarios[0]
+        self.assertEqual(scenario.evidence_coverage, 0.0)
+        self.assertEqual(
+            scenario.missing_expected_evidence_ids, ["evidence-expected-marker"]
+        )
+
+    def test_cloudformation_yaml_scope_ignores_same_key_outside_resources(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            corpus_root = Path(tmpdir)
+            _write_single_scenario_corpus(corpus_root, selector="wrong section marker")
+            (corpus_root / "scenarios" / "single" / "artifacts" / "main.tf").write_text(
+                "Parameters:\n"
+                "  TemplateResource:\n"
+                "    wrong section marker\n"
+                "Resources:\n"
+                "  TemplateResource:\n"
+                "    Type: AWS::S3::Bucket\n",
+                encoding="utf-8",
+            )
+
+            with patch(
+                "services.benchmark_runner_service._run_analysis_core",
+                return_value=_analysis_result(
+                    evidence_summary="Observed CloudFormation resource evidence.",
+                    evidence_tool="cloudformation",
+                    evidence_resource="resource/TemplateResource",
+                    change_metadata={},
+                    files=[
+                        (
+                            "artifacts/main.tf",
+                            b"Parameters:\n"
+                            b"  TemplateResource:\n"
+                            b"    wrong section marker\n"
+                            b"Resources:\n"
+                            b"  TemplateResource:\n"
+                            b"    Type: AWS::S3::Bucket\n",
+                        )
+                    ],
+                ),
+            ):
+                result = run_benchmark_corpus(corpus_root)
+
+        self.assertFalse(result.passed)
+        scenario = result.scenarios[0]
+        self.assertEqual(scenario.evidence_coverage, 0.0)
+        self.assertEqual(
+            scenario.missing_expected_evidence_ids, ["evidence-expected-marker"]
+        )
+
+    def test_cloudformation_json_scope_ignores_same_key_outside_resources(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            corpus_root = Path(tmpdir)
+            _write_single_scenario_corpus(corpus_root, selector="wrong section marker")
+            cloudformation_json = json.dumps(
+                {
+                    "TemplateResource": {
+                        "Description": "wrong section marker",
+                    },
+                    "Resources": {
+                        "TemplateResource": {
+                            "Type": "AWS::S3::Bucket",
+                        }
+                    },
+                }
+            )
+            (corpus_root / "scenarios" / "single" / "artifacts" / "main.tf").write_text(
+                cloudformation_json,
+                encoding="utf-8",
+            )
+
+            with patch(
+                "services.benchmark_runner_service._run_analysis_core",
+                return_value=_analysis_result(
+                    evidence_summary="Observed CloudFormation resource evidence.",
+                    evidence_tool="cloudformation",
+                    evidence_resource="resource/TemplateResource",
+                    change_metadata={},
+                    files=[("artifacts/main.tf", cloudformation_json.encode("utf-8"))],
+                ),
+            ):
+                result = run_benchmark_corpus(corpus_root)
+
+        self.assertFalse(result.passed)
+        scenario = result.scenarios[0]
+        self.assertEqual(scenario.evidence_coverage, 0.0)
+        self.assertEqual(
+            scenario.missing_expected_evidence_ids, ["evidence-expected-marker"]
+        )
+
+    def test_cloudformation_top_level_inline_resources_map_matches_selector(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            corpus_root = Path(tmpdir)
+            _write_single_scenario_corpus(corpus_root, selector="inline marker")
+            cloudformation_yaml = (
+                "Resources: {TemplateResource: {Type: AWS::S3::Bucket, "
+                "Description: inline marker}}\n"
+            )
+            (corpus_root / "scenarios" / "single" / "artifacts" / "main.tf").write_text(
+                cloudformation_yaml,
+                encoding="utf-8",
+            )
+
+            with patch(
+                "services.benchmark_runner_service._run_analysis_core",
+                return_value=_analysis_result(
+                    evidence_summary="Observed CloudFormation inline resource evidence.",
+                    evidence_tool="cloudformation",
+                    evidence_resource="resource/TemplateResource",
+                    change_metadata={},
+                    files=[("artifacts/main.tf", cloudformation_yaml.encode("utf-8"))],
+                ),
+            ):
+                result = run_benchmark_corpus(corpus_root)
+
+        self.assertTrue(result.passed)
+        scenario = result.scenarios[0]
+        self.assertEqual(scenario.evidence_coverage, 1.0)
+        self.assertEqual(scenario.missing_expected_evidence_ids, [])
+
+    def test_cloudformation_yaml_scope_matches_direct_resource_not_nested_key(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            corpus_root = Path(tmpdir)
+            _write_single_scenario_corpus(corpus_root, selector="expected marker")
+            cloudformation_yaml = (
+                "Resources:\n"
+                "  OtherResource:\n"
+                "    Type: AWS::S3::Bucket\n"
+                "    Properties:\n"
+                "      TemplateResource:\n"
+                "        Description: wrong nested marker\n"
+                "  TemplateResource:\n"
+                "    Type: AWS::S3::Bucket\n"
+                "    Description: expected marker\n"
+            )
+            (corpus_root / "scenarios" / "single" / "artifacts" / "main.tf").write_text(
+                cloudformation_yaml,
+                encoding="utf-8",
+            )
+
+            with patch(
+                "services.benchmark_runner_service._run_analysis_core",
+                return_value=_analysis_result(
+                    evidence_summary="Observed CloudFormation resource evidence.",
+                    evidence_tool="cloudformation",
+                    evidence_resource="resource/TemplateResource",
+                    change_metadata={},
+                    files=[("artifacts/main.tf", cloudformation_yaml.encode("utf-8"))],
+                ),
+            ):
+                result = run_benchmark_corpus(corpus_root)
+
+        self.assertTrue(result.passed)
+        scenario = result.scenarios[0]
+        self.assertEqual(scenario.evidence_coverage, 1.0)
+        self.assertEqual(scenario.missing_expected_evidence_ids, [])
+
+    def test_kubernetes_evidence_uses_metadata_name_for_document_scope(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            corpus_root = Path(tmpdir)
+            _write_single_scenario_corpus(corpus_root, selector="wrong nested marker")
+            kubernetes_yaml = (
+                "apiVersion: apps/v1\n"
+                "kind: Deployment\n"
+                "metadata:\n"
+                "  name: other\n"
+                "spec:\n"
+                "  template:\n"
+                "    spec:\n"
+                "      containers:\n"
+                "        - name: Expected\n"
+                "          image: wrong nested marker\n"
+                "---\n"
+                "apiVersion: apps/v1\n"
+                "kind: Deployment\n"
+                "metadata:\n"
+                "  name: Expected\n"
+                "spec: {}\n"
+            )
+            (corpus_root / "scenarios" / "single" / "artifacts" / "main.tf").write_text(
+                kubernetes_yaml,
+                encoding="utf-8",
+            )
+
+            with patch(
+                "services.benchmark_runner_service._run_analysis_core",
+                return_value=_analysis_result(
+                    evidence_summary="Observed Kubernetes resource evidence.",
+                    evidence_tool="kubernetes",
+                    evidence_resource="Deployment/Expected",
+                    change_metadata={},
+                    files=[("artifacts/main.tf", kubernetes_yaml.encode("utf-8"))],
+                ),
+            ):
+                result = run_benchmark_corpus(corpus_root)
+
+        self.assertFalse(result.passed)
+        scenario = result.scenarios[0]
+        self.assertEqual(scenario.evidence_coverage, 0.0)
+        self.assertEqual(
+            scenario.missing_expected_evidence_ids, ["evidence-expected-marker"]
+        )
+
+    def test_kubernetes_document_separator_comments_preserve_document_scope(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            corpus_root = Path(tmpdir)
+            _write_single_scenario_corpus(corpus_root, selector="expected marker")
+            kubernetes_yaml = (
+                "apiVersion: apps/v1\n"
+                "kind: Deployment\n"
+                "metadata:\n"
+                "  name: other\n"
+                "spec:\n"
+                "  note: wrong marker\n"
+                "--- # second document\n"
+                "apiVersion: apps/v1\n"
+                "kind: Deployment\n"
+                "metadata:\n"
+                "  name: Expected\n"
+                "spec:\n"
+                "  note: expected marker\n"
+            )
+            (corpus_root / "scenarios" / "single" / "artifacts" / "main.tf").write_text(
+                kubernetes_yaml,
+                encoding="utf-8",
+            )
+
+            with patch(
+                "services.benchmark_runner_service._run_analysis_core",
+                return_value=_analysis_result(
+                    evidence_summary="Observed Kubernetes resource evidence.",
+                    evidence_tool="kubernetes",
+                    evidence_resource="Deployment/Expected",
+                    change_metadata={},
+                    files=[("artifacts/main.tf", kubernetes_yaml.encode("utf-8"))],
+                ),
+            ):
+                result = run_benchmark_corpus(corpus_root)
+
+        self.assertTrue(result.passed)
+        scenario = result.scenarios[0]
+        self.assertEqual(scenario.evidence_coverage, 1.0)
+        self.assertEqual(scenario.missing_expected_evidence_ids, [])
+
+    def test_cloudformation_inline_yaml_resource_matches_expected_selector(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            corpus_root = Path(tmpdir)
+            _write_single_scenario_corpus(corpus_root, selector="inline marker")
+            (corpus_root / "scenarios" / "single" / "artifacts" / "main.tf").write_text(
+                "Resources:\n"
+                "  TemplateResource: {Type: AWS::S3::Bucket, Description: inline marker}\n",
+                encoding="utf-8",
+            )
+
+            with patch(
+                "services.benchmark_runner_service._run_analysis_core",
+                return_value=_analysis_result(
+                    evidence_summary="Observed CloudFormation inline resource evidence.",
+                    evidence_tool="cloudformation",
+                    evidence_resource="resource/TemplateResource",
+                    change_metadata={},
+                    files=[
+                        (
+                            "artifacts/main.tf",
+                            b"Resources:\n"
+                            b"  TemplateResource: {Type: AWS::S3::Bucket, Description: inline marker}\n",
+                        )
+                    ],
+                ),
+            ):
+                result = run_benchmark_corpus(corpus_root)
+
+        self.assertTrue(result.passed)
+        scenario = result.scenarios[0]
+        self.assertEqual(scenario.evidence_coverage, 1.0)
+        self.assertEqual(scenario.missing_expected_evidence_ids, [])
+
+    def test_kubernetes_duplicate_kind_name_uses_related_change_occurrence(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            corpus_root = Path(tmpdir)
+            _write_single_scenario_corpus(
+                corpus_root, selector="expected namespace marker"
+            )
+            kubernetes_yaml = (
+                "apiVersion: apps/v1\n"
+                "kind: Deployment\n"
+                "metadata:\n"
+                "  name: checkout\n"
+                "  namespace: default\n"
+                "spec:\n"
+                "  note: wrong namespace marker\n"
+                "---\n"
+                "apiVersion: apps/v1\n"
+                "kind: Deployment\n"
+                "metadata:\n"
+                "  name: checkout\n"
+                "  namespace: payments\n"
+                "spec:\n"
+                "  note: expected namespace marker\n"
+            )
+            (corpus_root / "scenarios" / "single" / "artifacts" / "main.tf").write_text(
+                kubernetes_yaml,
+                encoding="utf-8",
+            )
+            changes = [
+                UnifiedChange(
+                    change_id="chg-first",
+                    source_file="artifacts/main.tf",
+                    tool="kubernetes",
+                    resource_id="Deployment/checkout",
+                    action="apply",
+                    summary="First duplicate deployment.",
+                ),
+                UnifiedChange(
+                    change_id="chg-second",
+                    source_file="artifacts/main.tf",
+                    tool="kubernetes",
+                    resource_id="Deployment/checkout",
+                    action="apply",
+                    summary="Second duplicate deployment.",
+                ),
+            ]
+
+            with patch(
+                "services.benchmark_runner_service._run_analysis_core",
+                return_value=_analysis_result_with_changes(
+                    artifact_path="artifacts/main.tf",
+                    tool="kubernetes",
+                    resource_id="Deployment/checkout",
+                    changes=changes,
+                    related_change_id="chg-second",
+                    files=[("artifacts/main.tf", kubernetes_yaml.encode("utf-8"))],
+                ),
+            ):
+                result = run_benchmark_corpus(corpus_root)
+
+        self.assertTrue(result.passed)
+        scenario = result.scenarios[0]
+        self.assertEqual(scenario.evidence_coverage, 1.0)
+        self.assertEqual(scenario.missing_expected_evidence_ids, [])
+
+    def test_ansible_duplicate_task_name_uses_related_change_occurrence(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            corpus_root = Path(tmpdir)
+            _write_single_scenario_corpus(corpus_root, selector="expected task marker")
+            playbook_yaml = (
+                "- hosts: all\n"
+                "  tasks:\n"
+                "    - name: Restart service\n"
+                "      debug:\n"
+                "        msg: wrong task marker\n"
+                "    - name: Restart service\n"
+                "      debug:\n"
+                "        msg: expected task marker\n"
+            )
+            (corpus_root / "scenarios" / "single" / "artifacts" / "main.tf").write_text(
+                playbook_yaml,
+                encoding="utf-8",
+            )
+            changes = [
+                UnifiedChange(
+                    change_id="chg-first",
+                    source_file="artifacts/main.tf",
+                    tool="ansible",
+                    resource_id="Restart service",
+                    action="modify",
+                    summary="First duplicate task.",
+                ),
+                UnifiedChange(
+                    change_id="chg-second",
+                    source_file="artifacts/main.tf",
+                    tool="ansible",
+                    resource_id="Restart service",
+                    action="modify",
+                    summary="Second duplicate task.",
+                ),
+            ]
+
+            with patch(
+                "services.benchmark_runner_service._run_analysis_core",
+                return_value=_analysis_result_with_changes(
+                    artifact_path="artifacts/main.tf",
+                    tool="ansible",
+                    resource_id="Restart service",
+                    changes=changes,
+                    related_change_id="chg-second",
+                    files=[("artifacts/main.tf", playbook_yaml.encode("utf-8"))],
+                ),
+            ):
+                result = run_benchmark_corpus(corpus_root)
+
+        self.assertTrue(result.passed)
+        scenario = result.scenarios[0]
+        self.assertEqual(scenario.evidence_coverage, 1.0)
+        self.assertEqual(scenario.missing_expected_evidence_ids, [])
+
+    def test_jenkins_duplicate_stage_name_uses_related_change_occurrence(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            corpus_root = Path(tmpdir)
+            _write_single_scenario_corpus(corpus_root, selector="expected stage marker")
+            jenkinsfile = (
+                'stage("Deploy") { steps { echo "wrong stage marker" } }\n'
+                'stage("Deploy") { steps { echo "expected stage marker" } }\n'
+            )
+            (corpus_root / "scenarios" / "single" / "artifacts" / "main.tf").write_text(
+                jenkinsfile,
+                encoding="utf-8",
+            )
+            changes = [
+                UnifiedChange(
+                    change_id="chg-first",
+                    source_file="artifacts/main.tf",
+                    tool="jenkins",
+                    resource_id="stage/Deploy",
+                    action="modify",
+                    summary="First duplicate stage.",
+                ),
+                UnifiedChange(
+                    change_id="chg-second",
+                    source_file="artifacts/main.tf",
+                    tool="jenkins",
+                    resource_id="stage/Deploy",
+                    action="modify",
+                    summary="Second duplicate stage.",
+                ),
+            ]
+
+            with patch(
+                "services.benchmark_runner_service._run_analysis_core",
+                return_value=_analysis_result_with_changes(
+                    artifact_path="artifacts/main.tf",
+                    tool="jenkins",
+                    resource_id="stage/Deploy",
+                    changes=changes,
+                    related_change_id="chg-second",
+                    files=[("artifacts/main.tf", jenkinsfile.encode("utf-8"))],
+                ),
+            ):
+                result = run_benchmark_corpus(corpus_root)
+
+        self.assertTrue(result.passed)
+        scenario = result.scenarios[0]
+        self.assertEqual(scenario.evidence_coverage, 1.0)
+        self.assertEqual(scenario.missing_expected_evidence_ids, [])
+
+    def test_one_observed_evidence_cannot_cover_multiple_expected_evidence_ids(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            corpus_root = Path(tmpdir)
+            _write_single_scenario_corpus(corpus_root, selector="first marker")
+            scenario_path = corpus_root / "scenarios" / "single" / "scenario.json"
+            scenario_payload = json.loads(scenario_path.read_text(encoding="utf-8"))
+            scenario_payload["expected_evidence"].append(
+                {
+                    "id": "evidence-second-marker",
+                    "artifact_path": "artifacts/main.tf",
+                    "selector": "second marker",
+                    "description": "Second expected marker evidence.",
+                }
+            )
+            scenario_payload["expected_findings"][0]["evidence_ids"] = [
+                "evidence-expected-marker",
+                "evidence-second-marker",
+            ]
+            scenario_path.write_text(json.dumps(scenario_payload), encoding="utf-8")
+            (corpus_root / "scenarios" / "single" / "artifacts" / "main.tf").write_text(
+                "resource fixture\nfirst marker\nsecond marker\n",
+                encoding="utf-8",
+            )
+
+            with patch(
+                "services.benchmark_runner_service._run_analysis_core",
+                return_value=_analysis_result(
+                    evidence_summary="Observed evidence covers first marker and second marker.",
+                    files=[
+                        (
+                            "artifacts/main.tf",
+                            b"resource fixture\nfirst marker\nsecond marker\n",
+                        )
+                    ],
+                ),
+            ):
+                result = run_benchmark_corpus(corpus_root)
+
+        self.assertFalse(result.passed)
+        scenario = result.scenarios[0]
+        self.assertEqual(scenario.evidence_coverage, 0.5)
+        self.assertEqual(
+            scenario.missing_expected_evidence_ids, ["evidence-second-marker"]
+        )
+        self.assertEqual(scenario.finding_coverage, 0.0)
+
+    def test_finding_coverage_requires_expected_finding_match(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            corpus_root = Path(tmpdir)
+            _write_single_scenario_corpus(corpus_root, selector="expected marker")
+
+            with patch(
+                "services.benchmark_runner_service._run_analysis_core",
+                return_value=_analysis_result(finding_title="HIGH: Different risk"),
+            ):
+                result = run_benchmark_corpus(corpus_root)
+
+        self.assertFalse(result.passed)
+        scenario = result.scenarios[0]
+        self.assertEqual(scenario.evidence_coverage, 1.0)
+        self.assertEqual(scenario.finding_coverage, 0.0)
+        self.assertEqual(
+            scenario.missing_expected_finding_ids, ["finding-expected-risk"]
+        )
+
+    def test_warn_expectation_fails_on_stop_verdict(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            corpus_root = Path(tmpdir)
+            _write_single_scenario_corpus(corpus_root, selector="expected marker")
+
+            with patch(
+                "services.benchmark_runner_service._run_analysis_core",
+                return_value=_analysis_result(
+                    assessment_severity="critical",
+                    assessment_recommendation="no-go",
+                    assessment_score=92,
+                ),
+            ):
+                result = run_benchmark_corpus(corpus_root)
+
+        self.assertFalse(result.passed)
+        scenario = result.scenarios[0]
+        self.assertEqual(scenario.expected_verdict, "warn")
+        self.assertEqual(scenario.actual_verdict, "stop")
+        self.assertFalse(scenario.passed)
+
+    def test_failed_expected_unsupported_scenario_counts_as_failed(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            corpus_root = Path(tmpdir)
+            _write_unsupported_corpus(corpus_root)
+            scenario_path = corpus_root / "scenarios" / "notes-only" / "scenario.json"
+            scenario_payload = json.loads(scenario_path.read_text(encoding="utf-8"))
+            scenario_payload["expected_findings"][0]["title"] = "Different finding"
+            scenario_path.write_text(json.dumps(scenario_payload), encoding="utf-8")
+
+            result = run_benchmark_corpus(corpus_root)
+
+        self.assertFalse(result.passed)
+        self.assertEqual(result.summary.failed_count, 1)
+        self.assertEqual(result.summary.unsupported_count, 0)
+        scenario = result.scenarios[0]
+        self.assertTrue(scenario.unsupported)
+        self.assertEqual(scenario.status, "failed")
+        self.assertEqual(scenario.finding_coverage, 0.0)
+
+    def test_unsupported_finding_coverage_requires_artifact_specific_evidence(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            corpus_root = Path(tmpdir)
+            _write_unsupported_two_artifact_corpus(corpus_root)
+
+            result = run_benchmark_corpus(corpus_root)
+
+        self.assertFalse(result.passed)
+        self.assertEqual(result.summary.failed_count, 1)
+        self.assertEqual(result.summary.unsupported_count, 0)
+        scenario = result.scenarios[0]
+        self.assertTrue(scenario.unsupported)
+        self.assertEqual(scenario.status, "failed")
+        self.assertEqual(scenario.evidence_coverage, 1.0)
+        self.assertEqual(scenario.finding_coverage, 0.5)
+        self.assertEqual(
+            scenario.missing_expected_finding_ids, ["finding-two-mismatched"]
+        )
+        refs_by_title = {
+            finding.title: finding.evidence_refs for finding in scenario.findings
+        }
+        self.assertEqual(
+            refs_by_title["Unsupported artifact: artifacts/one.txt"], ["evidence-one"]
+        )
+        self.assertEqual(
+            refs_by_title["Unsupported artifact: artifacts/two.txt"], ["evidence-two"]
+        )
+
+    def test_unsupported_evidence_coverage_requires_selector_in_current_artifact_text(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            corpus_root = Path(tmpdir)
+            _write_unsupported_corpus(corpus_root)
+
+            with patch(
+                "services.benchmark_runner_service._scenario_files",
+                return_value=[("artifacts/notes.txt", b"different unsupported note\n")],
+            ):
+                result = run_benchmark_corpus(corpus_root)
+
+        self.assertFalse(result.passed)
+        self.assertEqual(result.summary.failed_count, 1)
+        self.assertEqual(result.summary.unsupported_count, 0)
+        scenario = result.scenarios[0]
+        self.assertTrue(scenario.unsupported)
+        self.assertEqual(scenario.evidence_coverage, 0.0)
+        self.assertEqual(scenario.finding_coverage, 0.0)
+        self.assertEqual(scenario.missing_expected_evidence_ids, ["evidence-notes"])
+
+    def test_scenario_file_read_rejects_artifact_paths_that_escape_corpus(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            corpus_root = Path(tmpdir)
+            scenario_dir = corpus_root / "scenarios" / "single"
+            scenario_dir.mkdir(parents=True)
+            (corpus_root.parent / "outside.txt").write_text(
+                "outside marker",
+                encoding="utf-8",
+            )
+
+            with self.assertRaisesRegex(ValueError, "escapes corpus"):
+                benchmark_runner_module._scenario_files(
+                    corpus_root=corpus_root,
+                    scenario_path="scenarios/single/scenario.json",
+                    artifacts=[SimpleNamespace(path="../../../outside.txt")],
+                )
+
+    def test_execution_failure_does_not_count_as_unsupported_input(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            corpus_root = Path(tmpdir)
+            _write_single_scenario_corpus(corpus_root, selector="expected marker")
+
+            with patch(
+                "services.benchmark_runner_service._run_analysis_core",
+                side_effect=RuntimeError("analysis core crashed"),
+            ):
+                result = run_benchmark_corpus(corpus_root)
+
+        self.assertFalse(result.passed)
+        self.assertEqual(result.summary.failed_count, 1)
+        self.assertEqual(result.summary.unsupported_count, 0)
+        scenario = result.scenarios[0]
+        self.assertEqual(scenario.status, "failed")
+        self.assertEqual(scenario.actual_verdict, "error")
+        self.assertFalse(scenario.unsupported)
+        self.assertEqual(scenario.unsupported_reasons, [])
+        self.assertEqual(scenario.errors, ["analysis core crashed"])
+
+    def test_runner_uses_shared_analysis_artifact_builder(self) -> None:
+        with patch(
+            "services.benchmark_runner_service.build_analysis_artifacts",
+            wraps=__import__(
+                "services.analysis_service", fromlist=["build_analysis_artifacts"]
+            ).build_analysis_artifacts,
+        ) as build_analysis_artifacts:
+            result = run_benchmark_corpus()
+
+        self.assertEqual(
+            build_analysis_artifacts.call_count, result.summary.scenario_count
+        )
+        for call in build_analysis_artifacts.call_args_list:
+            self.assertFalse(call.kwargs["include_topology_context"])
+            self.assertFalse(call.kwargs["include_incident_context"])
+            self.assertFalse(call.kwargs["include_narrative"])
+            self.assertFalse(call.kwargs["allow_llm_assistance"])
+
+    def test_benchmark_profile_skips_ambient_topology_narrative_and_llm(self) -> None:
+        def fail_ambient_call(*args, **kwargs):
+            raise AssertionError("benchmark run touched ambient service state")
+
+        with (
+            patch(
+                "services.analysis_service.load_topology", side_effect=fail_ambient_call
+            ),
+            patch(
+                "services.analysis_service.get_topology_status",
+                side_effect=fail_ambient_call,
+            ),
+            patch(
+                "services.analysis_service.generate_narrative",
+                side_effect=fail_ambient_call,
+            ),
+            patch(
+                "analysis.risk_scorer.generate_completion_with_settings",
+                side_effect=fail_ambient_call,
+            ),
+        ):
+            result = run_benchmark_corpus()
+
+        self.assertEqual(result.summary.scenario_count, len(result.scenarios))


### PR DESCRIPTION
Story 6.2 adds a benchmark runner that evaluates the shared analysis core against curated Terraform, CloudFormation, Kubernetes, Jenkins, GitHub Actions, and GitLab CI scenarios. The implementation keeps the runner local-first, exposes CLI execution, and records deterministic evidence for known coverage gaps while preserving the existing advisory analysis posture.

Constraint: Benchmark execution must use synthetic fixtures and avoid persisting secrets or real infrastructure state
Constraint: Story review required fixes for CloudFormation selector scoping and duplicate Jenkins stage matching
Rejected: Treat CLI benchmark failures as test failures | current corpus intentionally exposes unsupported coverage gaps through structured JSON
Confidence: high
Scope-risk: moderate
Directive: Do not broaden benchmark selectors without preserving occurrence-aware and direct-resource matching semantics
Tested: ./.venv/bin/python -m unittest tests.test_services.test_benchmark_runner_service -q
Tested: ./.venv/bin/python -m unittest discover -q
Tested: bash scripts/ci-local.sh
Tested: ./.venv/bin/ruff check .
Tested: ./.venv/bin/ruff format --check .
Tested: ./.venv/bin/bandit -q -r parsers/cloudformation_parser.py services/benchmark_runner_service.py tests/test_services/test_benchmark_runner_service.py
Tested: ./.venv/bin/python cli.py benchmark run
Not-tested: Browser UI validation, not applicable because Story 6.2 does not touch UI routes or components

## What does this PR do?

<!-- Brief description of changes -->

## Type of change
- [ ] Feature (new functionality)
- [ ] Bugfix (non-breaking fix)
- [ ] Release preparation
- [ ] Hotfix (critical production fix)
- [ ] Docs / refactor / chore

## Checklist
- [ ] I have followed the branch naming convention
- [ ] Tests pass locally (`pytest tests/ -v`)
- [ ] Linting passes (`ruff check .`)
- [ ] Docker build succeeds
- [ ] I have updated docs if needed
- [ ] No secrets or .env values committed

## Related issue
Closes #