### PR TITLE
Make calibration evidence trustworthy enough to close Story 6.4

### DIFF
--- a/_bmad-output/implementation-artifacts/6-4-outcome-calibration-metrics.md
+++ b/_bmad-output/implementation-artifacts/6-4-outcome-calibration-metrics.md
@@ -1,0 +1,200 @@
+# Story 6.4: Outcome Calibration Metrics
+
+Status: review
+
+<!-- Generated from updated PRD/architecture/epics plus implementation-readiness-report-2026-05-01.md. -->
+
+## Story
+
+As a maintainer,
+I want deployment outcomes and feedback to inform calibration metrics,
+So that false positives and false reassurance can be tracked.
+
+## Acceptance Criteria
+
+1. Given feedback and deployment outcomes exist, When calibration views or exports are generated, Then precision, recall proxy signals, false-positive rate, false-reassurance cases, and confidence trends are computed per project/workspace where possible. And historical report verdicts remain immutable.
+2. Given feedback or outcome data is sparse or biased, When calibration metrics are shown, Then the dashboard labels confidence limitations and avoids implying statistical certainty.
+
+### Requirement Traceability
+
+- Primary PRD requirements: Epic 6 coverage: BEN-01..11, INC-09..11, HIS-04, HIS-06..07, NFR-PERF-01..05, DOC-14, DOC-27.
+- Supporting PRD / NFR / differentiation requirements: See `_bmad-output/planning-artifacts/prd.md`, `_bmad-output/planning-artifacts/architecture.md`, and `_bmad-output/planning-artifacts/implementation-readiness-report-2026-05-01.md`.
+- Coverage intent: Baseline + Delta.
+- Story alignment note: This story was created from the updated Epic 6 plan after the 2026-05-01 readiness rerun. The readiness report verified 187/187 PRD functional requirement IDs in the epics artifact, 38 NFR IDs present, and no critical or major readiness defects.
+
+## Tasks / Subtasks
+
+- [x] Implement and verify acceptance criterion 1. (AC: 1)
+- [x] Implement and verify acceptance criterion 2. (AC: 2)
+- [x] Reuse existing services, repositories, schemas, and UI/CLI/API helpers before adding new abstractions. (AC: all)
+- [x] Add or update deterministic regression coverage for the changed behavior. (AC: all)
+- [x] Update relevant docs or examples if the story changes user-visible, operator, API, CLI, integration, or contribution behavior. (AC: all)
+- [x] Run required validation and record commands/results in the Dev Agent Record. (AC: all)
+
+### Review Findings
+
+- [x] [Review][Patch] Include feedback-only calibration inputs instead of filtering feedback to analysis IDs with deployment outcomes. [services/backtesting_service.py:93]
+- [x] [Review][Patch] Use consistent denominator units for false-positive rate so finding-level feedback cannot exceed deployment/report-level warned totals. [services/backtesting_service.py:378]
+- [x] [Review][Patch] Preserve distinct false-reassurance cases and avoid counting reviewer missed-finding feedback against unrelated successful outcomes. [services/backtesting_service.py:390]
+- [x] [Review][Patch] Prevent workspace-scoped backtests from updating the project-global weekly last-run marker. [services/backtesting_service.py:587]
+- [x] [Review][Patch] Make confidence trend sampling internally consistent when one analysis has multiple deployment outcomes, and avoid reporting missing confidence as an average of 0.0. [services/backtesting_service.py:434]
+- [x] [Review][Patch] Base sparse/biased feedback limitations on effective latest feedback signals or expose raw feedback history separately. [services/backtesting_service.py:481]
+- [x] [Review][Patch] Add regression coverage for biased-feedback and feedback-only calibration paths required by AC2. [tests/test_services/test_backtesting_service.py:297]
+- [x] [Review][Patch] Keep the history page workspace filter consistent by scoping risk trends with the selected workspace alongside history rows and calibration. [ui/routes/history.py:370]
+- [x] [Review][Patch] Avoid scanning every persisted setting when invalidating one project's calibration snapshots. [services/backtesting_service.py:546]
+- [x] [Review][Patch] Do not count missed-finding feedback on warned reports as false reassurance. [services/backtesting_service.py:465]
+- [x] [Review][Patch] Refresh or expire stale workspace-scoped calibration snapshots before returning cached dashboard seeds. [services/backtesting_service.py:716]
+- [x] [Review][Patch] Re-render history risk-trend and calibration summary cards after workspace/filter changes. [ui/routes/history.py:589]
+- [x] [Review][Patch] Surface active feedback-bias limitations instead of displaying only the first calibration limitation. [ui/routes/history.py:257]
+- [x] [Review][Patch] Treat corrupt cached calibration snapshots as stale and recompute instead of crashing history. [services/backtesting_service.py:759]
+- [x] [Review][Patch] Reject future-dated cached calibration snapshots before applying freshness checks. [services/backtesting_service.py:292]
+- [x] [Review][Patch] Invalidate calibration snapshots when analysis reports are deleted. [services/report_service.py:4711]
+- [x] [Review][Patch] Separate reviewer-only false-reassurance signals from deployment-backed rates and feedback-bias labels. [services/backtesting_service.py:497]
+- [x] [Review][Patch] Keep calibration feedback metrics scoped to the active 7-day backtest window or explicitly split windowed and lifetime feedback signals. [services/backtesting_service.py:93]
+- [x] [Review][Patch] Validate cached calibration snapshot schema and resolved project/workspace scope before reusing fresh-looking snapshots. [services/backtesting_service.py:292]
+- [x] [Review][Patch] Run and record local app startup/manual sanity validation for the changed history calibration UI flow. [ui/routes/history.py:160]
+- [x] [Review][Patch] Tighten cached calibration snapshot validation to reject wrong-window, partial-shape, and malformed nested metric payloads. [services/backtesting_service.py:342]
+- [x] [Review][Patch] Keep feedback-only cases out of deployment-sample confidence trend buckets or expose separate feedback-only bucket counts. [services/backtesting_service.py:631]
+- [x] [Review][Patch] Sort false-reassurance cases by a common event timestamp across deployment-backed and reviewer-missed cases. [services/backtesting_service.py:559]
+- [x] [Review][Patch] Make the empty history calibration seed mirror the full calibration payload shape. [ui/routes/history.py:88]
+
+## Dev Notes
+
+### Epic Context
+
+- Epic: 6. Benchmarks, Calibration, and Honest Failure Reporting
+- Epic goal: Prove trust claims with measurable, repeatable evidence.
+- Epic coverage: BEN-01..11, INC-09..11, HIS-04, HIS-06..07, NFR-PERF-01..05, DOC-14, DOC-27
+
+### Architecture and Product Guardrails
+
+- Preserve DeployWhisper's local-first raw artifact boundary: raw IaC, scanner artifacts, incident exports, and sensitive context stay in the user's infrastructure by default.
+- Preserve the advisory-first core. Optional adapters may interpret report outputs, but canonical report semantics remain advisory unless explicit story scope says otherwise.
+- Reuse the shared analysis core and service layer before adapting UI, API, CLI, GitHub, or future workflow surfaces.
+- Keep Evidence Law behavior intact: no high or critical finding without deterministic evidence.
+- Keep project/workspace scope explicit for reports, incidents, topology, outcomes, feedback, scanner imports, and connector-related data.
+- Do not introduce new dependencies unless the active story explicitly requires and justifies them.
+
+### Source Tree Guidance
+
+- API routes belong under `api/routes/` and should use existing `ApiRoute` / `ApiError` envelope patterns.
+- Shared orchestration belongs in `services/`; parsers normalize input, analysis modules score/derive risk, and surfaces adapt outputs.
+- UI work belongs under `ui/routes/` and `ui/components/`, following the existing NiceGUI composition style.
+- CLI behavior belongs under `cli/` and must call the same service-layer paths as UI/API flows.
+- Persistence work belongs under `models/` with Alembic migrations when schema changes are required.
+- Documentation required by a story should be updated in the same workstream.
+
+### Testing Requirements
+
+- Use standard-library `unittest` in the existing `tests/test_*` layout.
+- Add focused regression tests for the layer changed by the story before broad refactors.
+- For Python changes, run `./.venv/bin/ruff check .`, `./.venv/bin/ruff format --check .`, and `./.venv/bin/python -m unittest discover -q` before closing implementation.
+- Use `bash scripts/ci-local.sh` for broader or cross-layer changes.
+
+### Project Structure Notes
+
+- Follow the current repository shape documented in `_bmad-output/project-context.md` and `AGENTS.md`.
+- If implementation reveals a conflict between this story and the current code baseline, keep the smallest compatible change and update the story notes rather than silently drifting from the PRD.
+
+### References
+
+- `_bmad-output/planning-artifacts/epics.md` - source Epic 6 / Story 6.4 definition.
+- `_bmad-output/planning-artifacts/prd.md` - functional and non-functional requirements.
+- `_bmad-output/planning-artifacts/architecture.md` - target architecture, boundaries, and guardrails.
+- `_bmad-output/planning-artifacts/ux-design-specification.md` - UX expectations for user-facing stories.
+- `_bmad-output/planning-artifacts/implementation-readiness-report-2026-05-01.md` - readiness verdict and residual story-format concern.
+- `_bmad-output/project-context.md` - repository-specific implementation rules.
+
+## Dev Agent Record
+
+### Agent Model Used
+
+Codex GPT-5
+
+### Debug Log References
+
+- 2026-06-03: Loaded BMad config, sprint status, project context, and Story 6.4.
+- 2026-06-03: Started implementation on `feature/6-4-outcome-calibration-metrics`.
+- 2026-06-03: Added RED service/UI tests for feedback-derived calibration metrics, workspace scoping, sparse-data labeling, and historical verdict immutability.
+- 2026-06-03: Extended `services.backtesting_service` to compute false-positive rate, false-reassurance cases/rate, recall proxy signals, confidence trend buckets, confidence limitation labels, and workspace-scoped calibration snapshots.
+- 2026-06-03: Updated feedback writes to invalidate calibration snapshots without mutating historical reports.
+- 2026-06-03: Updated the history calibration card to show the shared "Directional only" / limitation label.
+- 2026-06-03: Updated outcome-linking documentation for the new calibration fields and directional-evidence semantics.
+- 2026-06-03: Validation passed: `./.venv/bin/python -m unittest tests.test_services.test_backtesting_service.BacktestingServiceTests.test_run_weekly_backtest_includes_feedback_outcome_calibration_metrics -q`.
+- 2026-06-03: Validation passed: `./.venv/bin/python -m unittest tests.test_ui.test_history_page.HistoryPageRenderingTests.test_history_page_renders_calibration_snapshot_from_backtest_feed -q`.
+- 2026-06-03: Validation passed: `./.venv/bin/python -m unittest tests.test_services.test_backtesting_service -q`.
+- 2026-06-03: Validation passed: `./.venv/bin/python -m unittest tests.test_services.test_feedback_service -q`.
+- 2026-06-03: Validation passed: `./.venv/bin/python -m unittest tests.test_ui.test_history_page -q`.
+- 2026-06-03: Validation passed: `./.venv/bin/ruff check .`.
+- 2026-06-03: Validation passed: `./.venv/bin/ruff format --check .`.
+- 2026-06-03: Validation passed: `./.venv/bin/bandit -q services/backtesting_service.py services/feedback_service.py ui/routes/history.py`.
+- 2026-06-03: Validation passed: `./.venv/bin/python -m unittest discover -q` (447 tests, 1 skipped).
+- 2026-06-03: Validation passed: `bash scripts/ci-local.sh`.
+- 2026-06-03: UI validation note: `npm run test:ui-review` failed because `127.0.0.1:8080` was already in use; reran with `APP_PORT=18080 npm run test:ui-review` and Playwright passed (4 tests).
+- 2026-06-03: Addressed code-review findings for feedback-only calibration inputs, rate denominators, false-reassurance case identity, workspace last-run behavior, confidence bucket sampling, effective feedback limitation labels, workspace-scoped history trends, and targeted snapshot invalidation.
+- 2026-06-03: Added regression coverage for feedback-only signals, biased/sparse feedback labels, bounded false-positive rates, distinct missed-finding cases, workspace-scoped scheduler state, duplicate-outcome confidence buckets, unknown-confidence buckets, and workspace-scoped history trend fetching.
+- 2026-06-03: Validation passed after review fixes: `./.venv/bin/python -m unittest tests.test_services.test_backtesting_service -q`.
+- 2026-06-03: Validation passed after review fixes: `./.venv/bin/python -m unittest tests.test_ui.test_history_page -q`.
+- 2026-06-03: Validation passed after review fixes: `./.venv/bin/ruff check .`.
+- 2026-06-03: Validation passed after review fixes: `./.venv/bin/ruff format --check .`.
+- 2026-06-03: Validation passed after review fixes: `./.venv/bin/bandit -q services/backtesting_service.py services/feedback_service.py ui/routes/history.py models/repositories/settings.py`.
+- 2026-06-03: Validation passed after review fixes: `./.venv/bin/python -m unittest discover -q` (449 tests, 1 skipped).
+- 2026-06-03: Validation passed after review fixes: `bash scripts/ci-local.sh`.
+- 2026-06-03: UI validation passed after review fixes: `APP_PORT=18080 npm run test:ui-review` (4 Playwright tests).
+- 2026-06-03: Final validation refresh passed: `./.venv/bin/python -m unittest tests.test_services.test_backtesting_service -q` (16 tests), `./.venv/bin/python -m unittest tests.test_ui.test_history_page -q` (54 tests), `./.venv/bin/python -m unittest discover -q` (449 tests, 1 skipped), `bash scripts/ci-local.sh`, and `APP_PORT=18080 npm run test:ui-review` (4 Playwright tests).
+- 2026-06-03: Re-ran BMad code review on Story 6.4. Four patch findings remain open; story moved back to in-progress for follow-up fixes.
+- 2026-06-03: Fixed second rerun code-review findings: warned reports no longer count as false reassurance, stale workspace calibration snapshots refresh on read, history summary cards rerender after filters, and all active calibration limitation labels are shown.
+- 2026-06-03: Validation passed after second rerun fixes: `./.venv/bin/python -m unittest tests.test_services.test_backtesting_service -q` (18 tests), `./.venv/bin/python -m unittest tests.test_ui.test_history_page -q` (56 tests), `./.venv/bin/ruff check .`, `./.venv/bin/ruff format --check .`, `./.venv/bin/bandit -q services/backtesting_service.py services/feedback_service.py ui/routes/history.py models/repositories/settings.py`, `./.venv/bin/python -m unittest discover -q` (451 tests, 1 skipped), `bash scripts/ci-local.sh`, and `APP_PORT=18080 npm run test:ui-review` (4 Playwright tests).
+- 2026-06-03: Re-ran BMad code review on Story 6.4. Four patch findings remain open; story moved back to in-progress for follow-up fixes. Dismissed as noise: initial workspace summary mismatch because no workspace is selected on first render, latest-feedback ordering because feedback repository returns newest-first, and report-level missed-note collapse because Story 6.4 intentionally uses latest effective feedback.
+- 2026-06-03: Fixed third rerun code-review findings: malformed/future-dated cached calibration snapshots now recompute, report deletion invalidates calibration snapshots, and reviewer-only missed feedback is separated from deployment-backed false-reassurance rates and feedback-bias labels.
+- 2026-06-03: Validation passed after third rerun fixes: `./.venv/bin/python -m unittest tests.test_services.test_backtesting_service -q` (22 tests), `./.venv/bin/python -m unittest tests.test_ui.test_history_page -q` (56 tests), `./.venv/bin/ruff check .`, `./.venv/bin/ruff format --check .`, `./.venv/bin/bandit -q services/backtesting_service.py services/feedback_service.py services/report_service.py ui/routes/history.py models/repositories/settings.py`, `./.venv/bin/python -m unittest discover -q` (451 tests, 1 skipped), `bash scripts/ci-local.sh`, and `APP_PORT=18080 npm run test:ui-review` (4 Playwright tests).
+- 2026-06-03: Re-ran BMad code review on Story 6.4. Three patch findings remain open; story moved back to in-progress for follow-up fixes. Dismissed as noise: initial workspace summary mismatch because no workspace is selected on first render, latest-feedback ordering because the feedback repository returns newest-first, and risk-assessment row duplication because `risk_assessments.analysis_id` is the primary key.
+- 2026-06-03: Fixed fourth rerun code-review findings: calibration metrics now use windowed feedback while preserving lifetime feedback history counts, cached calibration snapshots validate schema and project/workspace scope before reuse, and local app startup/history-route sanity was run.
+- 2026-06-03: Validation passed after fourth rerun fixes: `./.venv/bin/python -m unittest tests.test_services.test_backtesting_service -q` (25 tests), `./.venv/bin/python -m unittest tests.test_ui.test_history_page -q` (56 tests), `./.venv/bin/ruff check .`, `./.venv/bin/ruff format --check .`, `./.venv/bin/bandit -q services/backtesting_service.py services/feedback_service.py services/report_service.py ui/routes/history.py models/repositories/settings.py models/repositories/feedback_events.py`, `./.venv/bin/python -m unittest discover -q` (451 tests, 1 skipped), `bash scripts/ci-local.sh`, `APP_PORT=18080 npm run test:ui-review` (4 Playwright tests), and local app sanity: `APP_PORT=18081 ./.venv/bin/python app.py` plus `curl -fsSL http://127.0.0.1:18081/history` returned the rendered history page. Initial sandboxed app startup hit a NiceGUI process-pool `PermissionError`, so the same command was rerun outside the sandbox for validation.
+- 2026-06-03: Re-ran BMad code review on Story 6.4. Four patch findings remain open; story moved back to in-progress for follow-up fixes. Dismissed as noise: initial history summaries cannot be workspace-scoped on first render because the route has no deep-link/preselected workspace path and initializes the workspace filter to all workspaces.
+- 2026-06-03: Fixed fifth rerun code-review findings: cached calibration snapshots now reject wrong-window, partial, and malformed nested metric payloads; feedback-only cases stay out of deployment confidence trend buckets; false-reassurance cases sort by event timestamp across sources; and the empty history calibration seed mirrors the full payload shape.
+- 2026-06-03: Validation passed after fifth rerun fixes: `./.venv/bin/python -m unittest tests.test_services.test_backtesting_service -q` (29 tests), `./.venv/bin/python -m unittest tests.test_ui.test_history_page -q` (57 tests), `./.venv/bin/ruff check .`, `./.venv/bin/ruff format --check .`, `./.venv/bin/bandit -q services/backtesting_service.py services/feedback_service.py services/report_service.py ui/routes/history.py models/repositories/settings.py models/repositories/feedback_events.py`, `./.venv/bin/python -m unittest discover -q` (452 tests, 1 skipped), `bash scripts/ci-local.sh`, `APP_PORT=18080 npm run test:ui-review` (4 Playwright tests), and local app sanity: `APP_PORT=18081 ./.venv/bin/python app.py` plus `curl -fsSL http://127.0.0.1:18081/history` returned the rendered history page.
+- 2026-06-03: Final closeout review found additional patch findings around cache window bounds, orphaned feedback, stale-feedback limitation labels, duplicate-source false-reassurance evidence, and confidence bucket count units; patched before closeout.
+- 2026-06-03: Validation passed after final closeout fixes: `./.venv/bin/python -m unittest tests.test_services.test_backtesting_service -q` (32 tests), `./.venv/bin/python -m unittest tests.test_ui.test_history_page -q` (57 tests), `./.venv/bin/ruff check .`, `./.venv/bin/ruff format --check .`, `./.venv/bin/bandit -q services/backtesting_service.py services/feedback_service.py services/report_service.py ui/routes/history.py models/repositories/settings.py models/repositories/feedback_events.py`, `./.venv/bin/python -m unittest discover -q` (452 tests, 1 skipped), `bash scripts/ci-local.sh`, `APP_PORT=18080 npm run test:ui-review` (4 Playwright tests), and local app sanity: `APP_PORT=18081 ./.venv/bin/python app.py` plus `curl -fsSL http://127.0.0.1:18081/history` returned the rendered history page.
+
+### Completion Notes List
+
+- Implemented shared calibration metrics on the existing weekly backtesting feed rather than adding a separate dashboard-only path.
+- Added project/workspace-scoped calibration snapshots and feedback-triggered cache invalidation.
+- Preserved existing `overall_precision` / `overall_recall` fields while adding structured `calibration_metrics`, `false_positive_cases`, `false_reassurance_cases`, `confidence_trends`, `confidence_limitations`, `confidence_label`, and `statistical_certainty`.
+- Historical report verdict fields remain immutable; calibration changes aggregate views only.
+- Sparse or biased inputs are labeled as directional evidence and not statistically certain.
+- Review fixes now include feedback-only reviewer signals, latest-effective feedback counts, bounded reviewer feedback rates, workspace-safe scheduler state, and consistent workspace filtering across history summaries.
+- Second rerun review fixes now exclude warned reports from false-reassurance feedback counts, expire stale cached calibration snapshots, refresh history summary cards after workspace/filter changes, and preserve all active limitation labels.
+- Third rerun review fixes now harden cached calibration snapshot reads, invalidate calibration caches on report deletion, and keep deployment-backed rates distinct from reviewer-only missed-feedback evidence.
+- Fourth rerun review fixes now keep weekly feedback-derived metrics scoped to the active backtest window, expose lifetime feedback only as history context, reject old-schema or wrong-scope cached calibration snapshots, and record direct local app/history-route validation.
+- Fifth rerun review fixes now fully validate cached calibration payload shape, keep feedback-only evidence out of deployment confidence buckets, apply event-time ordering to false-reassurance cases, and align the empty history seed with the full calibration payload.
+- Final closeout review fixes now validate cached window bounds, ignore orphaned feedback after report deletion, preserve deployment-backed and reviewer-missed false-reassurance evidence separately, and keep confidence bucket error counts on sampled-analysis units.
+
+### File List
+
+- `docs/outcome-linking.md`
+- `models/repositories/feedback_events.py`
+- `models/repositories/settings.py`
+- `services/backtesting_service.py`
+- `services/feedback_service.py`
+- `services/report_service.py`
+- `tests/test_services/test_backtesting_service.py`
+- `tests/test_ui/test_history_page.py`
+- `ui/routes/history.py`
+- `_bmad-output/implementation-artifacts/sprint-status.yaml`
+
+## Change Log
+
+- 2026-05-01: Story created/aligned from updated PRD, architecture, epics, sprint status, and readiness report.
+- 2026-06-03: Implemented outcome calibration metrics and moved story to review.
+- 2026-06-03: Fixed Story 6.4 review findings, expanded regressions, and moved story back to review.
+- 2026-06-03: Re-ran code review and moved story back to in-progress for four remaining patch findings.
+- 2026-06-03: Fixed remaining Story 6.4 rerun review findings, expanded regressions, and moved story back to review.
+- 2026-06-03: Re-ran code review and moved story back to in-progress for four cache/deletion/calibration-math patch findings.
+- 2026-06-03: Fixed third rerun review findings, expanded regressions, and moved story back to review.
+- 2026-06-03: Re-ran code review and moved story back to in-progress for three feedback-window, cache-validation, and local-run evidence patch findings.
+- 2026-06-03: Fixed fourth rerun review findings, expanded regressions, and moved story back to review.
+- 2026-06-03: Re-ran code review and moved story back to in-progress for four cache-shape, confidence-bucket, ordering, and empty-seed patch findings.
+- 2026-06-03: Fixed fifth rerun review findings, expanded regressions, and moved story back to review.
+- 2026-06-03: Fixed final closeout review findings and kept Story 6.4 in review for closeout.

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -104,7 +104,7 @@ development_status:
   6-1-benchmark-corpus-v1: review
   6-2-benchmark-runner: review
   6-3-honest-failure-report-generator: done
-  6-4-outcome-calibration-metrics: ready-for-dev
+  6-4-outcome-calibration-metrics: review
   6-5-incident-backtesting: ready-for-dev
   6-6-risk-trend-review: ready-for-dev
   epic-6-retrospective: optional

--- a/docs/outcome-linking.md
+++ b/docs/outcome-linking.md
@@ -10,7 +10,7 @@ DeployWhisper can now link incident records back to persisted analysis reports a
 
 ## Weekly Backtesting
 
-- `services.backtesting_service.run_weekly_backtest(...)` computes a 7-day backtest window for one project.
+- `services.backtesting_service.run_weekly_backtest(...)` computes a 7-day backtest window for one project, or one workspace when `workspace_id` / `workspace_key` is supplied.
 - Failed deploys are currently defined as deployment outcomes labeled `failure` or `rolled_back`.
 - Linked incidents enrich failed deployment rows with incident context, but they do not create synthetic failed-deploy rows on their own.
 - DeployWhisper counts a deploy as having warned when the persisted report recommendation is not `go`.
@@ -21,10 +21,24 @@ DeployWhisper can now link incident records back to persisted analysis reports a
   - overall recall
   - per-severity precision/recall seed data
   - row-level failed-deploy backtest records
+  - reviewer-feedback false-positive cases and false-positive rate across the latest effective finding-feedback signals
+  - false-reassurance cases from latest missed-finding feedback or failed deploys that followed a `go` recommendation
+  - deployment-backed false-reassurance rate, with reviewer-only missed-finding signals reported as counts/cases rather than deployment rates
+  - confidence trend buckets based on deployment-outcome samples and persisted report confidence, with missing legacy confidence shown as unknown rather than `0.0`
+  - confidence limitation labels when outcomes or feedback are too sparse or biased for statistical certainty
+- Calibration metrics are directional signals. Sparse or biased inputs are labeled explicitly and should not be presented as statistically certain.
+- Feedback-only reviewer signals are included in calibration cases even when no deployment outcome is linked yet, so dashboards do not claim "no calibration inputs" when review evidence exists.
+- `calibration_metrics.feedback_event_count` reports the deduplicated latest effective feedback signals used for current calibration. `feedback_history_event_count` reports the raw historical feedback event count when callers need audit/history volume.
+- Feedback and deployment outcomes update aggregate calibration metrics only; historical report severity, recommendation, verdict confidence, and narrative fields remain immutable.
+- False-reassurance reviewer feedback is counted only when the report did not warn, so missed-finding notes on caution/no-go reports do not imply the advisory system reassured the user.
 
 ## Scheduler and Calibration Feed
 
 - The app lifecycle scheduler now runs `run_due_weekly_backtests()` alongside topology drift checks.
-- Backtest snapshots are cached in `app_settings` per project.
+- Backtest snapshots are cached in `app_settings` per project, with separate workspace-scoped cache keys when workspace filtering is requested.
+- Workspace-scoped on-demand backtests write only the workspace snapshot; they do not update the project-global weekly last-run marker used by the scheduler.
+- Cached calibration snapshots are reused only while their recorded 7-day window is fresh, not future-dated, structurally complete, and scoped to the requested project/workspace; stale, malformed, old-schema, clock-skewed, or wrong-scope snapshots are recomputed on read without stamping the scheduler last-run marker.
 - `services.backtesting_service.fetch_calibration_dashboard_seed(...)` returns the latest cached snapshot or computes one on demand.
-- The history view renders a calibration snapshot card from that shared feed so later dashboard work can reuse the same storage contract.
+- Reviewer feedback, deployment outcomes, and report deletion invalidate cached snapshots for the affected project so dashboard views and exports pick up false-positive and false-reassurance updates.
+- Calibration math uses feedback recorded inside the active 7-day backtest window for false-positive, false-reassurance, sparse-feedback, and feedback-bias signals. The payload also keeps a `feedback_history_event_count` lifetime counter so operators can distinguish current-window evidence from older reviewer activity.
+- The history view renders a calibration snapshot card from that shared feed, including the "Directional only" / sparse-data label when calibration evidence is limited. Workspace filters apply consistently to history rows, calibration, and adjacent risk-trend summaries.

--- a/models/repositories/feedback_events.py
+++ b/models/repositories/feedback_events.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from datetime import datetime
+
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 
@@ -48,6 +50,8 @@ def list_feedback_events(
     project_id: int | None = None,
     workspace_id: int | None = None,
     analysis_id: int | None = None,
+    created_from: datetime | None = None,
+    created_to: datetime | None = None,
     limit: int | None = None,
 ) -> list[FeedbackEvent]:
     stmt = select(FeedbackEvent).order_by(
@@ -59,6 +63,10 @@ def list_feedback_events(
         stmt = stmt.where(FeedbackEvent.workspace_id == workspace_id)
     if analysis_id is not None:
         stmt = stmt.where(FeedbackEvent.analysis_id == analysis_id)
+    if created_from is not None:
+        stmt = stmt.where(FeedbackEvent.created_at >= created_from)
+    if created_to is not None:
+        stmt = stmt.where(FeedbackEvent.created_at <= created_to)
     if limit is not None:
         stmt = stmt.limit(max(1, limit))
     result = session.execute(stmt)

--- a/models/repositories/settings.py
+++ b/models/repositories/settings.py
@@ -33,3 +33,11 @@ def delete_setting(session: Session, key: str) -> None:
         return
     session.delete(record)
     session.commit()
+
+
+def delete_settings_by_key_prefix(session: Session, prefix: str) -> int:
+    records = session.query(AppSetting).filter(AppSetting.key.like(f"{prefix}%")).all()
+    for record in records:
+        session.delete(record)
+    session.commit()
+    return len(records)

--- a/services/backtesting_service.py
+++ b/services/backtesting_service.py
@@ -11,12 +11,26 @@ from typing import Any
 from sqlalchemy import select
 
 from models.database import SessionLocal
-from models.repositories.settings import delete_setting, get_setting, upsert_setting
-from models.tables import AnalysisReport, DeploymentOutcome, IncidentRecord
+from models.repositories.feedback_events import list_feedback_events
+from models.repositories.settings import (
+    delete_setting,
+    delete_settings_by_key_prefix,
+    get_setting,
+    upsert_setting,
+)
+from models.tables import (
+    AnalysisReport,
+    DeploymentOutcome,
+    FeedbackEvent,
+    IncidentRecord,
+)
+from models.tables import RiskAssessment as PersistedRiskAssessment
 from services.project_service import (
     build_project_payload,
+    build_workspace_payload,
     list_projects,
     resolve_project_reference,
+    resolve_workspace_reference,
 )
 
 BACKTEST_WINDOW_DAYS = 7
@@ -30,8 +44,11 @@ def _last_run_key(project_id: int) -> str:
     return f"{BACKTEST_LAST_RUN_KEY}{project_id}"
 
 
-def _snapshot_key(project_id: int) -> str:
-    return f"{BACKTEST_SNAPSHOT_KEY}{project_id}"
+def _snapshot_key(project_id: int, workspace_id: int | None = None) -> str:
+    key = f"{BACKTEST_SNAPSHOT_KEY}{project_id}"
+    if workspace_id is not None:
+        key = f"{key}:workspace:{workspace_id}"
+    return key
 
 
 def _warned(report: AnalysisReport | None) -> bool:
@@ -43,15 +60,23 @@ def _warned(report: AnalysisReport | None) -> bool:
 def _outcome_rows(
     *,
     project_id: int,
+    workspace_id: int | None = None,
     window_start: datetime,
     window_end: datetime,
-) -> list[tuple[DeploymentOutcome, AnalysisReport | None]]:
+) -> list[
+    tuple[DeploymentOutcome, AnalysisReport | None, PersistedRiskAssessment | None]
+]:
     with SessionLocal() as session:
         stmt = (
-            select(DeploymentOutcome, AnalysisReport)
+            select(DeploymentOutcome, AnalysisReport, PersistedRiskAssessment)
             .join(
                 AnalysisReport,
                 DeploymentOutcome.analysis_id == AnalysisReport.id,
+                isouter=True,
+            )
+            .join(
+                PersistedRiskAssessment,
+                AnalysisReport.id == PersistedRiskAssessment.analysis_id,
                 isouter=True,
             )
             .where(DeploymentOutcome.project_id == project_id)
@@ -59,6 +84,50 @@ def _outcome_rows(
             .where(DeploymentOutcome.deployed_at <= window_end)
             .order_by(DeploymentOutcome.deployed_at.asc(), DeploymentOutcome.id.asc())
         )
+        if workspace_id is not None:
+            stmt = stmt.where(DeploymentOutcome.workspace_id == workspace_id)
+        result = session.execute(stmt)
+        return list(result.all())
+
+
+def _feedback_rows(
+    *,
+    project_id: int,
+    workspace_id: int | None = None,
+    created_from: datetime | None = None,
+    created_to: datetime | None = None,
+) -> list[FeedbackEvent]:
+    with SessionLocal() as session:
+        return list_feedback_events(
+            session,
+            project_id=project_id,
+            workspace_id=workspace_id,
+            created_from=created_from,
+            created_to=created_to,
+        )
+
+
+def _analysis_context_rows(
+    *,
+    project_id: int,
+    workspace_id: int | None = None,
+    analysis_ids: set[int],
+) -> list[tuple[AnalysisReport, PersistedRiskAssessment | None]]:
+    if not analysis_ids:
+        return []
+    with SessionLocal() as session:
+        stmt = (
+            select(AnalysisReport, PersistedRiskAssessment)
+            .join(
+                PersistedRiskAssessment,
+                AnalysisReport.id == PersistedRiskAssessment.analysis_id,
+                isouter=True,
+            )
+            .where(AnalysisReport.project_id == project_id)
+            .where(AnalysisReport.id.in_(sorted(analysis_ids)))
+        )
+        if workspace_id is not None:
+            stmt = stmt.where(AnalysisReport.workspace_id == workspace_id)
         result = session.execute(stmt)
         return list(result.all())
 
@@ -125,6 +194,101 @@ def _serialize_timestamp(value: datetime) -> str:
     return value.isoformat()
 
 
+def _confidence_bucket(confidence: float | None) -> str:
+    if confidence is None:
+        return "unknown"
+    if confidence >= 0.85:
+        return "high"
+    if confidence >= 0.60:
+        return "medium"
+    return "low"
+
+
+def _serialize_feedback_case(
+    *,
+    event: FeedbackEvent,
+    report: AnalysisReport | None,
+    reason: str,
+) -> dict[str, Any]:
+    return {
+        "analysis_id": event.analysis_id,
+        "finding_id": event.finding_id,
+        "reason": reason,
+        "note": event.false_positive_reason or event.false_negative_note,
+        "severity": report.severity if report is not None else None,
+        "recommendation": report.recommendation if report is not None else None,
+        "created_at": _serialize_timestamp(event.created_at),
+    }
+
+
+def _calibration_limitations(
+    *,
+    sample_size: int,
+    feedback_event_count: int,
+    feedback_history_event_count: int,
+    false_positive_count: int,
+    missed_feedback_count: int,
+    useful_feedback_count: int,
+    neutral_feedback_count: int,
+) -> list[dict[str, str]]:
+    limitations: list[dict[str, str]] = []
+    if sample_size < 10:
+        limitations.append(
+            {
+                "code": "sparse_outcomes",
+                "label": "Sparse calibration data",
+                "message": (
+                    f"Only {sample_size} linked deployment outcomes are available; "
+                    "treat precision, recall proxy, and error rates as directional."
+                ),
+            }
+        )
+    if feedback_event_count < 5:
+        limitations.append(
+            {
+                "code": "sparse_feedback",
+                "label": "Limited reviewer feedback",
+                "message": (
+                    f"Only {feedback_event_count} feedback events are linked to this "
+                    "calibration window, so reviewer-error signals may be incomplete."
+                ),
+            }
+        )
+    feedback_type_counts = [
+        false_positive_count,
+        missed_feedback_count,
+        useful_feedback_count,
+        neutral_feedback_count,
+    ]
+    if feedback_event_count > 0 and max(feedback_type_counts) == feedback_event_count:
+        limitations.append(
+            {
+                "code": "feedback_bias",
+                "label": "Feedback may be biased",
+                "message": (
+                    "Current feedback is concentrated in one outcome type; do not "
+                    "treat it as statistically representative."
+                ),
+            }
+        )
+    if (
+        sample_size == 0
+        and feedback_event_count == 0
+        and feedback_history_event_count == 0
+    ):
+        limitations.append(
+            {
+                "code": "no_calibration_inputs",
+                "label": "No calibration inputs",
+                "message": (
+                    "No deployment outcomes or feedback are linked yet; calibration "
+                    "metrics cannot imply statistical certainty."
+                ),
+            }
+        )
+    return limitations
+
+
 def _coerce_utc_timestamp(value: str) -> datetime:
     parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
     if parsed.tzinfo is None:
@@ -134,25 +298,248 @@ def _coerce_utc_timestamp(value: str) -> datetime:
     return parsed
 
 
+def _calibration_case_event_timestamp(case: dict[str, Any]) -> datetime:
+    value = case.get("created_at") or case.get("deployed_at")
+    if isinstance(value, str) and value.strip():
+        try:
+            return _coerce_utc_timestamp(value)
+        except ValueError:
+            pass
+    return datetime.min.replace(tzinfo=UTC)
+
+
+def _cached_snapshot_is_fresh(snapshot: dict[str, Any], *, now: datetime) -> bool:
+    window = snapshot.get("window")
+    if not isinstance(window, dict):
+        return False
+    window_start = window.get("start")
+    if not isinstance(window_start, str) or not window_start.strip():
+        return False
+    window_end = window.get("end")
+    if not isinstance(window_end, str) or not window_end.strip():
+        return False
+    try:
+        snapshot_start = _coerce_utc_timestamp(window_start)
+        snapshot_end = _coerce_utc_timestamp(window_end)
+    except ValueError:
+        return False
+    if snapshot_end > now:
+        return False
+    if snapshot_end - snapshot_start != timedelta(days=BACKTEST_WINDOW_DAYS):
+        return False
+    return now - snapshot_end < timedelta(days=BACKTEST_WINDOW_DAYS)
+
+
+def _payload_project_id(payload: dict[str, Any]) -> int | None:
+    project = payload.get("project")
+    if not isinstance(project, dict):
+        return None
+    project_id = project.get("id")
+    return int(project_id) if isinstance(project_id, int) else None
+
+
+def _payload_workspace_id(payload: dict[str, Any]) -> int | None:
+    workspace = payload.get("workspace")
+    if workspace is None:
+        return None
+    if not isinstance(workspace, dict):
+        return None
+    workspace_id = workspace.get("id")
+    return int(workspace_id) if isinstance(workspace_id, int) else None
+
+
+def _cached_snapshot_matches_scope(
+    snapshot: dict[str, Any],
+    *,
+    project_id: int,
+    workspace_id: int | None,
+) -> bool:
+    return (
+        _payload_project_id(snapshot) == project_id
+        and _payload_workspace_id(snapshot) == workspace_id
+    )
+
+
+def _is_int_payload_value(value: Any) -> bool:
+    return isinstance(value, int) and not isinstance(value, bool)
+
+
+def _is_numeric_payload_value(value: Any) -> bool:
+    return isinstance(value, int | float) and not isinstance(value, bool)
+
+
+def _has_required_fields(
+    payload: dict[str, Any],
+    fields: dict[str, type | tuple[type, ...]],
+) -> bool:
+    return all(
+        isinstance(payload.get(field), field_type)
+        for field, field_type in fields.items()
+    )
+
+
+def _cached_snapshot_has_required_shape(snapshot: dict[str, Any]) -> bool:
+    window = snapshot.get("window")
+    if not isinstance(window, dict):
+        return False
+    window_days = window.get("days")
+    if not _is_int_payload_value(window_days) or window_days != BACKTEST_WINDOW_DAYS:
+        return False
+    if not isinstance(window.get("start"), str) or not isinstance(
+        window.get("end"), str
+    ):
+        return False
+    required_integer_fields = ["failed_deploy_count", "warned_failed_deploy_count"]
+    for field in required_integer_fields:
+        if not _is_int_payload_value(snapshot.get(field)):
+            return False
+    required_numeric_fields = ["overall_precision", "overall_recall"]
+    for field in required_numeric_fields:
+        if not _is_numeric_payload_value(snapshot.get(field)):
+            return False
+    if not _has_required_fields(
+        snapshot,
+        {
+            "backtest_rows": list,
+            "by_severity": dict,
+            "false_positive_cases": list,
+            "false_reassurance_cases": list,
+            "confidence_trends": dict,
+        },
+    ):
+        return False
+    confidence_trends = snapshot["confidence_trends"]
+    if not isinstance(confidence_trends.get("buckets"), dict):
+        return False
+    if not _is_int_payload_value(confidence_trends.get("sample_size")):
+        return False
+    if not isinstance(snapshot.get("confidence_limitations"), list):
+        return False
+    if not isinstance(snapshot.get("confidence_label"), str):
+        return False
+    if not isinstance(snapshot.get("statistical_certainty"), bool):
+        return False
+    calibration_metrics = snapshot.get("calibration_metrics")
+    if not isinstance(calibration_metrics, dict):
+        return False
+    required_integer_metric_fields = [
+        "sample_size",
+        "feedback_event_count",
+        "feedback_history_event_count",
+        "false_positive_count",
+        "false_reassurance_count",
+        "deployment_false_reassurance_count",
+        "reviewer_missed_feedback_count",
+    ]
+    for field in required_integer_metric_fields:
+        if not _is_int_payload_value(calibration_metrics.get(field)):
+            return False
+    required_numeric_metric_fields = [
+        "precision",
+        "recall_proxy",
+        "false_positive_rate",
+        "false_reassurance_rate",
+    ]
+    for field in required_numeric_metric_fields:
+        if not _is_numeric_payload_value(calibration_metrics.get(field)):
+            return False
+    recall_proxy_signals = calibration_metrics.get("recall_proxy_signals")
+    if not isinstance(recall_proxy_signals, dict):
+        return False
+    return all(
+        _is_int_payload_value(recall_proxy_signals.get(field))
+        for field in [
+            "failed_deploy_count",
+            "warned_failed_deploy_count",
+            "failed_without_warning_count",
+            "missed_feedback_count",
+        ]
+    )
+
+
+def _cached_snapshot_is_usable(
+    snapshot: dict[str, Any],
+    *,
+    project_id: int,
+    workspace_id: int | None,
+    now: datetime,
+) -> bool:
+    return (
+        _cached_snapshot_is_fresh(snapshot, now=now)
+        and _cached_snapshot_matches_scope(
+            snapshot,
+            project_id=project_id,
+            workspace_id=workspace_id,
+        )
+        and _cached_snapshot_has_required_shape(snapshot)
+    )
+
+
 def _build_summary(
     *,
     project,
-    rows: list[tuple[DeploymentOutcome, AnalysisReport | None]],
+    workspace=None,
+    rows: list[
+        tuple[DeploymentOutcome, AnalysisReport | None, PersistedRiskAssessment | None]
+    ],
     window_start: datetime,
     window_end: datetime,
 ) -> dict[str, Any]:
     failed_rows: list[dict[str, Any]] = []
     warned_total = 0
     true_positive = 0
+    outcome_report_count = 0
+    failed_without_warning_count = 0
+    report_by_analysis_id: dict[int, AnalysisReport] = {}
+    confidence_by_analysis_id: dict[int, float | None] = {}
+    warning_by_analysis_id: dict[int, bool] = {}
+    failed_by_analysis_id: dict[int, bool] = {}
+    outcome_confidence_samples: list[tuple[int, float | None, bool, bool]] = []
     by_severity_counts: dict[str, dict[str, int]] = defaultdict(
         lambda: {"warned": 0, "failed": 0, "true_positive": 0}
     )
     analysis_ids = {
         int(outcome.analysis_id)
-        for outcome, _ in rows
+        for outcome, _, _ in rows
         if outcome.analysis_id is not None
     }
     incidents = _incident_rows(project_id=project.id, analysis_ids=analysis_ids)
+    feedback_history_events = _feedback_rows(
+        project_id=project.id,
+        workspace_id=workspace.id if workspace is not None else None,
+    )
+    feedback_history_events = [
+        event for event in feedback_history_events if event.analysis_id is not None
+    ]
+    feedback_events = _feedback_rows(
+        project_id=project.id,
+        workspace_id=workspace.id if workspace is not None else None,
+        created_from=window_start,
+        created_to=window_end,
+    )
+    feedback_events = [
+        event for event in feedback_events if event.analysis_id is not None
+    ]
+    feedback_analysis_ids = {
+        int(event.analysis_id)
+        for event in feedback_events
+        if event.analysis_id is not None
+    }
+    feedback_only_analysis_ids = feedback_analysis_ids - analysis_ids
+    for report, risk_assessment in _analysis_context_rows(
+        project_id=project.id,
+        workspace_id=workspace.id if workspace is not None else None,
+        analysis_ids=feedback_only_analysis_ids,
+    ):
+        analysis_id = int(report.id)
+        report_by_analysis_id[analysis_id] = report
+        confidence_by_analysis_id[analysis_id] = (
+            float(risk_assessment.confidence)
+            if risk_assessment is not None and risk_assessment.confidence is not None
+            else None
+        )
+        warning_by_analysis_id[analysis_id] = _warned(report)
+        failed_by_analysis_id.setdefault(analysis_id, False)
     incident_by_analysis_id: dict[int, IncidentRecord] = {}
     for incident in incidents:
         analysis_id = (
@@ -166,13 +553,26 @@ def _build_summary(
         ) <= _incident_event_timestamp(incident):
             incident_by_analysis_id[analysis_id] = incident
 
-    for outcome, report in rows:
+    for outcome, report, risk_assessment in rows:
         if outcome.analysis_id is None or report is None:
             continue
+        outcome_report_count += 1
         did_warn = _warned(report)
         failed = outcome.outcome_label in {"failure", "rolled_back"}
         severity = str(report.severity if report is not None else "unknown").lower()
         analysis_id = int(outcome.analysis_id)
+        confidence = (
+            float(risk_assessment.confidence)
+            if risk_assessment is not None and risk_assessment.confidence is not None
+            else None
+        )
+        report_by_analysis_id[analysis_id] = report
+        confidence_by_analysis_id[analysis_id] = confidence
+        warning_by_analysis_id[analysis_id] = did_warn
+        failed_by_analysis_id[analysis_id] = failed or failed_by_analysis_id.get(
+            analysis_id, False
+        )
+        outcome_confidence_samples.append((analysis_id, confidence, did_warn, failed))
         if did_warn:
             warned_total += 1
             by_severity_counts[severity]["warned"] += 1
@@ -196,10 +596,189 @@ def _build_summary(
             if did_warn:
                 true_positive += 1
                 by_severity_counts[severity]["true_positive"] += 1
+            else:
+                failed_without_warning_count += 1
 
     failed_deploy_count = len(failed_rows)
     overall_precision = true_positive / warned_total if warned_total else 0.0
     overall_recall = true_positive / failed_deploy_count if failed_deploy_count else 0.0
+
+    latest_finding_feedback: dict[tuple[int | None, str], FeedbackEvent] = {}
+    latest_false_negative_feedback: dict[
+        tuple[int | None, str | None], FeedbackEvent
+    ] = {}
+    for event in feedback_events:
+        if event.finding_id is not None and event.false_negative_note is None:
+            latest_finding_feedback.setdefault(
+                (event.analysis_id, event.finding_id), event
+            )
+        if event.false_negative_note:
+            latest_false_negative_feedback.setdefault(
+                (event.analysis_id, event.finding_id), event
+            )
+
+    false_positive_cases = [
+        _serialize_feedback_case(
+            event=event,
+            report=report_by_analysis_id.get(int(event.analysis_id)),
+            reason="reviewer_false_positive_feedback",
+        )
+        for event in latest_finding_feedback.values()
+        if event.analysis_id is not None and bool(event.false_positive_flag)
+    ]
+    false_positive_count = len(false_positive_cases)
+    effective_finding_feedback_count = len(latest_finding_feedback)
+    false_positive_denominator = max(
+        effective_finding_feedback_count,
+        false_positive_count,
+    )
+    false_positive_rate = (
+        false_positive_count / false_positive_denominator
+        if false_positive_denominator
+        else 0.0
+    )
+
+    false_reassurance_cases: list[dict[str, Any]] = []
+    for failed_row in failed_rows:
+        if failed_row["did_warn"] or failed_row["analysis_id"] is None:
+            continue
+        analysis_id = int(failed_row["analysis_id"])
+        false_reassurance_cases.append(
+            {
+                "analysis_id": analysis_id,
+                "finding_id": None,
+                "reason": "failed_without_warning",
+                "note": "Deployment failed or rolled back after a GO report.",
+                "severity": failed_row["severity"],
+                "recommendation": failed_row["recommendation"],
+                "deployed_at": failed_row["deployed_at"],
+            }
+        )
+    for event in latest_false_negative_feedback.values():
+        if event.analysis_id is None:
+            continue
+        analysis_id = int(event.analysis_id)
+        if warning_by_analysis_id.get(analysis_id, False):
+            continue
+        if analysis_id in analysis_ids and not failed_by_analysis_id.get(
+            analysis_id, False
+        ):
+            continue
+        report = report_by_analysis_id.get(analysis_id)
+        false_reassurance_cases.append(
+            _serialize_feedback_case(
+                event=event,
+                report=report,
+                reason="reviewer_missed_finding_feedback",
+            )
+        )
+    false_reassurance_cases.sort(
+        key=_calibration_case_event_timestamp,
+        reverse=True,
+    )
+    false_reassurance_count = len(false_reassurance_cases)
+    false_reassurance_rate = (
+        failed_without_warning_count / failed_deploy_count
+        if failed_deploy_count
+        else 0.0
+    )
+
+    confidence_accumulators: dict[str, dict[str, float | int]] = defaultdict(
+        lambda: {
+            "sample_count": 0,
+            "numeric_confidence_count": 0,
+            "confidence_sum": 0.0,
+            "warned_count": 0,
+            "failed_count": 0,
+            "true_positive_count": 0,
+            "false_positive_count": 0,
+            "false_reassurance_count": 0,
+        }
+    )
+    for analysis_id, confidence, did_warn, failed in outcome_confidence_samples:
+        bucket = _confidence_bucket(confidence)
+        bucket_payload = confidence_accumulators[bucket]
+        bucket_payload["sample_count"] = int(bucket_payload["sample_count"]) + 1
+        if confidence is not None:
+            bucket_payload["numeric_confidence_count"] = (
+                int(bucket_payload["numeric_confidence_count"]) + 1
+            )
+            bucket_payload["confidence_sum"] = (
+                float(bucket_payload["confidence_sum"]) + confidence
+            )
+        if did_warn:
+            bucket_payload["warned_count"] = int(bucket_payload["warned_count"]) + 1
+        if failed:
+            bucket_payload["failed_count"] = int(bucket_payload["failed_count"]) + 1
+            if did_warn:
+                bucket_payload["true_positive_count"] = (
+                    int(bucket_payload["true_positive_count"]) + 1
+                )
+    outcome_sample_analysis_ids = {
+        analysis_id for analysis_id, _, _, _ in outcome_confidence_samples
+    }
+    false_positive_bucket_analysis_ids: set[int] = set()
+    for case in false_positive_cases:
+        analysis_id = case.get("analysis_id")
+        if analysis_id is None or int(analysis_id) not in outcome_sample_analysis_ids:
+            continue
+        if int(analysis_id) in false_positive_bucket_analysis_ids:
+            continue
+        false_positive_bucket_analysis_ids.add(int(analysis_id))
+        bucket = _confidence_bucket(confidence_by_analysis_id.get(int(analysis_id)))
+        confidence_accumulators[bucket]["false_positive_count"] = (
+            int(confidence_accumulators[bucket]["false_positive_count"]) + 1
+        )
+    false_reassurance_bucket_analysis_ids: set[int] = set()
+    for case in false_reassurance_cases:
+        analysis_id = case.get("analysis_id")
+        if analysis_id is None or int(analysis_id) not in outcome_sample_analysis_ids:
+            continue
+        if int(analysis_id) in false_reassurance_bucket_analysis_ids:
+            continue
+        false_reassurance_bucket_analysis_ids.add(int(analysis_id))
+        bucket = _confidence_bucket(confidence_by_analysis_id.get(int(analysis_id)))
+        confidence_accumulators[bucket]["false_reassurance_count"] = (
+            int(confidence_accumulators[bucket]["false_reassurance_count"]) + 1
+        )
+    confidence_buckets = {}
+    for bucket, values in confidence_accumulators.items():
+        sample_count = int(values["sample_count"])
+        numeric_confidence_count = int(values["numeric_confidence_count"])
+        confidence_buckets[bucket] = {
+            "sample_count": sample_count,
+            "average_confidence": (
+                float(values["confidence_sum"]) / numeric_confidence_count
+                if numeric_confidence_count
+                else None
+            ),
+            "warned_count": int(values["warned_count"]),
+            "failed_count": int(values["failed_count"]),
+            "true_positive_count": int(values["true_positive_count"]),
+            "false_positive_count": int(values["false_positive_count"]),
+            "false_reassurance_count": int(values["false_reassurance_count"]),
+        }
+
+    useful_feedback_count = sum(
+        1
+        for event in latest_finding_feedback.values()
+        if not bool(event.false_positive_flag) and bool(event.useful)
+    )
+    neutral_feedback_count = (
+        effective_finding_feedback_count - false_positive_count - useful_feedback_count
+    )
+    effective_feedback_count = effective_finding_feedback_count + len(
+        latest_false_negative_feedback
+    )
+    limitations = _calibration_limitations(
+        sample_size=outcome_report_count,
+        feedback_event_count=effective_feedback_count,
+        feedback_history_event_count=len(feedback_history_events),
+        false_positive_count=false_positive_count,
+        missed_feedback_count=len(latest_false_negative_feedback),
+        useful_feedback_count=useful_feedback_count,
+        neutral_feedback_count=neutral_feedback_count,
+    )
 
     by_severity = {
         severity: {
@@ -217,6 +796,9 @@ def _build_summary(
 
     return {
         "project": build_project_payload(project),
+        "workspace": build_workspace_payload(workspace)
+        if workspace is not None
+        else None,
         "window": {
             "start": _serialize_timestamp(window_start),
             "end": _serialize_timestamp(window_end),
@@ -228,18 +810,52 @@ def _build_summary(
         "overall_recall": overall_recall,
         "backtest_rows": failed_rows,
         "by_severity": by_severity,
+        "false_positive_cases": false_positive_cases,
+        "false_reassurance_cases": false_reassurance_cases,
+        "confidence_trends": {
+            "buckets": confidence_buckets,
+            "sample_size": outcome_report_count,
+        },
+        "confidence_limitations": limitations,
+        "confidence_label": "Calibrated" if not limitations else "Directional only",
+        "statistical_certainty": not limitations,
+        "calibration_metrics": {
+            "sample_size": outcome_report_count,
+            "feedback_event_count": effective_feedback_count,
+            "feedback_history_event_count": len(feedback_history_events),
+            "precision": overall_precision,
+            "recall_proxy": overall_recall,
+            "false_positive_count": false_positive_count,
+            "false_positive_rate": false_positive_rate,
+            "false_reassurance_count": false_reassurance_count,
+            "false_reassurance_rate": false_reassurance_rate,
+            "deployment_false_reassurance_count": failed_without_warning_count,
+            "reviewer_missed_feedback_count": len(latest_false_negative_feedback),
+            "recall_proxy_signals": {
+                "failed_deploy_count": failed_deploy_count,
+                "warned_failed_deploy_count": true_positive,
+                "failed_without_warning_count": failed_without_warning_count,
+                "missed_feedback_count": len(latest_false_negative_feedback),
+            },
+        },
     }
 
 
 def invalidate_backtesting_snapshot(*, project_id: int) -> None:
     with SessionLocal() as session:
         delete_setting(session, _snapshot_key(project_id))
+        delete_settings_by_key_prefix(
+            session,
+            f"{_snapshot_key(project_id)}:workspace:",
+        )
 
 
 def run_weekly_backtest(
     *,
     project_id: int | None = None,
     project_key: str | None = None,
+    workspace_id: int | None = None,
+    workspace_key: str | None = None,
     now: datetime | None = None,
     record_last_run: bool = True,
 ) -> dict[str, Any]:
@@ -247,20 +863,27 @@ def run_weekly_backtest(
     if reference_now.tzinfo is None:
         reference_now = reference_now.replace(tzinfo=UTC)
     project = resolve_project_reference(project_id=project_id, project_key=project_key)
+    workspace = resolve_workspace_reference(
+        project_id=project.id,
+        workspace_id=workspace_id,
+        workspace_key=workspace_key,
+    )
     window_start = reference_now - timedelta(days=BACKTEST_WINDOW_DAYS)
     rows = _outcome_rows(
         project_id=project.id,
+        workspace_id=workspace.id if workspace is not None else None,
         window_start=window_start,
         window_end=reference_now,
     )
     summary = _build_summary(
         project=project,
+        workspace=workspace,
         rows=rows,
         window_start=window_start,
         window_end=reference_now,
     )
     with SessionLocal() as session:
-        if record_last_run:
+        if record_last_run and workspace is None:
             upsert_setting(
                 session,
                 key=_last_run_key(project.id),
@@ -268,7 +891,10 @@ def run_weekly_backtest(
             )
         upsert_setting(
             session,
-            key=_snapshot_key(project.id),
+            key=_snapshot_key(
+                project.id,
+                workspace.id if workspace is not None else None,
+            ),
             value=json.dumps(summary),
         )
     return summary
@@ -299,10 +925,48 @@ def fetch_calibration_dashboard_seed(
     *,
     project_id: int | None = None,
     project_key: str | None = None,
+    workspace_id: int | None = None,
+    workspace_key: str | None = None,
+    now: datetime | None = None,
 ) -> dict[str, Any]:
+    reference_now = now or datetime.now(UTC)
+    if reference_now.tzinfo is None:
+        reference_now = reference_now.replace(tzinfo=UTC)
+    else:
+        reference_now = reference_now.astimezone(UTC)
     project = resolve_project_reference(project_id=project_id, project_key=project_key)
+    workspace = resolve_workspace_reference(
+        project_id=project.id,
+        workspace_id=workspace_id,
+        workspace_key=workspace_key,
+    )
     with SessionLocal() as session:
-        snapshot = get_setting(session, _snapshot_key(project.id))
+        snapshot = get_setting(
+            session,
+            _snapshot_key(
+                project.id,
+                workspace.id if workspace is not None else None,
+            ),
+        )
     if snapshot is not None:
-        return json.loads(snapshot.value)
-    return run_weekly_backtest(project_id=project.id, record_last_run=False)
+        try:
+            snapshot_payload = json.loads(snapshot.value)
+        except (TypeError, ValueError):
+            logger.warning(
+                "Ignoring invalid cached calibration snapshot for project %s.",
+                project.id,
+            )
+            snapshot_payload = None
+        if isinstance(snapshot_payload, dict) and _cached_snapshot_is_usable(
+            snapshot_payload,
+            project_id=project.id,
+            workspace_id=workspace.id if workspace is not None else None,
+            now=reference_now,
+        ):
+            return snapshot_payload
+    return run_weekly_backtest(
+        project_id=project.id,
+        workspace_id=workspace.id if workspace is not None else None,
+        now=reference_now,
+        record_last_run=False,
+    )

--- a/services/feedback_service.py
+++ b/services/feedback_service.py
@@ -69,6 +69,12 @@ def _project_payload(
     )
 
 
+def _invalidate_calibration_snapshot(project_id: int) -> None:
+    from services.backtesting_service import invalidate_backtesting_snapshot
+
+    invalidate_backtesting_snapshot(project_id=project_id)
+
+
 def _resolve_summary_scope(
     *,
     project_id: int | None,
@@ -142,6 +148,7 @@ def record_finding_feedback(
             false_positive_reason=normalized_reason,
             outcome_label=outcome_label,
         )
+        _invalidate_calibration_snapshot(report.project_id)
         return _serialize_event(event)
 
 
@@ -191,6 +198,7 @@ def record_false_negative_feedback(
             false_negative_note=normalized_note,
             outcome_label="missed",
         )
+        _invalidate_calibration_snapshot(report.project_id)
         return _serialize_event(event)
 
 

--- a/services/report_service.py
+++ b/services/report_service.py
@@ -4709,9 +4709,17 @@ def fetch_active_dashboard_report(
 
 
 def remove_analysis_report(report_id: int) -> bool:
+    project_id: int | None = None
     with SessionLocal() as session:
+        report = get_analysis_report(session, report_id, include_evidence=False)
+        if report is not None:
+            project_id = report.project_id
         removed = delete_analysis_report(session, report_id)
     if removed:
+        if project_id is not None:
+            from services.backtesting_service import invalidate_backtesting_snapshot
+
+            invalidate_backtesting_snapshot(project_id=project_id)
         delete_report_artifacts(report_id)
     return removed
 

--- a/tests/test_services/test_backtesting_service.py
+++ b/tests/test_services/test_backtesting_service.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import os
 import tempfile
 import unittest
@@ -16,11 +17,13 @@ import models.repositories.analysis_reports as analysis_reports_repository_modul
 import models.tables as tables_module
 import services.backtesting_service as backtesting_service_module
 import services.deployment_outcome_service as deployment_outcome_service_module
+import services.feedback_service as feedback_service_module
 import services.incident_service as incident_service_module
 import services.project_service as project_service_module
 import services.report_service as report_service_module
 from models.repositories.settings import get_setting, upsert_setting
 from analysis.risk_scorer import RiskAssessment
+from evidence.models import Finding
 from llm.narrator import NarrativeResult
 from parsers.base import ParseBatchResult, ParsedFileResult
 
@@ -36,12 +39,18 @@ class BacktestingServiceTests(unittest.TestCase):
         reload(analysis_reports_repository_module)
         reload(project_service_module)
         reload(report_service_module)
+        reload(feedback_service_module)
         reload(deployment_outcome_service_module)
         reload(backtesting_service_module)
         database_module.init_db()
         self.project = project_service_module.create_project(
             project_key="payments",
             display_name="Payments",
+        )
+        self.workspace = project_service_module.create_workspace(
+            project_key="payments",
+            workspace_key="prod",
+            display_name="Production",
         )
 
     def tearDown(self) -> None:
@@ -56,7 +65,31 @@ class BacktestingServiceTests(unittest.TestCase):
         recommendation: str,
         severity: str,
         file_name: str,
+        confidence: float = 1.0,
+        workspace_id: int | None = None,
+        include_finding: bool = False,
+        finding_count: int = 1,
     ) -> dict:
+        findings = (
+            [
+                Finding(
+                    finding_id=f"finding-{file_name.replace('.', '-')}-{index}",
+                    analysis_id=0,
+                    title=f"{severity.upper()}: {top_risk}",
+                    description=top_risk,
+                    severity=severity,
+                    category="calibration/test",
+                    deterministic=True,
+                    confidence=confidence,
+                    uncertainty_note=None,
+                    evidence_refs=[],
+                    skill_id=None,
+                )
+                for index in range(finding_count)
+            ]
+            if include_finding
+            else []
+        )
         return report_service_module.persist_analysis_report(
             ParseBatchResult(
                 files=[
@@ -73,6 +106,7 @@ class BacktestingServiceTests(unittest.TestCase):
                 severity=severity,
                 recommendation=recommendation,
                 top_risk=top_risk,
+                confidence=confidence,
                 contributors=[],
                 interaction_risks=[],
                 partial_context=False,
@@ -85,12 +119,21 @@ class BacktestingServiceTests(unittest.TestCase):
                 degraded=False,
                 warnings=[],
             ),
+            findings=findings,
             project_id=self.project.id,
+            workspace_id=workspace_id,
             audit_context={"source_interface": "api"},
         )
 
     def _recent_deployed_at(self, *, hours_ago: int = 24) -> str:
         return (datetime.now(UTC) - timedelta(hours=hours_ago)).isoformat()
+
+    def _stamp_all_feedback_created_at(self, created_at: datetime) -> None:
+        with database_module.SessionLocal() as session:
+            events = session.query(tables_module.FeedbackEvent).all()
+            for event in events:
+                event.created_at = created_at
+            session.commit()
 
     def test_run_weekly_backtest_computes_failed_deploy_warning_rows(self) -> None:
         warned_report = self._persist_report(
@@ -142,6 +185,877 @@ class BacktestingServiceTests(unittest.TestCase):
         self.assertTrue(summary["backtest_rows"][0]["did_warn"])
         self.assertFalse(summary["backtest_rows"][1]["did_warn"])
 
+    def test_run_weekly_backtest_includes_feedback_outcome_calibration_metrics(
+        self,
+    ) -> None:
+        warned_failure_report = self._persist_report(
+            top_risk="Warned production deploy failed later.",
+            recommendation="no-go",
+            severity="high",
+            file_name="warned-failure.tf",
+            confidence=0.88,
+            workspace_id=self.workspace.id,
+            include_finding=True,
+        )
+        warned_success_report = self._persist_report(
+            top_risk="Warned production deploy succeeded.",
+            recommendation="caution",
+            severity="medium",
+            file_name="warned-success.tf",
+            confidence=0.72,
+            workspace_id=self.workspace.id,
+            include_finding=True,
+        )
+        quiet_failure_report = self._persist_report(
+            top_risk="GO report missed rollback risk.",
+            recommendation="go",
+            severity="low",
+            file_name="quiet-failure.tf",
+            confidence=0.52,
+            workspace_id=self.workspace.id,
+        )
+        staging = project_service_module.create_workspace(
+            project_key="payments",
+            workspace_key="staging",
+            display_name="Staging",
+        )
+        staging_report = self._persist_report(
+            top_risk="Staging deploy should not enter prod metrics.",
+            recommendation="no-go",
+            severity="critical",
+            file_name="staging.tf",
+            confidence=0.95,
+            workspace_id=staging.id,
+        )
+
+        deployment_outcome_service_module.record_deployment_outcome(
+            analysis_id=warned_failure_report["id"],
+            outcome="failure",
+            deployed_at="2026-04-29T09:00:00Z",
+        )
+        deployment_outcome_service_module.record_deployment_outcome(
+            analysis_id=warned_success_report["id"],
+            outcome="success",
+            deployed_at="2026-04-29T10:00:00Z",
+        )
+        deployment_outcome_service_module.record_deployment_outcome(
+            analysis_id=quiet_failure_report["id"],
+            outcome="rolled_back",
+            deployed_at="2026-04-29T11:00:00Z",
+        )
+        deployment_outcome_service_module.record_deployment_outcome(
+            analysis_id=staging_report["id"],
+            outcome="failure",
+            deployed_at="2026-04-29T12:00:00Z",
+        )
+        feedback_service_module.record_finding_feedback(
+            analysis_id=warned_failure_report["id"],
+            finding_id=warned_failure_report["findings"][0]["finding_id"],
+            useful=True,
+        )
+        feedback_service_module.record_finding_feedback(
+            analysis_id=warned_success_report["id"],
+            finding_id=warned_success_report["findings"][0]["finding_id"],
+            useful=False,
+            false_positive_flag=True,
+            false_positive_reason="The compensating control already covered this.",
+        )
+        feedback_service_module.record_false_negative_feedback(
+            analysis_id=quiet_failure_report["id"],
+            note="Missed a rollback dependency that caused the incident.",
+        )
+        self._stamp_all_feedback_created_at(datetime(2026, 4, 29, 12, 0, tzinfo=UTC))
+        before = report_service_module.fetch_analysis_report(
+            warned_success_report["id"]
+        )
+
+        summary = backtesting_service_module.run_weekly_backtest(
+            project_id=self.project.id,
+            workspace_id=self.workspace.id,
+            now=datetime(2026, 4, 30, 12, 0, tzinfo=UTC),
+        )
+        after = report_service_module.fetch_analysis_report(warned_success_report["id"])
+
+        self.assertEqual(summary["workspace"]["workspace_key"], "prod")
+        self.assertEqual(summary["failed_deploy_count"], 2)
+        self.assertEqual(summary["warned_failed_deploy_count"], 1)
+        self.assertEqual(summary["overall_precision"], 0.5)
+        self.assertEqual(summary["overall_recall"], 0.5)
+        metrics = summary["calibration_metrics"]
+        self.assertEqual(metrics["sample_size"], 3)
+        self.assertEqual(metrics["feedback_event_count"], 3)
+        self.assertEqual(metrics["feedback_history_event_count"], 3)
+        self.assertEqual(metrics["precision"], 0.5)
+        self.assertEqual(metrics["recall_proxy"], 0.5)
+        self.assertEqual(metrics["false_positive_count"], 1)
+        self.assertEqual(metrics["false_positive_rate"], 0.5)
+        self.assertEqual(metrics["false_reassurance_count"], 2)
+        self.assertEqual(metrics["false_reassurance_rate"], 0.5)
+        self.assertEqual(
+            metrics["recall_proxy_signals"]["failed_without_warning_count"], 1
+        )
+        self.assertEqual(
+            summary["false_positive_cases"][0]["analysis_id"],
+            warned_success_report["id"],
+        )
+        self.assertEqual(
+            summary["false_reassurance_cases"][0]["analysis_id"],
+            quiet_failure_report["id"],
+        )
+        confidence_buckets = summary["confidence_trends"]["buckets"]
+        self.assertEqual(confidence_buckets["high"]["sample_count"], 1)
+        self.assertEqual(confidence_buckets["medium"]["sample_count"], 1)
+        self.assertEqual(confidence_buckets["low"]["sample_count"], 1)
+        limitation_codes = {
+            limitation["code"] for limitation in summary["confidence_limitations"]
+        }
+        self.assertIn("sparse_outcomes", limitation_codes)
+        self.assertFalse(summary["statistical_certainty"])
+        self.assertEqual(summary["confidence_label"], "Directional only")
+        self.assertIsNotNone(before)
+        self.assertIsNotNone(after)
+        if before is None or after is None:
+            self.fail("Expected report before and after calibration metrics.")
+        self.assertEqual(after["severity"], before["severity"])
+        self.assertEqual(after["recommendation"], before["recommendation"])
+        self.assertEqual(after["confidence"], before["confidence"])
+
+    def test_run_weekly_backtest_includes_feedback_only_calibration_inputs(
+        self,
+    ) -> None:
+        feedback_only_report = self._persist_report(
+            top_risk="Reviewer found a noisy warning without deployment outcome.",
+            recommendation="caution",
+            severity="medium",
+            file_name="feedback-only.tf",
+            workspace_id=self.workspace.id,
+            include_finding=True,
+        )
+
+        feedback_service_module.record_finding_feedback(
+            analysis_id=feedback_only_report["id"],
+            finding_id=feedback_only_report["findings"][0]["finding_id"],
+            useful=False,
+            false_positive_flag=True,
+            false_positive_reason="Reviewer confirmed this warning was noisy.",
+        )
+        self._stamp_all_feedback_created_at(datetime(2026, 4, 29, 12, 0, tzinfo=UTC))
+
+        summary = backtesting_service_module.run_weekly_backtest(
+            project_id=self.project.id,
+            workspace_id=self.workspace.id,
+            now=datetime(2026, 4, 30, 12, 0, tzinfo=UTC),
+        )
+
+        metrics = summary["calibration_metrics"]
+        self.assertEqual(metrics["sample_size"], 0)
+        self.assertEqual(metrics["feedback_event_count"], 1)
+        self.assertEqual(metrics["false_positive_count"], 1)
+        self.assertEqual(metrics["false_positive_rate"], 1.0)
+        self.assertEqual(summary["false_positive_cases"][0]["severity"], "medium")
+        limitation_codes = {
+            limitation["code"] for limitation in summary["confidence_limitations"]
+        }
+        self.assertNotIn("no_calibration_inputs", limitation_codes)
+        self.assertIn("sparse_outcomes", limitation_codes)
+        self.assertIn("sparse_feedback", limitation_codes)
+        self.assertIn("feedback_bias", limitation_codes)
+        bucket_false_positive_count = sum(
+            bucket["false_positive_count"]
+            for bucket in summary["confidence_trends"]["buckets"].values()
+        )
+        self.assertEqual(bucket_false_positive_count, 0)
+
+    def test_run_weekly_backtest_excludes_stale_feedback_from_window_metrics(
+        self,
+    ) -> None:
+        stale_feedback_report = self._persist_report(
+            top_risk="Old reviewer feedback should stay out of current calibration.",
+            recommendation="caution",
+            severity="medium",
+            file_name="stale-feedback.tf",
+            workspace_id=self.workspace.id,
+            include_finding=True,
+        )
+        feedback_service_module.record_finding_feedback(
+            analysis_id=stale_feedback_report["id"],
+            finding_id=stale_feedback_report["findings"][0]["finding_id"],
+            useful=False,
+            false_positive_flag=True,
+            false_positive_reason="Old reviewer feedback outside this window.",
+        )
+        self._stamp_all_feedback_created_at(datetime(2026, 4, 1, 12, 0, tzinfo=UTC))
+
+        summary = backtesting_service_module.run_weekly_backtest(
+            project_id=self.project.id,
+            workspace_id=self.workspace.id,
+            now=datetime(2026, 4, 30, 12, 0, tzinfo=UTC),
+        )
+
+        metrics = summary["calibration_metrics"]
+        self.assertEqual(metrics["feedback_event_count"], 0)
+        self.assertEqual(metrics["feedback_history_event_count"], 1)
+        self.assertEqual(metrics["false_positive_count"], 0)
+        self.assertEqual(summary["false_positive_cases"], [])
+        limitation_codes = {
+            limitation["code"] for limitation in summary["confidence_limitations"]
+        }
+        self.assertIn("sparse_feedback", limitation_codes)
+        self.assertNotIn("no_calibration_inputs", limitation_codes)
+
+    def test_run_weekly_backtest_includes_feedback_only_false_reassurance(
+        self,
+    ) -> None:
+        feedback_only_report = self._persist_report(
+            top_risk="Reviewer found a missed risk without deployment outcome.",
+            recommendation="go",
+            severity="low",
+            file_name="feedback-only-miss.tf",
+            workspace_id=self.workspace.id,
+            include_finding=True,
+        )
+
+        feedback_service_module.record_false_negative_feedback(
+            analysis_id=feedback_only_report["id"],
+            finding_id=feedback_only_report["findings"][0]["finding_id"],
+            note="Reviewer identified a missed rollback dependency.",
+        )
+        self._stamp_all_feedback_created_at(datetime(2026, 4, 29, 12, 0, tzinfo=UTC))
+
+        summary = backtesting_service_module.run_weekly_backtest(
+            project_id=self.project.id,
+            workspace_id=self.workspace.id,
+            now=datetime(2026, 4, 30, 12, 0, tzinfo=UTC),
+        )
+
+        metrics = summary["calibration_metrics"]
+        self.assertEqual(metrics["sample_size"], 0)
+        self.assertEqual(metrics["feedback_event_count"], 1)
+        self.assertEqual(metrics["false_reassurance_count"], 1)
+        self.assertEqual(metrics["false_reassurance_rate"], 0.0)
+        self.assertEqual(metrics["deployment_false_reassurance_count"], 0)
+        self.assertEqual(metrics["reviewer_missed_feedback_count"], 1)
+        self.assertEqual(
+            summary["false_reassurance_cases"][0]["analysis_id"],
+            feedback_only_report["id"],
+        )
+        bucket_false_reassurance_count = sum(
+            bucket["false_reassurance_count"]
+            for bucket in summary["confidence_trends"]["buckets"].values()
+        )
+        self.assertEqual(bucket_false_reassurance_count, 0)
+        limitation_codes = {
+            limitation["code"] for limitation in summary["confidence_limitations"]
+        }
+        self.assertNotIn("no_calibration_inputs", limitation_codes)
+        self.assertIn("feedback_bias", limitation_codes)
+
+    def test_false_reassurance_cases_sort_by_event_timestamp(self) -> None:
+        deployment_miss_report = self._persist_report(
+            top_risk="Older GO deployment failed without warning.",
+            recommendation="go",
+            severity="low",
+            file_name="older-deploy-miss.tf",
+        )
+        reviewer_miss_report = self._persist_report(
+            top_risk="Newer reviewer missed finding should sort first.",
+            recommendation="go",
+            severity="low",
+            file_name="newer-reviewer-miss.tf",
+            workspace_id=self.workspace.id,
+            include_finding=True,
+        )
+        deployment_outcome_service_module.record_deployment_outcome(
+            analysis_id=deployment_miss_report["id"],
+            outcome="failure",
+            deployed_at="2026-04-29T09:00:00Z",
+        )
+        feedback_service_module.record_false_negative_feedback(
+            analysis_id=reviewer_miss_report["id"],
+            finding_id=reviewer_miss_report["findings"][0]["finding_id"],
+            note="Reviewer identified a missed risk after the deploy event.",
+        )
+        self._stamp_all_feedback_created_at(datetime(2026, 4, 29, 12, 0, tzinfo=UTC))
+
+        summary = backtesting_service_module.run_weekly_backtest(
+            project_id=self.project.id,
+            now=datetime(2026, 4, 30, 12, 0, tzinfo=UTC),
+        )
+
+        self.assertEqual(
+            [case["reason"] for case in summary["false_reassurance_cases"]],
+            ["reviewer_missed_finding_feedback", "failed_without_warning"],
+        )
+
+    def test_run_weekly_backtest_bounds_feedback_rates_and_preserves_missed_cases(
+        self,
+    ) -> None:
+        noisy_report = self._persist_report(
+            top_risk="One warned report has multiple noisy findings.",
+            recommendation="caution",
+            severity="medium",
+            file_name="multi-finding.tf",
+            include_finding=True,
+            finding_count=2,
+        )
+        missed_report = self._persist_report(
+            top_risk="GO report missed multiple rollback risks.",
+            recommendation="go",
+            severity="low",
+            file_name="multiple-misses.tf",
+            include_finding=True,
+            finding_count=2,
+        )
+        success_missed_report = self._persist_report(
+            top_risk="Successful deploy has unrelated missed-feedback note.",
+            recommendation="go",
+            severity="low",
+            file_name="successful-miss.tf",
+            include_finding=True,
+        )
+        deployment_outcome_service_module.record_deployment_outcome(
+            analysis_id=noisy_report["id"],
+            outcome="success",
+            deployed_at="2026-04-29T09:00:00Z",
+        )
+        deployment_outcome_service_module.record_deployment_outcome(
+            analysis_id=missed_report["id"],
+            outcome="failure",
+            deployed_at="2026-04-29T10:00:00Z",
+        )
+        deployment_outcome_service_module.record_deployment_outcome(
+            analysis_id=success_missed_report["id"],
+            outcome="success",
+            deployed_at="2026-04-29T11:00:00Z",
+        )
+        for finding in noisy_report["findings"]:
+            feedback_service_module.record_finding_feedback(
+                analysis_id=noisy_report["id"],
+                finding_id=finding["finding_id"],
+                useful=False,
+                false_positive_flag=True,
+                false_positive_reason="Reviewer confirmed noisy warning.",
+            )
+        for finding in missed_report["findings"]:
+            feedback_service_module.record_false_negative_feedback(
+                analysis_id=missed_report["id"],
+                finding_id=finding["finding_id"],
+                note="Missed a distinct rollback dependency.",
+            )
+        feedback_service_module.record_false_negative_feedback(
+            analysis_id=success_missed_report["id"],
+            finding_id=success_missed_report["findings"][0]["finding_id"],
+            note="This note should not count against a successful outcome.",
+        )
+        self._stamp_all_feedback_created_at(datetime(2026, 4, 29, 12, 0, tzinfo=UTC))
+
+        summary = backtesting_service_module.run_weekly_backtest(
+            project_id=self.project.id,
+            now=datetime(2026, 4, 30, 12, 0, tzinfo=UTC),
+        )
+
+        metrics = summary["calibration_metrics"]
+        self.assertEqual(metrics["false_positive_count"], 2)
+        self.assertEqual(metrics["false_positive_rate"], 1.0)
+        self.assertEqual(metrics["false_reassurance_count"], 3)
+        self.assertEqual(metrics["false_reassurance_rate"], 1.0)
+        confidence_buckets = summary["confidence_trends"]["buckets"]
+        self.assertEqual(confidence_buckets["high"]["false_positive_count"], 1)
+        self.assertEqual(confidence_buckets["high"]["false_reassurance_count"], 1)
+        self.assertEqual(
+            {
+                case["finding_id"]
+                for case in summary["false_reassurance_cases"]
+                if case["finding_id"] is not None
+            },
+            {finding["finding_id"] for finding in missed_report["findings"]},
+        )
+
+    def test_failed_without_warning_keeps_deployment_case_with_reviewer_miss(
+        self,
+    ) -> None:
+        missed_report = self._persist_report(
+            top_risk="GO report missed a deploy rollback.",
+            recommendation="go",
+            severity="low",
+            file_name="deployment-and-reviewer-miss.tf",
+            include_finding=True,
+        )
+        deployment_outcome_service_module.record_deployment_outcome(
+            analysis_id=missed_report["id"],
+            outcome="failure",
+            deployed_at="2026-04-29T09:00:00Z",
+        )
+        feedback_service_module.record_false_negative_feedback(
+            analysis_id=missed_report["id"],
+            finding_id=missed_report["findings"][0]["finding_id"],
+            note="Reviewer found the missed deploy risk after the failure.",
+        )
+        self._stamp_all_feedback_created_at(datetime(2026, 4, 29, 12, 0, tzinfo=UTC))
+
+        summary = backtesting_service_module.run_weekly_backtest(
+            project_id=self.project.id,
+            now=datetime(2026, 4, 30, 12, 0, tzinfo=UTC),
+        )
+
+        self.assertEqual(
+            [case["reason"] for case in summary["false_reassurance_cases"]],
+            ["reviewer_missed_finding_feedback", "failed_without_warning"],
+        )
+        metrics = summary["calibration_metrics"]
+        self.assertEqual(metrics["deployment_false_reassurance_count"], 1)
+        self.assertEqual(metrics["reviewer_missed_feedback_count"], 1)
+
+    def test_feedback_bias_uses_reviewer_feedback_not_outcome_misses(self) -> None:
+        quiet_failure_report = self._persist_report(
+            top_risk="GO report later failed without reviewer feedback.",
+            recommendation="go",
+            severity="low",
+            file_name="quiet-outcome-miss.tf",
+        )
+        useful_report = self._persist_report(
+            top_risk="Useful warning should balance feedback mix.",
+            recommendation="caution",
+            severity="medium",
+            file_name="useful-feedback.tf",
+            include_finding=True,
+        )
+        noisy_report = self._persist_report(
+            top_risk="Noisy warning should balance feedback mix.",
+            recommendation="caution",
+            severity="medium",
+            file_name="noisy-feedback.tf",
+            include_finding=True,
+        )
+        deployment_outcome_service_module.record_deployment_outcome(
+            analysis_id=quiet_failure_report["id"],
+            outcome="failure",
+            deployed_at="2026-04-29T10:00:00Z",
+        )
+        feedback_service_module.record_finding_feedback(
+            analysis_id=useful_report["id"],
+            finding_id=useful_report["findings"][0]["finding_id"],
+            useful=True,
+        )
+        feedback_service_module.record_finding_feedback(
+            analysis_id=noisy_report["id"],
+            finding_id=noisy_report["findings"][0]["finding_id"],
+            useful=False,
+            false_positive_flag=True,
+            false_positive_reason="Reviewer confirmed the warning was noisy.",
+        )
+        self._stamp_all_feedback_created_at(datetime(2026, 4, 29, 12, 0, tzinfo=UTC))
+
+        summary = backtesting_service_module.run_weekly_backtest(
+            project_id=self.project.id,
+            now=datetime(2026, 4, 30, 12, 0, tzinfo=UTC),
+        )
+
+        metrics = summary["calibration_metrics"]
+        self.assertEqual(metrics["false_reassurance_count"], 1)
+        self.assertEqual(metrics["deployment_false_reassurance_count"], 1)
+        self.assertEqual(metrics["false_reassurance_rate"], 1.0)
+        limitation_codes = {
+            limitation["code"] for limitation in summary["confidence_limitations"]
+        }
+        self.assertNotIn("feedback_bias", limitation_codes)
+
+    def test_warned_report_false_negative_feedback_is_not_false_reassurance(
+        self,
+    ) -> None:
+        warned_report = self._persist_report(
+            top_risk="Warned report should not be false reassurance.",
+            recommendation="caution",
+            severity="medium",
+            file_name="warned-miss.tf",
+            include_finding=True,
+        )
+        deployment_outcome_service_module.record_deployment_outcome(
+            analysis_id=warned_report["id"],
+            outcome="failure",
+            deployed_at="2026-04-29T10:00:00Z",
+        )
+        feedback_service_module.record_false_negative_feedback(
+            analysis_id=warned_report["id"],
+            finding_id=warned_report["findings"][0]["finding_id"],
+            note="Reviewer added missed-finding context to a report that warned.",
+        )
+        self._stamp_all_feedback_created_at(datetime(2026, 4, 29, 12, 0, tzinfo=UTC))
+
+        summary = backtesting_service_module.run_weekly_backtest(
+            project_id=self.project.id,
+            now=datetime(2026, 4, 30, 12, 0, tzinfo=UTC),
+        )
+
+        metrics = summary["calibration_metrics"]
+        self.assertEqual(summary["warned_failed_deploy_count"], 1)
+        self.assertEqual(metrics["false_reassurance_count"], 0)
+        self.assertEqual(summary["false_reassurance_cases"], [])
+
+    def test_workspace_backtest_does_not_stamp_project_last_run(self) -> None:
+        warned_report = self._persist_report(
+            top_risk="Workspace backtest should not mark project due state.",
+            recommendation="caution",
+            severity="medium",
+            file_name="workspace-last-run.tf",
+            workspace_id=self.workspace.id,
+        )
+        deployment_outcome_service_module.record_deployment_outcome(
+            analysis_id=warned_report["id"],
+            outcome="failure",
+            deployed_at="2026-04-29T09:00:00Z",
+        )
+
+        summary = backtesting_service_module.run_weekly_backtest(
+            project_id=self.project.id,
+            workspace_id=self.workspace.id,
+            now=datetime(2026, 4, 30, 12, 0, tzinfo=UTC),
+        )
+
+        self.assertEqual(summary["failed_deploy_count"], 1)
+        with database_module.SessionLocal() as session:
+            self.assertIsNone(
+                get_setting(
+                    session,
+                    f"backtesting:last_run_at:project:{self.project.id}",
+                )
+            )
+            self.assertIsNotNone(
+                get_setting(
+                    session,
+                    (
+                        f"backtesting:snapshot:project:{self.project.id}"
+                        f":workspace:{self.workspace.id}"
+                    ),
+                )
+            )
+
+    def test_workspace_calibration_seed_refreshes_stale_cached_snapshot(self) -> None:
+        warned_report = self._persist_report(
+            top_risk="Old workspace snapshot should refresh on read.",
+            recommendation="caution",
+            severity="medium",
+            file_name="workspace-stale-cache.tf",
+            workspace_id=self.workspace.id,
+        )
+        deployment_outcome_service_module.record_deployment_outcome(
+            analysis_id=warned_report["id"],
+            outcome="failure",
+            deployed_at="2026-04-29T09:00:00Z",
+        )
+        old_summary = backtesting_service_module.run_weekly_backtest(
+            project_id=self.project.id,
+            workspace_id=self.workspace.id,
+            now=datetime(2026, 4, 30, 12, 0, tzinfo=UTC),
+        )
+
+        refreshed = backtesting_service_module.fetch_calibration_dashboard_seed(
+            project_id=self.project.id,
+            workspace_id=self.workspace.id,
+            now=datetime(2026, 5, 8, 12, 0, tzinfo=UTC),
+        )
+
+        self.assertEqual(old_summary["failed_deploy_count"], 1)
+        self.assertEqual(refreshed["failed_deploy_count"], 0)
+        self.assertEqual(
+            refreshed["window"]["end"],
+            "2026-05-08T12:00:00+00:00",
+        )
+        with database_module.SessionLocal() as session:
+            self.assertIsNotNone(
+                get_setting(
+                    session,
+                    (
+                        f"backtesting:snapshot:project:{self.project.id}"
+                        f":workspace:{self.workspace.id}"
+                    ),
+                )
+            )
+
+    def test_calibration_seed_refreshes_corrupt_cached_snapshot(self) -> None:
+        warned_report = self._persist_report(
+            top_risk="Corrupt cached calibration should self-heal.",
+            recommendation="caution",
+            severity="medium",
+            file_name="corrupt-cache.tf",
+        )
+        deployment_outcome_service_module.record_deployment_outcome(
+            analysis_id=warned_report["id"],
+            outcome="failure",
+            deployed_at="2026-04-29T09:00:00Z",
+        )
+        with database_module.SessionLocal() as session:
+            upsert_setting(
+                session,
+                key=f"backtesting:snapshot:project:{self.project.id}",
+                value="{not-valid-json",
+            )
+
+        refreshed = backtesting_service_module.fetch_calibration_dashboard_seed(
+            project_id=self.project.id,
+            now=datetime(2026, 4, 30, 12, 0, tzinfo=UTC),
+        )
+
+        self.assertEqual(refreshed["failed_deploy_count"], 1)
+        self.assertEqual(refreshed["warned_failed_deploy_count"], 1)
+
+    def test_calibration_seed_refreshes_future_dated_cached_snapshot(self) -> None:
+        with database_module.SessionLocal() as session:
+            upsert_setting(
+                session,
+                key=f"backtesting:snapshot:project:{self.project.id}",
+                value=json.dumps(
+                    {
+                        "window": {
+                            "end": "2026-05-20T12:00:00+00:00",
+                            "days": 7,
+                        },
+                        "failed_deploy_count": 99,
+                    }
+                ),
+            )
+
+        refreshed = backtesting_service_module.fetch_calibration_dashboard_seed(
+            project_id=self.project.id,
+            now=datetime(2026, 4, 30, 12, 0, tzinfo=UTC),
+        )
+
+        self.assertEqual(refreshed["failed_deploy_count"], 0)
+        self.assertEqual(
+            refreshed["window"]["end"],
+            "2026-04-30T12:00:00+00:00",
+        )
+
+    def test_calibration_seed_refreshes_old_schema_cached_snapshot(self) -> None:
+        warned_report = self._persist_report(
+            top_risk="Fresh old-schema cache should refresh on read.",
+            recommendation="caution",
+            severity="medium",
+            file_name="old-schema-cache.tf",
+        )
+        deployment_outcome_service_module.record_deployment_outcome(
+            analysis_id=warned_report["id"],
+            outcome="failure",
+            deployed_at="2026-04-29T09:00:00Z",
+        )
+        with database_module.SessionLocal() as session:
+            upsert_setting(
+                session,
+                key=f"backtesting:snapshot:project:{self.project.id}",
+                value=json.dumps(
+                    {
+                        "project": {"id": self.project.id},
+                        "window": {
+                            "end": "2026-04-30T12:00:00+00:00",
+                            "days": 7,
+                        },
+                        "failed_deploy_count": 99,
+                        "warned_failed_deploy_count": 0,
+                        "overall_precision": 0.0,
+                        "overall_recall": 0.0,
+                    }
+                ),
+            )
+
+        refreshed = backtesting_service_module.fetch_calibration_dashboard_seed(
+            project_id=self.project.id,
+            now=datetime(2026, 4, 30, 12, 0, tzinfo=UTC),
+        )
+
+        self.assertEqual(refreshed["failed_deploy_count"], 1)
+        self.assertEqual(refreshed["warned_failed_deploy_count"], 1)
+        self.assertIn("calibration_metrics", refreshed)
+
+    def test_calibration_seed_rejects_wrong_window_cached_snapshot(self) -> None:
+        cached = backtesting_service_module.run_weekly_backtest(
+            project_id=self.project.id,
+            now=datetime(2026, 4, 30, 12, 0, tzinfo=UTC),
+        )
+        cached["window"]["days"] = 14
+        cached["failed_deploy_count"] = 99
+        with database_module.SessionLocal() as session:
+            upsert_setting(
+                session,
+                key=f"backtesting:snapshot:project:{self.project.id}",
+                value=json.dumps(cached),
+            )
+
+        refreshed = backtesting_service_module.fetch_calibration_dashboard_seed(
+            project_id=self.project.id,
+            now=datetime(2026, 4, 30, 12, 0, tzinfo=UTC),
+        )
+
+        self.assertEqual(refreshed["failed_deploy_count"], 0)
+        self.assertEqual(refreshed["window"]["days"], 7)
+
+    def test_calibration_seed_rejects_mismatched_window_bounds_snapshot(self) -> None:
+        cached = backtesting_service_module.run_weekly_backtest(
+            project_id=self.project.id,
+            now=datetime(2026, 4, 30, 12, 0, tzinfo=UTC),
+        )
+        cached["window"]["start"] = "2026-04-20T12:00:00+00:00"
+        cached["failed_deploy_count"] = 99
+        with database_module.SessionLocal() as session:
+            upsert_setting(
+                session,
+                key=f"backtesting:snapshot:project:{self.project.id}",
+                value=json.dumps(cached),
+            )
+
+        refreshed = backtesting_service_module.fetch_calibration_dashboard_seed(
+            project_id=self.project.id,
+            now=datetime(2026, 4, 30, 12, 0, tzinfo=UTC),
+        )
+
+        self.assertEqual(refreshed["failed_deploy_count"], 0)
+        self.assertEqual(
+            refreshed["window"]["start"],
+            "2026-04-23T12:00:00+00:00",
+        )
+
+    def test_calibration_seed_rejects_partial_shape_cached_snapshot(self) -> None:
+        cached = backtesting_service_module.run_weekly_backtest(
+            project_id=self.project.id,
+            now=datetime(2026, 4, 30, 12, 0, tzinfo=UTC),
+        )
+        cached.pop("false_reassurance_cases")
+        cached["failed_deploy_count"] = 99
+        with database_module.SessionLocal() as session:
+            upsert_setting(
+                session,
+                key=f"backtesting:snapshot:project:{self.project.id}",
+                value=json.dumps(cached),
+            )
+
+        refreshed = backtesting_service_module.fetch_calibration_dashboard_seed(
+            project_id=self.project.id,
+            now=datetime(2026, 4, 30, 12, 0, tzinfo=UTC),
+        )
+
+        self.assertEqual(refreshed["failed_deploy_count"], 0)
+        self.assertIn("false_reassurance_cases", refreshed)
+
+    def test_calibration_seed_rejects_malformed_nested_metrics_snapshot(
+        self,
+    ) -> None:
+        cached = backtesting_service_module.run_weekly_backtest(
+            project_id=self.project.id,
+            now=datetime(2026, 4, 30, 12, 0, tzinfo=UTC),
+        )
+        cached["failed_deploy_count"] = 99
+        cached["calibration_metrics"]["false_positive_rate"] = "1.0"
+        cached["calibration_metrics"]["recall_proxy_signals"]["failed_deploy_count"] = (
+            "0"
+        )
+        with database_module.SessionLocal() as session:
+            upsert_setting(
+                session,
+                key=f"backtesting:snapshot:project:{self.project.id}",
+                value=json.dumps(cached),
+            )
+
+        refreshed = backtesting_service_module.fetch_calibration_dashboard_seed(
+            project_id=self.project.id,
+            now=datetime(2026, 4, 30, 12, 0, tzinfo=UTC),
+        )
+
+        self.assertEqual(refreshed["failed_deploy_count"], 0)
+        self.assertIsInstance(
+            refreshed["calibration_metrics"]["false_positive_rate"],
+            float,
+        )
+
+    def test_workspace_calibration_seed_rejects_wrong_scope_cached_snapshot(
+        self,
+    ) -> None:
+        staging = project_service_module.create_workspace(
+            project_key="payments",
+            workspace_key="staging",
+            display_name="Staging",
+        )
+        cached = backtesting_service_module.run_weekly_backtest(
+            project_id=self.project.id,
+            workspace_id=self.workspace.id,
+            now=datetime(2026, 4, 30, 12, 0, tzinfo=UTC),
+        )
+        cached["workspace"] = {
+            "id": staging.id,
+            "workspace_key": "staging",
+            "display_name": "Staging",
+        }
+        cached["failed_deploy_count"] = 99
+        with database_module.SessionLocal() as session:
+            upsert_setting(
+                session,
+                key=(
+                    f"backtesting:snapshot:project:{self.project.id}"
+                    f":workspace:{self.workspace.id}"
+                ),
+                value=json.dumps(cached),
+            )
+
+        refreshed = backtesting_service_module.fetch_calibration_dashboard_seed(
+            project_id=self.project.id,
+            workspace_id=self.workspace.id,
+            now=datetime(2026, 4, 30, 12, 0, tzinfo=UTC),
+        )
+
+        self.assertEqual(refreshed["failed_deploy_count"], 0)
+        self.assertEqual(refreshed["workspace"]["id"], self.workspace.id)
+
+    def test_confidence_trends_count_outcomes_and_preserve_unknown_confidence(
+        self,
+    ) -> None:
+        duplicate_report = self._persist_report(
+            top_risk="Duplicate outcomes should stay in confidence sample.",
+            recommendation="caution",
+            severity="medium",
+            file_name="duplicate-confidence.tf",
+            confidence=0.72,
+        )
+        unknown_report = self._persist_report(
+            top_risk="Missing confidence should not become zero.",
+            recommendation="go",
+            severity="low",
+            file_name="unknown-confidence.tf",
+            confidence=0.51,
+        )
+        with database_module.SessionLocal() as session:
+            risk_assessment = (
+                session.query(tables_module.RiskAssessment)
+                .filter_by(analysis_id=unknown_report["id"])
+                .one()
+            )
+            session.delete(risk_assessment)
+            session.commit()
+        deployment_outcome_service_module.record_deployment_outcome(
+            analysis_id=duplicate_report["id"],
+            outcome="failure",
+            deployed_at="2026-04-29T09:00:00Z",
+        )
+        deployment_outcome_service_module.record_deployment_outcome(
+            analysis_id=duplicate_report["id"],
+            outcome="rolled_back",
+            deployed_at="2026-04-29T10:00:00Z",
+        )
+        deployment_outcome_service_module.record_deployment_outcome(
+            analysis_id=unknown_report["id"],
+            outcome="success",
+            deployed_at="2026-04-29T11:00:00Z",
+        )
+
+        summary = backtesting_service_module.run_weekly_backtest(
+            project_id=self.project.id,
+            now=datetime(2026, 4, 30, 12, 0, tzinfo=UTC),
+        )
+
+        buckets = summary["confidence_trends"]["buckets"]
+        self.assertEqual(summary["confidence_trends"]["sample_size"], 3)
+        self.assertEqual(buckets["medium"]["sample_count"], 2)
+        self.assertEqual(buckets["medium"]["average_confidence"], 0.72)
+        self.assertEqual(buckets["unknown"]["sample_count"], 1)
+        self.assertIsNone(buckets["unknown"]["average_confidence"])
+
     def test_run_due_weekly_backtests_persists_and_reuses_snapshot(self) -> None:
         warned_report = self._persist_report(
             top_risk="Warned deploy failed later.",
@@ -168,7 +1082,8 @@ class BacktestingServiceTests(unittest.TestCase):
         self.assertEqual(second, [])
 
         cached = backtesting_service_module.fetch_calibration_dashboard_seed(
-            project_id=self.project.id
+            project_id=self.project.id,
+            now=datetime(2026, 5, 1, 12, 0, tzinfo=UTC),
         )
         self.assertEqual(cached["failed_deploy_count"], 1)
         self.assertEqual(cached["warned_failed_deploy_count"], 1)
@@ -350,6 +1265,107 @@ class BacktestingServiceTests(unittest.TestCase):
         self.assertEqual(first["failed_deploy_count"], 1)
         self.assertEqual(refreshed["failed_deploy_count"], 2)
         self.assertEqual(refreshed["warned_failed_deploy_count"], 1)
+
+    def test_record_finding_feedback_invalidates_cached_calibration_snapshot(
+        self,
+    ) -> None:
+        warned_report = self._persist_report(
+            top_risk="Warned deploy later marked noisy.",
+            recommendation="caution",
+            severity="medium",
+            file_name="warned-feedback.tf",
+            include_finding=True,
+        )
+        deployment_outcome_service_module.record_deployment_outcome(
+            analysis_id=warned_report["id"],
+            outcome="success",
+            deployed_at=self._recent_deployed_at(hours_ago=24),
+        )
+        first = backtesting_service_module.fetch_calibration_dashboard_seed(
+            project_id=self.project.id
+        )
+
+        feedback_service_module.record_finding_feedback(
+            analysis_id=warned_report["id"],
+            finding_id=warned_report["findings"][0]["finding_id"],
+            useful=False,
+            false_positive_flag=True,
+            false_positive_reason="Control owner confirmed the warning was noisy.",
+        )
+        refreshed = backtesting_service_module.fetch_calibration_dashboard_seed(
+            project_id=self.project.id
+        )
+
+        self.assertEqual(first["calibration_metrics"]["false_positive_count"], 0)
+        self.assertEqual(refreshed["calibration_metrics"]["false_positive_count"], 1)
+        self.assertEqual(refreshed["calibration_metrics"]["false_positive_rate"], 1.0)
+
+    def test_remove_analysis_report_invalidates_cached_calibration_snapshot(
+        self,
+    ) -> None:
+        warned_report = self._persist_report(
+            top_risk="Deleted report should leave calibration cache stale.",
+            recommendation="caution",
+            severity="medium",
+            file_name="deleted-report-cache.tf",
+        )
+        deployment_outcome_service_module.record_deployment_outcome(
+            analysis_id=warned_report["id"],
+            outcome="failure",
+            deployed_at=self._recent_deployed_at(hours_ago=24),
+        )
+        first = backtesting_service_module.fetch_calibration_dashboard_seed(
+            project_id=self.project.id
+        )
+
+        removed = report_service_module.remove_analysis_report(warned_report["id"])
+        refreshed = backtesting_service_module.fetch_calibration_dashboard_seed(
+            project_id=self.project.id
+        )
+
+        self.assertTrue(removed)
+        self.assertEqual(first["failed_deploy_count"], 1)
+        self.assertEqual(refreshed["failed_deploy_count"], 0)
+
+    def test_deleted_report_feedback_does_not_pollute_calibration_metrics(
+        self,
+    ) -> None:
+        noisy_report = self._persist_report(
+            top_risk="Deleted feedback should not remain calibration input.",
+            recommendation="caution",
+            severity="medium",
+            file_name="deleted-feedback-cache.tf",
+            include_finding=True,
+        )
+        feedback_service_module.record_finding_feedback(
+            analysis_id=noisy_report["id"],
+            finding_id=noisy_report["findings"][0]["finding_id"],
+            useful=False,
+            false_positive_flag=True,
+            false_positive_reason="Reviewer confirmed the warning was noisy.",
+        )
+        self._stamp_all_feedback_created_at(datetime(2026, 4, 29, 12, 0, tzinfo=UTC))
+        before_delete = backtesting_service_module.fetch_calibration_dashboard_seed(
+            project_id=self.project.id,
+            now=datetime(2026, 4, 30, 12, 0, tzinfo=UTC),
+        )
+
+        removed = report_service_module.remove_analysis_report(noisy_report["id"])
+        after_delete = backtesting_service_module.fetch_calibration_dashboard_seed(
+            project_id=self.project.id,
+            now=datetime(2026, 4, 30, 12, 0, tzinfo=UTC),
+        )
+
+        self.assertTrue(removed)
+        self.assertEqual(
+            before_delete["calibration_metrics"]["false_positive_count"], 1
+        )
+        self.assertEqual(after_delete["calibration_metrics"]["feedback_event_count"], 0)
+        self.assertEqual(
+            after_delete["calibration_metrics"]["feedback_history_event_count"],
+            0,
+        )
+        self.assertEqual(after_delete["calibration_metrics"]["false_positive_count"], 0)
 
     def test_run_due_weekly_backtests_continues_after_one_project_failure(self) -> None:
         other_project = project_service_module.create_project(

--- a/tests/test_ui/test_history_page.py
+++ b/tests/test_ui/test_history_page.py
@@ -8,6 +8,7 @@ import tempfile
 import unittest
 from datetime import UTC, datetime, timedelta
 from importlib import reload
+from unittest import mock
 
 import app as app_module
 import config as config_module
@@ -56,6 +57,96 @@ class HistoryPageHelpersTests(unittest.TestCase):
                 "kubernetes": "Kubernetes",
                 "terraform": "Terraform",
             },
+        )
+
+    def test_fetch_history_risk_trends_uses_workspace_scope(self) -> None:
+        expected = {"total_reports": 1, "severity_counts": {"high": 1}}
+
+        with mock.patch.object(
+            history_module,
+            "fetch_risk_trends",
+            return_value=expected,
+        ) as fetch_risk_trends:
+            result = history_module._fetch_history_risk_trends(
+                has_history_scope=True,
+                project_id=7,
+                workspace_key="prod",
+            )
+
+        self.assertEqual(result, expected)
+        fetch_risk_trends.assert_called_once_with(
+            project_id=7,
+            workspace_key="prod",
+        )
+
+    def test_fetch_history_risk_trends_returns_empty_without_scope(self) -> None:
+        with mock.patch.object(
+            history_module, "fetch_risk_trends"
+        ) as fetch_risk_trends:
+            result = history_module._fetch_history_risk_trends(
+                has_history_scope=False,
+                project_id=None,
+                workspace_key="prod",
+            )
+
+        self.assertEqual(result["total_reports"], 0)
+        fetch_risk_trends.assert_not_called()
+
+    def test_calibration_limitation_labels_preserve_all_active_warnings(self) -> None:
+        labels = history_module._calibration_limitation_labels(
+            {
+                "confidence_limitations": [
+                    {"label": "Sparse calibration data"},
+                    {"label": "Limited reviewer feedback"},
+                    {"label": "Feedback may be biased"},
+                ]
+            }
+        )
+
+        self.assertEqual(
+            labels,
+            [
+                "Sparse calibration data",
+                "Limited reviewer feedback",
+                "Feedback may be biased",
+            ],
+        )
+
+    def test_empty_calibration_dashboard_seed_matches_full_payload_shape(self) -> None:
+        seed = history_module._empty_calibration_dashboard_seed()
+
+        self.assertIn("project", seed)
+        self.assertIn("workspace", seed)
+        self.assertEqual(set(seed["window"]), {"start", "end", "days"})
+        self.assertIn("false_positive_cases", seed)
+        self.assertIn("false_reassurance_cases", seed)
+        self.assertEqual(seed["confidence_trends"], {"buckets": {}, "sample_size": 0})
+        metrics = seed["calibration_metrics"]
+        self.assertEqual(
+            {
+                "sample_size",
+                "feedback_event_count",
+                "feedback_history_event_count",
+                "precision",
+                "recall_proxy",
+                "false_positive_count",
+                "false_positive_rate",
+                "false_reassurance_count",
+                "false_reassurance_rate",
+                "deployment_false_reassurance_count",
+                "reviewer_missed_feedback_count",
+                "recall_proxy_signals",
+            },
+            set(metrics),
+        )
+        self.assertEqual(
+            {
+                "failed_deploy_count",
+                "warned_failed_deploy_count",
+                "failed_without_warning_count",
+                "missed_feedback_count",
+            },
+            set(metrics["recall_proxy_signals"]),
         )
 
     def test_recommendation_helpers_preserve_semantic_go_no_go_styling(self) -> None:
@@ -1665,6 +1756,31 @@ class HistoryPageRenderingTests(unittest.TestCase):
         self.assertIn("1 warned", response.text)
         self.assertIn("Precision 1.00", response.text)
         self.assertIn("Recall 1.00", response.text)
+        self.assertIn("Directional only", response.text)
+        self.assertIn("Sparse calibration data", response.text)
+
+    def test_history_page_renders_feedback_bias_calibration_limitation(self) -> None:
+        report = self._persist_report(
+            score=42,
+            severity="medium",
+            recommendation="caution",
+            top_risk="Reviewer marked feedback as noisy.",
+            opening_sentence="Reviewer feedback should shape calibration labels.",
+        )
+        feedback_service_module.record_finding_feedback(
+            analysis_id=report["id"],
+            finding_id=report["findings"][0]["finding_id"],
+            useful=False,
+            false_positive_flag=True,
+            false_positive_reason="Reviewer confirmed the warning was noisy.",
+        )
+
+        response = self.client.get("/history")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("Sparse calibration data", response.text)
+        self.assertIn("Limited reviewer feedback", response.text)
+        self.assertIn("Feedback may be biased", response.text)
 
     def test_history_page_shows_diff_indicator_for_rescanned_same_artifact(
         self,

--- a/ui/routes/history.py
+++ b/ui/routes/history.py
@@ -71,16 +71,73 @@ def _empty_risk_trends() -> dict[str, Any]:
     }
 
 
+def _fetch_history_risk_trends(
+    *,
+    has_history_scope: bool,
+    project_id: int | None,
+    workspace_key: str | None = None,
+) -> dict[str, Any]:
+    if not has_history_scope:
+        return _empty_risk_trends()
+    return fetch_risk_trends(
+        project_id=project_id,
+        workspace_key=workspace_key,
+    )
+
+
 def _empty_calibration_dashboard_seed() -> dict[str, Any]:
     return {
+        "project": None,
+        "workspace": None,
+        "window": {"start": None, "end": None, "days": 7},
         "failed_deploy_count": 0,
         "warned_failed_deploy_count": 0,
         "overall_precision": 0.0,
         "overall_recall": 0.0,
-        "window": {"days": 7},
         "backtest_rows": [],
         "by_severity": {},
+        "false_positive_cases": [],
+        "false_reassurance_cases": [],
+        "confidence_trends": {"buckets": {}, "sample_size": 0},
+        "calibration_metrics": {
+            "sample_size": 0,
+            "feedback_event_count": 0,
+            "feedback_history_event_count": 0,
+            "precision": 0.0,
+            "recall_proxy": 0.0,
+            "false_positive_count": 0,
+            "false_positive_rate": 0.0,
+            "false_reassurance_count": 0,
+            "false_reassurance_rate": 0.0,
+            "deployment_false_reassurance_count": 0,
+            "reviewer_missed_feedback_count": 0,
+            "recall_proxy_signals": {
+                "failed_deploy_count": 0,
+                "warned_failed_deploy_count": 0,
+                "failed_without_warning_count": 0,
+                "missed_feedback_count": 0,
+            },
+        },
+        "confidence_limitations": [
+            {
+                "code": "no_calibration_inputs",
+                "label": "No calibration inputs",
+                "message": "No deployment outcomes or feedback are linked yet.",
+            }
+        ],
+        "confidence_label": "Directional only",
+        "statistical_certainty": False,
     }
+
+
+def _calibration_limitation_labels(calibration: dict[str, Any]) -> list[str]:
+    labels: list[str] = []
+    for limitation in calibration.get("confidence_limitations") or []:
+        if isinstance(limitation, dict):
+            label = str(limitation.get("label") or "").strip()
+            if label:
+                labels.append(label)
+    return labels or ["Calibration evidence available"]
 
 
 def _history_workspace_options(project_key: str | None) -> dict[str, str]:
@@ -147,10 +204,9 @@ def build_history_page() -> None:
         )
         reports = reports_page["items"]
         total_report_count = reports_page["total_count"]
-        trends = (
-            _empty_risk_trends()
-            if not has_history_scope
-            else fetch_risk_trends(project_id=active_project_id)
+        trends = _fetch_history_risk_trends(
+            has_history_scope=has_history_scope,
+            project_id=active_project_id,
         )
         calibration = (
             _empty_calibration_dashboard_seed()
@@ -193,8 +249,12 @@ def build_history_page() -> None:
                     back_href="/",
                     back_label="Back to dashboard",
                 )
-            with ui.card().classes("w-full dw-panel shadow-none p-4"):
-                with ui.column().classes("gap-0"):
+            risk_trends_card = ui.card().classes("w-full dw-panel shadow-none p-4")
+            calibration_card = ui.card().classes("w-full dw-panel shadow-none p-4")
+
+            def render_risk_trends_summary() -> None:
+                risk_trends_card.clear()
+                with risk_trends_card, ui.column().classes("gap-0"):
                     ui.label("Risk trends").classes("dw-eyebrow mb-1")
                     ui.label(
                         f"{trends['total_reports']} reports · "
@@ -212,8 +272,10 @@ def build_history_page() -> None:
                             )[:3]
                         )
                     ).classes("mt-[2px] text-sm dw-muted")
-            with ui.card().classes("w-full dw-panel shadow-none p-4"):
-                with ui.column().classes("gap-0"):
+
+            def render_calibration_summary() -> None:
+                calibration_card.clear()
+                with calibration_card, ui.column().classes("gap-0"):
                     ui.label("Calibration snapshot").classes("dw-eyebrow mb-1")
                     ui.label(
                         f"{calibration['failed_deploy_count']} failed deploys · "
@@ -224,6 +286,19 @@ def build_history_page() -> None:
                         f"Recall {calibration['overall_recall']:.2f} · "
                         f"{calibration['window']['days']}d window"
                     ).classes("mt-[2px] text-sm dw-muted")
+                    limitation_label = " · ".join(
+                        _calibration_limitation_labels(calibration)
+                    )
+                    ui.label(
+                        f"{calibration.get('confidence_label', 'Directional only')} · "
+                        f"{limitation_label}"
+                    ).classes("mt-[2px] text-sm dw-muted")
+
+            def render_summaries() -> None:
+                render_risk_trends_summary()
+                render_calibration_summary()
+
+            render_summaries()
             search_input = (
                 ui.input(placeholder="Search top risk or summary")
                 .props("outlined dense clearable prepend-icon=search")
@@ -340,15 +415,18 @@ def build_history_page() -> None:
                 )
                 reports = page_payload["items"]
                 total_report_count = page_payload["total_count"]
-                trends = (
-                    _empty_risk_trends()
-                    if not has_history_scope
-                    else fetch_risk_trends(project_id=active_project_id)
+                trends = _fetch_history_risk_trends(
+                    has_history_scope=has_history_scope,
+                    project_id=active_project_id,
+                    workspace_key=current_workspace_key(),
                 )
                 calibration = (
                     _empty_calibration_dashboard_seed()
                     if not has_history_scope
-                    else fetch_calibration_dashboard_seed(project_id=active_project_id)
+                    else fetch_calibration_dashboard_seed(
+                        project_id=active_project_id,
+                        workspace_key=current_workspace_key(),
+                    )
                 )
                 max_page = max(
                     1, (total_report_count - 1) // page_state["page_size"] + 1
@@ -540,6 +618,7 @@ def build_history_page() -> None:
                 )
                 page_state["page"] = min(max(1, page_state["page"] + delta), max_page)
                 refresh_data(search_input.value.strip() if search_input.value else None)
+                render_summaries()
                 render_history()
                 render_actions()
 
@@ -548,6 +627,7 @@ def build_history_page() -> None:
                 page_state["page"] = 1
                 selected_ids.clear()
                 refresh_data(query)
+                render_summaries()
                 render_history()
                 render_actions()
 


### PR DESCRIPTION
Story 6.4 adds outcome calibration metrics across deployment outcomes, reviewer feedback, confidence trends, scoped history rendering, and cache reuse. The final review pass found that stale or orphaned feedback and loose cache-window validation could still make calibration evidence look more certain than it was, so the closeout keeps those paths explicitly bounded and regression-tested.

Constraint: DeployWhisper remains local-first and advisory-first; calibration metrics must not mutate historical report verdicts.

Rejected: Keep reviewer-only misses as replacements for deployment misses | it drops deployment event evidence needed for false-reassurance review.

Rejected: Trust fresh cache timestamps by end time alone | wrong start bounds can reuse the wrong 7-day window.

Confidence: high

Scope-risk: moderate

Directive: Do not reuse cached calibration snapshots without validating scope, exact 7-day bounds, and nested metric shape.

Tested: ./.venv/bin/python -m unittest tests.test_services.test_backtesting_service -q (32 tests)

Tested: ./.venv/bin/python -m unittest tests.test_ui.test_history_page -q (57 tests)

Tested: ./.venv/bin/ruff check .

Tested: ./.venv/bin/ruff format --check .

Tested: ./.venv/bin/bandit -q services/backtesting_service.py services/feedback_service.py services/report_service.py ui/routes/history.py models/repositories/settings.py models/repositories/feedback_events.py

Tested: ./.venv/bin/python -m unittest discover -q (452 tests, 1 skipped)

Tested: bash scripts/ci-local.sh

Tested: APP_PORT=18080 npm run test:ui-review (4 Playwright tests)

Tested: APP_PORT=18081 ./.venv/bin/python app.py plus curl -fsSL http://127.0.0.1:18081/history

Not-tested: VoiceOver-specific UI review

## What does this PR do?

<!-- Brief description of changes -->

## Type of change
- [ ] Feature (new functionality)
- [ ] Bugfix (non-breaking fix)
- [ ] Release preparation
- [ ] Hotfix (critical production fix)
- [ ] Docs / refactor / chore

## Checklist
- [ ] I have followed the branch naming convention
- [ ] Tests pass locally (`pytest tests/ -v`)
- [ ] Linting passes (`ruff check .`)
- [ ] Docker build succeeds
- [ ] I have updated docs if needed
- [ ] No secrets or .env values committed

## Related issue
Closes #