### PR TITLE
Prove risk trends from persisted calibration history

### DIFF
--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -1,5 +1,5 @@
 # generated: 2026-05-01
-# last_updated: 2026-06-08
+# last_updated: 2026-06-09
 # project: deploywhisper
 # project_key: NOKEY
 # tracking_system: file-system
@@ -35,7 +35,7 @@
 # - Dev moves story to review, then runs code-review
 
 generated: 2026-05-01
-last_updated: 2026-06-08
+last_updated: 2026-06-09
 project: deploywhisper
 project_key: NOKEY
 tracking_system: file-system
@@ -106,7 +106,7 @@ development_status:
   6-3-honest-failure-report-generator: done
   6-4-outcome-calibration-metrics: review
   6-5-incident-backtesting: done
-  6-6-risk-trend-review: ready-for-dev
+  6-6-risk-trend-review: done
   epic-6-retrospective: optional
 
   epic-7: in-progress

--- a/api/routes/analyses.py
+++ b/api/routes/analyses.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import hmac
 import os
 from datetime import UTC, datetime
-from typing import Annotated
+from typing import Annotated, Literal
 
 from fastapi import APIRouter, Depends, File, Form, Header, Query, UploadFile
 from pydantic import ValidationError
@@ -52,6 +52,7 @@ from services.project_service import resolve_project_reference
 router = APIRouter(prefix="/api/v1/analyses", tags=["analyses"], route_class=ApiRoute)
 READ_CHUNK_BYTES = 1024 * 1024
 _HISTORY_ANALYSIS_STATUSES = {"complete", "degraded", "fallback"}
+AnalysisOutcomeFilter = Literal["success", "failure", "rolled_back", "rollback"]
 
 
 def _list_report_schema_meta(reports: list[dict]) -> dict[str, object]:
@@ -411,9 +412,30 @@ def list_analyses(
     recommendation: str | None = Query(default=None),
     search: str | None = Query(default=None),
     toolchain: str | None = Query(default=None),
+    outcome: AnalysisOutcomeFilter | None = Query(
+        default=None,
+        description=(
+            "Optional deployment outcome filter. Allowed values: success, failure, "
+            "rolled_back, rollback."
+        ),
+    ),
     analysis_status: str | None = Query(default=None),
-    created_from: datetime | None = Query(default=None),
-    created_to: datetime | None = Query(default=None),
+    created_from: datetime | None = Query(
+        default=None,
+        description=(
+            "Optional inclusive activity-window start timestamp. Matches reports "
+            "created in the window or reports with deployment-outcome/reviewer-feedback "
+            "activity in the window."
+        ),
+    ),
+    created_to: datetime | None = Query(
+        default=None,
+        description=(
+            "Optional inclusive activity-window end timestamp. Matches reports "
+            "created in the window or reports with deployment-outcome/reviewer-feedback "
+            "activity in the window."
+        ),
+    ),
     page: int = Query(default=1, ge=1),
     page_size: int = Query(default=50, ge=1, le=100),
     authorization: dict[str, object] = Depends(_authorization_context),
@@ -455,6 +477,7 @@ def list_analyses(
             recommendation=recommendation,
             search=search,
             toolchain=toolchain,
+            outcome=outcome,
             analysis_status=analysis_status,
             created_from=created_from,
             created_to=created_to,

--- a/cli/analyze.py
+++ b/cli/analyze.py
@@ -59,8 +59,10 @@ from services.intake_service import (
 )
 from services.report_service import (
     REPORT_SCHEMA_VERSION,
+    ReportTrendError,
     build_report_advisory_payload,
     fetch_analysis_report,
+    fetch_risk_trends,
 )
 from services.topology_service import get_topology_status, import_topology_source
 from pydantic import ValidationError
@@ -931,6 +933,62 @@ def _run_benchmark_backtest_incidents(args: argparse.Namespace) -> int:
     return 0 if result.get("passed") else 1
 
 
+def _parse_trend_timestamp(value: str | None) -> datetime | None:
+    if value is None:
+        return None
+    normalized = value.strip()
+    if not normalized:
+        return None
+    if normalized.endswith("Z"):
+        normalized = normalized[:-1] + "+00:00"
+    parsed = datetime.fromisoformat(normalized)
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=UTC)
+    return parsed
+
+
+def _run_benchmark_risk_trends(args: argparse.Namespace) -> int:
+    try:
+        if args.project_id is None and not args.project_key:
+            raise ReportTrendError(
+                "missing_project_scope",
+                "Project scope is required for risk trend review.",
+            )
+        created_from = _parse_trend_timestamp(args.created_from)
+        created_to = _parse_trend_timestamp(args.created_to)
+        if (
+            created_from is not None
+            and created_to is not None
+            and created_from > created_to
+        ):
+            raise ReportTrendError(
+                "invalid_time_window",
+                "created_from must be earlier than or equal to created_to.",
+            )
+        result = fetch_risk_trends(
+            project_id=args.project_id,
+            project_key=args.project_key,
+            workspace_id=args.workspace_id,
+            workspace_key=args.workspace_key,
+            severity=args.severity,
+            toolchain=args.toolchain,
+            outcome=args.outcome,
+            created_from=created_from,
+            created_to=created_to,
+        )
+    except (ValueError, OSError, ValidationError) as exc:
+        _emit_json(
+            build_error(
+                code=getattr(exc, "code", "risk_trend_export_failed"),
+                message=str(exc),
+            ),
+            stream=sys.stderr,
+        )
+        return 1
+    _emit_json(result, stream=sys.stdout)
+    return 0
+
+
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description="DeployWhisper CLI")
     subparsers = parser.add_subparsers(dest="command")
@@ -1283,6 +1341,56 @@ def build_parser() -> argparse.ArgumentParser:
         "--workspace-key",
         help="Optional DeployWhisper workspace key.",
     )
+    benchmark_risk_trends_parser = benchmark_subparsers.add_parser(
+        "risk-trends",
+        help="Export scoped risk trend review data as JSON.",
+    )
+    benchmark_risk_trends_parser.add_argument(
+        "--project-id",
+        type=int,
+        help="DeployWhisper numeric project id.",
+    )
+    benchmark_risk_trends_parser.add_argument(
+        "--project-key",
+        help="DeployWhisper project key.",
+    )
+    benchmark_risk_trends_parser.add_argument(
+        "--workspace-id",
+        type=int,
+        help="Optional DeployWhisper numeric workspace id.",
+    )
+    benchmark_risk_trends_parser.add_argument(
+        "--workspace-key",
+        help="Optional DeployWhisper workspace key.",
+    )
+    benchmark_risk_trends_parser.add_argument(
+        "--severity",
+        choices=("critical", "high", "medium", "low"),
+        help="Optional risk severity filter.",
+    )
+    benchmark_risk_trends_parser.add_argument(
+        "--toolchain",
+        help="Optional normalized toolchain filter, such as terraform or kubernetes.",
+    )
+    benchmark_risk_trends_parser.add_argument(
+        "--outcome",
+        choices=("success", "failure", "rolled_back", "rollback"),
+        help="Optional deployment outcome filter.",
+    )
+    benchmark_risk_trends_parser.add_argument(
+        "--created-from",
+        help=(
+            "Optional inclusive activity-window start timestamp "
+            "(report created, outcome deployed, or feedback created), ISO-8601 or Zulu."
+        ),
+    )
+    benchmark_risk_trends_parser.add_argument(
+        "--created-to",
+        help=(
+            "Optional inclusive activity-window end timestamp "
+            "(report created, outcome deployed, or feedback created), ISO-8601 or Zulu."
+        ),
+    )
 
     return parser
 
@@ -1342,6 +1450,8 @@ def main() -> None:
         raise SystemExit(_run_benchmark_run(args.path))
     if args.command == "benchmark" and args.benchmark_command == "backtest-incidents":
         raise SystemExit(_run_benchmark_backtest_incidents(args))
+    if args.command == "benchmark" and args.benchmark_command == "risk-trends":
+        raise SystemExit(_run_benchmark_risk_trends(args))
 
     print("DeployWhisper CLI ready: foundation-check")
 

--- a/docs/outcome-linking.md
+++ b/docs/outcome-linking.md
@@ -52,6 +52,38 @@ python -m cli.analyze benchmark backtest-incidents --project-key <project>
 - Scenario rows link incident metadata, linked report metadata, expected evidence from the original persisted report, observed replay evidence, observed findings, context TODOs, and improvement guidance.
 - The command exits non-zero when any scenario is missed or errors, so it can be used as a guardrail for benchmark claims while still reporting unsupported and insufficient-context scenarios explicitly.
 
+## Risk Trend Review
+
+- The history view includes a project-scoped risk trend card that updates with the selected workspace, time range, risk severity, toolchain, and deployment outcome filters. Project scope is required for CLI trend export.
+- Trend data preserves historical report immutability. Feedback and deployment outcomes are joined as calibration signals, but they do not rewrite stored report verdicts, severity, recommendation, confidence, narrative, or context-completeness metadata.
+- When a bounded time range is selected, the trend payload includes current and previous equal-length windows plus deltas so managers can compare whether signals are improving or recurring. Previous comparison windows use an exclusive upper bound, so events exactly at the current window start are counted only in the current window.
+- Report rows are included when they were created in the selected window or have selected-window feedback/outcome activity. Deployment outcomes use `deployed_at` for the event window; reviewer feedback uses feedback `created_at`. The History table and trend card share this activity-window behavior.
+- The trend payload compares:
+  - verdict / recommendation distribution
+  - high and critical report frequency
+  - toolchain frequency
+  - deployment outcome distribution
+  - linked deployment outcome counts
+  - reviewer false-positive feedback
+  - deployment-backed and reviewer-backed false-reassurance signals
+  - partial-context count/rate and average context-completeness score
+- Sparse or missing report, feedback, outcome, and context-completeness inputs are returned as explicit limitation labels. Empty or unauthorized project scopes return no report metadata from inaccessible projects, and future-schema reports that history cannot render are excluded from trend summaries.
+- Export scoped trend data from the CLI:
+
+```bash
+python -m cli.analyze benchmark risk-trends \
+  --project-key payments \
+  --workspace-key prod \
+  --severity high \
+  --toolchain terraform \
+  --outcome failure \
+  --created-from 2026-06-01T00:00:00Z \
+  --created-to 2026-06-08T00:00:00Z
+```
+
+- The CLI emits the same JSON payload used by the history trend card so browser review and exported trend data stay aligned.
+- API history consumers can use the same outcome scope with `GET /api/v1/analyses?outcome=failure` alongside existing project, workspace, severity, toolchain, status, and time filters.
+
 ## Scheduler and Calibration Feed
 
 - The app lifecycle scheduler now runs `run_due_weekly_backtests()` alongside topology drift checks.

--- a/migrations/versions/025_add_event_analysis_indexes.py
+++ b/migrations/versions/025_add_event_analysis_indexes.py
@@ -1,0 +1,64 @@
+"""Add event analysis indexes for risk trends.
+
+Revision ID: 025_add_event_analysis_indexes
+Revises: 024_add_analysis_duration_seconds
+Create Date: 2026-06-09
+"""
+
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "025_add_event_analysis_indexes"
+down_revision = "024_add_analysis_duration_seconds"
+branch_labels = None
+depends_on = None
+
+
+def _index_columns(table_name: str, index_name: str) -> tuple[str, ...] | None:
+    inspector = sa.inspect(op.get_bind())
+    for index in inspector.get_indexes(table_name):
+        if index["name"] == index_name:
+            return tuple(index.get("column_names") or ())
+    return None
+
+
+def _ensure_index(table_name: str, index_name: str, columns: list[str]) -> None:
+    existing_columns = _index_columns(table_name, index_name)
+    expected_columns = tuple(columns)
+    if existing_columns == expected_columns:
+        return
+    if existing_columns is not None:
+        op.drop_index(index_name, table_name=table_name)
+    op.create_index(index_name, table_name, columns)
+
+
+def upgrade() -> None:
+    _ensure_index(
+        "deployment_outcomes",
+        "ix_deployment_outcomes_analysis_deployed_outcome",
+        ["analysis_id", "deployed_at", "outcome_label"],
+    )
+    _ensure_index(
+        "feedback_events",
+        "ix_feedback_events_analysis_created",
+        ["analysis_id", "created_at"],
+    )
+
+
+def downgrade() -> None:
+    if _index_columns("feedback_events", "ix_feedback_events_analysis_created"):
+        op.drop_index(
+            "ix_feedback_events_analysis_created",
+            table_name="feedback_events",
+        )
+    if _index_columns(
+        "deployment_outcomes",
+        "ix_deployment_outcomes_analysis_deployed_outcome",
+    ):
+        op.drop_index(
+            "ix_deployment_outcomes_analysis_deployed_outcome",
+            table_name="deployment_outcomes",
+        )

--- a/models/database.py
+++ b/models/database.py
@@ -55,6 +55,7 @@ _KNOWN_ALEMBIC_REVISIONS = {
     "022_add_deployment_outcome_notes",
     "023_add_incident_ingestion_sources",
     "024_add_analysis_duration_seconds",
+    "025_add_event_analysis_indexes",
 }
 _BASELINE_TABLES = {"analysis_reports", "app_settings"}
 _EVIDENCE_TABLES = {
@@ -414,6 +415,27 @@ def _analysis_report_duration_metric_complete(connection) -> bool:
     )
 
 
+def _event_analysis_indexes_complete(connection) -> bool:
+    inspector = inspect(connection)
+    if not {"deployment_outcomes", "feedback_events"}.issubset(
+        set(inspector.get_table_names())
+    ):
+        return False
+    deployment_indexes = {
+        index.get("name"): tuple(index.get("column_names") or [])
+        for index in inspector.get_indexes("deployment_outcomes")
+    }
+    feedback_indexes = {
+        index.get("name"): tuple(index.get("column_names") or [])
+        for index in inspector.get_indexes("feedback_events")
+    }
+    return deployment_indexes.get(
+        "ix_deployment_outcomes_analysis_deployed_outcome"
+    ) == ("analysis_id", "deployed_at", "outcome_label") and feedback_indexes.get(
+        "ix_feedback_events_analysis_created"
+    ) == ("analysis_id", "created_at")
+
+
 def _index_has_workspace_null_predicate(index: dict) -> bool:
     dialect_options = index.get("dialect_options") or {}
     predicate_sql = " ".join(
@@ -757,6 +779,9 @@ def _bootstrap_brownfield_revision() -> None:
             has_analysis_duration_metric
             and _analysis_report_duration_metric_complete(connection)
         )
+        has_complete_event_analysis_indexes = _event_analysis_indexes_complete(
+            connection
+        )
         if has_incident_ingestion_sources and not (
             has_complete_learning_context_scope
             and has_complete_submission_manifest_payload
@@ -864,6 +889,9 @@ def _bootstrap_brownfield_revision() -> None:
             and has_complete_incident_ingestion_sources
             and has_complete_analysis_duration_metric
         ):
+            if has_complete_event_analysis_indexes:
+                _write_alembic_revision(connection, "025_add_event_analysis_indexes")
+                return
             _write_alembic_revision(connection, "024_add_analysis_duration_seconds")
             return
         if (

--- a/models/repositories/analysis_reports.py
+++ b/models/repositories/analysis_reports.py
@@ -9,14 +9,16 @@ from collections.abc import Sequence
 from datetime import UTC, datetime, timedelta
 from typing import Any
 
-from sqlalchemy import and_, func, not_, or_, select
+from sqlalchemy import and_, case, exists, func, literal, not_, or_, select
 from sqlalchemy.orm import Session, selectinload
 
 from evidence.models import EvidenceItem as EvidenceItemPayload
 from evidence.models import Finding as FindingPayload
 from models.tables import (
     AnalysisReport,
+    DeploymentOutcome,
     EvidenceItem as PersistedEvidenceItem,
+    FeedbackEvent,
     Finding as PersistedFinding,
     RiskAssessment as PersistedRiskAssessment,
 )
@@ -24,6 +26,7 @@ from models.tables import (
 _FINDING_SEVERITY_ORDER = {"low": 1, "medium": 2, "high": 3, "critical": 4}
 _SEVERITY_SCORE_FLOOR = {"low": 0, "medium": 42, "high": 70, "critical": 90}
 _SEVERITY_SCORE_CEILING = {"low": 39, "medium": 69, "high": 89, "critical": 100}
+_ACTIVITY_ORDER_FLOOR = datetime.min.replace(tzinfo=UTC)
 _VERDICT_PREFIX_PATTERN = re.compile(
     r"^\s*(critical|high|medium|low|no-go|go|caution)"
     r"(?:\s*:\s*|\s+-\s+|"
@@ -111,6 +114,167 @@ def _analysis_status_predicate(analysis_status: str):
     if analysis_status == "fallback":
         return AnalysisReport.narrative_source == "fallback"
     return None
+
+
+def _exclusive_window_predicate(column, *, start=None, end=None, before=None):
+    predicates = []
+    if start is not None:
+        predicates.append(column >= start)
+    if end is not None:
+        predicates.append(column <= end)
+    if before is not None:
+        predicates.append(column < before)
+    if not predicates:
+        return None
+    return and_(*predicates)
+
+
+def _same_report_scope_predicate(model):
+    return and_(
+        model.project_id == AnalysisReport.project_id,
+        or_(
+            and_(model.workspace_id.is_(None), AnalysisReport.workspace_id.is_(None)),
+            model.workspace_id == AnalysisReport.workspace_id,
+        ),
+    )
+
+
+def _outcome_exists_predicate(outcome_label: str | None = None):
+    predicate = exists().where(DeploymentOutcome.analysis_id == AnalysisReport.id)
+    predicate = predicate.where(_same_report_scope_predicate(DeploymentOutcome))
+    if outcome_label:
+        predicate = predicate.where(DeploymentOutcome.outcome_label == outcome_label)
+    return predicate
+
+
+def _activity_window_predicate(
+    *,
+    activity_from: datetime | None = None,
+    activity_to: datetime | None = None,
+    activity_before: datetime | None = None,
+    outcome_label: str | None = None,
+):
+    report_window = _exclusive_window_predicate(
+        AnalysisReport.created_at,
+        start=activity_from,
+        end=activity_to,
+        before=activity_before,
+    )
+    outcome_window = _exclusive_window_predicate(
+        DeploymentOutcome.deployed_at,
+        start=activity_from,
+        end=activity_to,
+        before=activity_before,
+    )
+    feedback_window = _exclusive_window_predicate(
+        FeedbackEvent.created_at,
+        start=activity_from,
+        end=activity_to,
+        before=activity_before,
+    )
+    predicates = []
+    if report_window is not None:
+        predicates.append(report_window)
+    if outcome_window is not None:
+        outcome_exists = exists().where(
+            DeploymentOutcome.analysis_id == AnalysisReport.id
+        )
+        outcome_exists = outcome_exists.where(
+            _same_report_scope_predicate(DeploymentOutcome)
+        )
+        outcome_exists = outcome_exists.where(outcome_window)
+        if outcome_label:
+            outcome_exists = outcome_exists.where(
+                DeploymentOutcome.outcome_label == outcome_label
+            )
+        predicates.append(outcome_exists)
+    if feedback_window is not None:
+        predicates.append(
+            exists()
+            .where(FeedbackEvent.analysis_id == AnalysisReport.id)
+            .where(_same_report_scope_predicate(FeedbackEvent))
+            .where(feedback_window)
+        )
+    if not predicates:
+        return None
+    return or_(*predicates)
+
+
+def _greatest_datetime_expression(candidates):
+    greatest = candidates[0]
+    for candidate in candidates[1:]:
+        greatest = case((candidate > greatest, candidate), else_=greatest)
+    return greatest
+
+
+def _activity_order_expression(
+    *,
+    activity_from: datetime | None = None,
+    activity_to: datetime | None = None,
+    activity_before: datetime | None = None,
+    outcome_label: str | None = None,
+):
+    report_window = _exclusive_window_predicate(
+        AnalysisReport.created_at,
+        start=activity_from,
+        end=activity_to,
+        before=activity_before,
+    )
+    outcome_window = _exclusive_window_predicate(
+        DeploymentOutcome.deployed_at,
+        start=activity_from,
+        end=activity_to,
+        before=activity_before,
+    )
+    feedback_window = _exclusive_window_predicate(
+        FeedbackEvent.created_at,
+        start=activity_from,
+        end=activity_to,
+        before=activity_before,
+    )
+    if report_window is None and outcome_window is None and feedback_window is None:
+        return None
+
+    outcome_latest = (
+        select(func.max(DeploymentOutcome.deployed_at))
+        .where(DeploymentOutcome.analysis_id == AnalysisReport.id)
+        .where(_same_report_scope_predicate(DeploymentOutcome))
+    )
+    if outcome_window is not None:
+        outcome_latest = outcome_latest.where(outcome_window)
+    if outcome_label:
+        outcome_latest = outcome_latest.where(
+            DeploymentOutcome.outcome_label == outcome_label
+        )
+
+    feedback_latest = (
+        select(func.max(FeedbackEvent.created_at))
+        .where(FeedbackEvent.analysis_id == AnalysisReport.id)
+        .where(_same_report_scope_predicate(FeedbackEvent))
+    )
+    if feedback_window is not None:
+        feedback_latest = feedback_latest.where(feedback_window)
+
+    report_activity = (
+        case((report_window, AnalysisReport.created_at), else_=None)
+        if report_window is not None
+        else None
+    )
+    candidates = [
+        func.coalesce(
+            outcome_latest.correlate(AnalysisReport).scalar_subquery(),
+            literal(_ACTIVITY_ORDER_FLOOR),
+        ),
+        func.coalesce(
+            feedback_latest.correlate(AnalysisReport).scalar_subquery(),
+            literal(_ACTIVITY_ORDER_FLOOR),
+        ),
+    ]
+    if report_activity is not None:
+        candidates.append(
+            func.coalesce(report_activity, literal(_ACTIVITY_ORDER_FLOOR))
+        )
+    return _greatest_datetime_expression(candidates)
 
 
 def _normalize_report_severity(severity: str) -> str:
@@ -647,6 +811,7 @@ def delete_analysis_report(session: Session, report_id: int) -> bool:
 def list_analysis_reports(
     session: Session,
     *,
+    analysis_ids: Sequence[int] | None = None,
     project_id: int | None = None,
     workspace_id: int | None = None,
     severity: str | None = None,
@@ -656,16 +821,27 @@ def list_analysis_reports(
     analysis_status: str | None = None,
     created_from: datetime | None = None,
     created_to: datetime | None = None,
+    created_before: datetime | None = None,
+    activity_from: datetime | None = None,
+    activity_to: datetime | None = None,
+    activity_before: datetime | None = None,
+    outcome_label: str | None = None,
     report_schema_versions: Sequence[str] | None = None,
     limit: int | None = None,
     offset: int | None = None,
+    id_before: int | None = None,
     include_evidence: bool = False,
+    order_by_activity: bool = True,
 ) -> list[AnalysisReport]:
-    stmt = (
-        select(AnalysisReport)
-        .options(*_report_load_options(include_evidence=include_evidence))
-        .order_by(AnalysisReport.id.desc())
+    if analysis_ids is not None and not analysis_ids:
+        return []
+    stmt = select(AnalysisReport).options(
+        *_report_load_options(include_evidence=include_evidence)
     )
+    if analysis_ids is not None:
+        stmt = stmt.where(AnalysisReport.id.in_(tuple(analysis_ids)))
+    if id_before is not None:
+        stmt = stmt.where(AnalysisReport.id < id_before)
     if project_id is not None:
         stmt = stmt.where(AnalysisReport.project_id == project_id)
     if workspace_id is not None:
@@ -678,6 +854,18 @@ def list_analysis_reports(
         stmt = stmt.where(AnalysisReport.created_at >= created_from)
     if created_to is not None:
         stmt = stmt.where(AnalysisReport.created_at <= created_to)
+    if created_before is not None:
+        stmt = stmt.where(AnalysisReport.created_at < created_before)
+    activity_predicate = _activity_window_predicate(
+        activity_from=activity_from,
+        activity_to=activity_to,
+        activity_before=activity_before,
+        outcome_label=outcome_label,
+    )
+    if activity_predicate is not None:
+        stmt = stmt.where(activity_predicate)
+    if outcome_label:
+        stmt = stmt.where(_outcome_exists_predicate(outcome_label))
     if toolchain:
         predicate = _toolchain_predicate(toolchain)
         if predicate is not None:
@@ -703,6 +891,20 @@ def list_analysis_reports(
                 AnalysisReport.report_schema_version == "",
             )
         stmt = stmt.where(schema_predicate)
+    activity_order = (
+        _activity_order_expression(
+            activity_from=activity_from,
+            activity_to=activity_to,
+            activity_before=activity_before,
+            outcome_label=outcome_label,
+        )
+        if order_by_activity
+        else None
+    )
+    if activity_order is not None:
+        stmt = stmt.order_by(activity_order.desc(), AnalysisReport.id.desc())
+    else:
+        stmt = stmt.order_by(AnalysisReport.id.desc())
     if offset:
         stmt = stmt.offset(offset)
     if limit is not None:
@@ -714,6 +916,7 @@ def list_analysis_reports(
 def count_analysis_reports(
     session: Session,
     *,
+    analysis_ids: Sequence[int] | None = None,
     project_id: int | None = None,
     workspace_id: int | None = None,
     severity: str | None = None,
@@ -723,9 +926,18 @@ def count_analysis_reports(
     analysis_status: str | None = None,
     created_from: datetime | None = None,
     created_to: datetime | None = None,
+    created_before: datetime | None = None,
+    activity_from: datetime | None = None,
+    activity_to: datetime | None = None,
+    activity_before: datetime | None = None,
+    outcome_label: str | None = None,
     report_schema_versions: Sequence[str] | None = None,
 ) -> int:
+    if analysis_ids is not None and not analysis_ids:
+        return 0
     stmt = select(func.count()).select_from(AnalysisReport)
+    if analysis_ids is not None:
+        stmt = stmt.where(AnalysisReport.id.in_(tuple(analysis_ids)))
     if project_id is not None:
         stmt = stmt.where(AnalysisReport.project_id == project_id)
     if workspace_id is not None:
@@ -738,6 +950,18 @@ def count_analysis_reports(
         stmt = stmt.where(AnalysisReport.created_at >= created_from)
     if created_to is not None:
         stmt = stmt.where(AnalysisReport.created_at <= created_to)
+    if created_before is not None:
+        stmt = stmt.where(AnalysisReport.created_at < created_before)
+    activity_predicate = _activity_window_predicate(
+        activity_from=activity_from,
+        activity_to=activity_to,
+        activity_before=activity_before,
+        outcome_label=outcome_label,
+    )
+    if activity_predicate is not None:
+        stmt = stmt.where(activity_predicate)
+    if outcome_label:
+        stmt = stmt.where(_outcome_exists_predicate(outcome_label))
     if toolchain:
         predicate = _toolchain_predicate(toolchain)
         if predicate is not None:
@@ -772,6 +996,14 @@ def count_analysis_reports_by_field(
     *,
     project_id: int | None = None,
     workspace_id: int | None = None,
+    severity: str | None = None,
+    recommendation: str | None = None,
+    search: str | None = None,
+    toolchain: str | None = None,
+    analysis_status: str | None = None,
+    created_from: datetime | None = None,
+    created_to: datetime | None = None,
+    report_schema_versions: Sequence[str] | None = None,
 ) -> dict[str, int]:
     column = getattr(AnalysisReport, field_name)
     stmt = select(column, func.count()).group_by(column)
@@ -779,6 +1011,39 @@ def count_analysis_reports_by_field(
         stmt = stmt.where(AnalysisReport.project_id == project_id)
     if workspace_id is not None:
         stmt = stmt.where(AnalysisReport.workspace_id == workspace_id)
+    if severity:
+        stmt = stmt.where(AnalysisReport.severity == severity)
+    if recommendation:
+        stmt = stmt.where(AnalysisReport.recommendation == recommendation)
+    if created_from is not None:
+        stmt = stmt.where(AnalysisReport.created_at >= created_from)
+    if created_to is not None:
+        stmt = stmt.where(AnalysisReport.created_at <= created_to)
+    if toolchain:
+        predicate = _toolchain_predicate(toolchain)
+        if predicate is not None:
+            stmt = stmt.where(predicate)
+    if analysis_status:
+        predicate = _analysis_status_predicate(analysis_status)
+        if predicate is not None:
+            stmt = stmt.where(predicate)
+    if search:
+        like = f"%{search}%"
+        stmt = stmt.where(
+            AnalysisReport.top_risk.ilike(like)
+            | AnalysisReport.narrative_opening.ilike(like)
+            | AnalysisReport.parse_summary.ilike(like)
+        )
+    if report_schema_versions is not None:
+        schema_versions = tuple(report_schema_versions)
+        schema_predicate = AnalysisReport.report_schema_version.in_(schema_versions)
+        if "v1" in schema_versions:
+            schema_predicate = or_(
+                schema_predicate,
+                AnalysisReport.report_schema_version.is_(None),
+                AnalysisReport.report_schema_version == "",
+            )
+        stmt = stmt.where(schema_predicate)
     rows = session.execute(stmt).all()
     return {str(value): int(count) for value, count in rows if value is not None}
 

--- a/models/repositories/deployment_outcomes.py
+++ b/models/repositories/deployment_outcomes.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Sequence
 from datetime import datetime
 
 from sqlalchemy import select
@@ -57,22 +58,37 @@ def list_deployment_outcomes(
     project_id: int | None = None,
     workspace_id: int | None = None,
     analysis_id: int | None = None,
+    analysis_ids: Sequence[int] | None = None,
     outcome_label: str | None = None,
-    limit: int = 100,
+    deployed_from: datetime | None = None,
+    deployed_to: datetime | None = None,
+    deployed_before: datetime | None = None,
+    limit: int | None = 100,
 ) -> list[DeploymentOutcome]:
+    if analysis_ids is not None and not analysis_ids:
+        return []
     stmt = (
         select(DeploymentOutcome)
         .options(*_deployment_outcome_load_options())
         .order_by(DeploymentOutcome.deployed_at.desc(), DeploymentOutcome.id.desc())
-        .limit(max(1, limit))
     )
+    if limit is not None:
+        stmt = stmt.limit(max(1, limit))
     if project_id is not None:
         stmt = stmt.where(DeploymentOutcome.project_id == project_id)
     if workspace_id is not None:
         stmt = stmt.where(DeploymentOutcome.workspace_id == workspace_id)
     if analysis_id is not None:
         stmt = stmt.where(DeploymentOutcome.analysis_id == analysis_id)
+    if analysis_ids is not None:
+        stmt = stmt.where(DeploymentOutcome.analysis_id.in_(tuple(analysis_ids)))
     if outcome_label:
         stmt = stmt.where(DeploymentOutcome.outcome_label == outcome_label)
+    if deployed_from is not None:
+        stmt = stmt.where(DeploymentOutcome.deployed_at >= deployed_from)
+    if deployed_to is not None:
+        stmt = stmt.where(DeploymentOutcome.deployed_at <= deployed_to)
+    if deployed_before is not None:
+        stmt = stmt.where(DeploymentOutcome.deployed_at < deployed_before)
     result = session.execute(stmt)
     return list(result.scalars().all())

--- a/models/repositories/feedback_events.py
+++ b/models/repositories/feedback_events.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Sequence
 from datetime import datetime
 
 from sqlalchemy import select
@@ -50,10 +51,14 @@ def list_feedback_events(
     project_id: int | None = None,
     workspace_id: int | None = None,
     analysis_id: int | None = None,
+    analysis_ids: Sequence[int] | None = None,
     created_from: datetime | None = None,
     created_to: datetime | None = None,
+    created_before: datetime | None = None,
     limit: int | None = None,
 ) -> list[FeedbackEvent]:
+    if analysis_ids is not None and not analysis_ids:
+        return []
     stmt = select(FeedbackEvent).order_by(
         FeedbackEvent.created_at.desc(), FeedbackEvent.id.desc()
     )
@@ -63,10 +68,14 @@ def list_feedback_events(
         stmt = stmt.where(FeedbackEvent.workspace_id == workspace_id)
     if analysis_id is not None:
         stmt = stmt.where(FeedbackEvent.analysis_id == analysis_id)
+    if analysis_ids is not None:
+        stmt = stmt.where(FeedbackEvent.analysis_id.in_(tuple(analysis_ids)))
     if created_from is not None:
         stmt = stmt.where(FeedbackEvent.created_at >= created_from)
     if created_to is not None:
         stmt = stmt.where(FeedbackEvent.created_at <= created_to)
+    if created_before is not None:
+        stmt = stmt.where(FeedbackEvent.created_at < created_before)
     if limit is not None:
         stmt = stmt.limit(max(1, limit))
     result = session.execute(stmt)

--- a/models/tables.py
+++ b/models/tables.py
@@ -547,6 +547,12 @@ if "DeploymentOutcome" not in globals():
 
         __tablename__ = "deployment_outcomes"
         __table_args__ = (
+            Index(
+                "ix_deployment_outcomes_analysis_deployed_outcome",
+                "analysis_id",
+                "deployed_at",
+                "outcome_label",
+            ),
             ForeignKeyConstraint(
                 ["project_id", "workspace_id"],
                 ["project_workspaces.project_id", "project_workspaces.id"],
@@ -602,6 +608,11 @@ if "FeedbackEvent" not in globals():
 
         __tablename__ = "feedback_events"
         __table_args__ = (
+            Index(
+                "ix_feedback_events_analysis_created",
+                "analysis_id",
+                "created_at",
+            ),
             ForeignKeyConstraint(
                 ["project_id", "workspace_id"],
                 ["project_workspaces.project_id", "project_workspaces.id"],

--- a/services/deployment_outcome_service.py
+++ b/services/deployment_outcome_service.py
@@ -282,7 +282,10 @@ def list_deployment_outcomes(
     project_key: str | None = None,
     workspace_id: int | None = None,
     workspace_key: str | None = None,
-    limit: int = 100,
+    deployed_from: datetime | None = None,
+    deployed_to: datetime | None = None,
+    deployed_before: datetime | None = None,
+    limit: int | None = 100,
 ) -> list[dict[str, Any]]:
     normalized_outcome = _normalize_outcome(outcome) if outcome is not None else None
     with SessionLocal() as session:
@@ -335,6 +338,9 @@ def list_deployment_outcomes(
             workspace_id=resolved_workspace_id,
             analysis_id=analysis_id,
             outcome_label=normalized_outcome,
+            deployed_from=deployed_from,
+            deployed_to=deployed_to,
+            deployed_before=deployed_before,
             limit=limit,
         )
         return [_serialize_deployment_outcome(item) for item in outcomes]

--- a/services/report_service.py
+++ b/services/report_service.py
@@ -36,7 +36,6 @@ from llm.narrator import NarrativeResult
 from models.database import SessionLocal
 from models.repositories.analysis_reports import (
     count_analysis_reports,
-    count_analysis_reports_by_field,
     create_analysis_report,
     delete_analysis_report,
     get_analysis_report,
@@ -44,6 +43,10 @@ from models.repositories.analysis_reports import (
     list_analysis_reports,
     update_analysis_report_share_settings,
 )
+from models.repositories.deployment_outcomes import (
+    list_deployment_outcomes as list_deployment_outcome_records,
+)
+from models.repositories.feedback_events import list_feedback_events
 from parsers.base import ParseBatchResult, ParsedFileResult
 from services.artifact_snapshot_service import (
     delete_report_artifacts,
@@ -152,6 +155,133 @@ class ReportSchemaVersionError(ValueError):
         self.code = code
         self.message = message
         self.status_code = status_code
+
+
+class ReportTrendError(ValueError):
+    """Raised when risk trend requests are invalid."""
+
+    def __init__(self, code: str, message: str) -> None:
+        super().__init__(message)
+        self.code = code
+        self.message = message
+
+
+_TREND_OUTCOME_ALIASES = {
+    "success": "success",
+    "failure": "failure",
+    "rolled_back": "rolled_back",
+    "rollback": "rolled_back",
+}
+_TREND_ANALYSIS_ID_CHUNK_SIZE = 100
+_TREND_REPORT_BATCH_SIZE = 100
+
+
+def _normalize_trend_outcome(value: str | None) -> str | None:
+    normalized = str(value or "").strip().lower().replace("-", "_")
+    if not normalized:
+        return None
+    try:
+        return _TREND_OUTCOME_ALIASES[normalized]
+    except KeyError as exc:
+        raise ReportTrendError(
+            "invalid_trend_outcome",
+            "Outcome must be one of: success, failure, rolled_back, rollback.",
+        ) from exc
+
+
+def _chunk_analysis_ids(analysis_ids: list[int] | set[int]) -> list[list[int]]:
+    ids = sorted({int(analysis_id) for analysis_id in analysis_ids})
+    return [
+        ids[index : index + _TREND_ANALYSIS_ID_CHUNK_SIZE]
+        for index in range(0, len(ids), _TREND_ANALYSIS_ID_CHUNK_SIZE)
+    ]
+
+
+def _trend_report_warned(report) -> bool:
+    return str(getattr(report, "recommendation", "") or "").strip().lower() != "go"
+
+
+def _previous_trend_window(
+    created_from: datetime | None,
+    created_to: datetime | None,
+) -> tuple[datetime, datetime] | None:
+    if created_from is None or created_to is None or created_from >= created_to:
+        return None
+    duration = created_to - created_from
+    return created_from - duration, created_from
+
+
+def _trend_window_summary(label: str, payload: dict) -> dict:
+    return {
+        "label": label,
+        "window": payload["window"],
+        "total_reports": payload["total_reports"],
+        "severity_counts": payload["severity_counts"],
+        "recommendation_counts": payload["recommendation_counts"],
+        "tool_counts": payload["tool_counts"],
+        "high_critical_frequency": payload["high_critical_frequency"],
+        "false_positive_signals": payload["false_positive_signals"],
+        "false_reassurance_signals": payload["false_reassurance_signals"],
+        "outcome_links": payload["outcome_links"],
+        "outcome_counts": payload["outcome_counts"],
+        "context_completeness": payload["context_completeness"],
+        "limitations": payload["limitations"],
+    }
+
+
+def _count_deltas(current_counts: dict, previous_counts: dict) -> dict:
+    keys = set(current_counts) | set(previous_counts)
+    return {
+        key: int(current_counts.get(key, 0)) - int(previous_counts.get(key, 0))
+        for key in sorted(keys)
+    }
+
+
+def _trend_delta(current: dict, previous: dict) -> dict:
+    return {
+        "total_reports_delta": current["total_reports"] - previous["total_reports"],
+        "severity_count_deltas": _count_deltas(
+            current["severity_counts"],
+            previous["severity_counts"],
+        ),
+        "recommendation_count_deltas": _count_deltas(
+            current["recommendation_counts"],
+            previous["recommendation_counts"],
+        ),
+        "tool_count_deltas": _count_deltas(
+            current["tool_counts"],
+            previous["tool_counts"],
+        ),
+        "outcome_count_deltas": _count_deltas(
+            current["outcome_counts"],
+            previous["outcome_counts"],
+        ),
+        "high_critical_count_delta": current["high_critical_frequency"]["count"]
+        - previous["high_critical_frequency"]["count"],
+        "high_critical_rate_delta": current["high_critical_frequency"]["rate"]
+        - previous["high_critical_frequency"]["rate"],
+        "false_positive_count_delta": current["false_positive_signals"]["count"]
+        - previous["false_positive_signals"]["count"],
+        "false_positive_rate_delta": current["false_positive_signals"]["rate"]
+        - previous["false_positive_signals"]["rate"],
+        "false_reassurance_count_delta": current["false_reassurance_signals"]["count"]
+        - previous["false_reassurance_signals"]["count"],
+        "false_reassurance_rate_delta": current["false_reassurance_signals"]["rate"]
+        - previous["false_reassurance_signals"]["rate"],
+        "linked_outcome_count_delta": current["outcome_links"]["linked_outcome_count"]
+        - previous["outcome_links"]["linked_outcome_count"],
+        "context_partial_count_delta": current["context_completeness"][
+            "partial_context_count"
+        ]
+        - previous["context_completeness"]["partial_context_count"],
+        "context_average_score_delta": (
+            None
+            if current["context_completeness"]["average_context_score"] is None
+            or previous["context_completeness"]["average_context_score"] is None
+            else current["context_completeness"]["average_context_score"]
+            - previous["context_completeness"]["average_context_score"]
+        ),
+    }
 
 
 def _resolve_project_id(
@@ -4249,6 +4379,7 @@ def fetch_filtered_analysis_history(
     recommendation: str | None = None,
     search: str | None = None,
     toolchain: str | None = None,
+    outcome: str | None = None,
     analysis_status: str | None = None,
     created_from: datetime | None = None,
     created_to: datetime | None = None,
@@ -4262,6 +4393,7 @@ def fetch_filtered_analysis_history(
         recommendation=recommendation,
         search=search,
         toolchain=toolchain,
+        outcome=outcome,
         analysis_status=analysis_status,
         created_from=created_from,
         created_to=created_to,
@@ -4279,6 +4411,7 @@ def fetch_filtered_analysis_history_page(
     recommendation: str | None = None,
     search: str | None = None,
     toolchain: str | None = None,
+    outcome: str | None = None,
     analysis_status: str | None = None,
     created_from: datetime | None = None,
     created_to: datetime | None = None,
@@ -4286,6 +4419,15 @@ def fetch_filtered_analysis_history_page(
     page_size: int = 50,
     skip_unreadable_schema: bool = False,
 ) -> dict[str, Any]:
+    if (
+        created_from is not None
+        and created_to is not None
+        and created_from > created_to
+    ):
+        raise ReportTrendError(
+            "invalid_time_window",
+            "created_from must be earlier than or equal to created_to.",
+        )
     page = max(page, 1)
     page_size = max(1, min(page_size, 100))
     offset = (page - 1) * page_size
@@ -4298,6 +4440,7 @@ def fetch_filtered_analysis_history_page(
     readable_schema_versions = (
         _readable_report_schema_versions() if skip_unreadable_schema else None
     )
+    normalized_outcome = _normalize_trend_outcome(outcome)
 
     def operation():
         with SessionLocal() as session:
@@ -4318,8 +4461,9 @@ def fetch_filtered_analysis_history_page(
                     search=search,
                     toolchain=toolchain,
                     analysis_status=analysis_status,
-                    created_from=created_from,
-                    created_to=created_to,
+                    activity_from=created_from,
+                    activity_to=created_to,
+                    outcome_label=normalized_outcome,
                     report_schema_versions=readable_schema_versions,
                     limit=page_size,
                     offset=offset,
@@ -4342,8 +4486,9 @@ def fetch_filtered_analysis_history_page(
                     search=search,
                     toolchain=toolchain,
                     analysis_status=analysis_status,
-                    created_from=created_from,
-                    created_to=created_to,
+                    activity_from=created_from,
+                    activity_to=created_to,
+                    outcome_label=normalized_outcome,
                     report_schema_versions=readable_schema_versions,
                 )
             else:
@@ -4356,8 +4501,9 @@ def fetch_filtered_analysis_history_page(
                     search=search,
                     toolchain=toolchain,
                     analysis_status=analysis_status,
-                    created_from=created_from,
-                    created_to=created_to,
+                    activity_from=created_from,
+                    activity_to=created_to,
+                    outcome_label=normalized_outcome,
                     limit=page_size,
                     offset=offset,
                     include_evidence=True,
@@ -4379,8 +4525,9 @@ def fetch_filtered_analysis_history_page(
                     search=search,
                     toolchain=toolchain,
                     analysis_status=analysis_status,
-                    created_from=created_from,
-                    created_to=created_to,
+                    activity_from=created_from,
+                    activity_to=created_to,
+                    outcome_label=normalized_outcome,
                 )
             return (
                 _attach_previous_scan_diffs(serialized_reports, serialized_all_reports),
@@ -4459,82 +4606,478 @@ def fetch_risk_trends(
     project_key: str | None = None,
     workspace_id: int | None = None,
     workspace_key: str | None = None,
+    severity: str | None = None,
+    toolchain: str | None = None,
+    outcome: str | None = None,
+    created_from: datetime | None = None,
+    created_to: datetime | None = None,
 ) -> dict:
     """Return high-signal trend summaries over stored reports."""
     trend_sample_size = 100
+    if project_id is None and project_key is None:
+        raise ReportTrendError(
+            "missing_project_scope",
+            "Project scope is required for risk trend review.",
+        )
+    if (
+        created_from is not None
+        and created_to is not None
+        and created_from > created_to
+    ):
+        raise ReportTrendError(
+            "invalid_time_window",
+            "created_from must be earlier than or equal to created_to.",
+        )
+    normalized_outcome = _normalize_trend_outcome(outcome)
     resolved_project_id, resolved_workspace_id = _resolve_report_scope(
         project_id=project_id,
         project_key=project_key,
         workspace_id=workspace_id,
         workspace_key=workspace_key,
     )
+    readable_schema_versions = _readable_report_schema_versions()
 
-    def operation():
-        with SessionLocal() as session:
-            reports = list_analysis_reports(
-                session,
-                project_id=resolved_project_id,
-                workspace_id=resolved_workspace_id,
-                limit=trend_sample_size,
-                include_evidence=False,
+    def list_trend_outcomes(
+        session,
+        analysis_ids: list[int],
+        *,
+        deployed_from: datetime | None,
+        deployed_to: datetime | None,
+        deployed_before: datetime | None,
+    ):
+        outcomes = []
+        for chunk in _chunk_analysis_ids(analysis_ids):
+            outcomes.extend(
+                list_deployment_outcome_records(
+                    session,
+                    project_id=resolved_project_id,
+                    workspace_id=resolved_workspace_id,
+                    analysis_ids=chunk,
+                    outcome_label=normalized_outcome,
+                    deployed_from=deployed_from,
+                    deployed_to=deployed_to,
+                    deployed_before=deployed_before,
+                    limit=None,
+                )
             )
+        return outcomes
+
+    def list_trend_feedback(
+        session,
+        analysis_ids: list[int],
+        *,
+        feedback_from: datetime | None,
+        feedback_to: datetime | None,
+        feedback_before: datetime | None,
+    ):
+        events = []
+        for chunk in _chunk_analysis_ids(analysis_ids):
+            events.extend(
+                list_feedback_events(
+                    session,
+                    project_id=resolved_project_id,
+                    workspace_id=resolved_workspace_id,
+                    analysis_ids=chunk,
+                    created_from=feedback_from,
+                    created_to=feedback_to,
+                    created_before=feedback_before,
+                    limit=None,
+                )
+            )
+        return events
+
+    def event_matches_report_scope(
+        event, report_scope_by_id: dict[int, tuple[int, int | None]]
+    ) -> bool:
+        if event.analysis_id is None:
+            return False
+        report_scope = report_scope_by_id.get(int(event.analysis_id))
+        if report_scope is None:
+            return False
+        report_project_id, report_workspace_id = report_scope
+        event_workspace_id = (
+            int(event.workspace_id) if event.workspace_id is not None else None
+        )
+        return (
+            int(event.project_id) == report_project_id
+            and event_workspace_id == report_workspace_id
+        )
+
+    def load_window(
+        window_start: datetime | None,
+        window_end: datetime | None,
+        *,
+        window_end_exclusive: bool = False,
+    ) -> dict:
+        inclusive_end = None if window_end_exclusive else window_end
+        exclusive_end = window_end if window_end_exclusive else None
+        with SessionLocal() as session:
+            report_ids: list[int] = []
+            report_scope_by_id: dict[int, tuple[int, int | None]] = {}
+            report_warned_by_id: dict[int, bool] = {}
+            severity_counts: Counter[str] = Counter()
+            recommendation_counts: Counter[str] = Counter()
+            tool_counts: Counter[str] = Counter()
+            audit_rows: list[dict] = []
+            context_scores: list[float] = []
+            partial_context_count = 0
+            missing_context_count = 0
+            id_before: int | None = None
+            while True:
+                report_batch = list_analysis_reports(
+                    session,
+                    project_id=resolved_project_id,
+                    workspace_id=resolved_workspace_id,
+                    severity=severity,
+                    toolchain=toolchain,
+                    activity_from=window_start,
+                    activity_to=inclusive_end,
+                    activity_before=exclusive_end,
+                    outcome_label=normalized_outcome,
+                    report_schema_versions=readable_schema_versions,
+                    limit=_TREND_REPORT_BATCH_SIZE,
+                    id_before=id_before,
+                    include_evidence=False,
+                    order_by_activity=False,
+                )
+                if not report_batch:
+                    break
+                id_before = int(report_batch[-1].id)
+                for report in report_batch:
+                    report_id = int(report.id)
+                    report_ids.append(report_id)
+                    report_scope_by_id[report_id] = (
+                        int(report.project_id),
+                        int(report.workspace_id)
+                        if report.workspace_id is not None
+                        else None,
+                    )
+                    report_warned_by_id[report_id] = _trend_report_warned(report)
+                    severity_counts[report.severity] += 1
+                    recommendation_counts[report.recommendation] += 1
+                    try:
+                        contributors = json.loads(report.contributors_json or "[]")
+                        analyzed_files = json.loads(report.analyzed_files_json or "[]")
+                    except json.JSONDecodeError:
+                        contributors = []
+                        analyzed_files = []
+                    submission_manifest, _ = _load_submission_manifest_payload(
+                        getattr(report, "submission_manifest_json", None)
+                    )
+                    submission_manifest_fallback = (
+                        _load_submission_manifest_fallback_payload(
+                            getattr(report, "submission_manifest_fallback_json", None)
+                        )
+                    )
+                    tools = _history_tool_mix(
+                        contributors if isinstance(contributors, list) else [],
+                        submission_manifest or {},
+                        analyzed_files if isinstance(analyzed_files, list) else [],
+                        submission_manifest_fallback,
+                    )
+                    for tool in tools:
+                        tool_counts[tool] += 1
+                    context_payload, context_warning = (
+                        _load_context_completeness_payload(
+                            report.risk_assessment.context_completeness_json
+                            if report.risk_assessment is not None
+                            else None
+                        )
+                    )
+                    if not context_warning:
+                        context_scores.append(float(context_payload["context_score"]))
+                        if bool(context_payload.get("partial_context")):
+                            partial_context_count += 1
+                    else:
+                        missing_context_count += 1
+                    if len(audit_rows) < trend_sample_size:
+                        audit_rows.append(
+                            {
+                                "id": report.id,
+                                "created_at": report.created_at.isoformat(),
+                                "severity": report.severity,
+                                "recommendation": report.recommendation,
+                                "top_risk": report.top_risk,
+                                "tools": tools,
+                                "audit": {
+                                    "llm_provider": report.llm_provider,
+                                    "source_interface": report.source_interface,
+                                },
+                            }
+                        )
+            outcomes = list_trend_outcomes(
+                session,
+                report_ids,
+                deployed_from=window_start,
+                deployed_to=inclusive_end,
+                deployed_before=exclusive_end,
+            )
+            outcomes = [
+                outcome
+                for outcome in outcomes
+                if event_matches_report_scope(outcome, report_scope_by_id)
+            ]
+            feedback_events = list_trend_feedback(
+                session,
+                report_ids,
+                feedback_from=window_start,
+                feedback_to=inclusive_end,
+                feedback_before=exclusive_end,
+            )
+            feedback_events = [
+                event
+                for event in feedback_events
+                if event_matches_report_scope(event, report_scope_by_id)
+            ]
             return {
-                "reports": reports,
-                "total_reports": count_analysis_reports(
-                    session,
-                    project_id=resolved_project_id,
-                    workspace_id=resolved_workspace_id,
+                "total_reports": len(report_ids),
+                "severity_counts": dict(severity_counts),
+                "recommendation_counts": dict(recommendation_counts),
+                "tool_counts": dict(tool_counts),
+                "outcomes": outcomes,
+                "outcome_counts": dict(
+                    Counter(outcome.outcome_label for outcome in outcomes)
                 ),
-                "severity_counts": count_analysis_reports_by_field(
-                    session,
-                    "severity",
-                    project_id=resolved_project_id,
-                    workspace_id=resolved_workspace_id,
-                ),
-                "recommendation_counts": count_analysis_reports_by_field(
-                    session,
-                    "recommendation",
-                    project_id=resolved_project_id,
-                    workspace_id=resolved_workspace_id,
-                ),
+                "feedback_events": feedback_events,
+                "report_warned_by_id": report_warned_by_id,
+                "context_scores": context_scores,
+                "partial_context_count": partial_context_count,
+                "missing_context_count": missing_context_count,
+                "audit_rows": audit_rows,
             }
 
-    trend_data = _run_with_schema_retry(operation)
-    reports = trend_data["reports"]
-
-    tool_counts: Counter[str] = Counter()
-    audit_rows: list[dict] = []
-
-    for report in reports:
-        contributors = json.loads(report.contributors_json or "[]")
-        tools = sorted(
-            {contributor.get("tool", "unknown") for contributor in contributors}
+    def build_payload(
+        trend_data: dict,
+        *,
+        window_start: datetime | None,
+        window_end: datetime | None,
+    ) -> dict:
+        total_reports = int(trend_data["total_reports"])
+        report_warned_by_id = trend_data["report_warned_by_id"]
+        context_scores = trend_data["context_scores"]
+        partial_context_count = int(trend_data["partial_context_count"])
+        missing_context_count = int(trend_data["missing_context_count"])
+        severe_count = sum(
+            int(trend_data["severity_counts"].get(label, 0))
+            for label in ("high", "critical")
         )
-        for tool in tools:
-            tool_counts[tool] += 1
-        audit_rows.append(
-            {
-                "id": report.id,
-                "created_at": report.created_at.isoformat(),
-                "severity": report.severity,
-                "recommendation": report.recommendation,
-                "top_risk": report.top_risk,
-                "tools": tools,
-                "audit": {
-                    "llm_provider": report.llm_provider,
-                    "source_interface": report.source_interface,
-                },
-            }
+        failed_outcomes = [
+            outcome
+            for outcome in trend_data["outcomes"]
+            if outcome.outcome_label in {"failure", "rolled_back"}
+        ]
+        warned_failed_analysis_ids = {
+            int(outcome.analysis_id)
+            for outcome in failed_outcomes
+            if outcome.analysis_id is not None
+            and report_warned_by_id.get(int(outcome.analysis_id), False)
+        }
+        warned_failed_outcomes = [
+            outcome
+            for outcome in failed_outcomes
+            if outcome.analysis_id is not None
+            and int(outcome.analysis_id) in warned_failed_analysis_ids
+        ]
+        deployment_false_reassurance = [
+            outcome
+            for outcome in failed_outcomes
+            if outcome.analysis_id is not None
+            and int(outcome.analysis_id) not in warned_failed_analysis_ids
+        ]
+        deployment_false_reassurance_analysis_ids = {
+            int(outcome.analysis_id)
+            for outcome in deployment_false_reassurance
+            if outcome.analysis_id is not None
+        }
+        false_positive_events = [
+            event
+            for event in trend_data["feedback_events"]
+            if bool(event.false_positive_flag)
+        ]
+        false_positive_analysis_ids = {
+            int(event.analysis_id)
+            for event in false_positive_events
+            if event.analysis_id is not None
+        }
+        false_negative_events = [
+            event
+            for event in trend_data["feedback_events"]
+            if event.false_negative_note
+            and event.analysis_id is not None
+            and not report_warned_by_id.get(int(event.analysis_id), False)
+        ]
+        false_negative_analysis_ids = {
+            int(event.analysis_id)
+            for event in false_negative_events
+            if event.analysis_id is not None
+        }
+        false_reassurance_analysis_ids = (
+            deployment_false_reassurance_analysis_ids | false_negative_analysis_ids
         )
+        limitations: list[dict[str, str]] = []
+        if total_reports == 0:
+            limitations.append(
+                {
+                    "code": "no_reports",
+                    "label": "No reports in scope",
+                    "message": "No persisted reports match the selected project, workspace, time, toolchain, severity, and outcome filters.",
+                }
+            )
+        elif total_reports < 5:
+            limitations.append(
+                {
+                    "code": "sparse_reports",
+                    "label": "Limited report history",
+                    "message": f"Only {total_reports} persisted reports match the selected scope; trend direction is directional only.",
+                }
+            )
+        if len(trend_data["outcomes"]) < 5:
+            limitations.append(
+                {
+                    "code": "sparse_outcomes",
+                    "label": "Limited deployment outcomes",
+                    "message": f"Only {len(trend_data['outcomes'])} linked deployment outcomes match this trend scope.",
+                }
+            )
+        if len(trend_data["feedback_events"]) < 5:
+            limitations.append(
+                {
+                    "code": "sparse_feedback",
+                    "label": "Limited reviewer feedback",
+                    "message": f"Only {len(trend_data['feedback_events'])} reviewer feedback events match this trend scope.",
+                }
+            )
+        if missing_context_count:
+            limitations.append(
+                {
+                    "code": "missing_context_completeness",
+                    "label": "Incomplete context metadata",
+                    "message": f"{missing_context_count} report(s) in scope lack valid context-completeness metadata.",
+                }
+            )
 
-    return {
-        "total_reports": trend_data["total_reports"],
-        "severity_counts": trend_data["severity_counts"],
-        "recommendation_counts": trend_data["recommendation_counts"],
-        "tool_counts": dict(tool_counts),
-        "audit_rows": audit_rows,
-        "trend_sample_size": trend_sample_size,
-    }
+        return {
+            "total_reports": total_reports,
+            "filters": {
+                "project_id": resolved_project_id,
+                "project_key": project_key,
+                "workspace_id": resolved_workspace_id,
+                "workspace_key": workspace_key,
+                "toolchain": toolchain,
+                "severity": severity,
+                "outcome": normalized_outcome,
+            },
+            "window": {
+                "start": window_start.isoformat() if window_start is not None else None,
+                "end": window_end.isoformat() if window_end is not None else None,
+            },
+            "severity_counts": trend_data["severity_counts"],
+            "recommendation_counts": trend_data["recommendation_counts"],
+            "high_critical_frequency": {
+                "count": severe_count,
+                "rate": severe_count / total_reports if total_reports else 0.0,
+            },
+            "tool_counts": trend_data["tool_counts"],
+            "outcome_counts": trend_data["outcome_counts"],
+            "outcome_links": {
+                "linked_outcome_count": len(trend_data["outcomes"]),
+                "failed_outcome_count": len(failed_outcomes),
+                "warned_failed_outcome_count": len(warned_failed_outcomes),
+                "analysis_ids": sorted(
+                    {
+                        int(outcome.analysis_id)
+                        for outcome in trend_data["outcomes"]
+                        if outcome.analysis_id is not None
+                    }
+                ),
+            },
+            "false_positive_signals": {
+                "count": len(false_positive_analysis_ids),
+                "event_count": len(false_positive_events),
+                "rate": len(false_positive_analysis_ids) / total_reports
+                if total_reports
+                else 0.0,
+            },
+            "false_reassurance_signals": {
+                "count": len(false_reassurance_analysis_ids),
+                "event_count": len(deployment_false_reassurance)
+                + len(false_negative_events),
+                "deployment_count": len(deployment_false_reassurance_analysis_ids),
+                "feedback_count": len(false_negative_analysis_ids),
+                "rate": len(false_reassurance_analysis_ids) / total_reports
+                if total_reports
+                else 0.0,
+            },
+            "context_completeness": {
+                "sample_size": len(context_scores),
+                "missing_count": missing_context_count,
+                "partial_context_count": partial_context_count,
+                "partial_context_rate": (
+                    partial_context_count / len(context_scores)
+                    if context_scores
+                    else 0.0
+                ),
+                "average_context_score": (
+                    sum(context_scores) / len(context_scores)
+                    if context_scores
+                    else None
+                ),
+            },
+            "limitations": limitations,
+            "audit_rows": trend_data["audit_rows"],
+            "trend_sample_size": trend_sample_size,
+        }
+
+    current_data = _run_with_schema_retry(lambda: load_window(created_from, created_to))
+    current_payload = build_payload(
+        current_data,
+        window_start=created_from,
+        window_end=created_to,
+    )
+    previous_window = _previous_trend_window(created_from, created_to)
+    if previous_window is None:
+        current_payload["trend_windows"] = [
+            _trend_window_summary("selected", current_payload)
+        ]
+        current_payload["trend_comparison"] = None
+        return current_payload
+
+    previous_start, previous_end = previous_window
+    previous_data = _run_with_schema_retry(
+        lambda: load_window(
+            previous_start,
+            previous_end,
+            window_end_exclusive=True,
+        )
+    )
+    previous_payload = build_payload(
+        previous_data,
+        window_start=previous_start,
+        window_end=previous_end,
+    )
+    current_payload["trend_windows"] = [
+        _trend_window_summary("previous", previous_payload),
+        _trend_window_summary("current", current_payload),
+    ]
+    previous_limitations = [
+        {
+            **limitation,
+            "code": f"previous_window_{limitation.get('code', 'limitation')}",
+            "label": f"Previous window: {limitation.get('label', 'Limitation')}",
+            "message": f"Previous comparison window: {limitation.get('message', '')}",
+        }
+        for limitation in previous_payload.get("limitations", [])
+        if isinstance(limitation, dict)
+    ]
+    current_payload["limitations"] = [
+        *current_payload["limitations"],
+        *previous_limitations,
+    ]
+    current_payload["trend_comparison"] = _trend_delta(
+        current_payload,
+        previous_payload,
+    )
+    return current_payload
 
 
 def fetch_dashboard_stats(

--- a/tests/test_api/test_analyses.py
+++ b/tests/test_api/test_analyses.py
@@ -15,6 +15,7 @@ import config as config_module
 import models.database as database_module
 import models.repositories.analysis_reports as analysis_reports_repository_module
 import models.tables as tables_module
+import services.deployment_outcome_service as deployment_outcome_service_module
 import services.project_service as project_service_module
 import services.report_service as report_service_module
 from analysis.blast_radius import BlastRadiusResult
@@ -46,6 +47,7 @@ class AnalysesApiTests(unittest.TestCase):
         reload(analysis_reports_repository_module)
         reload(project_service_module)
         reload(report_service_module)
+        reload(deployment_outcome_service_module)
         database_module.init_db()
         self.client = TestClient(create_app())
 
@@ -216,6 +218,20 @@ class AnalysesApiTests(unittest.TestCase):
         self.assertEqual(payload["data"][0]["advisory"]["advisory_only"], True)
         self.assertFalse(payload["data"][0]["advisory"]["should_block"])
         self.assertEqual(payload["data"][0]["advisory"]["recommendation"], "caution")
+
+    def test_list_analyses_rejects_reversed_activity_window(self) -> None:
+        response = self.client.get(
+            "/api/v1/analyses",
+            params={
+                "created_from": "2026-06-08T00:00:00Z",
+                "created_to": "2026-06-01T00:00:00Z",
+            },
+        )
+
+        self.assertEqual(response.status_code, 400)
+        payload = response.json()
+        self.assertEqual(payload["error"]["code"], "invalid_time_window")
+        self.assertIn("created_from", payload["error"]["message"])
 
     def test_list_analyses_meta_matches_legacy_report_schema(self) -> None:
         with sqlite3.connect(self.db_path) as conn:
@@ -907,6 +923,103 @@ class AnalysesApiTests(unittest.TestCase):
         self.assertEqual(foreign_response.json()["meta"]["total_count"], 0)
         self.assertEqual(foreign_response.json()["data"], [])
         self.assertNotIn("Platform production ingress widened.", foreign_response.text)
+
+    def test_list_analyses_filters_by_deployment_outcome(self) -> None:
+        failure_report = report_service_module.persist_analysis_report(
+            ParseBatchResult(
+                files=[
+                    ParsedFileResult(
+                        file_name="failure-plan.json",
+                        tool="terraform",
+                        status="parsed",
+                        changes=[],
+                    )
+                ]
+            ),
+            RiskAssessment(
+                score=45,
+                severity="medium",
+                recommendation="caution",
+                top_risk="Failure-linked report.",
+                contributors=[],
+                interaction_risks=[],
+                partial_context=False,
+                warnings=[],
+            ),
+            NarrativeResult(
+                opening_sentence="CAUTION: failure-linked report.",
+                explanation="Failure report.",
+                guidance=[],
+                degraded=False,
+                warnings=[],
+                source="llm",
+            ),
+        )
+        success_report = report_service_module.persist_analysis_report(
+            ParseBatchResult(
+                files=[
+                    ParsedFileResult(
+                        file_name="success-plan.json",
+                        tool="terraform",
+                        status="parsed",
+                        changes=[],
+                    )
+                ]
+            ),
+            RiskAssessment(
+                score=10,
+                severity="low",
+                recommendation="go",
+                top_risk="Success-linked report.",
+                contributors=[],
+                interaction_risks=[],
+                partial_context=False,
+                warnings=[],
+            ),
+            NarrativeResult(
+                opening_sentence="GO: success-linked report.",
+                explanation="Success report.",
+                guidance=[],
+                degraded=False,
+                warnings=[],
+                source="llm",
+            ),
+        )
+        deployment_outcome_service_module.record_deployment_outcome(
+            analysis_id=failure_report["id"],
+            outcome="failure",
+            deployed_at="2026-06-07T09:00:00Z",
+        )
+        deployment_outcome_service_module.record_deployment_outcome(
+            analysis_id=success_report["id"],
+            outcome="success",
+            deployed_at="2026-06-07T10:00:00Z",
+        )
+
+        response = self.client.get(
+            "/api/v1/analyses",
+            params={"outcome": "failure"},
+        )
+
+        self.assertEqual(response.status_code, 200)
+        payload = response.json()
+        self.assertEqual(payload["meta"]["total_count"], 1)
+        self.assertEqual(payload["data"][0]["id"], failure_report["id"])
+        self.assertNotIn("Success-linked report.", response.text)
+
+    def test_list_analyses_rejects_invalid_deployment_outcome_filter(self) -> None:
+        response = self.client.get(
+            "/api/v1/analyses",
+            params={"outcome": "failed"},
+        )
+
+        self.assertEqual(response.status_code, 422)
+        payload = response.json()
+        self.assertEqual(payload["error"]["code"], "request_validation_failed")
+        self.assertEqual(
+            payload["error"]["details"]["issues"][0]["loc"],
+            ["query", "outcome"],
+        )
 
     def test_list_analyses_rejects_naive_history_time_bounds(self) -> None:
         response = self.client.get(
@@ -2933,16 +3046,43 @@ class AnalysesApiTests(unittest.TestCase):
 
         self.assertEqual(response.status_code, 200)
         schema = response.json()
+
+        def schema_enum_values(schema_part: dict) -> set[str]:
+            values = set(schema_part.get("enum") or [])
+            for branch_key in ("anyOf", "oneOf", "allOf"):
+                for branch in schema_part.get(branch_key) or []:
+                    values.update(schema_enum_values(branch))
+            return values
+
         analyses_get = schema["paths"]["/api/v1/analyses"]["get"]
         analyses_post = schema["paths"]["/api/v1/analyses"]["post"]
         analyses_detail = schema["paths"]["/api/v1/analyses/{report_id}"]["get"]
         request_body_schema = analyses_post["requestBody"]["content"][
             "multipart/form-data"
         ]["schema"]
+        analyses_get_parameters = {
+            parameter["name"]: parameter for parameter in analyses_get["parameters"]
+        }
         self.assertIn("$ref", request_body_schema)
         component_name = request_body_schema["$ref"].split("/")[-1]
         self.assertEqual(
             schema["components"]["schemas"][component_name]["type"], "object"
+        )
+        self.assertIn(
+            "activity-window start timestamp",
+            analyses_get_parameters["created_from"]["description"],
+        )
+        self.assertIn(
+            "deployment-outcome/reviewer-feedback activity",
+            analyses_get_parameters["created_to"]["description"],
+        )
+        self.assertIn(
+            "deployment outcome filter",
+            analyses_get_parameters["outcome"]["description"],
+        )
+        self.assertEqual(
+            schema_enum_values(analyses_get_parameters["outcome"]["schema"]),
+            {"success", "failure", "rolled_back", "rollback"},
         )
         self.assertIn("AnalysisRunResponse", str(analyses_post["responses"]["200"]))
         self.assertIn("ErrorResponse", str(analyses_post["responses"]["400"]))

--- a/tests/test_cli/test_analyze.py
+++ b/tests/test_cli/test_analyze.py
@@ -344,6 +344,127 @@ class AnalyzeCliTests(unittest.TestCase):
             workspace_key=None,
         )
 
+    def test_benchmark_risk_trends_command_exports_scoped_json(self) -> None:
+        output = io.StringIO()
+        result = {
+            "total_reports": 3,
+            "severity_counts": {"high": 2, "critical": 1},
+            "false_positive_signals": {"count": 1, "rate": 1 / 3},
+        }
+
+        with (
+            patch(
+                "sys.argv",
+                [
+                    "deploywhisper",
+                    "benchmark",
+                    "risk-trends",
+                    "--project-key",
+                    "payments",
+                    "--workspace-key",
+                    "prod",
+                    "--severity",
+                    "high",
+                    "--toolchain",
+                    "terraform",
+                    "--outcome",
+                    "failure",
+                    "--created-from",
+                    "2026-06-01T00:00:00Z",
+                    "--created-to",
+                    "2026-06-08T00:00:00Z",
+                ],
+            ),
+            patch("cli.analyze.fetch_risk_trends", return_value=result) as mocked,
+            redirect_stdout(output),
+        ):
+            with self.assertRaises(SystemExit) as ctx:
+                main()
+
+        payload = json.loads(output.getvalue())
+        self.assertEqual(ctx.exception.code, 0)
+        self.assertEqual(payload["total_reports"], 3)
+        mocked.assert_called_once()
+        kwargs = mocked.call_args.kwargs
+        self.assertEqual(kwargs["project_key"], "payments")
+        self.assertEqual(kwargs["workspace_key"], "prod")
+        self.assertEqual(kwargs["severity"], "high")
+        self.assertEqual(kwargs["toolchain"], "terraform")
+        self.assertEqual(kwargs["outcome"], "failure")
+        self.assertEqual(
+            kwargs["created_from"].isoformat(), "2026-06-01T00:00:00+00:00"
+        )
+        self.assertEqual(kwargs["created_to"].isoformat(), "2026-06-08T00:00:00+00:00")
+
+    def test_benchmark_risk_trends_help_describes_activity_window(self) -> None:
+        output = io.StringIO()
+
+        with (
+            patch("sys.argv", ["deploywhisper", "benchmark", "risk-trends", "--help"]),
+            redirect_stdout(output),
+        ):
+            with self.assertRaises(SystemExit) as ctx:
+                main()
+
+        self.assertEqual(ctx.exception.code, 0)
+        help_text = output.getvalue()
+        self.assertIn("activity-window start timestamp", help_text)
+        self.assertIn("outcome deployed", help_text)
+        self.assertIn("feedback", help_text)
+        self.assertIn("created), ISO-8601 or Zulu", help_text)
+
+    def test_benchmark_risk_trends_rejects_reversed_time_window(self) -> None:
+        output = io.StringIO()
+
+        with (
+            patch(
+                "sys.argv",
+                [
+                    "deploywhisper",
+                    "benchmark",
+                    "risk-trends",
+                    "--project-key",
+                    "payments",
+                    "--created-from",
+                    "2026-06-08T00:00:00Z",
+                    "--created-to",
+                    "2026-06-01T00:00:00Z",
+                ],
+            ),
+            patch("cli.analyze.fetch_risk_trends") as mocked,
+            redirect_stderr(output),
+        ):
+            with self.assertRaises(SystemExit) as ctx:
+                main()
+
+        payload = json.loads(output.getvalue())
+        self.assertEqual(ctx.exception.code, 1)
+        self.assertEqual(payload["error"]["code"], "invalid_time_window")
+        mocked.assert_not_called()
+
+    def test_benchmark_risk_trends_requires_project_scope(self) -> None:
+        output = io.StringIO()
+
+        with (
+            patch(
+                "sys.argv",
+                [
+                    "deploywhisper",
+                    "benchmark",
+                    "risk-trends",
+                ],
+            ),
+            patch("cli.analyze.fetch_risk_trends") as mocked,
+            redirect_stderr(output),
+        ):
+            with self.assertRaises(SystemExit) as ctx:
+                main()
+
+        payload = json.loads(output.getvalue())
+        self.assertEqual(ctx.exception.code, 1)
+        self.assertEqual(payload["error"]["code"], "missing_project_scope")
+        mocked.assert_not_called()
+
     def test_benchmark_run_command_reports_invalid_corpus_as_json(self) -> None:
         output = io.StringIO()
 

--- a/tests/test_infra/test_container_contract.py
+++ b/tests/test_infra/test_container_contract.py
@@ -38,6 +38,7 @@ class ContainerContractTests(unittest.TestCase):
                 "022_add_deployment_outcome_notes.py",
                 "023_add_incident_ingestion_sources.py",
                 "024_add_analysis_duration_seconds.py",
+                "025_add_event_analysis_indexes.py",
             ],
         )
         baseline_content = migrations[0].read_text(encoding="utf-8")
@@ -61,6 +62,7 @@ class ContainerContractTests(unittest.TestCase):
         deployment_notes_content = migrations[18].read_text(encoding="utf-8")
         incident_ingestion_sources_content = migrations[19].read_text(encoding="utf-8")
         analysis_duration_content = migrations[20].read_text(encoding="utf-8")
+        event_indexes_content = migrations[21].read_text(encoding="utf-8")
         self.assertIn("down_revision = None", baseline_content)
         self.assertIn('"app_settings"', baseline_content)
         self.assertIn(
@@ -167,6 +169,15 @@ class ContainerContractTests(unittest.TestCase):
             analysis_duration_content,
         )
         self.assertIn('"analysis_duration_seconds"', analysis_duration_content)
+        self.assertIn(
+            'down_revision = "024_add_analysis_duration_seconds"',
+            event_indexes_content,
+        )
+        self.assertIn(
+            "ix_deployment_outcomes_analysis_deployed_outcome",
+            event_indexes_content,
+        )
+        self.assertIn("ix_feedback_events_analysis_created", event_indexes_content)
 
     def test_dockerfile_exists(self) -> None:
         self.assertTrue(Path("Dockerfile").exists())

--- a/tests/test_infra/test_migrations.py
+++ b/tests/test_infra/test_migrations.py
@@ -131,6 +131,16 @@ class MigrationTests(unittest.TestCase):
             sqlite_conn.close()
         return str(row[0] if row else "")
 
+    def _index_columns(self, index_name: str) -> tuple[str, ...]:
+        sqlite_conn = sqlite3.connect(self.db_path)
+        try:
+            return tuple(
+                row[2]
+                for row in sqlite_conn.execute(f"PRAGMA index_info({index_name})")
+            )
+        finally:
+            sqlite_conn.close()
+
     def _assert_incident_ingestion_source_schema(self) -> None:
         columns = self._table_columns("incident_ingestion_sources")
         self.assertTrue(
@@ -265,6 +275,14 @@ class MigrationTests(unittest.TestCase):
         self.assertIn("notes", self._table_columns("deployment_outcomes"))
         self.assertIn("finding_id", self._table_columns("feedback_events"))
         self.assertIn("false_positive_reason", self._table_columns("feedback_events"))
+        self.assertEqual(
+            self._index_columns("ix_deployment_outcomes_analysis_deployed_outcome"),
+            ("analysis_id", "deployed_at", "outcome_label"),
+        )
+        self.assertEqual(
+            self._index_columns("ix_feedback_events_analysis_created"),
+            ("analysis_id", "created_at"),
+        )
         self.assertIn("report_schema_version", self._table_columns("analysis_reports"))
         self.assertIn("blast_radius_json", self._table_columns("analysis_reports"))
         self.assertIn("rollback_plan_json", self._table_columns("analysis_reports"))
@@ -339,6 +357,33 @@ class MigrationTests(unittest.TestCase):
             if row[1] == "submission_manifest_fallback_json"
         )
         self.assertIsNone(submission_manifest_fallback_row[4])
+
+    def test_event_index_upgrade_repairs_wrong_same_name_indexes(self) -> None:
+        command.upgrade(self._config(), "024_add_analysis_duration_seconds")
+        sqlite_conn = sqlite3.connect(self.db_path)
+        try:
+            sqlite_conn.execute(
+                "CREATE INDEX ix_deployment_outcomes_analysis_deployed_outcome "
+                "ON deployment_outcomes (analysis_id)"
+            )
+            sqlite_conn.execute(
+                "CREATE INDEX ix_feedback_events_analysis_created "
+                "ON feedback_events (created_at)"
+            )
+            sqlite_conn.commit()
+        finally:
+            sqlite_conn.close()
+
+        command.upgrade(self._config(), "head")
+
+        self.assertEqual(
+            self._index_columns("ix_deployment_outcomes_analysis_deployed_outcome"),
+            ("analysis_id", "deployed_at", "outcome_label"),
+        )
+        self.assertEqual(
+            self._index_columns("ix_feedback_events_analysis_created"),
+            ("analysis_id", "created_at"),
+        )
 
     def test_learning_context_scope_rejects_cross_project_workspace_rows(
         self,
@@ -1056,7 +1101,7 @@ class MigrationTests(unittest.TestCase):
         self.assertIn("topology_versions", tables)
         self.assertIn("incident_ingestion_sources", tables)
         self._assert_incident_ingestion_source_schema()
-        self.assertEqual(revision, "024_add_analysis_duration_seconds")
+        self.assertEqual(revision, "025_add_event_analysis_indexes")
 
     def test_init_db_repairs_partial_evidence_schema_without_alembic_version(
         self,
@@ -1107,7 +1152,7 @@ class MigrationTests(unittest.TestCase):
         self.assertIn("projects", tables)
         self.assertIn("incident_ingestion_sources", tables)
         self._assert_incident_ingestion_source_schema()
-        self.assertEqual(revision, "024_add_analysis_duration_seconds")
+        self.assertEqual(revision, "025_add_event_analysis_indexes")
 
     def test_init_db_repairs_current_schema_without_alembic_version(self) -> None:
         command.upgrade(self._config(), "head")
@@ -1133,7 +1178,7 @@ class MigrationTests(unittest.TestCase):
         finally:
             sqlite_conn.close()
 
-        self.assertEqual(revision, "024_add_analysis_duration_seconds")
+        self.assertEqual(revision, "025_add_event_analysis_indexes")
         self.assertIn("report_schema_version", columns)
         self.assertIn("blast_radius_json", columns)
         self.assertIn("project_id", columns)
@@ -1142,6 +1187,38 @@ class MigrationTests(unittest.TestCase):
         self.assertIn("submission_manifest_fallback_json", columns)
         self.assertIn("analysis_duration_seconds", columns)
         self._assert_incident_ingestion_source_schema()
+
+    def test_init_db_repairs_revision_024_schema_then_applies_event_indexes(
+        self,
+    ) -> None:
+        command.upgrade(self._config(), "024_add_analysis_duration_seconds")
+        sqlite_conn = sqlite3.connect(self.db_path)
+        sqlite_conn.execute("DROP TABLE alembic_version")
+        sqlite_conn.commit()
+        sqlite_conn.close()
+
+        reload(config_module)
+        reload(tables_module)
+        reload(database_module)
+        database_module.init_db()
+
+        sqlite_conn = sqlite3.connect(self.db_path)
+        try:
+            revision = sqlite_conn.execute(
+                "SELECT version_num FROM alembic_version"
+            ).fetchone()[0]
+        finally:
+            sqlite_conn.close()
+
+        self.assertEqual(revision, "025_add_event_analysis_indexes")
+        self.assertEqual(
+            self._index_columns("ix_deployment_outcomes_analysis_deployed_outcome"),
+            ("analysis_id", "deployed_at", "outcome_label"),
+        )
+        self.assertEqual(
+            self._index_columns("ix_feedback_events_analysis_created"),
+            ("analysis_id", "created_at"),
+        )
 
     def test_init_db_accepts_current_incident_matches_revision(self) -> None:
         command.upgrade(self._config(), "head")
@@ -1159,7 +1236,7 @@ class MigrationTests(unittest.TestCase):
         finally:
             sqlite_conn.close()
 
-        self.assertEqual(revision, "024_add_analysis_duration_seconds")
+        self.assertEqual(revision, "025_add_event_analysis_indexes")
         self._assert_incident_ingestion_source_schema()
 
     def test_init_db_rejects_partial_report_workspace_scope_schema(self) -> None:
@@ -1591,7 +1668,7 @@ class MigrationTests(unittest.TestCase):
         finally:
             sqlite_conn.close()
 
-        self.assertEqual(revision, "024_add_analysis_duration_seconds")
+        self.assertEqual(revision, "025_add_event_analysis_indexes")
         self._assert_incident_ingestion_source_schema()
 
 

--- a/tests/test_services/test_report_trends.py
+++ b/tests/test_services/test_report_trends.py
@@ -5,16 +5,24 @@ from __future__ import annotations
 import os
 import tempfile
 import unittest
+from datetime import UTC, datetime, timedelta
 from importlib import reload
 from pathlib import Path
+from unittest.mock import patch
+
+from sqlalchemy import text
+from sqlalchemy.dialects import postgresql
 
 import config as config_module
 import models.database as database_module
 import models.repositories.analysis_reports as analysis_reports_repository_module
 import models.tables as tables_module
+import services.deployment_outcome_service as deployment_outcome_service_module
+import services.feedback_service as feedback_service_module
+import services.project_service as project_service_module
 import services.report_service as report_service_module
 from analysis.risk_scorer import RiskAssessment, RiskContributor
-from evidence.models import EvidenceItem, Finding
+from evidence.models import ContextCompleteness, EvidenceItem, Finding
 from llm.narrator import NarrativeResult
 from parsers.base import ParseBatchResult, ParsedFileResult, UnifiedChange
 
@@ -28,7 +36,10 @@ class ReportTrendTests(unittest.TestCase):
         reload(tables_module)
         reload(database_module)
         reload(analysis_reports_repository_module)
+        reload(project_service_module)
         reload(report_service_module)
+        reload(feedback_service_module)
+        reload(deployment_outcome_service_module)
         database_module.init_db()
 
     def tearDown(self) -> None:
@@ -43,7 +54,11 @@ class ReportTrendTests(unittest.TestCase):
         recommendation: str,
         tool: str,
         source_interface: str = "ui",
-    ) -> None:
+        project_id: int | None = None,
+        workspace_id: int | None = None,
+        partial_context: bool = False,
+        context_score: float = 1.0,
+    ) -> dict:
         evidence_id = f"ev-{tool}-{severity}"
         finding_id = f"finding-{tool}-{severity}"
         resource_id = f"{tool}/resource"
@@ -84,8 +99,18 @@ class ReportTrendTests(unittest.TestCase):
                 )
             ],
             interaction_risks=[],
-            partial_context=False,
+            partial_context=partial_context,
             warnings=[],
+            context_completeness=ContextCompleteness(
+                topology_freshness_days=0,
+                topology_last_imported_at="2026-06-01T00:00:00Z",
+                incident_index_size=4,
+                parser_success_rate=1.0,
+                parser_success_by_tool={tool: 1.0},
+                context_score=context_score,
+                partial_context=partial_context,
+                context_todos=["Refresh topology context."] if partial_context else [],
+            ),
         )
         narrative = NarrativeResult(
             opening_sentence=f"{recommendation.upper()}: {tool} change",
@@ -94,11 +119,13 @@ class ReportTrendTests(unittest.TestCase):
             degraded=False,
             warnings=[],
         )
-        report_service_module.persist_analysis_report(
+        return report_service_module.persist_analysis_report(
             parse_batch,
             assessment,
             narrative,
             audit_context={"source_interface": source_interface},
+            project_id=project_id,
+            workspace_id=workspace_id,
             findings=[
                 Finding(
                     finding_id=finding_id,
@@ -134,16 +161,1151 @@ class ReportTrendTests(unittest.TestCase):
             else None,
         )
 
+    def _set_report_created_at(self, report_id: int, created_at: datetime) -> None:
+        with database_module.SessionLocal() as session:
+            report = session.get(tables_module.AnalysisReport, report_id)
+            self.assertIsNotNone(report)
+            report.created_at = created_at
+            session.commit()
+
+    def _set_report_schema_version(self, report_id: int, version: str) -> None:
+        with database_module.SessionLocal() as session:
+            report = session.get(tables_module.AnalysisReport, report_id)
+            self.assertIsNotNone(report)
+            report.report_schema_version = version
+            session.commit()
+
+    def _set_report_contributors_json(self, report_id: int, payload: str) -> None:
+        with database_module.SessionLocal() as session:
+            report = session.get(tables_module.AnalysisReport, report_id)
+            self.assertIsNotNone(report)
+            report.contributors_json = payload
+            session.commit()
+
+    def _set_feedback_created_at(self, analysis_id: int, created_at: datetime) -> None:
+        with database_module.SessionLocal() as session:
+            session.execute(
+                text(
+                    "UPDATE feedback_events SET created_at = :created_at "
+                    "WHERE analysis_id = :analysis_id"
+                ),
+                {"created_at": created_at, "analysis_id": analysis_id},
+            )
+            session.commit()
+
+    def _set_outcome_scope(
+        self,
+        analysis_id: int,
+        *,
+        project_id: int,
+        workspace_id: int | None = None,
+    ) -> None:
+        with database_module.SessionLocal() as session:
+            session.execute(
+                text(
+                    "UPDATE deployment_outcomes "
+                    "SET project_id = :project_id, workspace_id = :workspace_id "
+                    "WHERE analysis_id = :analysis_id"
+                ),
+                {
+                    "analysis_id": analysis_id,
+                    "project_id": project_id,
+                    "workspace_id": workspace_id,
+                },
+            )
+            session.commit()
+
+    def _set_feedback_scope(
+        self,
+        analysis_id: int,
+        *,
+        project_id: int,
+        workspace_id: int | None = None,
+    ) -> None:
+        with database_module.SessionLocal() as session:
+            session.execute(
+                text(
+                    "UPDATE feedback_events "
+                    "SET project_id = :project_id, workspace_id = :workspace_id "
+                    "WHERE analysis_id = :analysis_id"
+                ),
+                {
+                    "analysis_id": analysis_id,
+                    "project_id": project_id,
+                    "workspace_id": workspace_id,
+                },
+            )
+            session.commit()
+
+    def _set_context_completeness_json(self, report_id: int, payload: str) -> None:
+        with database_module.SessionLocal() as session:
+            session.execute(
+                text(
+                    "UPDATE risk_assessments SET context_completeness_json = :payload "
+                    "WHERE analysis_id = :report_id"
+                ),
+                {"payload": payload, "report_id": report_id},
+            )
+            session.commit()
+
     def test_fetch_risk_trends_summarizes_severity_and_tools(self) -> None:
-        self._persist(severity="high", recommendation="caution", tool="terraform")
-        self._persist(severity="critical", recommendation="no-go", tool="kubernetes")
-        trends = report_service_module.fetch_risk_trends()
+        project = project_service_module.create_project(
+            project_key="payments",
+            display_name="Payments",
+        )
+        self._persist(
+            severity="high",
+            recommendation="caution",
+            tool="terraform",
+            project_id=project.id,
+        )
+        self._persist(
+            severity="critical",
+            recommendation="no-go",
+            tool="kubernetes",
+            project_id=project.id,
+        )
+        trends = report_service_module.fetch_risk_trends(project_id=project.id)
         self.assertEqual(trends["total_reports"], 2)
         self.assertEqual(trends["severity_counts"]["high"], 1)
         self.assertEqual(trends["severity_counts"]["critical"], 1)
         self.assertEqual(trends["tool_counts"]["terraform"], 1)
         self.assertEqual(len(trends["audit_rows"]), 2)
         self.assertEqual(trends["audit_rows"][0]["audit"]["llm_provider"], "ollama")
+
+    def test_fetch_risk_trends_requires_project_scope(self) -> None:
+        with self.assertRaises(report_service_module.ReportTrendError) as ctx:
+            report_service_module.fetch_risk_trends()
+
+        self.assertEqual(ctx.exception.code, "missing_project_scope")
+
+    def test_fetch_risk_trends_filters_scope_window_toolchain_and_severity(
+        self,
+    ) -> None:
+        project = project_service_module.create_project(
+            project_key="payments",
+            display_name="Payments",
+        )
+        prod = project_service_module.create_workspace(
+            project_key="payments",
+            workspace_key="prod",
+            display_name="Production",
+        )
+        staging = project_service_module.create_workspace(
+            project_key="payments",
+            workspace_key="staging",
+            display_name="Staging",
+        )
+        other_project = project_service_module.create_project(
+            project_key="search",
+            display_name="Search",
+        )
+        now = datetime(2026, 6, 8, 12, 0, tzinfo=UTC)
+        included = self._persist(
+            severity="high",
+            recommendation="no-go",
+            tool="terraform",
+            project_id=project.id,
+            workspace_id=prod.id,
+            partial_context=True,
+            context_score=0.54,
+        )
+        wrong_workspace = self._persist(
+            severity="high",
+            recommendation="no-go",
+            tool="terraform",
+            project_id=project.id,
+            workspace_id=staging.id,
+        )
+        wrong_tool = self._persist(
+            severity="high",
+            recommendation="no-go",
+            tool="kubernetes",
+            project_id=project.id,
+            workspace_id=prod.id,
+        )
+        wrong_severity = self._persist(
+            severity="medium",
+            recommendation="caution",
+            tool="terraform",
+            project_id=project.id,
+            workspace_id=prod.id,
+        )
+        out_of_window = self._persist(
+            severity="critical",
+            recommendation="no-go",
+            tool="terraform",
+            project_id=project.id,
+            workspace_id=prod.id,
+        )
+        out_of_scope = self._persist(
+            severity="critical",
+            recommendation="no-go",
+            tool="terraform",
+            project_id=other_project.id,
+        )
+        self._set_report_created_at(included["id"], now - timedelta(days=1))
+        self._set_report_created_at(wrong_workspace["id"], now - timedelta(days=1))
+        self._set_report_created_at(wrong_tool["id"], now - timedelta(days=1))
+        self._set_report_created_at(wrong_severity["id"], now - timedelta(days=1))
+        self._set_report_created_at(out_of_window["id"], now - timedelta(days=45))
+        self._set_report_created_at(out_of_scope["id"], now - timedelta(days=1))
+
+        trends = report_service_module.fetch_risk_trends(
+            project_id=project.id,
+            workspace_key="prod",
+            created_from=now - timedelta(days=7),
+            created_to=now,
+            toolchain="terraform",
+            severity="high",
+        )
+
+        self.assertEqual(trends["total_reports"], 1)
+        self.assertEqual(trends["window"]["start"], "2026-06-01T12:00:00+00:00")
+        self.assertEqual(trends["window"]["end"], "2026-06-08T12:00:00+00:00")
+        self.assertEqual(trends["filters"]["project_id"], project.id)
+        self.assertEqual(trends["filters"]["workspace_key"], "prod")
+        self.assertEqual(trends["filters"]["toolchain"], "terraform")
+        self.assertEqual(trends["filters"]["severity"], "high")
+        self.assertEqual(trends["severity_counts"], {"high": 1})
+        self.assertEqual(trends["high_critical_frequency"]["count"], 1)
+        self.assertEqual(trends["high_critical_frequency"]["rate"], 1.0)
+        self.assertEqual(trends["tool_counts"], {"terraform": 1})
+        self.assertEqual(trends["context_completeness"]["partial_context_count"], 1)
+        self.assertEqual(trends["context_completeness"]["average_context_score"], 0.54)
+        self.assertEqual([row["id"] for row in trends["audit_rows"]], [included["id"]])
+
+    def test_fetch_risk_trends_counts_analyzed_file_tool_without_contributors(
+        self,
+    ) -> None:
+        project = project_service_module.create_project(
+            project_key="payments-analyzed-tools",
+            display_name="Payments Analyzed Tools",
+        )
+        report = self._persist(
+            severity="low",
+            recommendation="go",
+            tool="terraform",
+            project_id=project.id,
+        )
+        self._set_report_contributors_json(report["id"], "[]")
+
+        trends = report_service_module.fetch_risk_trends(
+            project_id=project.id,
+            toolchain="terraform",
+        )
+
+        self.assertEqual(trends["total_reports"], 1)
+        self.assertEqual(trends["tool_counts"], {"terraform": 1})
+
+    def test_fetch_risk_trends_includes_feedback_outcome_and_sparse_limitations(
+        self,
+    ) -> None:
+        project = project_service_module.create_project(
+            project_key="payments",
+            display_name="Payments",
+        )
+        warned_failure = self._persist(
+            severity="high",
+            recommendation="no-go",
+            tool="terraform",
+            project_id=project.id,
+        )
+        clean_failure = self._persist(
+            severity="low",
+            recommendation="go",
+            tool="terraform",
+            project_id=project.id,
+        )
+        false_positive = self._persist(
+            severity="critical",
+            recommendation="no-go",
+            tool="kubernetes",
+            project_id=project.id,
+        )
+        out_of_scope = self._persist(
+            severity="high",
+            recommendation="no-go",
+            tool="terraform",
+        )
+
+        deployment_outcome_service_module.record_deployment_outcome(
+            analysis_id=warned_failure["id"],
+            outcome="rolled_back",
+            deployed_at="2026-06-07T08:00:00Z",
+        )
+        deployment_outcome_service_module.record_deployment_outcome(
+            analysis_id=clean_failure["id"],
+            outcome="failure",
+            deployed_at="2026-06-07T09:00:00Z",
+        )
+        deployment_outcome_service_module.record_deployment_outcome(
+            analysis_id=out_of_scope["id"],
+            outcome="failure",
+            deployed_at="2026-06-07T10:00:00Z",
+        )
+        feedback_service_module.record_finding_feedback(
+            analysis_id=false_positive["id"],
+            finding_id=false_positive["findings"][0]["finding_id"],
+            useful=False,
+            false_positive_flag=True,
+            false_positive_reason="Known compensating control.",
+        )
+        feedback_service_module.record_false_negative_feedback(
+            analysis_id=clean_failure["id"],
+            note="Low-risk verdict missed the failed deploy signal.",
+        )
+
+        trends = report_service_module.fetch_risk_trends(project_id=project.id)
+
+        self.assertEqual(trends["total_reports"], 3)
+        self.assertEqual(trends["outcome_links"]["linked_outcome_count"], 2)
+        self.assertEqual(trends["outcome_links"]["failed_outcome_count"], 2)
+        self.assertEqual(trends["outcome_links"]["warned_failed_outcome_count"], 1)
+        self.assertEqual(
+            trends["false_positive_signals"],
+            {"count": 1, "event_count": 1, "rate": 1 / 3},
+        )
+        self.assertEqual(trends["false_reassurance_signals"]["count"], 1)
+        self.assertEqual(trends["false_reassurance_signals"]["event_count"], 2)
+        self.assertEqual(trends["false_reassurance_signals"]["deployment_count"], 1)
+        self.assertEqual(trends["false_reassurance_signals"]["feedback_count"], 1)
+        self.assertEqual(trends["false_reassurance_signals"]["rate"], 1 / 3)
+        limitation_codes = {limitation["code"] for limitation in trends["limitations"]}
+        self.assertIn("sparse_reports", limitation_codes)
+        self.assertIn("sparse_feedback", limitation_codes)
+        self.assertNotIn(out_of_scope["id"], trends["outcome_links"]["analysis_ids"])
+
+    def test_fetch_risk_trends_surfaces_previous_window_limitations(self) -> None:
+        project = project_service_module.create_project(
+            project_key="payments-previous-limitations",
+            display_name="Payments Previous Limitations",
+        )
+        for index in range(5):
+            report = self._persist(
+                severity="low",
+                recommendation="go",
+                tool="terraform",
+                project_id=project.id,
+            )
+            self._set_report_created_at(
+                report["id"],
+                datetime(2026, 6, 2 + index, tzinfo=UTC),
+            )
+
+        trends = report_service_module.fetch_risk_trends(
+            project_id=project.id,
+            created_from=datetime(2026, 6, 1, tzinfo=UTC),
+            created_to=datetime(2026, 6, 8, tzinfo=UTC),
+        )
+
+        limitation_codes = {limitation["code"] for limitation in trends["limitations"]}
+        self.assertIn("previous_window_no_reports", limitation_codes)
+        previous_window, current_window = trends["trend_windows"]
+        self.assertEqual(previous_window["label"], "previous")
+        self.assertIn(
+            "no_reports",
+            {limitation["code"] for limitation in previous_window["limitations"]},
+        )
+        self.assertEqual(current_window["label"], "current")
+        self.assertNotIn(
+            "previous_window_no_reports",
+            {limitation["code"] for limitation in current_window["limitations"]},
+        )
+
+    def test_activity_window_ignores_out_of_scope_event_rows(self) -> None:
+        project = project_service_module.create_project(
+            project_key="payments-scope",
+            display_name="Payments Scope",
+        )
+        other_project = project_service_module.create_project(
+            project_key="other-scope",
+            display_name="Other Scope",
+        )
+        outcome_report = self._persist(
+            severity="low",
+            recommendation="go",
+            tool="terraform",
+            project_id=project.id,
+        )
+        feedback_report = self._persist(
+            severity="low",
+            recommendation="go",
+            tool="terraform",
+            project_id=project.id,
+        )
+        self._set_report_created_at(
+            outcome_report["id"],
+            datetime(2026, 5, 1, tzinfo=UTC),
+        )
+        self._set_report_created_at(
+            feedback_report["id"],
+            datetime(2026, 5, 2, tzinfo=UTC),
+        )
+        deployment_outcome_service_module.record_deployment_outcome(
+            analysis_id=outcome_report["id"],
+            outcome="failure",
+            deployed_at="2026-06-07T09:00:00Z",
+        )
+        self._set_outcome_scope(
+            outcome_report["id"],
+            project_id=other_project.id,
+        )
+        feedback_service_module.record_false_negative_feedback(
+            analysis_id=feedback_report["id"],
+            note="Out-of-scope feedback must not qualify the report.",
+        )
+        self._set_feedback_created_at(
+            feedback_report["id"],
+            datetime(2026, 6, 7, tzinfo=UTC),
+        )
+        self._set_feedback_scope(
+            feedback_report["id"],
+            project_id=other_project.id,
+        )
+
+        page = report_service_module.fetch_filtered_analysis_history_page(
+            project_id=project.id,
+            created_from=datetime(2026, 6, 1, tzinfo=UTC),
+            created_to=datetime(2026, 6, 8, tzinfo=UTC),
+            skip_unreadable_schema=True,
+        )
+        trends = report_service_module.fetch_risk_trends(
+            project_id=project.id,
+            created_from=datetime(2026, 6, 1, tzinfo=UTC),
+            created_to=datetime(2026, 6, 8, tzinfo=UTC),
+        )
+
+        self.assertEqual(page["total_count"], 0)
+        self.assertEqual(page["items"], [])
+        self.assertEqual(trends["total_reports"], 0)
+        self.assertEqual(trends["outcome_links"]["linked_outcome_count"], 0)
+        self.assertEqual(trends["false_reassurance_signals"]["count"], 0)
+
+    def test_project_wide_trends_ignore_wrong_workspace_event_rows(self) -> None:
+        project = project_service_module.create_project(
+            project_key="payments-workspace-events",
+            display_name="Payments Workspace Events",
+        )
+        prod = project_service_module.create_workspace(
+            project_key=project.project_key,
+            workspace_key="prod",
+            display_name="Production",
+            environment="prod",
+        )
+        staging = project_service_module.create_workspace(
+            project_key=project.project_key,
+            workspace_key="staging",
+            display_name="Staging",
+            environment="staging",
+        )
+        report = self._persist(
+            severity="low",
+            recommendation="go",
+            tool="terraform",
+            project_id=project.id,
+            workspace_id=prod.id,
+        )
+        deployment_outcome_service_module.record_deployment_outcome(
+            analysis_id=report["id"],
+            outcome="failure",
+            deployed_at="2026-06-07T09:00:00Z",
+        )
+        self._set_outcome_scope(
+            report["id"],
+            project_id=project.id,
+            workspace_id=staging.id,
+        )
+        feedback_service_module.record_false_negative_feedback(
+            analysis_id=report["id"],
+            note="Wrong-workspace event must not count in project-wide trends.",
+        )
+        self._set_feedback_scope(
+            report["id"],
+            project_id=project.id,
+            workspace_id=staging.id,
+        )
+
+        trends = report_service_module.fetch_risk_trends(project_id=project.id)
+
+        self.assertEqual(trends["total_reports"], 1)
+        self.assertEqual(trends["outcome_links"]["linked_outcome_count"], 0)
+        self.assertEqual(trends["outcome_counts"], {})
+        self.assertEqual(trends["false_reassurance_signals"]["count"], 0)
+        self.assertEqual(trends["false_reassurance_signals"]["event_count"], 0)
+
+    def test_fetch_risk_trends_keyset_batches_activity_window_scope(self) -> None:
+        project = project_service_module.create_project(
+            project_key="payments-batched-trends",
+            display_name="Payments Batched Trends",
+        )
+        report_ids = []
+        for index in range(5):
+            report = self._persist(
+                severity="low",
+                recommendation="go",
+                tool="terraform" if index % 2 else "kubernetes",
+                project_id=project.id,
+            )
+            report_ids.append(report["id"])
+            self._set_report_created_at(
+                report["id"],
+                datetime(2026, 6, 2 + index, tzinfo=UTC),
+            )
+        original_list_analysis_reports = report_service_module.list_analysis_reports
+        report_query_calls: list[dict] = []
+        created_from = datetime(2026, 6, 1, tzinfo=UTC)
+        created_to = datetime(2026, 6, 8, tzinfo=UTC)
+
+        def recording_list_analysis_reports(*args, **kwargs):
+            report_query_calls.append(dict(kwargs))
+            return original_list_analysis_reports(*args, **kwargs)
+
+        with (
+            patch.object(report_service_module, "_TREND_REPORT_BATCH_SIZE", 2),
+            patch.object(
+                report_service_module,
+                "list_analysis_reports",
+                side_effect=recording_list_analysis_reports,
+            ),
+        ):
+            trends = report_service_module.fetch_risk_trends(
+                project_id=project.id,
+                created_from=created_from,
+                created_to=created_to,
+            )
+
+        self.assertEqual(trends["total_reports"], 5)
+        current_window_calls = [
+            call for call in report_query_calls if call["activity_from"] == created_from
+        ]
+        self.assertGreaterEqual(len(current_window_calls), 3)
+        self.assertEqual(
+            len(report_ids),
+            len({report_id for report_id in report_ids}),
+        )
+        self.assertTrue(
+            all(call.get("offset") is None for call in current_window_calls)
+        )
+        self.assertTrue(
+            all(call["order_by_activity"] is False for call in current_window_calls)
+        )
+        self.assertIsNone(current_window_calls[0]["id_before"])
+        self.assertTrue(
+            all(call["id_before"] is not None for call in current_window_calls[1:])
+        )
+        self.assertTrue(all(call["limit"] == 2 for call in current_window_calls))
+
+    def test_fetch_risk_trends_aggregates_signals_beyond_audit_sample(
+        self,
+    ) -> None:
+        project = project_service_module.create_project(
+            project_key="payments",
+            display_name="Payments",
+        )
+        older_signal = self._persist(
+            severity="high",
+            recommendation="no-go",
+            tool="terraform",
+            project_id=project.id,
+            partial_context=True,
+            context_score=0.25,
+        )
+        deployment_outcome_service_module.record_deployment_outcome(
+            analysis_id=older_signal["id"],
+            outcome="failure",
+            deployed_at="2026-06-07T08:00:00Z",
+        )
+        feedback_service_module.record_finding_feedback(
+            analysis_id=older_signal["id"],
+            finding_id=older_signal["findings"][0]["finding_id"],
+            useful=False,
+            false_positive_flag=True,
+            false_positive_reason="Known exception.",
+        )
+        for index in range(105):
+            self._persist(
+                severity="low",
+                recommendation="go",
+                tool="kubernetes" if index % 2 else "terraform",
+                project_id=project.id,
+            )
+
+        trends = report_service_module.fetch_risk_trends(project_id=project.id)
+
+        self.assertEqual(trends["total_reports"], 106)
+        self.assertEqual(trends["outcome_links"]["linked_outcome_count"], 1)
+        self.assertEqual(trends["outcome_links"]["failed_outcome_count"], 1)
+        self.assertEqual(trends["false_positive_signals"]["count"], 1)
+        self.assertEqual(trends["context_completeness"]["sample_size"], 106)
+        self.assertEqual(trends["context_completeness"]["partial_context_count"], 1)
+        self.assertEqual(len(trends["audit_rows"]), 100)
+        self.assertNotIn(
+            older_signal["id"],
+            {row["id"] for row in trends["audit_rows"]},
+        )
+
+    def test_fetch_risk_trends_filters_and_counts_by_outcome(self) -> None:
+        project = project_service_module.create_project(
+            project_key="payments",
+            display_name="Payments",
+        )
+        success = self._persist(
+            severity="low",
+            recommendation="go",
+            tool="terraform",
+            project_id=project.id,
+        )
+        failure = self._persist(
+            severity="medium",
+            recommendation="caution",
+            tool="terraform",
+            project_id=project.id,
+        )
+        rolled_back = self._persist(
+            severity="critical",
+            recommendation="no-go",
+            tool="kubernetes",
+            project_id=project.id,
+        )
+        deployment_outcome_service_module.record_deployment_outcome(
+            analysis_id=success["id"],
+            outcome="success",
+            deployed_at="2026-06-07T08:00:00Z",
+        )
+        deployment_outcome_service_module.record_deployment_outcome(
+            analysis_id=failure["id"],
+            outcome="failure",
+            deployed_at="2026-06-07T09:00:00Z",
+        )
+        deployment_outcome_service_module.record_deployment_outcome(
+            analysis_id=rolled_back["id"],
+            outcome="rollback",
+            deployed_at="2026-06-07T10:00:00Z",
+        )
+
+        failure_trends = report_service_module.fetch_risk_trends(
+            project_id=project.id,
+            outcome="failure",
+        )
+        rollback_trends = report_service_module.fetch_risk_trends(
+            project_id=project.id,
+            outcome="rollback",
+        )
+
+        self.assertEqual(failure_trends["total_reports"], 1)
+        self.assertEqual(failure_trends["filters"]["outcome"], "failure")
+        self.assertEqual(failure_trends["severity_counts"], {"medium": 1})
+        self.assertEqual(failure_trends["outcome_counts"], {"failure": 1})
+        self.assertEqual(rollback_trends["total_reports"], 1)
+        self.assertEqual(rollback_trends["filters"]["outcome"], "rolled_back")
+        self.assertEqual(rollback_trends["outcome_counts"], {"rolled_back": 1})
+
+    def test_fetch_risk_trends_rates_use_unique_affected_reports(self) -> None:
+        project = project_service_module.create_project(
+            project_key="payments",
+            display_name="Payments",
+        )
+        false_positive = self._persist(
+            severity="critical",
+            recommendation="no-go",
+            tool="terraform",
+            project_id=project.id,
+        )
+        false_reassurance = self._persist(
+            severity="low",
+            recommendation="go",
+            tool="terraform",
+            project_id=project.id,
+        )
+        for _ in range(2):
+            feedback_service_module.record_finding_feedback(
+                analysis_id=false_positive["id"],
+                finding_id=false_positive["findings"][0]["finding_id"],
+                useful=False,
+                false_positive_flag=True,
+                false_positive_reason="Known exception.",
+            )
+        deployment_outcome_service_module.record_deployment_outcome(
+            analysis_id=false_reassurance["id"],
+            outcome="failure",
+            deployed_at="2026-06-07T09:00:00Z",
+        )
+        feedback_service_module.record_false_negative_feedback(
+            analysis_id=false_reassurance["id"],
+            note="Low-risk verdict missed failed deploy.",
+        )
+
+        trends = report_service_module.fetch_risk_trends(project_id=project.id)
+
+        self.assertEqual(trends["false_positive_signals"]["count"], 1)
+        self.assertEqual(trends["false_positive_signals"]["event_count"], 2)
+        self.assertEqual(trends["false_positive_signals"]["rate"], 0.5)
+        self.assertEqual(trends["false_reassurance_signals"]["count"], 1)
+        self.assertEqual(trends["false_reassurance_signals"]["event_count"], 2)
+        self.assertEqual(trends["false_reassurance_signals"]["deployment_count"], 1)
+        self.assertEqual(trends["false_reassurance_signals"]["feedback_count"], 1)
+        self.assertEqual(trends["false_reassurance_signals"]["rate"], 0.5)
+
+    def test_fetch_risk_trends_rejects_reversed_time_window(self) -> None:
+        project = project_service_module.create_project(
+            project_key="payments",
+            display_name="Payments",
+        )
+        with self.assertRaises(report_service_module.ReportTrendError) as ctx:
+            report_service_module.fetch_risk_trends(
+                project_id=project.id,
+                created_from=datetime(2026, 6, 8, tzinfo=UTC),
+                created_to=datetime(2026, 6, 1, tzinfo=UTC),
+            )
+
+        self.assertEqual(ctx.exception.code, "invalid_time_window")
+
+    def test_fetch_risk_trends_flags_missing_context_completeness(self) -> None:
+        project = project_service_module.create_project(
+            project_key="payments",
+            display_name="Payments",
+        )
+        valid = self._persist(
+            severity="low",
+            recommendation="go",
+            tool="terraform",
+            project_id=project.id,
+        )
+        missing = self._persist(
+            severity="low",
+            recommendation="go",
+            tool="terraform",
+            project_id=project.id,
+        )
+        self._set_context_completeness_json(missing["id"], "{}")
+
+        trends = report_service_module.fetch_risk_trends(project_id=project.id)
+
+        self.assertEqual(trends["context_completeness"]["sample_size"], 1)
+        self.assertEqual(trends["context_completeness"]["missing_count"], 1)
+        self.assertEqual(
+            trends["context_completeness"]["average_context_score"],
+            1.0,
+        )
+        limitation_codes = {limitation["code"] for limitation in trends["limitations"]}
+        self.assertIn("missing_context_completeness", limitation_codes)
+        self.assertIn(valid["id"], [row["id"] for row in trends["audit_rows"]])
+
+    def test_fetch_risk_trends_compares_current_and_previous_windows(self) -> None:
+        project = project_service_module.create_project(
+            project_key="payments",
+            display_name="Payments",
+        )
+        current = self._persist(
+            severity="low",
+            recommendation="go",
+            tool="terraform",
+            project_id=project.id,
+        )
+        previous = self._persist(
+            severity="critical",
+            recommendation="no-go",
+            tool="kubernetes",
+            project_id=project.id,
+        )
+        boundary = self._persist(
+            severity="high",
+            recommendation="no-go",
+            tool="cloudformation",
+            project_id=project.id,
+        )
+        boundary_outcome = self._persist(
+            severity="low",
+            recommendation="go",
+            tool="terraform",
+            project_id=project.id,
+        )
+        self._set_report_created_at(
+            current["id"],
+            datetime(2026, 6, 5, tzinfo=UTC),
+        )
+        self._set_report_created_at(
+            previous["id"],
+            datetime(2026, 5, 28, tzinfo=UTC),
+        )
+        self._set_report_created_at(
+            boundary["id"],
+            datetime(2026, 6, 1, tzinfo=UTC),
+        )
+        self._set_report_created_at(
+            boundary_outcome["id"],
+            datetime(2026, 5, 1, tzinfo=UTC),
+        )
+        deployment_outcome_service_module.record_deployment_outcome(
+            analysis_id=boundary_outcome["id"],
+            outcome="failure",
+            deployed_at="2026-06-01T00:00:00Z",
+        )
+
+        trends = report_service_module.fetch_risk_trends(
+            project_id=project.id,
+            created_from=datetime(2026, 6, 1, tzinfo=UTC),
+            created_to=datetime(2026, 6, 8, tzinfo=UTC),
+        )
+
+        self.assertEqual(
+            [window["label"] for window in trends["trend_windows"]],
+            ["previous", "current"],
+        )
+        self.assertEqual(trends["trend_windows"][0]["total_reports"], 1)
+        self.assertEqual(trends["trend_windows"][1]["total_reports"], 3)
+        self.assertEqual(
+            trends["trend_comparison"]["severity_count_deltas"]["high"],
+            1,
+        )
+        self.assertEqual(
+            trends["trend_comparison"]["tool_count_deltas"]["terraform"],
+            2,
+        )
+        self.assertEqual(
+            trends["trend_comparison"]["tool_count_deltas"]["kubernetes"],
+            -1,
+        )
+        self.assertEqual(
+            trends["trend_comparison"]["high_critical_count_delta"],
+            0,
+        )
+
+    def test_fetch_risk_trends_filters_outcome_and_feedback_by_event_window(
+        self,
+    ) -> None:
+        project = project_service_module.create_project(
+            project_key="payments",
+            display_name="Payments",
+        )
+        old_report_new_failure = self._persist(
+            severity="low",
+            recommendation="go",
+            tool="terraform",
+            project_id=project.id,
+        )
+        new_report_old_failure = self._persist(
+            severity="low",
+            recommendation="go",
+            tool="kubernetes",
+            project_id=project.id,
+        )
+        self._set_report_created_at(
+            old_report_new_failure["id"],
+            datetime(2026, 5, 1, tzinfo=UTC),
+        )
+        self._set_report_created_at(
+            new_report_old_failure["id"],
+            datetime(2026, 6, 5, tzinfo=UTC),
+        )
+        deployment_outcome_service_module.record_deployment_outcome(
+            analysis_id=old_report_new_failure["id"],
+            outcome="failure",
+            deployed_at="2026-06-07T09:00:00Z",
+        )
+        deployment_outcome_service_module.record_deployment_outcome(
+            analysis_id=new_report_old_failure["id"],
+            outcome="failure",
+            deployed_at="2026-05-20T09:00:00Z",
+        )
+        feedback_service_module.record_false_negative_feedback(
+            analysis_id=old_report_new_failure["id"],
+            note="Current-window reviewer miss.",
+        )
+        feedback_service_module.record_false_negative_feedback(
+            analysis_id=new_report_old_failure["id"],
+            note="Older reviewer miss.",
+        )
+        self._set_feedback_created_at(
+            old_report_new_failure["id"],
+            datetime(2026, 6, 7, tzinfo=UTC),
+        )
+        self._set_feedback_created_at(
+            new_report_old_failure["id"],
+            datetime(2026, 5, 20, tzinfo=UTC),
+        )
+
+        trends = report_service_module.fetch_risk_trends(
+            project_id=project.id,
+            created_from=datetime(2026, 6, 1, tzinfo=UTC),
+            created_to=datetime(2026, 6, 8, tzinfo=UTC),
+        )
+        outcome_filtered_trends = report_service_module.fetch_risk_trends(
+            project_id=project.id,
+            outcome="failure",
+            created_from=datetime(2026, 6, 1, tzinfo=UTC),
+            created_to=datetime(2026, 6, 8, tzinfo=UTC),
+        )
+
+        self.assertEqual(trends["total_reports"], 2)
+        self.assertEqual(trends["outcome_links"]["linked_outcome_count"], 1)
+        self.assertEqual(
+            trends["outcome_links"]["analysis_ids"],
+            [old_report_new_failure["id"]],
+        )
+        self.assertEqual(trends["false_reassurance_signals"]["deployment_count"], 1)
+        self.assertEqual(trends["false_reassurance_signals"]["feedback_count"], 1)
+        self.assertEqual(trends["false_reassurance_signals"]["event_count"], 2)
+        self.assertEqual(outcome_filtered_trends["total_reports"], 2)
+        self.assertEqual(
+            outcome_filtered_trends["outcome_links"]["analysis_ids"],
+            [old_report_new_failure["id"]],
+        )
+        self.assertEqual(
+            outcome_filtered_trends["tool_counts"],
+            {"terraform": 1, "kubernetes": 1},
+        )
+
+    def test_fetch_risk_trends_uses_warning_semantics_for_false_reassurance(
+        self,
+    ) -> None:
+        project = project_service_module.create_project(
+            project_key="payments",
+            display_name="Payments",
+        )
+        warned = self._persist(
+            severity="medium",
+            recommendation="caution",
+            tool="terraform",
+            project_id=project.id,
+        )
+        deployment_outcome_service_module.record_deployment_outcome(
+            analysis_id=warned["id"],
+            outcome="failure",
+            deployed_at="2026-06-07T09:00:00Z",
+        )
+        feedback_service_module.record_false_negative_feedback(
+            analysis_id=warned["id"],
+            note="Reviewer added missed-finding context to a report that warned.",
+        )
+
+        trends = report_service_module.fetch_risk_trends(project_id=project.id)
+
+        self.assertEqual(trends["outcome_links"]["warned_failed_outcome_count"], 1)
+        self.assertEqual(trends["false_reassurance_signals"]["count"], 0)
+        self.assertEqual(trends["false_reassurance_signals"]["event_count"], 0)
+
+    def test_fetch_risk_trends_excludes_unreadable_report_schemas(self) -> None:
+        project = project_service_module.create_project(
+            project_key="payments",
+            display_name="Payments",
+        )
+        readable = self._persist(
+            severity="low",
+            recommendation="go",
+            tool="terraform",
+            project_id=project.id,
+        )
+        unreadable = self._persist(
+            severity="critical",
+            recommendation="no-go",
+            tool="kubernetes",
+            project_id=project.id,
+        )
+        self._set_report_schema_version(unreadable["id"], "v999")
+
+        trends = report_service_module.fetch_risk_trends(project_id=project.id)
+
+        self.assertEqual(trends["total_reports"], 1)
+        self.assertEqual([row["id"] for row in trends["audit_rows"]], [readable["id"]])
+
+    def test_fetch_risk_trends_chunks_large_scoped_signal_queries(self) -> None:
+        project = project_service_module.create_project(
+            project_key="payments",
+            display_name="Payments",
+        )
+        first = None
+        for _ in range(205):
+            report = self._persist(
+                severity="low",
+                recommendation="go",
+                tool="terraform",
+                project_id=project.id,
+            )
+            if first is None:
+                first = report
+        self.assertIsNotNone(first)
+        deployment_outcome_service_module.record_deployment_outcome(
+            analysis_id=first["id"],
+            outcome="failure",
+            deployed_at="2026-06-07T09:00:00Z",
+        )
+
+        trends = report_service_module.fetch_risk_trends(project_id=project.id)
+
+        self.assertEqual(trends["total_reports"], 205)
+        self.assertEqual(trends["outcome_links"]["linked_outcome_count"], 1)
+        self.assertEqual(len(trends["audit_rows"]), 100)
+
+    def test_filtered_history_page_filters_by_outcome(self) -> None:
+        project = project_service_module.create_project(
+            project_key="payments",
+            display_name="Payments",
+        )
+        success = self._persist(
+            severity="low",
+            recommendation="go",
+            tool="terraform",
+            project_id=project.id,
+        )
+        failure = self._persist(
+            severity="low",
+            recommendation="go",
+            tool="terraform",
+            project_id=project.id,
+        )
+        deployment_outcome_service_module.record_deployment_outcome(
+            analysis_id=success["id"],
+            outcome="success",
+            deployed_at="2026-06-07T08:00:00Z",
+        )
+        deployment_outcome_service_module.record_deployment_outcome(
+            analysis_id=failure["id"],
+            outcome="failure",
+            deployed_at="2026-06-07T09:00:00Z",
+        )
+
+        page = report_service_module.fetch_filtered_analysis_history_page(
+            project_id=project.id,
+            outcome="failure",
+            skip_unreadable_schema=True,
+        )
+
+        self.assertEqual(page["total_count"], 1)
+        self.assertEqual([item["id"] for item in page["items"]], [failure["id"]])
+
+    def test_activity_window_history_orders_by_latest_activity_time(self) -> None:
+        project = project_service_module.create_project(
+            project_key="payments-activity-order",
+            display_name="Payments Activity Order",
+        )
+        old_report_recent_outcome = self._persist(
+            severity="low",
+            recommendation="go",
+            tool="terraform",
+            project_id=project.id,
+        )
+        newer_report_older_activity = self._persist(
+            severity="low",
+            recommendation="go",
+            tool="terraform",
+            project_id=project.id,
+        )
+        self._set_report_created_at(
+            old_report_recent_outcome["id"],
+            datetime(2026, 5, 1, tzinfo=UTC),
+        )
+        self._set_report_created_at(
+            newer_report_older_activity["id"],
+            datetime(2026, 6, 7, tzinfo=UTC),
+        )
+        deployment_outcome_service_module.record_deployment_outcome(
+            analysis_id=old_report_recent_outcome["id"],
+            outcome="failure",
+            deployed_at="2026-06-08T12:00:00Z",
+        )
+
+        page = report_service_module.fetch_filtered_analysis_history_page(
+            project_id=project.id,
+            created_from=datetime(2026, 6, 1, tzinfo=UTC),
+            created_to=datetime(2026, 6, 9, tzinfo=UTC),
+            page_size=1,
+            skip_unreadable_schema=True,
+        )
+
+        self.assertEqual(page["total_count"], 2)
+        self.assertEqual(
+            [item["id"] for item in page["items"]],
+            [old_report_recent_outcome["id"]],
+        )
+
+    def test_activity_order_expression_compiles_for_postgresql(self) -> None:
+        expression = analysis_reports_repository_module._activity_order_expression(
+            activity_from=datetime(2026, 6, 1, tzinfo=UTC),
+            activity_to=datetime(2026, 6, 9, tzinfo=UTC),
+        )
+
+        self.assertIsNotNone(expression)
+        compiled = str(expression.compile(dialect=postgresql.dialect()))
+        self.assertIn("CASE WHEN", compiled.upper())
+        self.assertNotIn("max(coalesce", compiled.lower())
+
+    def test_outcome_filtered_history_preserves_unfiltered_previous_scan_diff(
+        self,
+    ) -> None:
+        project = project_service_module.create_project(
+            project_key="payments-diff",
+            display_name="Payments Diff",
+        )
+        previous = self._persist(
+            severity="low",
+            recommendation="go",
+            tool="terraform",
+            project_id=project.id,
+        )
+        current = self._persist(
+            severity="high",
+            recommendation="no-go",
+            tool="terraform",
+            project_id=project.id,
+        )
+        self._set_report_created_at(
+            previous["id"],
+            datetime(2026, 6, 1, tzinfo=UTC),
+        )
+        self._set_report_created_at(
+            current["id"],
+            datetime(2026, 6, 2, tzinfo=UTC),
+        )
+        deployment_outcome_service_module.record_deployment_outcome(
+            analysis_id=current["id"],
+            outcome="failure",
+            deployed_at="2026-06-07T09:00:00Z",
+        )
+
+        page = report_service_module.fetch_filtered_analysis_history_page(
+            project_id=project.id,
+            outcome="failure",
+            skip_unreadable_schema=True,
+        )
+
+        self.assertEqual(page["total_count"], 1)
+        self.assertEqual([item["id"] for item in page["items"]], [current["id"]])
+        self.assertEqual(
+            page["items"][0]["previous_scan_diff"]["previous_report_id"],
+            previous["id"],
+        )
+
+    def test_filtered_history_page_handles_large_outcome_filtered_sets(
+        self,
+    ) -> None:
+        project = project_service_module.create_project(
+            project_key="payments-large",
+            display_name="Payments Large",
+        )
+        for index in range(205):
+            report = self._persist(
+                severity="low",
+                recommendation="go",
+                tool="terraform",
+                project_id=project.id,
+            )
+            deployment_outcome_service_module.record_deployment_outcome(
+                analysis_id=report["id"],
+                outcome="failure",
+                deployed_at=f"2026-06-07T09:{index % 60:02d}:00Z",
+            )
+
+        page = report_service_module.fetch_filtered_analysis_history_page(
+            project_id=project.id,
+            outcome="failure",
+            page_size=100,
+            skip_unreadable_schema=True,
+        )
+
+        self.assertEqual(page["total_count"], 205)
+        self.assertEqual(len(page["items"]), 100)
 
     def test_fetch_dashboard_stats_counts_scanned_files_and_severity(self) -> None:
         self._persist(severity="low", recommendation="go", tool="terraform")

--- a/tests/test_ui/test_history_page.py
+++ b/tests/test_ui/test_history_page.py
@@ -59,8 +59,37 @@ class HistoryPageHelpersTests(unittest.TestCase):
             },
         )
 
+    def test_history_filter_trend_refresh_scope_excludes_search_and_status(
+        self,
+    ) -> None:
+        trend_relevant = {
+            "workspace",
+            "time_range",
+            "severity",
+            "toolchain",
+            "outcome",
+        }
+        row_only = {"search", "analysis_status"}
+
+        self.assertEqual(
+            {
+                name
+                for name in trend_relevant
+                if history_module._history_filter_updates_risk_trends(name)
+            },
+            trend_relevant,
+        )
+        self.assertFalse(
+            any(
+                history_module._history_filter_updates_risk_trends(name)
+                for name in row_only
+            )
+        )
+
     def test_fetch_history_risk_trends_uses_workspace_scope(self) -> None:
         expected = {"total_reports": 1, "severity_counts": {"high": 1}}
+        created_from = datetime(2026, 6, 1, tzinfo=UTC)
+        created_to = datetime(2026, 6, 8, tzinfo=UTC)
 
         with mock.patch.object(
             history_module,
@@ -71,12 +100,22 @@ class HistoryPageHelpersTests(unittest.TestCase):
                 has_history_scope=True,
                 project_id=7,
                 workspace_key="prod",
+                severity="high",
+                toolchain="terraform",
+                outcome="failure",
+                created_from=created_from,
+                created_to=created_to,
             )
 
         self.assertEqual(result, expected)
         fetch_risk_trends.assert_called_once_with(
             project_id=7,
             workspace_key="prod",
+            severity="high",
+            toolchain="terraform",
+            outcome="failure",
+            created_from=created_from,
+            created_to=created_to,
         )
 
     def test_fetch_history_risk_trends_returns_empty_without_scope(self) -> None:
@@ -1032,6 +1071,7 @@ class HistoryPageRenderingTests(unittest.TestCase):
         reload(analysis_reports_repository_module)
         reload(project_service_module)
         reload(report_service_module)
+        reload(deployment_outcome_service_module)
         reload(feedback_service_module)
         reload(report_detail_page_module)
         reload(history_module)
@@ -1758,6 +1798,126 @@ class HistoryPageRenderingTests(unittest.TestCase):
         self.assertIn("Recall 1.00", response.text)
         self.assertIn("Directional only", response.text)
         self.assertIn("Sparse calibration data", response.text)
+
+    def test_history_page_renders_full_risk_trend_comparison(self) -> None:
+        project = project_service_module.create_project(
+            project_key="payments",
+            display_name="Payments",
+        )
+        project_service_module.set_active_project(project.id)
+        trend_payload = {
+            "total_reports": 3,
+            "filters": {"project_id": project.id},
+            "window": {
+                "start": "2026-06-01T00:00:00+00:00",
+                "end": "2026-06-08T00:00:00+00:00",
+            },
+            "severity_counts": {"critical": 1, "high": 1, "low": 1},
+            "recommendation_counts": {"no-go": 2, "go": 1},
+            "high_critical_frequency": {"count": 2, "rate": 2 / 3},
+            "tool_counts": {"terraform": 2, "kubernetes": 1},
+            "outcome_counts": {"failure": 1, "success": 1},
+            "outcome_links": {
+                "linked_outcome_count": 2,
+                "failed_outcome_count": 1,
+                "warned_failed_outcome_count": 1,
+                "analysis_ids": [1, 2],
+            },
+            "false_positive_signals": {"count": 1, "event_count": 1, "rate": 1 / 3},
+            "false_reassurance_signals": {
+                "count": 1,
+                "event_count": 1,
+                "deployment_count": 1,
+                "feedback_count": 0,
+                "rate": 1 / 3,
+            },
+            "context_completeness": {
+                "sample_size": 3,
+                "missing_count": 0,
+                "partial_context_count": 1,
+                "partial_context_rate": 1 / 3,
+                "average_context_score": 0.74,
+            },
+            "limitations": [],
+            "audit_rows": [],
+            "trend_sample_size": 100,
+            "trend_windows": [
+                {
+                    "label": "previous",
+                    "total_reports": 2,
+                    "severity_counts": {"critical": 1, "medium": 1},
+                    "recommendation_counts": {"no-go": 1, "caution": 1},
+                    "tool_counts": {"kubernetes": 2},
+                    "outcome_counts": {"success": 1},
+                    "high_critical_frequency": {"count": 1, "rate": 0.5},
+                    "outcome_links": {"linked_outcome_count": 1},
+                    "false_positive_signals": {"count": 0, "rate": 0.0},
+                    "false_reassurance_signals": {"count": 0, "rate": 0.0},
+                    "context_completeness": {
+                        "partial_context_count": 0,
+                        "average_context_score": 0.9,
+                    },
+                },
+                {
+                    "label": "current",
+                    "total_reports": 3,
+                    "severity_counts": {"critical": 1, "high": 1, "low": 1},
+                    "recommendation_counts": {"no-go": 2, "go": 1},
+                    "tool_counts": {"terraform": 2, "kubernetes": 1},
+                    "outcome_counts": {"failure": 1, "success": 1},
+                    "high_critical_frequency": {"count": 2, "rate": 2 / 3},
+                    "outcome_links": {"linked_outcome_count": 2},
+                    "false_positive_signals": {"count": 1, "rate": 1 / 3},
+                    "false_reassurance_signals": {"count": 1, "rate": 1 / 3},
+                    "context_completeness": {
+                        "partial_context_count": 1,
+                        "average_context_score": 0.74,
+                    },
+                },
+            ],
+            "trend_comparison": {
+                "total_reports_delta": 1,
+                "severity_count_deltas": {
+                    "critical": 0,
+                    "high": 1,
+                    "medium": -1,
+                    "low": 1,
+                },
+                "recommendation_count_deltas": {
+                    "no-go": 1,
+                    "caution": -1,
+                    "go": 1,
+                },
+                "tool_count_deltas": {"terraform": 2, "kubernetes": -1},
+                "outcome_count_deltas": {"failure": 1, "success": 0},
+                "high_critical_count_delta": 1,
+                "high_critical_rate_delta": 1 / 6,
+                "false_positive_count_delta": 1,
+                "false_positive_rate_delta": 1 / 3,
+                "false_reassurance_count_delta": 1,
+                "false_reassurance_rate_delta": 1 / 3,
+                "linked_outcome_count_delta": 1,
+                "context_partial_count_delta": 1,
+                "context_average_score_delta": -0.16,
+            },
+        }
+
+        with mock.patch.object(
+            history_module,
+            "_fetch_history_risk_trends",
+            return_value=trend_payload,
+        ):
+            response = self.client.get("/history")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("Window change", response.text)
+        self.assertIn("Verdict change", response.text)
+        self.assertIn("Recommendation change", response.text)
+        self.assertIn("no-go +1", response.text)
+        self.assertIn("caution -1", response.text)
+        self.assertIn("Outcome change", response.text)
+        self.assertIn("Toolchain change", response.text)
+        self.assertIn("Context change", response.text)
 
     def test_history_page_renders_feedback_bias_calibration_limitation(self) -> None:
         report = self._persist_report(

--- a/ui/components/dashboard_shell.py
+++ b/ui/components/dashboard_shell.py
@@ -174,12 +174,13 @@ def inject_shell_styles(*, force: bool = False) -> None:
   .q-drawer-container {{ pointer-events: none !important; }}
   .dw-dashboard-header {{
     left: 240px !important;
-    width: calc(100% - 240px) !important;
+    right: 0 !important;
+    width: auto !important;
   }}
   .dw-dashboard-main {{
     margin-left: 240px;
     margin-top: 68px;
-    width: calc(100% - 240px);
+    width: auto;
     min-width: 0;
   }}
   .dw-workspace-content {{
@@ -188,6 +189,27 @@ def inject_shell_styles(*, force: bool = False) -> None:
     margin: 0 auto;
     padding: 32px;
     min-width: 0;
+  }}
+  @media (max-width: 900px) {{
+    html, body {{
+      max-width: 100vw;
+      overflow-x: hidden;
+    }}
+    .dw-dashboard-header {{
+      left: 0 !important;
+      width: 100% !important;
+    }}
+    .dw-dashboard-main {{
+      margin-left: 0 !important;
+      width: 100% !important;
+      max-width: 100vw;
+      overflow-x: hidden;
+    }}
+    .q-page-container,
+    .nicegui-content {{
+      max-width: 100vw;
+      overflow-x: hidden;
+    }}
   }}
   .q-card {{
     border: 1px solid {ZINC_200};
@@ -314,7 +336,7 @@ def inject_shell_styles(*, force: bool = False) -> None:
     box-shadow: 0 0 0 1px rgba(255,105,0,0.28), 0 1px 3px rgba(0,0,0,0.06) !important;
   }}
   .dw-history-project-filter-field {{
-    min-height: 40px;
+    min-height: 64px;
     padding: 6px 12px 7px;
     border: 1px solid #d4d4d8;
     border-radius: 10px;
@@ -323,6 +345,10 @@ def inject_shell_styles(*, force: bool = False) -> None:
     min-width: 0;
   }}
   .dw-history-filter-control {{ min-width: 0; width: 100%; }}
+  .dw-history-filter-control .q-field__control {{
+    min-height: 64px !important;
+    height: 64px !important;
+  }}
   .dw-nav-inactive:hover {{
     background: {ZINC_100} !important;
     color: {ZINC_950} !important;
@@ -458,6 +484,10 @@ def inject_shell_styles(*, force: bool = False) -> None:
     gap: 12px;
     flex-wrap: wrap;
     width: 100%;
+    align-items: stretch;
+  }}
+  .dw-history-filter-row > * {{
+    min-height: 64px;
   }}
   .dw-danger-button {{ color: {RED} !important; }}
   .dw-report-signal-grid {{
@@ -465,11 +495,14 @@ def inject_shell_styles(*, force: bool = False) -> None:
     grid-template-columns: repeat(4, minmax(0, 1fr));
     gap: 12px;
     align-items: start;
+    max-width: 100%;
+    overflow-x: hidden;
   }}
   .dw-report-signal {{
     min-width: 0;
+    max-width: 100%;
     width: 100%;
-    overflow: visible;
+    overflow: hidden;
     align-self: stretch;
   }}
   .dw-report-signal-compact {{
@@ -507,13 +540,15 @@ def inject_shell_styles(*, force: bool = False) -> None:
       grid-column: span 2;
     }}
   }}
-  @media (max-width: 720px) {{
+  @media (max-width: 900px) {{
     .dw-report-signal-grid {{
-      grid-template-columns: 1fr;
+      display: flex;
+      flex-direction: column;
+      grid-template-columns: none;
     }}
     .dw-report-signal-long,
     .dw-report-signal-action {{
-      grid-column: span 1;
+      grid-column: auto;
     }}
   }}
   .dw-theme-toggle {{

--- a/ui/routes/dashboard.py
+++ b/ui/routes/dashboard.py
@@ -221,13 +221,35 @@ def inject_styles(*, force: bool = False) -> None:
   }}
   .dw-dashboard-header {{
     left: 240px !important;
-    width: calc(100% - 240px) !important;
+    right: 0 !important;
+    width: auto !important;
   }}
   .dw-dashboard-main {{
     margin-left: 240px;
     margin-top: 68px;
-    width: calc(100% - 240px);
+    width: auto;
     min-width: 0;
+  }}
+  @media (max-width: 900px) {{
+    html, body {{
+      max-width: 100vw;
+      overflow-x: hidden;
+    }}
+    .dw-dashboard-header {{
+      left: 0 !important;
+      width: 100% !important;
+    }}
+    .dw-dashboard-main {{
+      margin-left: 0 !important;
+      width: 100% !important;
+      max-width: 100vw;
+      overflow-x: hidden;
+    }}
+    .q-page-container,
+    .nicegui-content {{
+      max-width: 100vw;
+      overflow-x: hidden;
+    }}
   }}
   .q-card {{
     border: 1px solid {ZINC_200};
@@ -495,11 +517,14 @@ def inject_styles(*, force: bool = False) -> None:
     grid-template-columns: repeat(4, minmax(0, 1fr));
     gap: 12px;
     align-items: start;
+    max-width: 100%;
+    overflow-x: hidden;
   }}
   .dw-report-signal {{
     min-width: 0;
+    max-width: 100%;
     width: 100%;
-    overflow: visible;
+    overflow: hidden;
     align-self: stretch;
   }}
   .dw-report-signal-compact {{
@@ -537,13 +562,15 @@ def inject_styles(*, force: bool = False) -> None:
       grid-column: span 2;
     }}
   }}
-  @media (max-width: 720px) {{
+  @media (max-width: 900px) {{
     .dw-report-signal-grid {{
-      grid-template-columns: 1fr;
+      display: flex;
+      flex-direction: column;
+      grid-template-columns: none;
     }}
     .dw-report-signal-long,
     .dw-report-signal-action {{
-      grid-column: span 1;
+      grid-column: auto;
     }}
   }}
   .dw-panel-soft {{

--- a/ui/routes/history.py
+++ b/ui/routes/history.py
@@ -30,6 +30,10 @@ from ui.project_authorization import resolve_authorized_ui_active_project
 from ui.project_authorization import load_authorized_ui_projects
 from ui.theme import build_page_header
 
+_RISK_TREND_HISTORY_FILTERS = frozenset(
+    {"workspace", "time_range", "severity", "toolchain", "outcome"}
+)
+
 
 def page_selection_state(
     visible_ids: set[int], selected_ids: set[int]
@@ -64,10 +68,44 @@ def _empty_history_page() -> dict[str, Any]:
 def _empty_risk_trends() -> dict[str, Any]:
     return {
         "total_reports": 0,
+        "filters": {},
+        "window": {"start": None, "end": None},
         "severity_counts": {},
         "recommendation_counts": {},
+        "high_critical_frequency": {"count": 0, "rate": 0.0},
         "tool_counts": {},
+        "outcome_counts": {},
+        "outcome_links": {
+            "linked_outcome_count": 0,
+            "failed_outcome_count": 0,
+            "warned_failed_outcome_count": 0,
+            "analysis_ids": [],
+        },
+        "false_positive_signals": {"count": 0, "event_count": 0, "rate": 0.0},
+        "false_reassurance_signals": {
+            "count": 0,
+            "event_count": 0,
+            "deployment_count": 0,
+            "feedback_count": 0,
+            "rate": 0.0,
+        },
+        "context_completeness": {
+            "sample_size": 0,
+            "missing_count": 0,
+            "partial_context_count": 0,
+            "partial_context_rate": 0.0,
+            "average_context_score": None,
+        },
+        "limitations": [
+            {
+                "code": "no_authorized_project",
+                "label": "No authorized project",
+                "message": "Select an authorized project before reviewing risk trends.",
+            }
+        ],
         "audit_rows": [],
+        "trend_windows": [],
+        "trend_comparison": None,
         "trend_sample_size": 100,
     }
 
@@ -77,12 +115,22 @@ def _fetch_history_risk_trends(
     has_history_scope: bool,
     project_id: int | None,
     workspace_key: str | None = None,
+    severity: str | None = None,
+    toolchain: str | None = None,
+    outcome: str | None = None,
+    created_from: datetime | None = None,
+    created_to: datetime | None = None,
 ) -> dict[str, Any]:
     if not has_history_scope:
         return _empty_risk_trends()
     return fetch_risk_trends(
         project_id=project_id,
         workspace_key=workspace_key,
+        severity=severity,
+        toolchain=toolchain,
+        outcome=outcome,
+        created_from=created_from,
+        created_to=created_to,
     )
 
 
@@ -168,6 +216,10 @@ def _history_time_bounds(value: str | None) -> tuple[datetime | None, datetime |
     return None, None
 
 
+def _history_filter_updates_risk_trends(filter_name: str) -> bool:
+    return filter_name in _RISK_TREND_HISTORY_FILTERS
+
+
 def _history_toolchain_options(toolchains: list[str]) -> dict[str, str]:
     options = {"": "Any toolchain"}
     options.update({str(tool): str(tool).title() for tool in toolchains})
@@ -246,6 +298,30 @@ def build_history_page() -> None:
 
             def render_risk_trends_summary() -> None:
                 risk_trends_card.clear()
+
+                def count_delta(value: Any) -> str:
+                    return f"{int(value or 0):+d}"
+
+                def top_count_deltas(values: dict[str, Any], labels: list[str]) -> str:
+                    parts = [
+                        f"{label} {count_delta(values.get(label))}"
+                        for label in labels
+                        if int(values.get(label) or 0) != 0
+                    ]
+                    return ", ".join(parts) or "no change"
+
+                def top_dynamic_deltas(values: dict[str, Any]) -> str:
+                    changed = [
+                        (str(label), int(delta or 0))
+                        for label, delta in values.items()
+                        if int(delta or 0) != 0
+                    ]
+                    changed.sort(key=lambda item: abs(item[1]), reverse=True)
+                    return (
+                        ", ".join(f"{label} {delta:+d}" for label, delta in changed[:3])
+                        or "no change"
+                    )
+
                 with risk_trends_card, ui.column().classes("gap-0"):
                     ui.label("Risk trends").classes("dw-eyebrow mb-1")
                     ui.label(
@@ -253,6 +329,11 @@ def build_history_page() -> None:
                         f"{trends['severity_counts'].get('critical', 0)} critical · "
                         f"{trends['severity_counts'].get('high', 0)} high"
                     ).classes("text-lg font-medium dw-text leading-6")
+                    false_positive = trends.get("false_positive_signals", {})
+                    false_reassurance = trends.get("false_reassurance_signals", {})
+                    outcome_links = trends.get("outcome_links", {})
+                    context = trends.get("context_completeness", {})
+                    average_context = context.get("average_context_score")
                     ui.label(
                         "Top tools: "
                         + ", ".join(
@@ -264,6 +345,93 @@ def build_history_page() -> None:
                             )[:3]
                         )
                     ).classes("mt-[2px] text-sm dw-muted")
+                    outcome_counts = trends.get("outcome_counts", {})
+                    ui.label(
+                        "Outcomes: "
+                        + (
+                            ", ".join(
+                                f"{outcome} ({count})"
+                                for outcome, count in sorted(
+                                    outcome_counts.items(),
+                                    key=lambda item: item[1],
+                                    reverse=True,
+                                )[:3]
+                            )
+                            or "none linked"
+                        )
+                    ).classes("mt-[2px] text-sm dw-muted")
+                    ui.label(
+                        "Calibration signals: "
+                        f"{int(false_positive.get('count') or 0)} false-positive · "
+                        f"{int(false_reassurance.get('count') or 0)} false-reassurance · "
+                        f"{int(outcome_links.get('linked_outcome_count') or 0)} linked outcomes"
+                    ).classes("mt-[2px] text-sm dw-muted")
+                    ui.label(
+                        "Context completeness: "
+                        f"{int(context.get('partial_context_count') or 0)} partial · "
+                        + (
+                            f"average {float(average_context):.2f}"
+                            if average_context is not None
+                            else "average unavailable"
+                        )
+                    ).classes("mt-[2px] text-sm dw-muted")
+                    comparison = trends.get("trend_comparison") or {}
+                    if comparison:
+                        ui.label(
+                            "Window change: "
+                            f"{int(comparison.get('total_reports_delta') or 0):+d} reports · "
+                            f"{int(comparison.get('high_critical_count_delta') or 0):+d} high/critical · "
+                            f"{int(comparison.get('false_positive_count_delta') or 0):+d} false-positive · "
+                            f"{int(comparison.get('false_reassurance_count_delta') or 0):+d} false-reassurance · "
+                            f"{int(comparison.get('linked_outcome_count_delta') or 0):+d} linked outcomes"
+                        ).classes("mt-[2px] text-sm dw-muted")
+                        ui.label(
+                            "Verdict change: "
+                            + top_count_deltas(
+                                comparison.get("severity_count_deltas") or {},
+                                ["critical", "high", "medium", "low"],
+                            )
+                        ).classes("mt-[2px] text-sm dw-muted")
+                        ui.label(
+                            "Recommendation change: "
+                            + top_count_deltas(
+                                comparison.get("recommendation_count_deltas") or {},
+                                ["no-go", "caution", "go"],
+                            )
+                        ).classes("mt-[2px] text-sm dw-muted")
+                        ui.label(
+                            "Outcome change: "
+                            + top_dynamic_deltas(
+                                comparison.get("outcome_count_deltas") or {}
+                            )
+                        ).classes("mt-[2px] text-sm dw-muted")
+                        ui.label(
+                            "Toolchain change: "
+                            + top_dynamic_deltas(
+                                comparison.get("tool_count_deltas") or {}
+                            )
+                        ).classes("mt-[2px] text-sm dw-muted")
+                        context_score_delta = comparison.get(
+                            "context_average_score_delta"
+                        )
+                        ui.label(
+                            "Context change: "
+                            f"{count_delta(comparison.get('context_partial_count_delta'))} partial · "
+                            + (
+                                f"average {float(context_score_delta):+.2f}"
+                                if context_score_delta is not None
+                                else "average unavailable"
+                            )
+                        ).classes("mt-[2px] text-sm dw-muted")
+                    limitation_labels = [
+                        str(item.get("label"))
+                        for item in trends.get("limitations", [])
+                        if isinstance(item, dict) and item.get("label")
+                    ]
+                    if limitation_labels:
+                        ui.label(
+                            "Limitations: " + " · ".join(limitation_labels)
+                        ).classes("mt-[2px] text-sm dw-muted")
 
             def render_calibration_summary() -> None:
                 calibration_card.clear()
@@ -378,12 +546,30 @@ def build_history_page() -> None:
                             .props("outlined dense")
                             .classes("dw-history-filter-control min-w-[170px] flex-1")
                         )
+                        outcome_select = (
+                            ui.select(
+                                {
+                                    "": "Any outcome",
+                                    "success": "Success",
+                                    "failure": "Failure",
+                                    "rolled_back": "Rolled back",
+                                },
+                                value="",
+                                label="Outcome",
+                            )
+                            .props("outlined dense")
+                            .classes("dw-history-filter-control min-w-[170px] flex-1")
+                        )
             actions_row = ui.row().classes(
                 "w-full items-center justify-between gap-4 flex-wrap"
             )
             history_column = ui.column().classes("w-full gap-3")
 
-            def refresh_data(query: str | None = None) -> list[dict]:
+            def refresh_data(
+                query: str | None = None,
+                *,
+                refresh_trends: bool = True,
+            ) -> list[dict]:
                 nonlocal reports, trends, total_report_count, calibration
                 created_from, created_to = _history_time_bounds(
                     str(time_range_select.value or "")
@@ -397,6 +583,7 @@ def build_history_page() -> None:
                         severity=str(severity_select.value or "") or None,
                         search=query,
                         toolchain=str(toolchain_select.value or "") or None,
+                        outcome=str(outcome_select.value or "") or None,
                         analysis_status=str(status_select.value or "") or None,
                         created_from=created_from,
                         created_to=created_to,
@@ -407,19 +594,25 @@ def build_history_page() -> None:
                 )
                 reports = page_payload["items"]
                 total_report_count = page_payload["total_count"]
-                trends = _fetch_history_risk_trends(
-                    has_history_scope=has_history_scope,
-                    project_id=active_project_id,
-                    workspace_key=current_workspace_key(),
-                )
-                calibration = (
-                    _empty_calibration_dashboard_seed()
-                    if not has_history_scope
-                    else fetch_calibration_dashboard_seed(
+                if refresh_trends:
+                    trends = _fetch_history_risk_trends(
+                        has_history_scope=has_history_scope,
                         project_id=active_project_id,
                         workspace_key=current_workspace_key(),
+                        severity=str(severity_select.value or "") or None,
+                        toolchain=str(toolchain_select.value or "") or None,
+                        outcome=str(outcome_select.value or "") or None,
+                        created_from=created_from,
+                        created_to=created_to,
                     )
-                )
+                    calibration = (
+                        _empty_calibration_dashboard_seed()
+                        if not has_history_scope
+                        else fetch_calibration_dashboard_seed(
+                            project_id=active_project_id,
+                            workspace_key=current_workspace_key(),
+                        )
+                    )
                 max_page = max(
                     1, (total_report_count - 1) // page_state["page_size"] + 1
                 )
@@ -609,17 +802,20 @@ def build_history_page() -> None:
                     1, (total_report_count - 1) // page_state["page_size"] + 1
                 )
                 page_state["page"] = min(max(1, page_state["page"] + delta), max_page)
-                refresh_data(search_input.value.strip() if search_input.value else None)
-                render_summaries()
+                refresh_data(
+                    search_input.value.strip() if search_input.value else None,
+                    refresh_trends=False,
+                )
                 render_history()
                 render_actions()
 
-            def apply_filters() -> None:
+            def apply_filters(*, refresh_trends: bool = True) -> None:
                 query = search_input.value.strip() if search_input.value else None
                 page_state["page"] = 1
                 selected_ids.clear()
-                refresh_data(query)
-                render_summaries()
+                refresh_data(query, refresh_trends=refresh_trends)
+                if refresh_trends:
+                    render_summaries()
                 render_history()
                 render_actions()
 
@@ -627,28 +823,60 @@ def build_history_page() -> None:
                 if hasattr(event, "value"):
                     select.value = event.value
 
-            def apply_select_filter(select, event) -> None:
+            def apply_select_filter(select, event, *, filter_name: str) -> None:
                 sync_select_value(select, event)
-                apply_filters()
+                apply_filters(
+                    refresh_trends=_history_filter_updates_risk_trends(filter_name)
+                )
 
             def apply_workspace_filter(event) -> None:
                 sync_select_value(workspace_select, event)
                 sync_toolchain_options()
-                apply_filters()
+                apply_filters(
+                    refresh_trends=_history_filter_updates_risk_trends("workspace")
+                )
 
-            search_input.on("update:model-value", lambda *_: apply_filters())
+            search_input.on(
+                "update:model-value",
+                lambda *_: apply_filters(
+                    refresh_trends=_history_filter_updates_risk_trends("search")
+                ),
+            )
             workspace_select.on_value_change(apply_workspace_filter)
             time_range_select.on_value_change(
-                lambda event: apply_select_filter(time_range_select, event)
+                lambda event: apply_select_filter(
+                    time_range_select,
+                    event,
+                    filter_name="time_range",
+                )
             )
             severity_select.on_value_change(
-                lambda event: apply_select_filter(severity_select, event)
+                lambda event: apply_select_filter(
+                    severity_select,
+                    event,
+                    filter_name="severity",
+                )
             )
             toolchain_select.on_value_change(
-                lambda event: apply_select_filter(toolchain_select, event)
+                lambda event: apply_select_filter(
+                    toolchain_select,
+                    event,
+                    filter_name="toolchain",
+                )
             )
             status_select.on_value_change(
-                lambda event: apply_select_filter(status_select, event)
+                lambda event: apply_select_filter(
+                    status_select,
+                    event,
+                    filter_name="analysis_status",
+                )
+            )
+            outcome_select.on_value_change(
+                lambda event: apply_select_filter(
+                    outcome_select,
+                    event,
+                    filter_name="outcome",
+                )
             )
             render_history()
             render_actions()

--- a/ui/theme.py
+++ b/ui/theme.py
@@ -373,12 +373,15 @@ _REPORT_LAYOUT_CSS = """
   grid-template-columns: repeat(4, minmax(0, 1fr));
   gap: 12px;
   align-items: start;
+  max-width: 100%;
+  overflow-x: hidden;
 }
 
 .dw-report-signal {
   min-width: 0;
+  max-width: 100%;
   width: 100%;
-  overflow: visible;
+  overflow: hidden;
   align-self: stretch;
 }
 
@@ -425,14 +428,16 @@ _REPORT_LAYOUT_CSS = """
   }
 }
 
-@media (max-width: 720px) {
+@media (max-width: 900px) {
   .dw-report-signal-grid {
-    grid-template-columns: 1fr;
+    display: flex;
+    flex-direction: column;
+    grid-template-columns: none;
   }
 
   .dw-report-signal-long,
   .dw-report-signal-action {
-    grid-column: span 1;
+    grid-column: auto;
   }
 }
 


### PR DESCRIPTION
Story 6.6 adds scoped risk trend review across the shared service layer, History UI, API history filters, and CLI benchmark export. The implementation keeps reports immutable while joining reviewer feedback and deployment outcomes as calibration signals, adds over-time comparison windows, and hardens large-history query paths with chunking, indexes, and keyset batching.

Constraint: Story 6.6 requires project-scoped trend review by workspace, time window, severity, toolchain, and outcome.
Constraint: DeployWhisper must preserve local-first and advisory-first report semantics.
Rejected: Single aggregate trend card | did not satisfy the over-time trend comparison requirement.
Rejected: OFFSET over activity-ordered trend scans | large activity windows can stall History refresh and CLI exports.
Confidence: high
Scope-risk: moderate
Directive: Keep trend scope aligned across service, History UI, API, and CLI before adding new trend filters.
Tested: Full unittest discovery (463 tests, 1 skipped); focused Story 6.6 suite (63 tests); ruff check .; ruff format --check .; production Bandit; test Bandit with fixture skips; UI review (4 tests); git diff --check.
Not-tested: Live PostgreSQL runtime migration; PostgreSQL activity ordering was covered by dialect compilation regression.

## What does this PR do?

<!-- Brief description of changes -->

## Type of change
- [ ] Feature (new functionality)
- [ ] Bugfix (non-breaking fix)
- [ ] Release preparation
- [ ] Hotfix (critical production fix)
- [ ] Docs / refactor / chore

## Checklist
- [ ] I have followed the branch naming convention
- [ ] Tests pass locally (`pytest tests/ -v`)
- [ ] Linting passes (`ruff check .`)
- [ ] Docker build succeeds
- [ ] I have updated docs if needed
- [ ] No secrets or .env values committed

## Related issue
Closes #