### PR TITLE
Prove incident backtesting catches historical replay gaps

### DIFF
--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -1,5 +1,5 @@
 # generated: 2026-05-01
-# last_updated: 2026-06-03
+# last_updated: 2026-06-08
 # project: deploywhisper
 # project_key: NOKEY
 # tracking_system: file-system
@@ -35,7 +35,7 @@
 # - Dev moves story to review, then runs code-review
 
 generated: 2026-05-01
-last_updated: 2026-06-03
+last_updated: 2026-06-08
 project: deploywhisper
 project_key: NOKEY
 tracking_system: file-system
@@ -105,7 +105,7 @@ development_status:
   6-2-benchmark-runner: review
   6-3-honest-failure-report-generator: done
   6-4-outcome-calibration-metrics: review
-  6-5-incident-backtesting: ready-for-dev
+  6-5-incident-backtesting: done
   6-6-risk-trend-review: ready-for-dev
   epic-6-retrospective: optional
 

--- a/cli/analyze.py
+++ b/cli/analyze.py
@@ -42,6 +42,7 @@ from services.benchmark_corpus_service import (
     BenchmarkCorpusValidationError,
     validate_benchmark_corpus,
 )
+from services.backtesting_service import run_incident_backtest
 from services.benchmark_runner_service import run_benchmark_corpus
 from services.deployment_outcome_service import record_deployment_outcome
 from services.project_service import create_project, create_workspace
@@ -893,6 +894,43 @@ def _run_benchmark_run(path: str | None) -> int:
     return 0 if result.passed else 1
 
 
+def _run_benchmark_backtest_incidents(args: argparse.Namespace) -> int:
+    try:
+        result = run_incident_backtest(
+            project_id=args.project_id,
+            project_key=args.project_key,
+            workspace_id=args.workspace_id,
+            workspace_key=args.workspace_key,
+        )
+    except (ValueError, OSError, ValidationError) as exc:
+        _emit_json(
+            {
+                "passed": False,
+                "summary": {
+                    "project_id": args.project_id,
+                    "project_key": args.project_key,
+                    "workspace_id": args.workspace_id,
+                    "workspace_key": args.workspace_key,
+                    "scenario_count": 0,
+                    "detected_count": 0,
+                    "missed_count": 0,
+                    "unsupported_count": 0,
+                    "insufficient_context_count": 0,
+                    "error_count": 1,
+                    "generated_at": datetime.now(tz=UTC)
+                    .isoformat()
+                    .replace("+00:00", "Z"),
+                },
+                "scenarios": [],
+                "errors": [str(exc)],
+            },
+            stream=sys.stdout,
+        )
+        return 1
+    _emit_json(result, stream=sys.stdout)
+    return 0 if result.get("passed") else 1
+
+
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description="DeployWhisper CLI")
     subparsers = parser.add_subparsers(dest="command")
@@ -1223,6 +1261,28 @@ def build_parser() -> argparse.ArgumentParser:
         "--path",
         help="Optional benchmark corpus root. Defaults to benchmarks/corpus/v1.",
     )
+    benchmark_backtest_parser = benchmark_subparsers.add_parser(
+        "backtest-incidents",
+        help="Replay incident-linked artifacts against the current analysis core.",
+    )
+    benchmark_backtest_parser.add_argument(
+        "--project-id",
+        type=int,
+        help="DeployWhisper numeric project id.",
+    )
+    benchmark_backtest_parser.add_argument(
+        "--project-key",
+        help="DeployWhisper project key.",
+    )
+    benchmark_backtest_parser.add_argument(
+        "--workspace-id",
+        type=int,
+        help="Optional DeployWhisper numeric workspace id.",
+    )
+    benchmark_backtest_parser.add_argument(
+        "--workspace-key",
+        help="Optional DeployWhisper workspace key.",
+    )
 
     return parser
 
@@ -1280,6 +1340,8 @@ def main() -> None:
         raise SystemExit(_run_benchmark_validate_corpus(args.path))
     if args.command == "benchmark" and args.benchmark_command == "run":
         raise SystemExit(_run_benchmark_run(args.path))
+    if args.command == "benchmark" and args.benchmark_command == "backtest-incidents":
+        raise SystemExit(_run_benchmark_backtest_incidents(args))
 
     print("DeployWhisper CLI ready: foundation-check")
 

--- a/docs/outcome-linking.md
+++ b/docs/outcome-linking.md
@@ -32,6 +32,26 @@ DeployWhisper can now link incident records back to persisted analysis reports a
 - Feedback and deployment outcomes update aggregate calibration metrics only; historical report severity, recommendation, verdict confidence, and narrative fields remain immutable.
 - False-reassurance reviewer feedback is counted only when the report did not warn, so missed-finding notes on caution/no-go reports do not imply the advisory system reassured the user.
 
+## Incident Replay Backtesting
+
+- `services.backtesting_service.run_incident_backtest(...)` replays imported incident records that are linked to persisted analysis reports.
+- The replay uses the locally stored accepted artifact snapshots from the linked report and runs them through the shared analysis core with ambient topology, incident memory, narrative generation, and LLM assistance disabled. Raw artifacts remain local.
+- The CLI command is:
+
+```bash
+python -m cli.analyze benchmark backtest-incidents --project-key <project>
+```
+
+- Add `--workspace-key`, `--project-id`, or `--workspace-id` when a narrower scope is needed.
+- Each scenario is classified as:
+  - `detected` when the replay produces a caution/no-go warning.
+  - `missed` when the replay returns `go`.
+  - `unsupported` when the incident is not linked to a report, the linked report is unavailable, accepted artifact snapshots are missing, or the replay parser accepts no artifacts.
+  - `insufficient_context` when the shared analysis core reports insufficient supporting context.
+  - `error` when replay execution fails.
+- Scenario rows link incident metadata, linked report metadata, expected evidence from the original persisted report, observed replay evidence, observed findings, context TODOs, and improvement guidance.
+- The command exits non-zero when any scenario is missed or errors, so it can be used as a guardrail for benchmark claims while still reporting unsupported and insufficient-context scenarios explicitly.
+
 ## Scheduler and Calibration Feed
 
 - The app lifecycle scheduler now runs `run_due_weekly_backtests()` alongside topology drift checks.

--- a/services/backtesting_service.py
+++ b/services/backtesting_service.py
@@ -10,8 +10,11 @@ from typing import Any
 
 from sqlalchemy import select
 
+from services.artifact_snapshot_service import load_report_artifact
 from models.database import SessionLocal
+from models.repositories.analysis_reports import get_analysis_report
 from models.repositories.feedback_events import list_feedback_events
+from models.repositories.incident_records import list_incident_records
 from models.repositories.settings import (
     delete_setting,
     delete_settings_by_key_prefix,
@@ -36,6 +39,13 @@ from services.project_service import (
 BACKTEST_WINDOW_DAYS = 7
 BACKTEST_LAST_RUN_KEY = "backtesting:last_run_at:project:"
 BACKTEST_SNAPSHOT_KEY = "backtesting:snapshot:project:"
+INCIDENT_BACKTEST_STATUSES = (
+    "detected",
+    "missed",
+    "unsupported",
+    "insufficient_context",
+    "error",
+)
 
 logger = logging.getLogger(__name__)
 
@@ -192,6 +202,378 @@ def _serialize_timestamp(value: datetime) -> str:
     else:
         value = value.astimezone(UTC)
     return value.isoformat()
+
+
+def _load_json_object(raw_value: str | None) -> dict[str, Any]:
+    try:
+        decoded = json.loads(raw_value or "{}")
+    except json.JSONDecodeError:
+        return {}
+    return decoded if isinstance(decoded, dict) else {}
+
+
+def _load_json_list(raw_value: str | None) -> list[Any]:
+    try:
+        decoded = json.loads(raw_value or "[]")
+    except json.JSONDecodeError:
+        return []
+    return decoded if isinstance(decoded, list) else []
+
+
+def _accepted_replay_artifact_names(report: AnalysisReport) -> list[str]:
+    manifest = _load_json_object(report.submission_manifest_json)
+    items = manifest.get("items")
+    accepted = (
+        [
+            str(item.get("name"))
+            for item in items
+            if isinstance(item, dict)
+            and item.get("status") == "accepted"
+            and str(item.get("name") or "").strip()
+        ]
+        if isinstance(items, list)
+        else []
+    )
+    if accepted:
+        return list(dict.fromkeys(accepted))
+    fallback = _load_json_list(report.analyzed_files_json)
+    return list(
+        dict.fromkeys(
+            str(item) for item in fallback if isinstance(item, str) and item.strip()
+        )
+    )
+
+
+def _replay_artifact_files(
+    report: AnalysisReport,
+) -> tuple[list[tuple[str, bytes | None]], list[str], list[str]]:
+    missing: list[str] = []
+    files: list[tuple[str, bytes | None]] = []
+    for artifact_name in _accepted_replay_artifact_names(report):
+        snapshot = load_report_artifact(int(report.id), artifact_name)
+        if snapshot is None:
+            missing.append(artifact_name)
+            continue
+        files.append((artifact_name, snapshot.content.encode("utf-8")))
+    return files, [name for name, _ in files], missing
+
+
+def _incident_payload(incident: IncidentRecord) -> dict[str, Any]:
+    return {
+        "id": incident.id,
+        "project_id": incident.project_id,
+        "workspace_id": incident.workspace_id,
+        "title": incident.title,
+        "severity": incident.severity,
+        "source_file": incident.source_file,
+        "incident_date": incident.incident_date,
+        "analysis_id": incident.analysis_id,
+    }
+
+
+def _linked_report_payload(report: AnalysisReport | None) -> dict[str, Any] | None:
+    if report is None:
+        return None
+    return {
+        "id": report.id,
+        "project_id": report.project_id,
+        "workspace_id": report.workspace_id,
+        "severity": report.severity,
+        "recommendation": report.recommendation,
+        "risk_score": report.risk_score,
+        "top_risk": report.top_risk,
+        "created_at": _serialize_timestamp(report.created_at),
+    }
+
+
+def _expected_evidence_payload(report: AnalysisReport | None) -> list[dict[str, Any]]:
+    if report is None:
+        return []
+    evidence_items: list[dict[str, Any]] = []
+    for finding in report.findings:
+        for evidence in finding.evidence_items:
+            evidence_items.append(
+                {
+                    "evidence_id": evidence.evidence_id,
+                    "finding_id": evidence.finding_id,
+                    "source_ref": evidence.source_ref,
+                    "artifact": evidence.artifact,
+                    "location": evidence.location,
+                    "resource": evidence.resource,
+                    "operation": evidence.operation,
+                    "summary": evidence.summary,
+                    "severity_hint": evidence.severity_hint,
+                    "deterministic": evidence.deterministic,
+                }
+            )
+    return evidence_items
+
+
+def _observed_evidence_payload(evidence_items: list[Any]) -> list[dict[str, Any]]:
+    payload: list[dict[str, Any]] = []
+    for evidence in evidence_items:
+        if hasattr(evidence, "model_dump"):
+            item = evidence.model_dump(mode="json")
+        else:
+            item = dict(evidence)
+        payload.append(
+            {
+                "evidence_id": item.get("evidence_id"),
+                "source_ref": item.get("source_ref"),
+                "artifact": item.get("artifact"),
+                "location": item.get("location"),
+                "resource": item.get("resource"),
+                "operation": item.get("operation"),
+                "summary": item.get("summary"),
+                "severity_hint": item.get("severity_hint"),
+                "deterministic": item.get("deterministic"),
+            }
+        )
+    return payload
+
+
+def _observed_finding_payload(findings: list[Any]) -> list[dict[str, Any]]:
+    payload: list[dict[str, Any]] = []
+    for finding in findings:
+        if hasattr(finding, "model_dump"):
+            item = finding.model_dump(mode="json")
+        else:
+            item = dict(finding)
+        payload.append(
+            {
+                "finding_id": item.get("finding_id"),
+                "title": item.get("title"),
+                "severity": item.get("severity"),
+                "category": item.get("category"),
+                "deterministic": item.get("deterministic"),
+                "confidence": item.get("confidence"),
+                "evidence_refs": item.get("evidence_refs") or [],
+            }
+        )
+    return payload
+
+
+def _run_incident_replay_analysis(files: list[tuple[str, bytes | None]]):
+    from services.analysis_service import build_analysis_artifacts
+
+    return build_analysis_artifacts(
+        files,
+        include_topology_context=False,
+        include_incident_context=False,
+        include_narrative=False,
+        allow_llm_assistance=False,
+    )
+
+
+def _incident_backtest_improvements(
+    *,
+    status: str,
+    context_todos: list[str],
+    missing_artifacts: list[str],
+) -> list[str]:
+    if status == "detected":
+        return ["No immediate analyzer improvement identified for this replay."]
+    if status == "missed":
+        return [
+            "Review incident prevention notes and add deterministic evidence/risk patterns for the missed change."
+        ]
+    if status == "insufficient_context":
+        return context_todos or [
+            "Import the missing topology, incident, scanner, or ownership context before rerunning the backtest."
+        ]
+    if missing_artifacts:
+        return ["Store accepted replay artifact snapshots for the linked report."]
+    return ["Link the incident to an analysis report with accepted replay artifacts."]
+
+
+def _classify_incident_replay(analysis_artifacts) -> tuple[str, str]:
+    assessment = analysis_artifacts.assessment
+    manifest = analysis_artifacts.submission_manifest
+    if getattr(manifest, "accepted_artifact_count", 0) == 0:
+        return "unsupported", "unsupported"
+    if assessment.context_completeness.insufficient_context:
+        return "insufficient_context", "insufficient_context"
+    if str(assessment.recommendation).lower() == "go":
+        return "missed", "go"
+    if (
+        str(assessment.recommendation).lower() == "no-go"
+        and assessment.severity == "critical"
+    ):
+        return "detected", "stop"
+    return "detected", "warn"
+
+
+def _unsupported_incident_scenario(
+    *,
+    incident: IncidentRecord,
+    report: AnalysisReport | None,
+    reasons: list[str],
+    missing_artifacts: list[str] | None = None,
+    replay_artifacts: list[str] | None = None,
+) -> dict[str, Any]:
+    missing_artifacts = missing_artifacts or []
+    replay_artifacts = replay_artifacts or []
+    return {
+        "incident": _incident_payload(incident),
+        "linked_report": _linked_report_payload(report),
+        "status": "unsupported",
+        "actual_verdict": "unsupported",
+        "actual_recommendation": None,
+        "actual_severity": None,
+        "actual_score": None,
+        "replay_artifacts": replay_artifacts,
+        "missing_replay_artifacts": missing_artifacts,
+        "expected_evidence": _expected_evidence_payload(report),
+        "observed_evidence": [],
+        "observed_findings": [],
+        "context_todos": [],
+        "reasons": reasons,
+        "what_would_need_to_improve": _incident_backtest_improvements(
+            status="unsupported",
+            context_todos=[],
+            missing_artifacts=missing_artifacts,
+        ),
+    }
+
+
+def _error_incident_scenario(
+    *,
+    incident: IncidentRecord,
+    report: AnalysisReport | None,
+    reasons: list[str],
+    replay_artifacts: list[str] | None = None,
+    missing_artifacts: list[str] | None = None,
+) -> dict[str, Any]:
+    return {
+        "incident": _incident_payload(incident),
+        "linked_report": _linked_report_payload(report),
+        "status": "error",
+        "actual_verdict": "error",
+        "actual_recommendation": None,
+        "actual_severity": None,
+        "actual_score": None,
+        "replay_artifacts": replay_artifacts or [],
+        "missing_replay_artifacts": missing_artifacts or [],
+        "expected_evidence": _expected_evidence_payload(report),
+        "observed_evidence": [],
+        "observed_findings": [],
+        "context_todos": [],
+        "reasons": reasons,
+        "what_would_need_to_improve": [
+            "Fix the replay execution error, then rerun incident backtesting."
+        ],
+    }
+
+
+def _run_incident_backtest_scenario(
+    *,
+    incident: IncidentRecord,
+    report: AnalysisReport | None,
+) -> dict[str, Any]:
+    if incident.analysis_id is None:
+        return _unsupported_incident_scenario(
+            incident=incident,
+            report=report,
+            reasons=["Incident is not linked to an analysis report."],
+        )
+    if report is None:
+        return _unsupported_incident_scenario(
+            incident=incident,
+            report=report,
+            reasons=["Linked analysis report is unavailable."],
+        )
+
+    try:
+        files, replay_artifact_names, missing_artifacts = _replay_artifact_files(report)
+    except Exception as exc:  # noqa: BLE001
+        return _error_incident_scenario(
+            incident=incident,
+            report=report,
+            reasons=[str(exc)],
+        )
+
+    if not files:
+        return _unsupported_incident_scenario(
+            incident=incident,
+            report=report,
+            reasons=["No accepted replay artifact snapshots are available."],
+            missing_artifacts=missing_artifacts,
+        )
+    if missing_artifacts:
+        return _unsupported_incident_scenario(
+            incident=incident,
+            report=report,
+            reasons=[
+                "Some accepted linked-report artifact snapshots were unavailable: "
+                + ", ".join(missing_artifacts)
+            ],
+            missing_artifacts=missing_artifacts,
+            replay_artifacts=replay_artifact_names,
+        )
+
+    try:
+        analysis_artifacts = _run_incident_replay_analysis(files)
+    except Exception as exc:  # noqa: BLE001
+        return _error_incident_scenario(
+            incident=incident,
+            report=report,
+            reasons=[str(exc)],
+            replay_artifacts=replay_artifact_names,
+            missing_artifacts=missing_artifacts,
+        )
+
+    status, actual_verdict = _classify_incident_replay(analysis_artifacts)
+    assessment = analysis_artifacts.assessment
+    context_todos = list(assessment.context_completeness.context_todos)
+    reasons = list(assessment.warnings)
+    return {
+        "incident": _incident_payload(incident),
+        "linked_report": _linked_report_payload(report),
+        "status": status,
+        "actual_verdict": actual_verdict,
+        "actual_recommendation": assessment.recommendation,
+        "actual_severity": assessment.severity,
+        "actual_score": assessment.score,
+        "replay_artifacts": replay_artifact_names,
+        "missing_replay_artifacts": missing_artifacts,
+        "expected_evidence": _expected_evidence_payload(report),
+        "observed_evidence": _observed_evidence_payload(
+            list(analysis_artifacts.evidence_items)
+        ),
+        "observed_findings": _observed_finding_payload(
+            list(analysis_artifacts.findings)
+        ),
+        "context_todos": context_todos,
+        "reasons": reasons,
+        "what_would_need_to_improve": _incident_backtest_improvements(
+            status=status,
+            context_todos=context_todos,
+            missing_artifacts=missing_artifacts,
+        ),
+    }
+
+
+def _incident_linked_report(
+    *,
+    session,
+    incident: IncidentRecord,
+    project_id: int,
+    workspace_id: int | None,
+) -> AnalysisReport | None:
+    if incident.analysis_id is None:
+        return None
+    report = get_analysis_report(
+        session,
+        int(incident.analysis_id),
+        project_id=project_id,
+        workspace_id=workspace_id,
+        include_evidence=True,
+    )
+    if report is None or workspace_id is not None:
+        return report
+    if report.workspace_id != incident.workspace_id:
+        return None
+    return report
 
 
 def _confidence_bucket(confidence: float | None) -> str:
@@ -898,6 +1280,75 @@ def run_weekly_backtest(
             value=json.dumps(summary),
         )
     return summary
+
+
+def run_incident_backtest(
+    *,
+    project_id: int | None = None,
+    project_key: str | None = None,
+    workspace_id: int | None = None,
+    workspace_key: str | None = None,
+    now: datetime | None = None,
+) -> dict[str, Any]:
+    """Replay incident-linked artifacts through the current analysis core."""
+
+    project = resolve_project_reference(project_id=project_id, project_key=project_key)
+    workspace = resolve_workspace_reference(
+        project_id=project.id,
+        workspace_id=workspace_id,
+        workspace_key=workspace_key,
+    )
+    generated_at = _serialize_timestamp(now or datetime.now(UTC))
+    with SessionLocal() as session:
+        incidents = list_incident_records(
+            session,
+            project_id=project.id,
+            workspace_id=workspace.id if workspace is not None else None,
+        )
+        scenarios = [
+            _run_incident_backtest_scenario(
+                incident=incident,
+                report=_incident_linked_report(
+                    session=session,
+                    incident=incident,
+                    project_id=project.id,
+                    workspace_id=workspace.id if workspace is not None else None,
+                ),
+            )
+            for incident in incidents
+        ]
+    counts = {
+        status: sum(1 for scenario in scenarios if scenario["status"] == status)
+        for status in INCIDENT_BACKTEST_STATUSES
+    }
+    summary = {
+        "project_id": project.id,
+        "project_key": project.project_key,
+        "workspace_id": workspace.id if workspace is not None else None,
+        "workspace_key": workspace.workspace_key if workspace is not None else None,
+        "scenario_count": len(scenarios),
+        "detected_count": counts["detected"],
+        "missed_count": counts["missed"],
+        "unsupported_count": counts["unsupported"],
+        "insufficient_context_count": counts["insufficient_context"],
+        "error_count": counts["error"],
+        "generated_at": generated_at,
+    }
+    return {
+        "passed": counts["missed"] == 0 and counts["error"] == 0,
+        "project": build_project_payload(project),
+        "workspace": build_workspace_payload(workspace)
+        if workspace is not None
+        else None,
+        "summary": summary,
+        "scenarios": scenarios,
+        "errors": [
+            reason
+            for scenario in scenarios
+            if scenario["status"] == "error"
+            for reason in scenario["reasons"]
+        ],
+    }
 
 
 def run_due_weekly_backtests(*, now: datetime | None = None) -> list[dict[str, Any]]:

--- a/tests/test_cli/test_analyze.py
+++ b/tests/test_cli/test_analyze.py
@@ -296,6 +296,54 @@ class AnalyzeCliTests(unittest.TestCase):
         self.assertFalse(payload["passed"])
         self.assertEqual(payload["summary"]["failed_count"], 1)
 
+    def test_benchmark_backtest_incidents_command_reports_project_results(
+        self,
+    ) -> None:
+        output = io.StringIO()
+        result = {
+            "passed": False,
+            "summary": {
+                "project_id": 7,
+                "workspace_id": None,
+                "scenario_count": 2,
+                "detected_count": 1,
+                "missed_count": 1,
+                "unsupported_count": 0,
+                "insufficient_context_count": 0,
+                "error_count": 0,
+                "generated_at": "2026-06-08T00:00:00Z",
+            },
+            "scenarios": [],
+            "errors": [],
+        }
+
+        with (
+            patch(
+                "sys.argv",
+                [
+                    "deploywhisper",
+                    "benchmark",
+                    "backtest-incidents",
+                    "--project-id",
+                    "7",
+                ],
+            ),
+            patch("cli.analyze.run_incident_backtest", return_value=result) as mocked,
+            redirect_stdout(output),
+        ):
+            with self.assertRaises(SystemExit) as ctx:
+                main()
+
+        payload = json.loads(output.getvalue())
+        self.assertEqual(ctx.exception.code, 1)
+        self.assertEqual(payload["summary"]["missed_count"], 1)
+        mocked.assert_called_once_with(
+            project_id=7,
+            project_key=None,
+            workspace_id=None,
+            workspace_key=None,
+        )
+
     def test_benchmark_run_command_reports_invalid_corpus_as_json(self) -> None:
         output = io.StringIO()
 

--- a/tests/test_services/test_backtesting_service.py
+++ b/tests/test_services/test_backtesting_service.py
@@ -14,7 +14,9 @@ from unittest import mock
 import config as config_module
 import models.database as database_module
 import models.repositories.analysis_reports as analysis_reports_repository_module
+import models.repositories.incident_records as incident_records_repository_module
 import models.tables as tables_module
+import services.artifact_snapshot_service as artifact_snapshot_service_module
 import services.backtesting_service as backtesting_service_module
 import services.deployment_outcome_service as deployment_outcome_service_module
 import services.feedback_service as feedback_service_module
@@ -23,7 +25,7 @@ import services.project_service as project_service_module
 import services.report_service as report_service_module
 from models.repositories.settings import get_setting, upsert_setting
 from analysis.risk_scorer import RiskAssessment
-from evidence.models import Finding
+from evidence.models import ContextCompleteness, EvidenceItem, Finding
 from llm.narrator import NarrativeResult
 from parsers.base import ParseBatchResult, ParsedFileResult
 
@@ -32,15 +34,20 @@ class BacktestingServiceTests(unittest.TestCase):
     def setUp(self) -> None:
         self.tempdir = tempfile.TemporaryDirectory()
         self.db_path = Path(self.tempdir.name) / "backtesting.db"
+        self.snapshot_dir = Path(self.tempdir.name) / "report-artifacts"
         os.environ["DATABASE_URL"] = f"sqlite:///{self.db_path}"
+        os.environ["ARTIFACT_SNAPSHOT_DIR"] = str(self.snapshot_dir)
         reload(config_module)
         reload(tables_module)
         reload(database_module)
         reload(analysis_reports_repository_module)
+        reload(incident_records_repository_module)
+        reload(artifact_snapshot_service_module)
         reload(project_service_module)
         reload(report_service_module)
         reload(feedback_service_module)
         reload(deployment_outcome_service_module)
+        reload(incident_service_module)
         reload(backtesting_service_module)
         database_module.init_db()
         self.project = project_service_module.create_project(
@@ -56,6 +63,7 @@ class BacktestingServiceTests(unittest.TestCase):
     def tearDown(self) -> None:
         database_module.engine.dispose()
         os.environ.pop("DATABASE_URL", None)
+        os.environ.pop("ARTIFACT_SNAPSHOT_DIR", None)
         self.tempdir.cleanup()
 
     def _persist_report(
@@ -123,6 +131,152 @@ class BacktestingServiceTests(unittest.TestCase):
             project_id=self.project.id,
             workspace_id=workspace_id,
             audit_context={"source_interface": "api"},
+        )
+
+    def _persist_replay_report(
+        self,
+        *,
+        file_name: str,
+        extra_file_names: list[str] | None = None,
+        recommendation: str = "go",
+        severity: str = "low",
+        project_id: int | None = None,
+        workspace_id: int | None = None,
+        artifact_snapshots: dict[str, bytes | None] | None = None,
+    ) -> dict:
+        file_names = [file_name, *(extra_file_names or [])]
+        if artifact_snapshots is None:
+            artifact_snapshots = {
+                name: f"resource {name}\n".encode("utf-8") for name in file_names
+            }
+        return report_service_module.persist_analysis_report(
+            ParseBatchResult(
+                files=[
+                    ParsedFileResult(
+                        file_name=name,
+                        tool="terraform",
+                        status="parsed",
+                        changes=[],
+                    )
+                    for name in file_names
+                ]
+            ),
+            RiskAssessment(
+                score=12 if recommendation == "go" else 66,
+                severity=severity,
+                recommendation=recommendation,
+                top_risk=f"Replay fixture for {file_name}.",
+                confidence=0.8,
+                contributors=[],
+                interaction_risks=[],
+                partial_context=False,
+                warnings=[],
+            ),
+            NarrativeResult(
+                opening_sentence=f"Replay fixture for {file_name}.",
+                explanation=f"Replay fixture for {file_name}.",
+                guidance=[],
+                degraded=False,
+                warnings=[],
+            ),
+            findings=[
+                Finding(
+                    finding_id=f"expected-{file_name.replace('.', '-')}",
+                    analysis_id=0,
+                    title=f"Expected incident evidence for {file_name}",
+                    description="Historical evidence expected during replay.",
+                    severity=severity,
+                    category="incident/backtest",
+                    deterministic=True,
+                    confidence=0.8,
+                    uncertainty_note=None,
+                    evidence_refs=[f"expected-evidence-{file_name.replace('.', '-')}"],
+                    skill_id=None,
+                )
+            ],
+            evidence_items=[
+                EvidenceItem(
+                    evidence_id=f"expected-evidence-{file_name.replace('.', '-')}",
+                    analysis_id=0,
+                    finding_id=f"expected-{file_name.replace('.', '-')}",
+                    source_type="artifact",
+                    source_ref=f"artifact://{file_name}#expected",
+                    artifact=file_name,
+                    location="line 1",
+                    resource="fixture",
+                    operation="modify",
+                    summary="Historical replay evidence.",
+                    severity_hint=severity,
+                    deterministic=True,
+                    confidence=0.8,
+                )
+            ],
+            project_id=project_id or self.project.id,
+            workspace_id=workspace_id,
+            audit_context={"source_interface": "api"},
+            artifact_snapshots=artifact_snapshots,
+        )
+
+    def _fake_replay_artifacts(
+        self,
+        *,
+        recommendation: str,
+        severity: str,
+        insufficient_context: bool = False,
+    ):
+        return mock.Mock(
+            assessment=RiskAssessment(
+                score=12 if recommendation == "go" else 66,
+                severity=severity,
+                recommendation=recommendation,
+                top_risk="Replay assessment.",
+                confidence=0.8,
+                contributors=[],
+                interaction_risks=[],
+                context_completeness=ContextCompleteness(
+                    context_score=0.4 if insufficient_context else 1.0,
+                    confidence_level="low" if insufficient_context else "high",
+                    insufficient_context=insufficient_context,
+                    context_todos=["Import more topology."]
+                    if insufficient_context
+                    else [],
+                ),
+                partial_context=False,
+                warnings=[],
+            ),
+            evidence_items=[
+                EvidenceItem(
+                    evidence_id="observed-evidence",
+                    analysis_id=0,
+                    finding_id="observed-finding",
+                    source_type="artifact",
+                    source_ref="artifact://fixture#observed",
+                    artifact="fixture.tf",
+                    location="line 1",
+                    resource="fixture",
+                    operation="modify",
+                    summary="Observed replay evidence.",
+                    severity_hint=severity,
+                    deterministic=True,
+                    confidence=0.8,
+                )
+            ],
+            findings=[
+                Finding(
+                    finding_id="observed-finding",
+                    analysis_id=0,
+                    title="Observed replay finding",
+                    description="Observed replay finding.",
+                    severity=severity,
+                    category="incident/backtest",
+                    deterministic=True,
+                    confidence=0.8,
+                    uncertainty_note=None,
+                    evidence_refs=["observed-evidence"],
+                    skill_id=None,
+                )
+            ],
+            submission_manifest=mock.Mock(accepted_artifact_count=1),
         )
 
     def _recent_deployed_at(self, *, hours_ago: int = 24) -> str:
@@ -1145,6 +1299,251 @@ class BacktestingServiceTests(unittest.TestCase):
         self.assertEqual(summary["overall_precision"], 1.0)
         self.assertEqual(summary["overall_recall"], 1.0)
         self.assertEqual(summary["backtest_rows"][0]["incident_id"], incident["id"])
+
+    def test_run_incident_backtest_replays_linked_report_artifacts(self) -> None:
+        detected_report = self._persist_replay_report(
+            file_name="detected.tf",
+            recommendation="caution",
+            severity="medium",
+        )
+        missed_report = self._persist_replay_report(file_name="missed.tf")
+        insufficient_report = self._persist_replay_report(file_name="insufficient.tf")
+        unsupported_report = self._persist_report(
+            top_risk="Legacy report lacks stored replay artifacts.",
+            recommendation="go",
+            severity="low",
+            file_name="unsupported.tf",
+        )
+
+        detected_incident = incident_service_module.ingest_incident_document(
+            "detected-incident.md",
+            "# Detected incident\nDate: 2026-04-29\nSeverity: high\nReplay should warn.",
+            analysis_id=detected_report["id"],
+        )
+        incident_service_module.ingest_incident_document(
+            "missed-incident.md",
+            "# Missed incident\nDate: 2026-04-29\nSeverity: high\nReplay should miss.",
+            analysis_id=missed_report["id"],
+        )
+        incident_service_module.ingest_incident_document(
+            "insufficient-incident.md",
+            "# Insufficient incident\nDate: 2026-04-29\nSeverity: high\nReplay lacks context.",
+            analysis_id=insufficient_report["id"],
+        )
+        incident_service_module.ingest_incident_document(
+            "unsupported-incident.md",
+            "# Unsupported incident\nDate: 2026-04-29\nSeverity: high\nNo replay artifact snapshot.",
+            analysis_id=unsupported_report["id"],
+        )
+
+        def fake_replay(files):
+            artifact_name = files[0][0]
+            if artifact_name == "detected.tf":
+                return self._fake_replay_artifacts(
+                    recommendation="caution",
+                    severity="medium",
+                )
+            if artifact_name == "insufficient.tf":
+                return self._fake_replay_artifacts(
+                    recommendation="go",
+                    severity="low",
+                    insufficient_context=True,
+                )
+            return self._fake_replay_artifacts(recommendation="go", severity="low")
+
+        with mock.patch(
+            "services.backtesting_service._run_incident_replay_analysis",
+            side_effect=fake_replay,
+        ):
+            result = backtesting_service_module.run_incident_backtest(
+                project_id=self.project.id,
+                now=datetime(2026, 4, 30, 12, 0, tzinfo=UTC),
+            )
+
+        self.assertFalse(result["passed"])
+        self.assertEqual(result["summary"]["scenario_count"], 4)
+        self.assertEqual(result["summary"]["detected_count"], 1)
+        self.assertEqual(result["summary"]["missed_count"], 1)
+        self.assertEqual(result["summary"]["insufficient_context_count"], 1)
+        self.assertEqual(result["summary"]["unsupported_count"], 1)
+        statuses = {
+            scenario["incident"]["source_file"]: scenario["status"]
+            for scenario in result["scenarios"]
+        }
+        self.assertEqual(statuses["detected-incident.md"], "detected")
+        self.assertEqual(statuses["missed-incident.md"], "missed")
+        self.assertEqual(statuses["insufficient-incident.md"], "insufficient_context")
+        self.assertEqual(statuses["unsupported-incident.md"], "unsupported")
+        detected = next(
+            scenario
+            for scenario in result["scenarios"]
+            if scenario["incident"]["id"] == detected_incident["id"]
+        )
+        self.assertEqual(detected["replay_artifacts"], ["detected.tf"])
+        self.assertEqual(detected["linked_report"]["id"], detected_report["id"])
+        self.assertTrue(detected["expected_evidence"])
+        self.assertEqual(
+            detected["expected_evidence"][0]["artifact"],
+            "detected.tf",
+        )
+        self.assertTrue(detected["observed_findings"][0]["evidence_refs"])
+        self.assertEqual(detected["incident"]["project_id"], self.project.id)
+        self.assertIsNone(detected["incident"]["workspace_id"])
+        self.assertEqual(detected["linked_report"]["project_id"], self.project.id)
+        self.assertIsNone(detected["linked_report"]["workspace_id"])
+
+    def test_run_incident_backtest_reports_unlinked_incident_as_unsupported(
+        self,
+    ) -> None:
+        incident_service_module.ingest_incident_document(
+            "unlinked-incident.md",
+            "# Unlinked incident\nDate: 2026-04-29\nSeverity: high\nNo replay report.",
+            project_id=self.project.id,
+        )
+
+        result = backtesting_service_module.run_incident_backtest(
+            project_id=self.project.id,
+            now=datetime(2026, 4, 30, 12, 0, tzinfo=UTC),
+        )
+
+        self.assertEqual(result["summary"]["scenario_count"], 1)
+        self.assertEqual(result["summary"]["unsupported_count"], 1)
+        self.assertEqual(result["scenarios"][0]["status"], "unsupported")
+        self.assertIn("Incident is not linked", result["scenarios"][0]["reasons"][0])
+
+    def test_run_incident_backtest_rejects_cross_scope_linked_report(
+        self,
+    ) -> None:
+        other_project = project_service_module.create_project(
+            project_key="identity",
+            display_name="Identity",
+        )
+        other_report = self._persist_replay_report(
+            file_name="identity.tf",
+            project_id=other_project.id,
+        )
+        with database_module.SessionLocal() as session:
+            incident_records_repository_module.create_incident_record(
+                session,
+                project_id=self.project.id,
+                title="Cross-scope incident",
+                severity="high",
+                source_file="cross-scope-incident.md",
+                incident_date="2026-04-29",
+                analysis_id=other_report["id"],
+                content="Cross-scope report links should not replay.",
+            )
+
+        with mock.patch(
+            "services.backtesting_service._run_incident_replay_analysis"
+        ) as replay:
+            result = backtesting_service_module.run_incident_backtest(
+                project_id=self.project.id,
+                now=datetime(2026, 4, 30, 12, 0, tzinfo=UTC),
+            )
+
+        replay.assert_not_called()
+        self.assertTrue(result["passed"])
+        self.assertEqual(result["summary"]["unsupported_count"], 1)
+        scenario = result["scenarios"][0]
+        self.assertEqual(scenario["status"], "unsupported")
+        self.assertIsNone(scenario["linked_report"])
+        self.assertIn("unavailable", scenario["reasons"][0])
+
+    def test_run_incident_backtest_rejects_cross_workspace_linked_report(
+        self,
+    ) -> None:
+        workspace_report = self._persist_replay_report(
+            file_name="workspace.tf",
+            workspace_id=self.workspace.id,
+        )
+        with database_module.SessionLocal() as session:
+            incident_records_repository_module.create_incident_record(
+                session,
+                project_id=self.project.id,
+                workspace_id=None,
+                title="Project incident linked to workspace report",
+                severity="high",
+                source_file="cross-workspace-incident.md",
+                incident_date="2026-04-29",
+                analysis_id=workspace_report["id"],
+                content="Cross-workspace report links should not replay.",
+            )
+
+        with mock.patch(
+            "services.backtesting_service._run_incident_replay_analysis"
+        ) as replay:
+            result = backtesting_service_module.run_incident_backtest(
+                project_id=self.project.id,
+                now=datetime(2026, 4, 30, 12, 0, tzinfo=UTC),
+            )
+
+        replay.assert_not_called()
+        self.assertTrue(result["passed"])
+        self.assertEqual(result["summary"]["unsupported_count"], 1)
+        scenario = result["scenarios"][0]
+        self.assertEqual(scenario["status"], "unsupported")
+        self.assertIsNone(scenario["linked_report"])
+        self.assertIn("unavailable", scenario["reasons"][0])
+
+    def test_run_incident_backtest_rejects_partial_replay_artifact_snapshots(
+        self,
+    ) -> None:
+        report = self._persist_replay_report(
+            file_name="partial-a.tf",
+            extra_file_names=["partial-b.tf"],
+        )
+        report_dir = self.snapshot_dir / str(report["id"])
+        manifest = json.loads(
+            (report_dir / "manifest.json").read_text(encoding="utf-8")
+        )
+        (report_dir / manifest["partial-b.tf"]).unlink()
+        incident_service_module.ingest_incident_document(
+            "partial-incident.md",
+            "# Partial incident\nDate: 2026-04-29\nSeverity: high\nReplay is incomplete.",
+            analysis_id=report["id"],
+        )
+
+        with mock.patch(
+            "services.backtesting_service._run_incident_replay_analysis"
+        ) as replay:
+            result = backtesting_service_module.run_incident_backtest(
+                project_id=self.project.id,
+                now=datetime(2026, 4, 30, 12, 0, tzinfo=UTC),
+            )
+
+        replay.assert_not_called()
+        self.assertTrue(result["passed"])
+        self.assertEqual(result["summary"]["unsupported_count"], 1)
+        scenario = result["scenarios"][0]
+        self.assertEqual(scenario["status"], "unsupported")
+        self.assertEqual(scenario["replay_artifacts"], ["partial-a.tf"])
+        self.assertEqual(scenario["missing_replay_artifacts"], ["partial-b.tf"])
+
+    def test_run_incident_backtest_reports_snapshot_load_error_per_scenario(
+        self,
+    ) -> None:
+        report = self._persist_replay_report(file_name="corrupt.tf")
+        incident_service_module.ingest_incident_document(
+            "corrupt-incident.md",
+            "# Corrupt incident\nDate: 2026-04-29\nSeverity: high\nSnapshot cannot load.",
+            analysis_id=report["id"],
+        )
+
+        with mock.patch(
+            "services.backtesting_service.load_report_artifact",
+            side_effect=ValueError("corrupt artifact manifest"),
+        ):
+            result = backtesting_service_module.run_incident_backtest(
+                project_id=self.project.id,
+                now=datetime(2026, 4, 30, 12, 0, tzinfo=UTC),
+            )
+
+        self.assertFalse(result["passed"])
+        self.assertEqual(result["summary"]["error_count"], 1)
+        scenario = result["scenarios"][0]
+        self.assertEqual(scenario["status"], "error")
+        self.assertIn("corrupt artifact manifest", scenario["reasons"])
 
     def test_run_weekly_backtest_counts_multiple_outcomes_for_one_analysis(
         self,


### PR DESCRIPTION
Story 6.5 adds an incident replay path that reuses the shared analysis core against persisted accepted report artifacts, then exposes the result through the benchmark CLI with explicit project/workspace scoping. Review follow-up tightened corrupted/missing replay handling and cross-scope report guards so benchmark rows do not overclaim when evidence is unavailable or mismatched.

Constraint: Preserve local-first raw artifact handling and shared analysis core reuse
Constraint: Story scope is CLI/service/docs/test only; no UI surface changed
Rejected: Treat unsupported or insufficient-context scenarios as command failures | docs define them as explicit reported states while missed/error drive non-zero exit
Confidence: high
Scope-risk: moderate
Tested: Focused Story 6.5 unittest set covering detected/missed/unsupported/insufficient/cross-scope/cross-workspace/snapshot-error CLI path
Tested: ./.venv/bin/ruff check .
Tested: ./.venv/bin/ruff format --check .
Tested: ./.venv/bin/bandit -q services/backtesting_service.py cli/analyze.py
Tested: ./.venv/bin/python -m unittest discover -q (456 tests, 1 skipped)
Not-tested: Browser/UI validation; no UI route or rendered browser surface changed

## What does this PR do?

<!-- Brief description of changes -->

## Type of change
- [ ] Feature (new functionality)
- [ ] Bugfix (non-breaking fix)
- [ ] Release preparation
- [ ] Hotfix (critical production fix)
- [ ] Docs / refactor / chore

## Checklist
- [ ] I have followed the branch naming convention
- [ ] Tests pass locally (`pytest tests/ -v`)
- [ ] Linting passes (`ruff check .`)
- [ ] Docker build succeeds
- [ ] I have updated docs if needed
- [ ] No secrets or .env values committed

## Related issue
Closes #