### PR TITLE
Make benchmark trust claims auditable

### DIFF
--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -103,7 +103,7 @@ development_status:
   epic-6: in-progress
   6-1-benchmark-corpus-v1: review
   6-2-benchmark-runner: review
-  6-3-honest-failure-report-generator: ready-for-dev
+  6-3-honest-failure-report-generator: done
   6-4-outcome-calibration-metrics: ready-for-dev
   6-5-incident-backtesting: ready-for-dev
   6-6-risk-trend-review: ready-for-dev

--- a/docs/benchmarks/corpus.md
+++ b/docs/benchmarks/corpus.md
@@ -45,3 +45,6 @@ The runner validates and loads the corpus, replays each scenario through the sam
 - observed findings with confidence and evidence references
 - finding coverage and selector-level evidence coverage against the scenario expectations
 - Evidence Law status, detail, and violation records
+- `honest_failure_report`, which groups detected scenarios, misses, regressions, false reassurance, false positives, unsupported scenarios, aggregate evidence coverage, the Evidence Law violation count, context limitations, and deterministic local `benchmark://issues/...` links for material misses that are not explicitly out of scope
+
+The honest-failure report does not open external tracker issues. Its linked issues are stable local records in the JSON payload so maintainers can route benchmark misses through the repository's normal issue or pull-request workflow without giving the benchmark runner network or write-side effects.

--- a/services/benchmark_failure_report_service.py
+++ b/services/benchmark_failure_report_service.py
@@ -1,0 +1,386 @@
+"""Honest benchmark failure report generation."""
+
+from __future__ import annotations
+
+import re
+from typing import Any, Literal
+
+from pydantic import BaseModel, Field
+
+
+BenchmarkIssueCategory = Literal[
+    "material_miss", "false_reassurance", "regression", "false_positive"
+]
+
+VERDICT_ORDER = {"go": 0, "warn": 1, "stop": 2}
+
+
+class BenchmarkReportSummary(BaseModel):
+    """Aggregate benchmark report identity and outcome."""
+
+    corpus_id: str
+    version: str
+    scenario_count: int
+    passed_count: int
+    failed_count: int
+    unsupported_count: int
+    evidence_law_violation_count: int
+    generated_at: str
+
+
+class BenchmarkReportScenario(BaseModel):
+    """Scenario entry included in an honest failure report category."""
+
+    id: str
+    name: str
+    path: str
+    status: str
+    expected_verdict: str
+    actual_verdict: str
+    expected_finding_count: int
+    actual_finding_count: int
+    finding_coverage: float
+    missing_expected_finding_ids: list[str] = Field(default_factory=list)
+    expected_evidence_count: int
+    actual_evidence_count: int
+    evidence_coverage: float
+    missing_expected_evidence_ids: list[str] = Field(default_factory=list)
+    issue_refs: list[str] = Field(default_factory=list)
+
+
+class BenchmarkEvidenceCoverageReport(BaseModel):
+    """Aggregate evidence coverage for a benchmark run."""
+
+    expected_evidence_count: int
+    actual_evidence_count: int
+    covered_expected_evidence_count: int
+    missing_expected_evidence_count: int
+    average_evidence_coverage: float
+    scenarios_below_full_coverage: list[str] = Field(default_factory=list)
+    missing_expected_evidence_ids: list[str] = Field(default_factory=list)
+
+
+class BenchmarkContextLimitation(BaseModel):
+    """Limitation that constrains benchmark interpretation."""
+
+    scope: str
+    scenario_id: str | None = None
+    message: str
+
+
+class BenchmarkLinkedIssue(BaseModel):
+    """Deterministic local issue record for a benchmark failure."""
+
+    issue_id: str
+    link: str
+    scenario_id: str
+    category: BenchmarkIssueCategory
+    severity: str
+    title: str
+    missing_expected_finding_ids: list[str] = Field(default_factory=list)
+    missing_expected_evidence_ids: list[str] = Field(default_factory=list)
+
+
+class BenchmarkHonestFailureReport(BaseModel):
+    """Honest benchmark report including misses and report limitations."""
+
+    summary: BenchmarkReportSummary
+    improvements: list[BenchmarkReportScenario] = Field(default_factory=list)
+    regressions: list[BenchmarkReportScenario] = Field(default_factory=list)
+    detected_scenarios: list[BenchmarkReportScenario] = Field(default_factory=list)
+    missed_scenarios: list[BenchmarkReportScenario] = Field(default_factory=list)
+    false_reassurance: list[BenchmarkReportScenario] = Field(default_factory=list)
+    false_positives: list[BenchmarkReportScenario] = Field(default_factory=list)
+    unsupported_scenarios: list[BenchmarkReportScenario] = Field(default_factory=list)
+    evidence_coverage: BenchmarkEvidenceCoverageReport
+    context_limitations: list[BenchmarkContextLimitation] = Field(default_factory=list)
+    linked_issues: list[BenchmarkLinkedIssue] = Field(default_factory=list)
+
+
+def _get(value: Any, name: str, default: Any = None) -> Any:
+    if isinstance(value, dict):
+        return value.get(name, default)
+    return getattr(value, name, default)
+
+
+def _slug(value: str) -> str:
+    slug = re.sub(r"[^a-z0-9]+", "-", value.casefold()).strip("-")
+    return slug or "scenario"
+
+
+def _expected_more_severe_than_actual(scenario: Any) -> bool:
+    expected = _get(scenario, "expected_verdict")
+    actual = _get(scenario, "actual_verdict")
+    if expected not in VERDICT_ORDER:
+        return False
+    if actual not in VERDICT_ORDER:
+        return expected in {"warn", "stop"}
+    return VERDICT_ORDER[expected] > VERDICT_ORDER[actual]
+
+
+def _is_unsupported(scenario: Any) -> bool:
+    return (
+        bool(_get(scenario, "unsupported")) or _get(scenario, "status") == "unsupported"
+    )
+
+
+def _is_out_of_scope_unsupported(scenario: Any) -> bool:
+    return (
+        _is_unsupported(scenario)
+        and _get(scenario, "expected_verdict") == "unsupported"
+    )
+
+
+def _is_false_positive(scenario: Any) -> bool:
+    return (
+        _get(scenario, "expected_verdict") == "go"
+        and not _get(scenario, "passed", False)
+        and (
+            _get(scenario, "actual_verdict") in {"warn", "stop"}
+            or _get(scenario, "actual_finding_count", 0)
+            > _get(scenario, "expected_finding_count", 0)
+        )
+    )
+
+
+def _is_missed(scenario: Any) -> bool:
+    if _is_out_of_scope_unsupported(scenario) or _is_false_positive(scenario):
+        return False
+    return (
+        bool(_get(scenario, "missing_expected_finding_ids", []))
+        or bool(_get(scenario, "missing_expected_evidence_ids", []))
+        or _expected_more_severe_than_actual(scenario)
+        or _get(scenario, "actual_verdict") == "error"
+    )
+
+
+def _is_false_reassurance(scenario: Any) -> bool:
+    if _is_out_of_scope_unsupported(scenario) or _is_false_positive(scenario):
+        return False
+    return _get(scenario, "expected_verdict") in {
+        "warn",
+        "stop",
+    } and _expected_more_severe_than_actual(scenario)
+
+
+def _scenario_entry(
+    scenario: Any, *, issue_refs: list[str] | None = None
+) -> BenchmarkReportScenario:
+    return BenchmarkReportScenario(
+        id=_get(scenario, "id"),
+        name=_get(scenario, "name"),
+        path=_get(scenario, "path"),
+        status=_get(scenario, "status"),
+        expected_verdict=_get(scenario, "expected_verdict"),
+        actual_verdict=_get(scenario, "actual_verdict"),
+        expected_finding_count=_get(scenario, "expected_finding_count", 0),
+        actual_finding_count=_get(scenario, "actual_finding_count", 0),
+        finding_coverage=_get(scenario, "finding_coverage", 0.0),
+        missing_expected_finding_ids=list(
+            _get(scenario, "missing_expected_finding_ids", [])
+        ),
+        expected_evidence_count=_get(scenario, "expected_evidence_count", 0),
+        actual_evidence_count=_get(scenario, "actual_evidence_count", 0),
+        evidence_coverage=_get(scenario, "evidence_coverage", 0.0),
+        missing_expected_evidence_ids=list(
+            _get(scenario, "missing_expected_evidence_ids", [])
+        ),
+        issue_refs=issue_refs or [],
+    )
+
+
+def _issue_category(scenario: Any) -> BenchmarkIssueCategory:
+    if _get(scenario, "missing_expected_finding_ids", []) or _get(
+        scenario, "missing_expected_evidence_ids", []
+    ):
+        return "material_miss"
+    if _is_false_reassurance(scenario):
+        return "false_reassurance"
+    if _is_false_positive(scenario):
+        return "false_positive"
+    if _get(scenario, "status") == "failed":
+        return "material_miss"
+    return "regression"
+
+
+def _linked_issue(scenario: Any) -> BenchmarkLinkedIssue:
+    issue_id = f"benchmark-issue-{_slug(_get(scenario, 'id'))}"
+    return BenchmarkLinkedIssue(
+        issue_id=issue_id,
+        link=f"benchmark://issues/{issue_id}",
+        scenario_id=_get(scenario, "id"),
+        category=_issue_category(scenario),
+        severity=_get(scenario, "actual_severity", "unknown"),
+        title=f"Benchmark miss: {_get(scenario, 'name')}",
+        missing_expected_finding_ids=list(
+            _get(scenario, "missing_expected_finding_ids", [])
+        ),
+        missing_expected_evidence_ids=list(
+            _get(scenario, "missing_expected_evidence_ids", [])
+        ),
+    )
+
+
+def _evidence_coverage(scenarios: list[Any]) -> BenchmarkEvidenceCoverageReport:
+    expected_count = sum(
+        _get(scenario, "expected_evidence_count", 0) for scenario in scenarios
+    )
+    actual_count = sum(
+        _get(scenario, "actual_evidence_count", 0) for scenario in scenarios
+    )
+    missing_ids = [
+        evidence_id
+        for scenario in scenarios
+        for evidence_id in _get(scenario, "missing_expected_evidence_ids", [])
+    ]
+    coverage_values = [
+        _get(scenario, "evidence_coverage", 0.0) for scenario in scenarios
+    ]
+    average = (
+        round(sum(coverage_values) / len(coverage_values), 2)
+        if coverage_values
+        else 1.0
+    )
+    return BenchmarkEvidenceCoverageReport(
+        expected_evidence_count=expected_count,
+        actual_evidence_count=actual_count,
+        covered_expected_evidence_count=max(expected_count - len(missing_ids), 0),
+        missing_expected_evidence_count=len(missing_ids),
+        average_evidence_coverage=average,
+        scenarios_below_full_coverage=[
+            _get(scenario, "id")
+            for scenario in scenarios
+            if _get(scenario, "evidence_coverage", 0.0) < 1.0
+        ],
+        missing_expected_evidence_ids=missing_ids,
+    )
+
+
+def _evidence_law_violation_count(scenarios: list[Any]) -> int:
+    return sum(
+        len(_get(scenario, "evidence_law_violations", [])) for scenario in scenarios
+    )
+
+
+def _context_limitations(scenarios: list[Any]) -> list[BenchmarkContextLimitation]:
+    limitations = [
+        BenchmarkContextLimitation(
+            scope="benchmark_baseline",
+            message=(
+                "Historical baseline not configured; improvements and regressions "
+                "are derived from the current benchmark run outcome."
+            ),
+        )
+    ]
+    for scenario in scenarios:
+        scenario_id = _get(scenario, "id")
+        for warning in _get(scenario, "coverage_warnings", []):
+            limitations.append(
+                BenchmarkContextLimitation(
+                    scope="coverage_warning",
+                    scenario_id=scenario_id,
+                    message=warning,
+                )
+            )
+        for reason in _get(scenario, "unsupported_reasons", []):
+            limitations.append(
+                BenchmarkContextLimitation(
+                    scope="unsupported",
+                    scenario_id=scenario_id,
+                    message=reason,
+                )
+            )
+        for error in _get(scenario, "errors", []):
+            limitations.append(
+                BenchmarkContextLimitation(
+                    scope="scenario_error",
+                    scenario_id=scenario_id,
+                    message=error,
+                )
+            )
+        for violation in _get(scenario, "evidence_law_violations", []):
+            limitations.append(
+                BenchmarkContextLimitation(
+                    scope="evidence_law",
+                    scenario_id=scenario_id,
+                    message=violation,
+                )
+            )
+    return limitations
+
+
+def generate_honest_failure_report(run_result: Any) -> BenchmarkHonestFailureReport:
+    """Generate an honest failure report from a benchmark run result."""
+
+    summary = _get(run_result, "summary")
+    scenarios = list(_get(run_result, "scenarios", []))
+    linked_issues = [
+        _linked_issue(scenario)
+        for scenario in scenarios
+        if _is_missed(scenario) and not _is_out_of_scope_unsupported(scenario)
+    ]
+    issue_refs_by_scenario = {
+        issue.scenario_id: [issue.link] for issue in linked_issues
+    }
+    return BenchmarkHonestFailureReport(
+        summary=BenchmarkReportSummary(
+            corpus_id=_get(summary, "corpus_id"),
+            version=_get(summary, "version"),
+            scenario_count=_get(summary, "scenario_count", 0),
+            passed_count=_get(summary, "passed_count", 0),
+            failed_count=_get(summary, "failed_count", 0),
+            unsupported_count=_get(summary, "unsupported_count", 0),
+            evidence_law_violation_count=_evidence_law_violation_count(scenarios),
+            generated_at=_get(summary, "generated_at"),
+        ),
+        improvements=[
+            _scenario_entry(scenario)
+            for scenario in scenarios
+            if _get(scenario, "passed", False) and not _is_unsupported(scenario)
+        ],
+        regressions=[
+            _scenario_entry(
+                scenario,
+                issue_refs=issue_refs_by_scenario.get(_get(scenario, "id"), []),
+            )
+            for scenario in scenarios
+            if _is_missed(scenario)
+        ],
+        detected_scenarios=[
+            _scenario_entry(scenario)
+            for scenario in scenarios
+            if not _is_unsupported(scenario)
+            and not _is_false_positive(scenario)
+            and _get(scenario, "finding_coverage", 0.0) == 1.0
+            and _get(scenario, "evidence_coverage", 0.0) == 1.0
+        ],
+        missed_scenarios=[
+            _scenario_entry(
+                scenario,
+                issue_refs=issue_refs_by_scenario.get(_get(scenario, "id"), []),
+            )
+            for scenario in scenarios
+            if _is_missed(scenario)
+        ],
+        false_reassurance=[
+            _scenario_entry(
+                scenario,
+                issue_refs=issue_refs_by_scenario.get(_get(scenario, "id"), []),
+            )
+            for scenario in scenarios
+            if _is_false_reassurance(scenario)
+        ],
+        false_positives=[
+            _scenario_entry(scenario)
+            for scenario in scenarios
+            if _is_false_positive(scenario)
+        ],
+        unsupported_scenarios=[
+            _scenario_entry(scenario)
+            for scenario in scenarios
+            if _is_unsupported(scenario)
+        ],
+        evidence_coverage=_evidence_coverage(scenarios),
+        context_limitations=_context_limitations(scenarios),
+        linked_issues=linked_issues,
+    )

--- a/services/benchmark_runner_service.py
+++ b/services/benchmark_runner_service.py
@@ -26,6 +26,10 @@ from services.benchmark_corpus_service import (
     ExpectedVerdict,
     load_benchmark_corpus,
 )
+from services.benchmark_failure_report_service import (
+    BenchmarkHonestFailureReport,
+    generate_honest_failure_report,
+)
 from services.confidence_ledger import EvidenceLawStatus, evidence_law_status
 from services.submission_manifest import SubmissionManifest
 
@@ -100,6 +104,7 @@ class BenchmarkRunResult(BaseModel):
     passed: bool
     summary: BenchmarkRunSummary
     scenarios: list[BenchmarkScenarioRunResult]
+    honest_failure_report: BenchmarkHonestFailureReport | None = None
 
 
 def _timestamp() -> str:
@@ -879,8 +884,10 @@ def run_benchmark_corpus(corpus_root: Path | str | None = None) -> BenchmarkRunR
         total_latency_ms=total_latency_ms,
         generated_at=_timestamp(),
     )
-    return BenchmarkRunResult(
+    result = BenchmarkRunResult(
         passed=all(scenario.passed for scenario in scenarios),
         summary=summary,
         scenarios=scenarios,
     )
+    result.honest_failure_report = generate_honest_failure_report(result)
+    return result

--- a/tests/test_cli/test_analyze.py
+++ b/tests/test_cli/test_analyze.py
@@ -258,6 +258,13 @@ class AnalyzeCliTests(unittest.TestCase):
         self.assertIn("evidence_law_violations", payload["scenarios"][0])
         self.assertIn("latency_ms", payload["scenarios"][0])
         self.assertIn("unsupported", payload["scenarios"][0])
+        self.assertIn("honest_failure_report", payload)
+        self.assertIn(
+            "evidence_law_violation_count",
+            payload["honest_failure_report"]["summary"],
+        )
+        self.assertIn("missed_scenarios", payload["honest_failure_report"])
+        self.assertIn("linked_issues", payload["honest_failure_report"])
 
     def test_benchmark_run_command_exits_nonzero_for_failed_result(self) -> None:
         output = io.StringIO()

--- a/tests/test_services/test_benchmark_failure_report_service.py
+++ b/tests/test_services/test_benchmark_failure_report_service.py
@@ -1,0 +1,287 @@
+"""Tests for honest benchmark failure report generation."""
+
+from __future__ import annotations
+
+import unittest
+
+from services.benchmark_failure_report_service import generate_honest_failure_report
+from services.benchmark_runner_service import (
+    BenchmarkRunResult,
+    BenchmarkRunSummary,
+    BenchmarkScenarioRunResult,
+)
+
+
+def _summary(*, scenario_count: int = 3) -> BenchmarkRunSummary:
+    return BenchmarkRunSummary(
+        corpus_id="honest-report-corpus",
+        version="1.0.0",
+        scenario_count=scenario_count,
+        passed_count=1,
+        failed_count=1,
+        unsupported_count=1,
+        total_latency_ms=42.0,
+        generated_at="2026-06-03T00:00:00Z",
+    )
+
+
+def _scenario(
+    *,
+    scenario_id: str,
+    name: str,
+    passed: bool,
+    status: str,
+    expected_verdict: str,
+    actual_verdict: str,
+    expected_finding_count: int = 1,
+    actual_finding_count: int = 1,
+    finding_coverage: float = 1.0,
+    missing_expected_finding_ids: list[str] | None = None,
+    expected_evidence_count: int = 1,
+    actual_evidence_count: int = 1,
+    evidence_coverage: float = 1.0,
+    missing_expected_evidence_ids: list[str] | None = None,
+    unsupported: bool = False,
+    unsupported_reasons: list[str] | None = None,
+    coverage_warnings: list[str] | None = None,
+    errors: list[str] | None = None,
+    evidence_law_violations: list[str] | None = None,
+) -> BenchmarkScenarioRunResult:
+    return BenchmarkScenarioRunResult(
+        id=scenario_id,
+        name=name,
+        path=f"scenarios/{scenario_id}/scenario.json",
+        passed=passed,
+        status=status,  # type: ignore[arg-type]
+        expected_verdict=expected_verdict,  # type: ignore[arg-type]
+        actual_verdict=actual_verdict,  # type: ignore[arg-type]
+        actual_recommendation="go" if actual_verdict == "go" else "no-go",
+        actual_severity="low" if actual_verdict == "go" else "high",
+        actual_score=10 if actual_verdict == "go" else 80,
+        expected_finding_count=expected_finding_count,
+        actual_finding_count=actual_finding_count,
+        finding_coverage=finding_coverage,
+        missing_expected_finding_ids=missing_expected_finding_ids or [],
+        expected_evidence_count=expected_evidence_count,
+        actual_evidence_count=actual_evidence_count,
+        evidence_coverage=evidence_coverage,
+        missing_expected_evidence_ids=missing_expected_evidence_ids or [],
+        evidence_law_status="Satisfied",
+        evidence_law_detail="Evidence Law satisfied.",
+        evidence_law_violations=evidence_law_violations or [],
+        latency_ms=1.0,
+        unsupported=unsupported,
+        unsupported_reasons=unsupported_reasons or [],
+        coverage_warnings=coverage_warnings or [],
+        findings=[],
+        errors=errors or [],
+    )
+
+
+class BenchmarkFailureReportServiceTests(unittest.TestCase):
+    def test_report_includes_required_honest_failure_categories(self) -> None:
+        detected = _scenario(
+            scenario_id="detected-risk",
+            name="Detected risk",
+            passed=True,
+            status="passed",
+            expected_verdict="warn",
+            actual_verdict="warn",
+        )
+        missed = _scenario(
+            scenario_id="missed-risk",
+            name="Missed risk",
+            passed=False,
+            status="failed",
+            expected_verdict="stop",
+            actual_verdict="go",
+            actual_finding_count=0,
+            finding_coverage=0.0,
+            missing_expected_finding_ids=["finding-critical"],
+            actual_evidence_count=0,
+            evidence_coverage=0.0,
+            missing_expected_evidence_ids=["evidence-critical"],
+            coverage_warnings=["artifact.tf: accepted - partial parser coverage"],
+        )
+        unsupported = _scenario(
+            scenario_id="unsupported-notes",
+            name="Unsupported notes",
+            passed=True,
+            status="unsupported",
+            expected_verdict="unsupported",
+            actual_verdict="unsupported",
+            expected_finding_count=1,
+            unsupported=True,
+            unsupported_reasons=[
+                "No benchmark artifacts were parsed by supported parsers."
+            ],
+        )
+        result = BenchmarkRunResult(
+            passed=False,
+            summary=_summary(),
+            scenarios=[detected, missed, unsupported],
+        )
+
+        report = generate_honest_failure_report(result)
+
+        self.assertEqual(report.summary.corpus_id, "honest-report-corpus")
+        self.assertEqual([item.id for item in report.improvements], ["detected-risk"])
+        self.assertEqual(
+            [item.id for item in report.detected_scenarios], ["detected-risk"]
+        )
+        self.assertEqual([item.id for item in report.regressions], ["missed-risk"])
+        self.assertEqual([item.id for item in report.missed_scenarios], ["missed-risk"])
+        self.assertEqual(
+            [item.id for item in report.false_reassurance], ["missed-risk"]
+        )
+        self.assertEqual(report.false_positives, [])
+        self.assertEqual(
+            [item.id for item in report.unsupported_scenarios],
+            ["unsupported-notes"],
+        )
+        self.assertEqual(report.evidence_coverage.expected_evidence_count, 3)
+        self.assertEqual(report.evidence_coverage.missing_expected_evidence_count, 1)
+        self.assertEqual(
+            report.evidence_coverage.scenarios_below_full_coverage, ["missed-risk"]
+        )
+        self.assertTrue(report.context_limitations)
+        self.assertIn(
+            "Historical baseline not configured",
+            report.context_limitations[0].message,
+        )
+
+    def test_material_misses_create_linked_issues_unless_out_of_scope(self) -> None:
+        missed = _scenario(
+            scenario_id="missed-risk",
+            name="Missed risk",
+            passed=False,
+            status="failed",
+            expected_verdict="warn",
+            actual_verdict="go",
+            actual_finding_count=0,
+            finding_coverage=0.0,
+            missing_expected_finding_ids=["finding-risk"],
+        )
+        unsupported = _scenario(
+            scenario_id="unsupported-notes",
+            name="Unsupported notes",
+            passed=True,
+            status="unsupported",
+            expected_verdict="unsupported",
+            actual_verdict="unsupported",
+            unsupported=True,
+            unsupported_reasons=["Plain text is outside parser scope."],
+        )
+        result = BenchmarkRunResult(
+            passed=False,
+            summary=_summary(scenario_count=2),
+            scenarios=[missed, unsupported],
+        )
+
+        report = generate_honest_failure_report(result)
+
+        self.assertEqual(len(report.linked_issues), 1)
+        issue = report.linked_issues[0]
+        self.assertEqual(issue.scenario_id, "missed-risk")
+        self.assertEqual(issue.category, "material_miss")
+        self.assertEqual(issue.link, "benchmark://issues/benchmark-issue-missed-risk")
+        self.assertIn("finding-risk", issue.missing_expected_finding_ids)
+        self.assertNotIn(
+            "unsupported-notes",
+            {linked_issue.scenario_id for linked_issue in report.linked_issues},
+        )
+
+    def test_unexpected_unsupported_failure_is_material_miss(self) -> None:
+        scenario = _scenario(
+            scenario_id="expected-supported-risk",
+            name="Expected supported risk",
+            passed=False,
+            status="failed",
+            expected_verdict="warn",
+            actual_verdict="unsupported",
+            actual_finding_count=0,
+            finding_coverage=0.0,
+            missing_expected_finding_ids=["finding-supported-risk"],
+            actual_evidence_count=0,
+            evidence_coverage=0.0,
+            missing_expected_evidence_ids=["evidence-supported-risk"],
+            unsupported=True,
+            unsupported_reasons=[
+                "No benchmark artifacts were parsed by supported parsers."
+            ],
+        )
+        result = BenchmarkRunResult(
+            passed=False,
+            summary=_summary(scenario_count=1),
+            scenarios=[scenario],
+        )
+
+        report = generate_honest_failure_report(result)
+
+        self.assertEqual(
+            [item.id for item in report.missed_scenarios],
+            ["expected-supported-risk"],
+        )
+        self.assertEqual(
+            [issue.scenario_id for issue in report.linked_issues],
+            ["expected-supported-risk"],
+        )
+        self.assertEqual(report.linked_issues[0].category, "material_miss")
+        self.assertEqual(
+            [item.id for item in report.unsupported_scenarios],
+            ["expected-supported-risk"],
+        )
+
+    def test_expected_go_overreporting_is_false_positive_not_material_miss(
+        self,
+    ) -> None:
+        false_positive = _scenario(
+            scenario_id="clean-change",
+            name="Clean change",
+            passed=False,
+            status="failed",
+            expected_verdict="go",
+            actual_verdict="warn",
+            expected_finding_count=0,
+            actual_finding_count=1,
+            expected_evidence_count=0,
+            actual_evidence_count=1,
+        )
+        result = BenchmarkRunResult(
+            passed=False,
+            summary=_summary(scenario_count=1),
+            scenarios=[false_positive],
+        )
+
+        report = generate_honest_failure_report(result)
+
+        self.assertEqual([item.id for item in report.false_positives], ["clean-change"])
+        self.assertEqual(report.missed_scenarios, [])
+        self.assertEqual(report.linked_issues, [])
+
+    def test_summary_includes_evidence_law_violation_count(self) -> None:
+        scenario = _scenario(
+            scenario_id="unsupported-severe-claim",
+            name="Unsupported severe claim",
+            passed=False,
+            status="failed",
+            expected_verdict="warn",
+            actual_verdict="error",
+            evidence_law_violations=[
+                "Unsupported high severity claim.",
+                "Missing deterministic evidence.",
+            ],
+        )
+        result = BenchmarkRunResult(
+            passed=False,
+            summary=_summary(scenario_count=1),
+            scenarios=[scenario],
+        )
+
+        report = generate_honest_failure_report(result)
+
+        self.assertEqual(report.summary.evidence_law_violation_count, 2)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add honest failure report generation to benchmark runs
- include misses, regressions, false reassurance, false positives, unsupported scenarios, evidence coverage, context limitations, linked local issue records, and Evidence Law violation count
- update CLI JSON contract tests and benchmark docs

## Validation
- ./.venv/bin/python -m unittest tests.test_services.test_benchmark_failure_report_service -q
- ./.venv/bin/python -m unittest tests.test_services.test_benchmark_failure_report_service tests.test_services.test_benchmark_runner_service tests.test_cli.test_analyze -q
- ./.venv/bin/ruff check .
- ./.venv/bin/ruff format --check .
- ./.venv/bin/bandit -q -r services/benchmark_failure_report_service.py services/benchmark_runner_service.py tests/test_services/test_benchmark_failure_report_service.py tests/test_cli/test_analyze.py
- ./.venv/bin/python cli.py benchmark run (emitted honest_failure_report; exited 1 for known current corpus misses)
- ./.venv/bin/python -m unittest discover -q
- bash scripts/ci-local.sh

## BMad
- Story 6.3 clean after re-run bmad-code-review
- sprint-status synced to done