### PR TITLE
Make blast radius topology context trustworthy

### DIFF
--- a/_bmad-output/implementation-artifacts/7-1-project-scoped-topology-context.md
+++ b/_bmad-output/implementation-artifacts/7-1-project-scoped-topology-context.md
@@ -1,0 +1,165 @@
+# Story 7.1: Project-Scoped Topology Context
+
+Status: review
+
+<!-- Generated from updated PRD/architecture/epics plus implementation-readiness-report-2026-05-01.md. -->
+
+## Story
+
+As a reviewer,
+I want blast radius computed from project-scoped topology,
+So that affected services and dependencies are meaningful.
+
+## Acceptance Criteria
+
+1. Given topology exists for a project/workspace, When analysis computes blast radius, Then affected services, dependencies, ownership, freshness, and context source are included in the report. And stale, missing, incomplete, or conflicting topology is explicit.
+
+### Requirement Traceability
+
+- Primary PRD requirements: Epic 7 coverage: CTX-01..13, ADM-03, PRJ-09, NFR-PERF-05, DOC-09.
+- Supporting PRD / NFR / differentiation requirements: See `_bmad-output/planning-artifacts/prd.md`, `_bmad-output/planning-artifacts/architecture.md`, and `_bmad-output/planning-artifacts/implementation-readiness-report-2026-05-01.md`.
+- Coverage intent: Baseline + Delta.
+- Story alignment note: This story was created from the updated Epic 7 plan after the 2026-05-01 readiness rerun. The readiness report verified 187/187 PRD functional requirement IDs in the epics artifact, 38 NFR IDs present, and no critical or major readiness defects.
+
+## Tasks / Subtasks
+
+- [x] Implement and verify acceptance criterion 1. (AC: 1)
+- [x] Reuse existing services, repositories, schemas, and UI/CLI/API helpers before adding new abstractions. (AC: all)
+- [x] Add or update deterministic regression coverage for the changed behavior. (AC: all)
+- [x] Update relevant docs or examples if the story changes user-visible, operator, API, CLI, integration, or contribution behavior. (AC: all)
+- [x] Run required validation and record commands/results in the Dev Agent Record. (AC: all)
+
+### Review Findings
+
+- [x] [Review][Patch] API report schema drops topology context fields [api/schemas.py:910]
+- [x] [Review][Patch] Downstream topology edges are rendered as service dependencies [analysis/blast_radius.py:17]
+- [x] [Review][Patch] Legacy blast-radius payloads default to missing topology context [analysis/blast_radius.py:49]
+- [x] [Review][Patch] Singular owner accepts malformed non-string values without a partial-parse warning [services/topology_service.py:787]
+- [x] [Review][Patch] Freshness rendering can crash on non-numeric persisted age_days values [ui/components/blast_radius_graph.py:103]
+- [x] [Review][Patch] Malformed entries inside `owners` lists are stringified and reported as real owners [services/topology_service.py:810]
+- [x] [Review][Patch] Legacy topology with missing source or freshness metadata can be classified as current [analysis/blast_radius.py:74]
+- [x] [Review][Patch] Whitespace-padded downstream service ids can drop transitive blast-radius services [analysis/blast_radius.py:225]
+- [x] [Review][Patch] Invalid topology `updated_at` can still serialize context state as current [analysis/blast_radius.py:83]
+- [x] [Review][Patch] Negative persisted freshness age renders impossible stale text [ui/components/blast_radius_graph.py:103]
+- [x] [Review][Patch] Partial persisted API context dictionaries can omit expected source/freshness keys [api/schemas.py:938]
+- [x] [Review][Patch] Malformed persisted blast-radius additive fields can break API/UI report loading [api/schemas.py:914]
+- [x] [Review][Patch] Partial or non-scalar topology source metadata is classified as current [analysis/blast_radius.py:67]
+- [x] [Review][Patch] Duplicate downstream edges render duplicate dependency labels [analysis/blast_radius.py:275]
+- [x] [Review][Patch] Stale/conflicting report states lack direct regression coverage [analysis/blast_radius.py:155]
+- [x] [Review][Patch] Report schema docs omit the explicit state/limitation contract [docs/schemas/report-v2.md:260]
+- [x] [Review][Patch] Malformed nested additive-field values can still break API/UI report loading [api/schemas.py:973]
+- [x] [Review][Patch] Future topology timestamps are treated as fresh current context [analysis/blast_radius.py:151]
+- [x] [Review][Patch] Legacy topology file source path is not propagated into blast-radius context source [services/topology_service.py:490]
+- [x] [Review][Patch] Legacy context-state contract documents `unknown` but emits `null` [docs/schemas/report-v2.md:440]
+- [x] [Review][Patch] Freshness `age_days` computation lacks deterministic shared-core coverage [analysis/blast_radius.py:151]
+- [x] [Review][Patch] Explicit legacy `context_state: null` still serializes as `null` instead of `unknown` [api/schemas.py:991]
+
+## Dev Notes
+
+### Epic Context
+
+- Epic: 7. Context Moat
+- Epic goal: Improve deployment-risk judgment with richer project-scoped context.
+- Epic coverage: CTX-01..13, ADM-03, PRJ-09, NFR-PERF-05, DOC-09
+
+### Architecture and Product Guardrails
+
+- Preserve DeployWhisper's local-first raw artifact boundary: raw IaC, scanner artifacts, incident exports, and sensitive context stay in the user's infrastructure by default.
+- Preserve the advisory-first core. Optional adapters may interpret report outputs, but canonical report semantics remain advisory unless explicit story scope says otherwise.
+- Reuse the shared analysis core and service layer before adapting UI, API, CLI, GitHub, or future workflow surfaces.
+- Keep Evidence Law behavior intact: no high or critical finding without deterministic evidence.
+- Keep project/workspace scope explicit for reports, incidents, topology, outcomes, feedback, scanner imports, and connector-related data.
+- Do not introduce new dependencies unless the active story explicitly requires and justifies them.
+
+### Source Tree Guidance
+
+- API routes belong under `api/routes/` and should use existing `ApiRoute` / `ApiError` envelope patterns.
+- Shared orchestration belongs in `services/`; parsers normalize input, analysis modules score/derive risk, and surfaces adapt outputs.
+- UI work belongs under `ui/routes/` and `ui/components/`, following the existing NiceGUI composition style.
+- CLI behavior belongs under `cli/` and must call the same service-layer paths as UI/API flows.
+- Persistence work belongs under `models/` with Alembic migrations when schema changes are required.
+- Documentation required by a story should be updated in the same workstream.
+
+### Testing Requirements
+
+- Use standard-library `unittest` in the existing `tests/test_*` layout.
+- Add focused regression tests for the layer changed by the story before broad refactors.
+- For Python changes, run `./.venv/bin/ruff check .`, `./.venv/bin/ruff format --check .`, and `./.venv/bin/python -m unittest discover -q` before closing implementation.
+- Use `bash scripts/ci-local.sh` for broader or cross-layer changes.
+
+### Project Structure Notes
+
+- Follow the current repository shape documented in `_bmad-output/project-context.md` and `AGENTS.md`.
+- If implementation reveals a conflict between this story and the current code baseline, keep the smallest compatible change and update the story notes rather than silently drifting from the PRD.
+
+### References
+
+- `_bmad-output/planning-artifacts/epics.md` - source Epic 7 / Story 7.1 definition.
+- `_bmad-output/planning-artifacts/prd.md` - functional and non-functional requirements.
+- `_bmad-output/planning-artifacts/architecture.md` - target architecture, boundaries, and guardrails.
+- `_bmad-output/planning-artifacts/ux-design-specification.md` - UX expectations for user-facing stories.
+- `_bmad-output/planning-artifacts/implementation-readiness-report-2026-05-01.md` - readiness verdict and residual story-format concern.
+- `_bmad-output/project-context.md` - repository-specific implementation rules.
+
+## Dev Agent Record
+
+### Agent Model Used
+
+GPT-5.4 Codex
+
+### Debug Log References
+
+- 2026-06-09: Started bmad-dev-story implementation on `feature/7-1-project-scoped-topology-context`.
+- 2026-06-09: Existing topology loading was already project/workspace scoped; Story 7.1 gap was that blast-radius report payloads did not carry topology source, freshness, dependency, ownership, or explicit context-state metadata.
+- 2026-06-09: Added RED regressions for enriched blast-radius output and topology owner preservation; initial focused run failed on missing `context_source`, `context_state`, and dropped ownership fields.
+- 2026-06-09: Implemented topology owner preservation, enriched `ImpactNode` / `BlastRadiusResult`, rendered topology source/freshness/owners/dependencies in the blast-radius panel text equivalent, and documented the additive report schema fields.
+- 2026-06-09: Validation passed: focused blast-radius/topology/report/UI regressions (8 tests); topology/blast-radius/UI suites (27 tests); docs/persistence regressions (3 tests); touched-file `py_compile`; touched-file Ruff; `./.venv/bin/ruff check .`; `./.venv/bin/ruff format --check .`; production Bandit; `APP_PORT=18109 npm run test:ui-review` (4 tests); `./.venv/bin/python -m unittest discover -q` (463 tests, 1 skipped).
+- 2026-06-09: Fixed code-review findings by preserving enriched blast-radius fields in API schemas, calculating dependencies from upstream topology edges, treating absent legacy context state as unknown, validating singular `owner`, and guarding malformed `freshness.age_days` rendering.
+- 2026-06-09: Review-fix validation passed: focused review regressions (16 tests); impacted analysis/topology/API/report/docs/UI suites (105 tests); touched-file `py_compile`; touched-file Ruff; `./.venv/bin/ruff check .`; `./.venv/bin/ruff format --check .`; `git diff --check`; production Bandit; `./.venv/bin/python -m unittest discover -q` (466 tests, 1 skipped); `APP_PORT=18109 npm run test:ui-review` (4 tests).
+- 2026-06-09: Fixed follow-up code-review findings by filtering malformed list owner entries, requiring topology source/freshness metadata for current context state, normalizing topology service/downstream IDs, treating invalid `updated_at` as incomplete context, guarding negative freshness ages, and normalizing partial persisted API context dictionaries.
+- 2026-06-09: Follow-up review-fix validation passed: focused review regressions (19 tests); impacted analysis/topology/API/report/docs/UI suites (111 tests); touched-file `py_compile`; touched-file Ruff; `./.venv/bin/ruff check .`; `./.venv/bin/ruff format --check .`; `git diff --check`; production Bandit; `./.venv/bin/python -m unittest discover -q` (468 tests, 1 skipped); `APP_PORT=18109 npm run test:ui-review` (4 tests).
+- 2026-06-09: Fixed final code-review findings by normalizing malformed persisted blast-radius additive fields in analysis/API schemas, requiring scalar complete topology source metadata, deduplicating downstream dependency metadata, adding direct stale/conflicting report-state regressions, and documenting context-state/limitation labels.
+- 2026-06-09: Final review-fix validation passed: targeted review regressions (24 tests); impacted analysis/topology/API/report/docs/UI suites (119 tests); touched-file `py_compile`; `./.venv/bin/ruff check .`; `./.venv/bin/ruff format --check .`; `git diff --check`; production Bandit; `./.venv/bin/python -m unittest discover -q` (470 tests, 1 skipped); `APP_PORT=18109 npm run test:ui-review` (4 tests).
+- 2026-06-09: Fixed latest code-review findings by sanitizing malformed nested persisted context fields, treating future topology timestamps as invalid freshness, propagating legacy topology file source paths into context source metadata, keeping legacy context state at `unknown`, and adding deterministic freshness `age_days` coverage with an injected clock.
+- 2026-06-09: Latest review-fix validation passed: focused review regressions (29 tests); impacted analysis/topology/API/report/docs/UI suites (123 tests); touched-file `py_compile`; touched-file Ruff check/format; `./.venv/bin/ruff check .`; `./.venv/bin/ruff format --check .`; `git diff --check`; production Bandit; `./.venv/bin/python -m unittest discover -q` (471 tests, 1 skipped); `APP_PORT=18109 npm run test:ui-review` (4 tests).
+- 2026-06-09: Fixed rerun code-review finding by normalizing explicit persisted `context_state: null` to `unknown` in shared blast-radius and API report schemas.
+- 2026-06-09: Rerun review-fix validation passed: focused schema regressions (21 tests); direct model repro (`unknown`/`unknown`); impacted analysis/API/report/docs/UI suites (101 tests); touched-file `py_compile`; touched-file Ruff check/format; `./.venv/bin/ruff check .`; `./.venv/bin/ruff format --check .`; `git diff --check`; production Bandit; `./.venv/bin/python -m unittest discover -q` (472 tests, 1 skipped); `APP_PORT=18109 npm run test:ui-review` (4 tests).
+
+### Completion Notes List
+
+- Enriched blast-radius report payloads with context source, freshness, context state, context limitations, affected-service dependencies, and owners.
+- Preserved valid `owner` / `owners` values through project/workspace-scoped topology save/import normalization and dropped malformed owner values with partial-parse warnings.
+- Updated the report blast-radius panel text equivalent so reviewers can see topology source, freshness, affected-service ownership, and true upstream dependencies.
+- Preserved enriched blast-radius topology context through API response schemas and fresh-analysis fallback payloads.
+- Kept legacy persisted blast-radius payloads from being falsely labeled as missing topology context.
+- Guarded report UI freshness rendering against malformed persisted `age_days` values.
+- Normalized malformed/partial persisted topology context so reviewers do not see fabricated owners, impossible freshness text, or falsely current context state.
+- Hardened legacy persisted blast-radius payload handling across API/UI report loading and documented the explicit topology context-state contract.
+- Hardened nested persisted topology context payloads and future freshness handling so malformed or temporally impossible topology context remains explicit instead of breaking report loading or being labeled current.
+- Normalized explicit legacy `context_state: null` values to `unknown` across shared analysis and API schema loading.
+- Updated the report schema documentation for the additive blast-radius context fields.
+
+### File List
+
+- `_bmad-output/implementation-artifacts/7-1-project-scoped-topology-context.md`
+- `_bmad-output/implementation-artifacts/sprint-status.yaml`
+- `analysis/blast_radius.py`
+- `api/schemas.py`
+- `docs/schemas/report-v2.md`
+- `services/topology_service.py`
+- `tests/test_analysis/test_blast_radius.py`
+- `tests/test_api/test_analyses.py`
+- `tests/test_services/test_report_service.py`
+- `tests/test_services/test_topology_service.py`
+- `tests/test_ui/test_blast_radius_panel.py`
+- `ui/components/blast_radius_graph.py`
+
+## Change Log
+
+- 2026-05-01: Story created/aligned from updated PRD, architecture, epics, sprint status, and readiness report.
+- 2026-06-09: Implemented Story 7.1 project-scoped topology context enrichment and moved story to review after focused, full unittest, lint, static-analysis, documentation, and UI validation.
+- 2026-06-09: Fixed Story 7.1 review findings and moved story back to review after focused, full unittest, lint, static-analysis, documentation, and UI validation.
+- 2026-06-09: Fixed follow-up Story 7.1 review findings and moved story back to review after targeted regression, impacted-suite, full unittest, lint, static-analysis, and UI validation.
+- 2026-06-09: Fixed final Story 7.1 review findings and moved story back to review after targeted regression, impacted-suite, full unittest, lint, static-analysis, and UI validation.
+- 2026-06-09: Fixed latest Story 7.1 review findings and moved story back to review after targeted regression, impacted-suite, full unittest, lint, static-analysis, and UI validation.
+- 2026-06-09: Fixed rerun Story 7.1 review finding and moved story back to review after targeted regression, impacted-suite, full unittest, lint, static-analysis, and UI validation.

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -110,7 +110,7 @@ development_status:
   epic-6-retrospective: optional
 
   epic-7: in-progress
-  7-1-project-scoped-topology-context: ready-for-dev
+  7-1-project-scoped-topology-context: review
   7-2-terraform-state-connector: ready-for-dev
   7-3-kubernetes-live-state-connector: ready-for-dev
   7-4-codeowners-and-ownership-mapping: ready-for-dev

--- a/analysis/blast_radius.py
+++ b/analysis/blast_radius.py
@@ -3,8 +3,10 @@
 from __future__ import annotations
 
 from collections import deque
+from datetime import UTC, datetime
+from typing import Any
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
 
 from parsers.base import UnifiedChange, is_non_mutating_action
 
@@ -13,6 +15,24 @@ class ImpactNode(BaseModel):
     service_id: str = Field(..., description="Stable service identifier")
     label: str = Field(..., description="Human-readable service label")
     depth: int = Field(..., description="0 for direct impact, 1+ for transitive impact")
+    dependencies: list[str] = Field(
+        default_factory=list,
+        description="Upstream service ids this service depends on in topology context",
+    )
+    owners: list[str] = Field(
+        default_factory=list,
+        description="Owner labels declared for this topology service",
+    )
+
+    @model_validator(mode="before")
+    @classmethod
+    def normalize_legacy_lists(cls, data: Any) -> Any:
+        if not isinstance(data, dict):
+            return data
+        normalized = dict(data)
+        normalized["dependencies"] = _text_list(normalized.get("dependencies"))
+        normalized["owners"] = _text_list(normalized.get("owners"))
+        return normalized
 
 
 class BlastRadiusResult(BaseModel):
@@ -29,11 +49,277 @@ class BlastRadiusResult(BaseModel):
     unmatched_resources: list[str] = Field(
         default_factory=list, description="Resources not found in topology context"
     )
+    context_source: dict[str, str | None] = Field(
+        default_factory=lambda: {"type": None, "ref": None},
+        description="Topology source metadata used for this blast-radius result",
+    )
+    freshness: dict[str, int | str | None] = Field(
+        default_factory=lambda: {"updated_at": None, "age_days": None},
+        description="Topology freshness metadata used for this blast-radius result",
+    )
+    context_state: str | None = Field(
+        default="unknown",
+        description="Topology context state: current, stale, missing, incomplete, conflicting, or unknown",
+    )
+    context_limitations: list[str] = Field(
+        default_factory=list,
+        description="Machine-readable topology context limitation labels",
+    )
+
+    @model_validator(mode="before")
+    @classmethod
+    def normalize_legacy_context(cls, data: Any) -> Any:
+        if not isinstance(data, dict):
+            return data
+        normalized = dict(data)
+        if not isinstance(normalized.get("affected"), list):
+            normalized["affected"] = []
+        if not isinstance(normalized.get("context_source"), dict):
+            normalized["context_source"] = {"type": None, "ref": None}
+        if not isinstance(normalized.get("freshness"), dict):
+            normalized["freshness"] = {"updated_at": None, "age_days": None}
+        else:
+            freshness = normalized["freshness"]
+            updated_at = freshness.get("updated_at")
+            age_days = freshness.get("age_days")
+            normalized["freshness"] = {
+                "updated_at": updated_at if isinstance(updated_at, str) else None,
+                "age_days": age_days if isinstance(age_days, int | str) else None,
+            }
+        context_source = normalized.get("context_source")
+        if isinstance(context_source, dict):
+            normalized["context_source"] = {
+                "type": _scalar_text_or_none(context_source.get("type")),
+                "ref": _scalar_text_or_none(context_source.get("ref")),
+            }
+        context_state = normalized.get("context_state")
+        if context_state is None or not isinstance(context_state, str):
+            normalized["context_state"] = "unknown"
+        normalized["context_limitations"] = _text_list(
+            normalized.get("context_limitations")
+        )
+        return normalized
+
+
+def _text_list(value: Any) -> list[str]:
+    if not isinstance(value, list):
+        return []
+    return [item.strip() for item in value if isinstance(item, str) and item.strip()]
+
+
+def _scalar_text_or_none(value: Any) -> str | None:
+    if isinstance(value, str):
+        return value.strip() or None
+    if isinstance(value, int | float | bool):
+        return str(value)
+    return None
+
+
+def _metadata_text(metadata: dict, key: str) -> str | None:
+    value = metadata.get(key)
+    if not isinstance(value, str):
+        return None
+    return value.strip() or None
+
+
+def _has_invalid_source_metadata(import_metadata: dict) -> bool:
+    return any(
+        key in import_metadata
+        and import_metadata.get(key) is not None
+        and not isinstance(import_metadata.get(key), str)
+        for key in ("source_type", "source_ref")
+    )
+
+
+def _topology_import_metadata(topology: dict | None) -> dict:
+    metadata = topology.get("metadata") if isinstance(topology, dict) else None
+    if not isinstance(metadata, dict):
+        return {}
+    import_metadata = metadata.get("import")
+    return import_metadata if isinstance(import_metadata, dict) else {}
+
+
+def _context_source(topology: dict | None) -> dict[str, str | None]:
+    import_metadata = _topology_import_metadata(topology)
+    source_type = _metadata_text(import_metadata, "source_type")
+    source_ref = _metadata_text(import_metadata, "source_ref")
+    return {"type": source_type, "ref": source_ref}
+
+
+def _topology_updated_at(topology: dict | None) -> str:
+    return (
+        str(topology.get("updated_at") or "").strip()
+        if isinstance(topology, dict)
+        else ""
+    )
+
+
+def _parse_topology_updated_at(updated_at_raw: str) -> datetime | None:
+    if not updated_at_raw:
+        return None
+    try:
+        updated_at = datetime.fromisoformat(updated_at_raw.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if updated_at.tzinfo is None:
+        updated_at = updated_at.replace(tzinfo=UTC)
+    return updated_at
+
+
+def _freshness_payload(
+    topology: dict | None, *, now: datetime | None = None
+) -> dict[str, int | str | None]:
+    updated_at_raw = _topology_updated_at(topology)
+    if not updated_at_raw:
+        return {"updated_at": None, "age_days": None}
+    updated_at = _parse_topology_updated_at(updated_at_raw)
+    if updated_at is None:
+        return {"updated_at": updated_at_raw, "age_days": None}
+    now = now or datetime.now(UTC)
+    if now.tzinfo is None:
+        now = now.replace(tzinfo=UTC)
+    if updated_at > now:
+        return {"updated_at": updated_at_raw, "age_days": None}
+    age_days = (now - updated_at).days
+    return {"updated_at": updated_at_raw, "age_days": age_days}
+
+
+def _warning_text(warning: str | None) -> str:
+    return str(warning or "").strip().lower()
+
+
+def _base_context_limitations(
+    topology: dict | None, warning: str | None, *, now: datetime | None = None
+) -> list[str]:
+    text = _warning_text(warning)
+    limitations: list[str] = []
+    if not topology:
+        if any(
+            token in text for token in ("validation failed", "circular", "duplicate")
+        ):
+            limitations.append("conflicting_topology")
+        else:
+            limitations.append("missing_topology")
+    if any(token in text for token in ("stale", "last updated more than")):
+        limitations.append("stale_topology")
+    if any(
+        token in text
+        for token in (
+            "validation failed",
+            "circular",
+            "duplicate",
+            "conflict",
+        )
+    ):
+        limitations.append("conflicting_topology")
+    if topology and text:
+        limitations.append("incomplete_topology")
+    if topology:
+        import_metadata = _topology_import_metadata(topology)
+        context_source = _context_source(topology)
+        if _has_invalid_source_metadata(import_metadata):
+            limitations.append("invalid_topology_source")
+        if not context_source["type"] or not context_source["ref"]:
+            limitations.append("missing_topology_source")
+        updated_at_raw = _topology_updated_at(topology)
+        if not updated_at_raw:
+            limitations.append("missing_topology_freshness")
+        else:
+            updated_at = _parse_topology_updated_at(updated_at_raw)
+            comparison_now = now or datetime.now(UTC)
+            if comparison_now.tzinfo is None:
+                comparison_now = comparison_now.replace(tzinfo=UTC)
+            if updated_at is None or updated_at > comparison_now:
+                limitations.append("invalid_topology_freshness")
+    import_warnings = _topology_import_metadata(topology).get("warnings", [])
+    if isinstance(import_warnings, list) and import_warnings:
+        limitations.append("incomplete_topology")
+    seen: set[str] = set()
+    unique: list[str] = []
+    for limitation in limitations:
+        if limitation in seen:
+            continue
+        seen.add(limitation)
+        unique.append(limitation)
+    return unique
+
+
+def _context_state(limitations: list[str]) -> str:
+    if "conflicting_topology" in limitations:
+        return "conflicting"
+    if "missing_topology" in limitations:
+        return "missing"
+    if "stale_topology" in limitations:
+        return "stale"
+    if (
+        "incomplete_topology" in limitations
+        or "missing_resource_mapping" in limitations
+    ):
+        return "incomplete"
+    if limitations:
+        return "incomplete"
+    return "current"
+
+
+def _service_owners(service: dict) -> list[str]:
+    owners: list[str] = []
+    owner_raw = service.get("owner")
+    if isinstance(owner_raw, str):
+        owner = owner_raw.strip()
+        if owner:
+            owners.append(owner)
+    owners_raw = service.get("owners", [])
+    owners.extend(_text_list(owners_raw))
+    seen: set[str] = set()
+    unique: list[str] = []
+    for item in owners:
+        if item in seen:
+            continue
+        seen.add(item)
+        unique.append(item)
+    return unique
+
+
+def _service_id(service: dict) -> str:
+    return str(service.get("id") or "").strip()
+
+
+def _service_downstream_ids(service: dict) -> list[str]:
+    downstream_raw = service.get("downstream", [])
+    if not isinstance(downstream_raw, list):
+        return []
+    downstream_ids: list[str] = []
+    seen: set[str] = set()
+    for item in downstream_raw:
+        downstream_id = str(item).strip()
+        if not downstream_id or downstream_id in seen:
+            continue
+        seen.add(downstream_id)
+        downstream_ids.append(downstream_id)
+    return downstream_ids
+
+
+def _service_resource_keys(service: dict) -> list[str]:
+    resource_keys_raw = service.get("resource_keys", [])
+    if not isinstance(resource_keys_raw, list):
+        return []
+    return [
+        resource_key
+        for resource_key in (str(item).strip() for item in resource_keys_raw)
+        if resource_key
+    ]
 
 
 def compute_blast_radius(
-    changes: list[UnifiedChange], topology: dict | None, warning: str | None = None
+    changes: list[UnifiedChange],
+    topology: dict | None,
+    warning: str | None = None,
+    *,
+    now: datetime | None = None,
 ) -> BlastRadiusResult:
+    base_limitations = _base_context_limitations(topology, warning, now=now)
+    context_source = _context_source(topology)
+    freshness = _freshness_payload(topology, now=now)
     mutating_changes = [
         change for change in changes if not is_non_mutating_action(change.action)
     ]
@@ -43,6 +329,10 @@ def compute_blast_radius(
             direct_count=0,
             transitive_count=0,
             warning=warning,
+            context_source=context_source,
+            freshness=freshness,
+            context_state=_context_state(base_limitations),
+            context_limitations=base_limitations,
         )
 
     if not topology:
@@ -51,22 +341,44 @@ def compute_blast_radius(
             direct_count=0,
             transitive_count=0,
             warning=warning or "Blast radius may be incomplete.",
+            context_source=context_source,
+            freshness=freshness,
+            context_state=_context_state(base_limitations),
+            context_limitations=base_limitations,
         )
 
-    services = topology.get("services", []) if isinstance(topology, dict) else []
+    services_raw = topology.get("services", []) if isinstance(topology, dict) else []
+    services = [
+        service
+        for service in services_raw
+        if isinstance(service, dict) and _service_id(service)
+    ]
     if not services:
         return BlastRadiusResult(
             affected=[],
             direct_count=0,
             transitive_count=0,
             warning=warning or "No topology services available.",
+            context_source=context_source,
+            freshness=freshness,
+            context_state=_context_state(base_limitations or ["incomplete_topology"]),
+            context_limitations=base_limitations or ["incomplete_topology"],
         )
 
     resource_to_service_ids: dict[str, list[str]] = {}
-    service_by_id = {service["id"]: service for service in services}
+    service_by_id = {_service_id(service): service for service in services}
+    upstream_by_service_id: dict[str, list[str]] = {
+        service_id: [] for service_id in service_by_id
+    }
     for service in services:
-        for resource_key in service.get("resource_keys", []):
-            resource_to_service_ids.setdefault(resource_key, []).append(service["id"])
+        source_service_id = _service_id(service)
+        for downstream_id in _service_downstream_ids(service):
+            if downstream_id in upstream_by_service_id:
+                upstream_by_service_id[downstream_id].append(source_service_id)
+    for service in services:
+        service_id = _service_id(service)
+        for resource_key in _service_resource_keys(service):
+            resource_to_service_ids.setdefault(resource_key, []).append(service_id)
 
     queue: deque[tuple[str, int]] = deque()
     seen: set[str] = set()
@@ -92,9 +404,11 @@ def compute_blast_radius(
                 service_id=service_id,
                 label=service.get("label", service_id),
                 depth=depth,
+                dependencies=upstream_by_service_id.get(service_id, []),
+                owners=_service_owners(service),
             )
         )
-        for downstream_id in service.get("downstream", []):
+        for downstream_id in _service_downstream_ids(service):
             if downstream_id in seen:
                 continue
             seen.add(downstream_id)
@@ -112,6 +426,9 @@ def compute_blast_radius(
             warning = missing_context_warning
     elif not affected and warning is None:
         warning = "No downstream dependencies found for the analyzed resources."
+    limitations = list(base_limitations)
+    if unmatched_resources and "missing_resource_mapping" not in limitations:
+        limitations.append("missing_resource_mapping")
 
     return BlastRadiusResult(
         affected=affected,
@@ -119,4 +436,8 @@ def compute_blast_radius(
         transitive_count=transitive_count,
         warning=warning,
         unmatched_resources=sorted(set(unmatched_resources)),
+        context_source=context_source,
+        freshness=freshness,
+        context_state=_context_state(limitations),
+        context_limitations=limitations,
     )

--- a/api/schemas.py
+++ b/api/schemas.py
@@ -911,6 +911,24 @@ class ImpactNodeData(BaseModel):
     service_id: str = Field(..., description="Stable service identifier")
     label: str = Field(..., description="Human-readable service label")
     depth: int = Field(..., description="0 for direct impact, 1+ for transitive impact")
+    dependencies: list[str] = Field(
+        default_factory=list,
+        description="Upstream service ids this service depends on in topology context",
+    )
+    owners: list[str] = Field(
+        default_factory=list,
+        description="Owner labels declared for this topology service",
+    )
+
+    @model_validator(mode="before")
+    @classmethod
+    def normalize_legacy_lists(cls, data: Any) -> Any:
+        if not isinstance(data, dict):
+            return data
+        normalized = dict(data)
+        normalized["dependencies"] = _text_list(normalized.get("dependencies"))
+        normalized["owners"] = _text_list(normalized.get("owners"))
+        return normalized
 
 
 class BlastRadiusData(BaseModel):
@@ -927,6 +945,84 @@ class BlastRadiusData(BaseModel):
     unmatched_resources: list[str] = Field(
         default_factory=list, description="Resources not found in topology context"
     )
+    context_source: dict[str, str | None] = Field(
+        default_factory=lambda: {"type": None, "ref": None},
+        description="Topology source metadata used for this blast-radius result",
+    )
+    freshness: dict[str, int | str | None] = Field(
+        default_factory=lambda: {"updated_at": None, "age_days": None},
+        description="Topology freshness metadata used for this blast-radius result",
+    )
+    context_state: str | None = Field(
+        default="unknown",
+        description="Topology context state: current, stale, missing, incomplete, conflicting, or unknown",
+    )
+    context_limitations: list[str] = Field(
+        default_factory=list,
+        description="Machine-readable topology context limitation labels",
+    )
+
+    @model_validator(mode="before")
+    @classmethod
+    def normalize_legacy_context(cls, data: Any) -> Any:
+        if not isinstance(data, dict):
+            return data
+        normalized = dict(data)
+        if not isinstance(normalized.get("affected"), list):
+            normalized["affected"] = []
+        if not isinstance(normalized.get("context_source"), dict):
+            normalized["context_source"] = {"type": None, "ref": None}
+        if not isinstance(normalized.get("freshness"), dict):
+            normalized["freshness"] = {"updated_at": None, "age_days": None}
+        else:
+            freshness = normalized["freshness"]
+            updated_at = freshness.get("updated_at")
+            age_days = freshness.get("age_days")
+            normalized["freshness"] = {
+                "updated_at": updated_at if isinstance(updated_at, str) else None,
+                "age_days": age_days if isinstance(age_days, int | str) else None,
+            }
+        context_source = normalized.get("context_source")
+        if isinstance(context_source, dict):
+            normalized["context_source"] = {
+                "type": _scalar_text_or_none(context_source.get("type")),
+                "ref": _scalar_text_or_none(context_source.get("ref")),
+            }
+        context_state = normalized.get("context_state")
+        if context_state is None or not isinstance(context_state, str):
+            normalized["context_state"] = "unknown"
+        normalized["context_limitations"] = _text_list(
+            normalized.get("context_limitations")
+        )
+        return normalized
+
+    @model_validator(mode="after")
+    def normalize_context_defaults(self) -> "BlastRadiusData":
+        context_source = dict(self.context_source or {})
+        self.context_source = {
+            "type": context_source.get("type"),
+            "ref": context_source.get("ref"),
+        }
+        freshness = dict(self.freshness or {})
+        self.freshness = {
+            "updated_at": freshness.get("updated_at"),
+            "age_days": freshness.get("age_days"),
+        }
+        return self
+
+
+def _text_list(value: Any) -> list[str]:
+    if not isinstance(value, list):
+        return []
+    return [item.strip() for item in value if isinstance(item, str) and item.strip()]
+
+
+def _scalar_text_or_none(value: Any) -> str | None:
+    if isinstance(value, str):
+        return value.strip() or None
+    if isinstance(value, int | float | bool):
+        return str(value)
+    return None
 
 
 class RollbackStepData(BaseModel):
@@ -1457,6 +1553,10 @@ def build_analysis_run_data(
                 "transitive_count": blast_radius.transitive_count,
                 "warning": blast_radius.warning,
                 "unmatched_resources": list(blast_radius.unmatched_resources),
+                "context_source": dict(blast_radius.context_source),
+                "freshness": dict(blast_radius.freshness),
+                "context_state": blast_radius.context_state,
+                "context_limitations": list(blast_radius.context_limitations),
             }
         ),
         rollback_plan=RollbackPlanData.model_validate(

--- a/docs/schemas/report-v2.md
+++ b/docs/schemas/report-v2.md
@@ -236,6 +236,38 @@ without storing raw plan internals in a separate contract.
     "insufficient_context": true,
     "partial_context": true
   },
+  "blast_radius": {
+    "affected": [
+      {
+        "service_id": "database",
+        "label": "Primary Database",
+        "depth": 0,
+        "dependencies": [],
+        "owners": ["sre"]
+      },
+      {
+        "service_id": "api",
+        "label": "Payments API",
+        "depth": 1,
+        "dependencies": ["database"],
+        "owners": ["payments"]
+      }
+    ],
+    "direct_count": 1,
+    "transitive_count": 1,
+    "warning": null,
+    "unmatched_resources": [],
+    "context_source": {
+      "type": "custom",
+      "ref": "topology.json"
+    },
+    "freshness": {
+      "updated_at": "2026-06-08T12:00:00Z",
+      "age_days": 1
+    },
+    "context_state": "current",
+    "context_limitations": []
+  },
   "rollback_plan": {
     "complexity": "medium",
     "complexity_score": 3,
@@ -402,6 +434,25 @@ without storing raw plan internals in a separate contract.
   }
 }
 ```
+
+### Blast-radius topology context
+
+`blast_radius.context_state` is the report-facing topology trust state. It is
+`current` when topology source and freshness metadata are valid and no
+limitations were detected. It is `stale` when freshness warnings indicate old
+topology, `missing` when no topology context was available, `incomplete` when
+source metadata, freshness metadata, resource mappings, or imported context are
+partial, `conflicting` when validation detects duplicate, circular, or otherwise
+conflicting topology, and `unknown` for legacy payloads where no state was
+persisted.
+
+`blast_radius.context_limitations` contains machine-readable reasons for
+non-current states. Current labels include `missing_topology`, `stale_topology`,
+`conflicting_topology`, `incomplete_topology`, `missing_topology_source`,
+`invalid_topology_source`, `missing_topology_freshness`,
+`invalid_topology_freshness`, and `missing_resource_mapping`. Consumers should
+treat unrecognized future labels as additional incomplete-context signals rather
+than failing report parsing.
 
 ### Analysis run incident and pattern matches
 

--- a/services/topology_service.py
+++ b/services/topology_service.py
@@ -263,6 +263,23 @@ def _extract_import_warnings(payload: dict[str, Any]) -> list[str]:
     return _unique_messages([str(item) for item in warnings])
 
 
+def _owner_labels(raw_owners: Any) -> tuple[list[str], bool]:
+    if raw_owners is None:
+        return [], False
+    if not isinstance(raw_owners, list):
+        return [], True
+    labels: list[str] = []
+    malformed = False
+    for owner in raw_owners:
+        if isinstance(owner, str):
+            label = owner.strip()
+            if label:
+                labels.append(label)
+        elif owner is not None:
+            malformed = True
+    return labels, malformed
+
+
 def _resource_snapshot(payload: dict[str, Any] | None) -> dict[str, dict[str, Any]]:
     if not payload:
         return {}
@@ -284,9 +301,12 @@ def _resource_snapshot(payload: dict[str, Any] | None) -> dict[str, dict[str, An
         ]
         if not resource_keys:
             resource_keys = [f"service:{service_id}"]
+        owners, _ = _owner_labels(service.get("owners", []))
         signature = {
             "service_id": service_id,
             "label": str(service.get("label") or service_id),
+            "owner": str(service.get("owner") or ""),
+            "owners": sorted(owners),
             "downstream": sorted(
                 str(target).strip()
                 for target in service.get("downstream", [])
@@ -489,6 +509,16 @@ def _read_legacy_topology_status() -> TopologyStatus | None:
                 "Topology validation failed — active topology must be a JSON object."
             ],
         )
+    metadata = payload.get("metadata")
+    if not isinstance(metadata, dict):
+        metadata = {}
+    import_metadata = metadata.get("import")
+    if not isinstance(import_metadata, dict):
+        import_metadata = {}
+    import_metadata.setdefault("source_type", "legacy-file")
+    import_metadata.setdefault("source_ref", str(legacy_path))
+    metadata["import"] = import_metadata
+    payload = {**payload, "metadata": metadata}
     return _build_topology_status(payload, path=legacy_path, exists=True)
 
 
@@ -776,16 +806,41 @@ def _build_custom_change_set(payload: dict[str, Any]) -> TopologyChangeSet:
         downstream = [
             str(target).strip() for target in downstream_raw if str(target).strip()
         ]
+        owner_raw = service.get("owner")
+        owner = ""
+        if owner_raw is not None:
+            if isinstance(owner_raw, str):
+                owner = owner_raw.strip()
+            else:
+                partially_parsed_resources.append(
+                    TopologyImportResource(
+                        resource_ref=service_id,
+                        service_id=service_id,
+                        message="Owner label was malformed and was dropped.",
+                    )
+                )
+        owners, malformed_owners = _owner_labels(service.get("owners", []))
+        if malformed_owners:
+            partially_parsed_resources.append(
+                TopologyImportResource(
+                    resource_ref=service_id,
+                    service_id=service_id,
+                    message="Owner labels were malformed and were dropped.",
+                )
+            )
 
         seen_service_ids.add(service_id)
-        services.append(
-            {
-                "id": service_id,
-                "label": str(service.get("label") or service_id),
-                "resource_keys": resource_keys,
-                "downstream": downstream,
-            }
-        )
+        normalized_service = {
+            "id": service_id,
+            "label": str(service.get("label") or service_id),
+            "resource_keys": resource_keys,
+            "downstream": downstream,
+        }
+        if owner:
+            normalized_service["owner"] = owner
+        if owners:
+            normalized_service["owners"] = owners
+        services.append(normalized_service)
 
         if resource_keys:
             for resource_key in resource_keys:
@@ -994,7 +1049,7 @@ def _persist_topology_payload(
 
 
 def _canonical_service(service: dict[str, Any]) -> dict[str, Any]:
-    return {
+    canonical = {
         "id": str(service.get("id") or "").strip(),
         "label": str(service.get("label") or "").strip(),
         "resource_keys": sorted(
@@ -1008,6 +1063,14 @@ def _canonical_service(service: dict[str, Any]) -> dict[str, Any]:
             if str(item).strip()
         ),
     }
+    owner = str(service.get("owner") or "").strip()
+    owners, _ = _owner_labels(service.get("owners", []))
+    owners = sorted(owners)
+    if owner:
+        canonical["owner"] = owner
+    if owners:
+        canonical["owners"] = owners
+    return canonical
 
 
 def _build_topology_diff(

--- a/tests/test_analysis/test_blast_radius.py
+++ b/tests/test_analysis/test_blast_radius.py
@@ -2,29 +2,40 @@
 
 from __future__ import annotations
 
+from datetime import UTC, datetime
 import unittest
 
-from analysis.blast_radius import compute_blast_radius
+from analysis.blast_radius import BlastRadiusResult, compute_blast_radius
 from parsers.base import UnifiedChange
 
 
 class BlastRadiusTests(unittest.TestCase):
     def test_compute_blast_radius_returns_direct_and_transitive_impact(self) -> None:
         topology = {
+            "updated_at": "2026-06-08T12:00:00Z",
+            "metadata": {
+                "import": {
+                    "source_type": "custom",
+                    "source_ref": "topology.json",
+                    "warnings": [],
+                }
+            },
             "services": [
                 {
                     "id": "database",
                     "label": "Database",
                     "resource_keys": ["aws_security_group.main"],
                     "downstream": ["api"],
+                    "owners": ["sre"],
                 },
                 {
                     "id": "api",
                     "label": "API Service",
                     "resource_keys": ["Deployment/api"],
                     "downstream": [],
+                    "owner": "payments",
                 },
-            ]
+            ],
         }
         changes = [
             UnifiedChange(
@@ -39,6 +50,433 @@ class BlastRadiusTests(unittest.TestCase):
         self.assertEqual(result.direct_count, 1)
         self.assertEqual(result.transitive_count, 1)
         self.assertIsNone(result.warning)
+        self.assertEqual(result.context_source["type"], "custom")
+        self.assertEqual(result.context_source["ref"], "topology.json")
+        self.assertEqual(result.freshness["updated_at"], "2026-06-08T12:00:00Z")
+        self.assertEqual(result.context_state, "current")
+        database_node = next(
+            node for node in result.affected if node.service_id == "database"
+        )
+        api_node = next(node for node in result.affected if node.service_id == "api")
+        self.assertEqual(database_node.dependencies, [])
+        self.assertEqual(database_node.owners, ["sre"])
+        self.assertEqual(api_node.dependencies, ["database"])
+        self.assertEqual(api_node.owners, ["payments"])
+
+    def test_compute_blast_radius_calculates_freshness_age_with_injected_clock(
+        self,
+    ) -> None:
+        topology = {
+            "updated_at": "2026-06-08T12:00:00Z",
+            "metadata": {
+                "import": {
+                    "source_type": "custom",
+                    "source_ref": "topology.json",
+                    "warnings": [],
+                }
+            },
+            "services": [
+                {
+                    "id": "api",
+                    "label": "API Service",
+                    "resource_keys": ["Deployment/api"],
+                    "downstream": [],
+                }
+            ],
+        }
+        changes = [
+            UnifiedChange(
+                source_file="manifest.yaml",
+                tool="kubernetes",
+                resource_id="Deployment/api",
+                action="modify",
+                summary="Kubernetes deployment changed.",
+            )
+        ]
+
+        result = compute_blast_radius(
+            changes, topology, now=datetime(2026, 6, 9, 12, 0, tzinfo=UTC)
+        )
+
+        self.assertEqual(result.freshness["age_days"], 1)
+
+    def test_compute_blast_radius_drops_malformed_owner_values(self) -> None:
+        topology = {
+            "services": [
+                {
+                    "id": "api",
+                    "label": "API Service",
+                    "resource_keys": ["Deployment/api"],
+                    "downstream": [],
+                    "owner": {"team": "payments"},
+                    "owners": ["sre", {"team": "security"}],
+                }
+            ]
+        }
+        changes = [
+            UnifiedChange(
+                source_file="manifest.yaml",
+                tool="kubernetes",
+                resource_id="Deployment/api",
+                action="modify",
+                summary="Kubernetes deployment changed.",
+            )
+        ]
+
+        result = compute_blast_radius(changes, topology)
+
+        self.assertEqual(result.affected[0].owners, ["sre"])
+
+    def test_compute_blast_radius_marks_missing_topology_metadata_incomplete(
+        self,
+    ) -> None:
+        topology = {
+            "services": [
+                {
+                    "id": "api",
+                    "label": "API Service",
+                    "resource_keys": ["Deployment/api"],
+                    "downstream": [],
+                }
+            ]
+        }
+        changes = [
+            UnifiedChange(
+                source_file="manifest.yaml",
+                tool="kubernetes",
+                resource_id="Deployment/api",
+                action="modify",
+                summary="Kubernetes deployment changed.",
+            )
+        ]
+
+        result = compute_blast_radius(changes, topology)
+
+        self.assertEqual(result.context_state, "incomplete")
+        self.assertIn("missing_topology_source", result.context_limitations)
+        self.assertIn("missing_topology_freshness", result.context_limitations)
+
+    def test_compute_blast_radius_marks_invalid_topology_freshness_incomplete(
+        self,
+    ) -> None:
+        topology = {
+            "updated_at": "not-a-date",
+            "metadata": {
+                "import": {
+                    "source_type": "custom",
+                    "source_ref": "topology.json",
+                    "warnings": [],
+                }
+            },
+            "services": [
+                {
+                    "id": "api",
+                    "label": "API Service",
+                    "resource_keys": ["Deployment/api"],
+                    "downstream": [],
+                }
+            ],
+        }
+        changes = [
+            UnifiedChange(
+                source_file="manifest.yaml",
+                tool="kubernetes",
+                resource_id="Deployment/api",
+                action="modify",
+                summary="Kubernetes deployment changed.",
+            )
+        ]
+
+        result = compute_blast_radius(changes, topology)
+
+        self.assertEqual(result.context_state, "incomplete")
+        self.assertIn("invalid_topology_freshness", result.context_limitations)
+
+    def test_compute_blast_radius_marks_future_topology_freshness_incomplete(
+        self,
+    ) -> None:
+        topology = {
+            "updated_at": "2099-01-01T00:00:00Z",
+            "metadata": {
+                "import": {
+                    "source_type": "custom",
+                    "source_ref": "topology.json",
+                    "warnings": [],
+                }
+            },
+            "services": [
+                {
+                    "id": "api",
+                    "label": "API Service",
+                    "resource_keys": ["Deployment/api"],
+                    "downstream": [],
+                }
+            ],
+        }
+        changes = [
+            UnifiedChange(
+                source_file="manifest.yaml",
+                tool="kubernetes",
+                resource_id="Deployment/api",
+                action="modify",
+                summary="Kubernetes deployment changed.",
+            )
+        ]
+
+        result = compute_blast_radius(
+            changes, topology, now=datetime(2026, 6, 9, 12, 0, tzinfo=UTC)
+        )
+
+        self.assertEqual(result.context_state, "incomplete")
+        self.assertEqual(result.freshness["age_days"], None)
+        self.assertIn("invalid_topology_freshness", result.context_limitations)
+
+    def test_compute_blast_radius_marks_partial_source_metadata_incomplete(
+        self,
+    ) -> None:
+        topology = {
+            "updated_at": "2026-06-08T12:00:00Z",
+            "metadata": {"import": {"source_type": "custom"}},
+            "services": [
+                {
+                    "id": "api",
+                    "label": "API Service",
+                    "resource_keys": ["Deployment/api"],
+                    "downstream": [],
+                }
+            ],
+        }
+        changes = [
+            UnifiedChange(
+                source_file="manifest.yaml",
+                tool="kubernetes",
+                resource_id="Deployment/api",
+                action="modify",
+                summary="Kubernetes deployment changed.",
+            )
+        ]
+
+        result = compute_blast_radius(changes, topology)
+
+        self.assertEqual(result.context_state, "incomplete")
+        self.assertEqual(result.context_source, {"type": "custom", "ref": None})
+        self.assertIn("missing_topology_source", result.context_limitations)
+
+    def test_compute_blast_radius_marks_non_scalar_source_metadata_incomplete(
+        self,
+    ) -> None:
+        topology = {
+            "updated_at": "2026-06-08T12:00:00Z",
+            "metadata": {
+                "import": {
+                    "source_type": {"kind": "custom"},
+                    "source_ref": "topology.json",
+                }
+            },
+            "services": [
+                {
+                    "id": "api",
+                    "label": "API Service",
+                    "resource_keys": ["Deployment/api"],
+                    "downstream": [],
+                }
+            ],
+        }
+        changes = [
+            UnifiedChange(
+                source_file="manifest.yaml",
+                tool="kubernetes",
+                resource_id="Deployment/api",
+                action="modify",
+                summary="Kubernetes deployment changed.",
+            )
+        ]
+
+        result = compute_blast_radius(changes, topology)
+
+        self.assertEqual(result.context_state, "incomplete")
+        self.assertEqual(result.context_source, {"type": None, "ref": "topology.json"})
+        self.assertIn("invalid_topology_source", result.context_limitations)
+        self.assertIn("missing_topology_source", result.context_limitations)
+
+    def test_compute_blast_radius_normalizes_downstream_service_ids(self) -> None:
+        topology = {
+            "updated_at": "2026-06-08T12:00:00Z",
+            "metadata": {
+                "import": {
+                    "source_type": "custom",
+                    "source_ref": "topology.json",
+                    "warnings": [],
+                }
+            },
+            "services": [
+                {
+                    "id": "database",
+                    "label": "Database",
+                    "resource_keys": ["aws_security_group.main"],
+                    "downstream": [" api "],
+                },
+                {
+                    "id": "api",
+                    "label": "API Service",
+                    "resource_keys": [],
+                    "downstream": [],
+                },
+            ],
+        }
+        changes = [
+            UnifiedChange(
+                source_file="plan.json",
+                tool="terraform",
+                resource_id="aws_security_group.main",
+                action="modify",
+                summary="Terraform changed a security group.",
+            )
+        ]
+
+        result = compute_blast_radius(changes, topology)
+
+        self.assertEqual(
+            [node.service_id for node in result.affected], ["database", "api"]
+        )
+        api_node = next(node for node in result.affected if node.service_id == "api")
+        self.assertEqual(api_node.dependencies, ["database"])
+
+    def test_compute_blast_radius_deduplicates_downstream_dependencies(self) -> None:
+        topology = {
+            "updated_at": "2026-06-08T12:00:00Z",
+            "metadata": {
+                "import": {
+                    "source_type": "custom",
+                    "source_ref": "topology.json",
+                    "warnings": [],
+                }
+            },
+            "services": [
+                {
+                    "id": "database",
+                    "label": "Database",
+                    "resource_keys": ["aws_security_group.main"],
+                    "downstream": ["api", " api ", "api"],
+                },
+                {
+                    "id": "api",
+                    "label": "API Service",
+                    "resource_keys": [],
+                    "downstream": [],
+                },
+            ],
+        }
+        changes = [
+            UnifiedChange(
+                source_file="plan.json",
+                tool="terraform",
+                resource_id="aws_security_group.main",
+                action="modify",
+                summary="Terraform changed a security group.",
+            )
+        ]
+
+        result = compute_blast_radius(changes, topology)
+
+        api_node = next(node for node in result.affected if node.service_id == "api")
+        self.assertEqual(api_node.dependencies, ["database"])
+
+    def test_legacy_blast_radius_payload_drops_malformed_additive_fields(self) -> None:
+        legacy_result = BlastRadiusResult.model_validate(
+            {
+                "affected": [
+                    {
+                        "service_id": "api",
+                        "label": "API Service",
+                        "depth": 0,
+                        "dependencies": None,
+                        "owners": None,
+                    }
+                ],
+                "direct_count": 1,
+                "transitive_count": 0,
+                "warning": None,
+                "unmatched_resources": [],
+                "context_source": "legacy",
+                "freshness": "unknown",
+                "context_limitations": "legacy",
+            }
+        )
+
+        self.assertEqual(legacy_result.affected[0].dependencies, [])
+        self.assertEqual(legacy_result.affected[0].owners, [])
+        self.assertEqual(legacy_result.context_source, {"type": None, "ref": None})
+        self.assertEqual(
+            legacy_result.freshness, {"updated_at": None, "age_days": None}
+        )
+        self.assertEqual(legacy_result.context_limitations, [])
+
+    def test_legacy_blast_radius_payload_drops_malformed_nested_additive_fields(
+        self,
+    ) -> None:
+        legacy_result = BlastRadiusResult.model_validate(
+            {
+                "affected": [
+                    {
+                        "service_id": "api",
+                        "label": "API Service",
+                        "depth": 0,
+                    }
+                ],
+                "direct_count": 1,
+                "transitive_count": 0,
+                "warning": None,
+                "unmatched_resources": [],
+                "context_source": {"type": {"kind": "custom"}, "ref": "topology.json"},
+                "freshness": {"updated_at": {"bad": "value"}, "age_days": []},
+                "context_state": {"state": "missing"},
+            }
+        )
+
+        self.assertEqual(
+            legacy_result.context_source, {"type": None, "ref": "topology.json"}
+        )
+        self.assertEqual(
+            legacy_result.freshness, {"updated_at": None, "age_days": None}
+        )
+        self.assertEqual(legacy_result.context_state, "unknown")
+
+    def test_legacy_blast_radius_payload_has_unknown_context_state(self) -> None:
+        legacy_result = BlastRadiusResult.model_validate(
+            {
+                "affected": [
+                    {
+                        "service_id": "api",
+                        "label": "API Service",
+                        "depth": 0,
+                    }
+                ],
+                "direct_count": 1,
+                "transitive_count": 0,
+                "warning": None,
+                "unmatched_resources": [],
+            }
+        )
+
+        self.assertEqual(legacy_result.context_state, "unknown")
+        self.assertEqual(legacy_result.context_limitations, [])
+
+    def test_legacy_blast_radius_payload_normalizes_null_context_state(
+        self,
+    ) -> None:
+        legacy_result = BlastRadiusResult.model_validate(
+            {
+                "affected": [],
+                "direct_count": 0,
+                "transitive_count": 0,
+                "warning": None,
+                "unmatched_resources": [],
+                "context_state": None,
+            }
+        )
+
+        self.assertEqual(legacy_result.context_state, "unknown")
 
     def test_compute_blast_radius_warns_when_no_matches_found(self) -> None:
         topology = {
@@ -64,6 +502,101 @@ class BlastRadiusTests(unittest.TestCase):
         self.assertTrue(result.warning)
         self.assertIn("no topology mapping found", result.warning)
         self.assertEqual(result.unmatched_resources, ["aws_security_group.main"])
+        self.assertEqual(result.context_state, "incomplete")
+        self.assertIn("missing_resource_mapping", result.context_limitations)
+
+    def test_compute_blast_radius_marks_missing_topology_context(self) -> None:
+        changes = [
+            UnifiedChange(
+                source_file="plan.json",
+                tool="terraform",
+                resource_id="aws_security_group.main",
+                action="modify",
+                summary="Terraform changed a security group.",
+            )
+        ]
+
+        result = compute_blast_radius(
+            changes,
+            None,
+            "Blast radius may be incomplete — service topology is not configured.",
+        )
+
+        self.assertEqual(result.context_state, "missing")
+        self.assertEqual(result.context_source["type"], None)
+        self.assertIn("missing_topology", result.context_limitations)
+
+    def test_compute_blast_radius_marks_stale_topology_context(self) -> None:
+        topology = {
+            "updated_at": "2026-06-08T12:00:00Z",
+            "metadata": {
+                "import": {
+                    "source_type": "custom",
+                    "source_ref": "topology.json",
+                    "warnings": [],
+                }
+            },
+            "services": [
+                {
+                    "id": "api",
+                    "label": "API Service",
+                    "resource_keys": ["Deployment/api"],
+                    "downstream": [],
+                }
+            ],
+        }
+        changes = [
+            UnifiedChange(
+                source_file="manifest.yaml",
+                tool="kubernetes",
+                resource_id="Deployment/api",
+                action="modify",
+                summary="Kubernetes deployment changed.",
+            )
+        ]
+
+        result = compute_blast_radius(
+            changes, topology, "Topology is stale: last updated more than 30 days ago."
+        )
+
+        self.assertEqual(result.context_state, "stale")
+        self.assertIn("stale_topology", result.context_limitations)
+
+    def test_compute_blast_radius_marks_conflicting_topology_context(self) -> None:
+        topology = {
+            "updated_at": "2026-06-08T12:00:00Z",
+            "metadata": {
+                "import": {
+                    "source_type": "custom",
+                    "source_ref": "topology.json",
+                    "warnings": [],
+                }
+            },
+            "services": [
+                {
+                    "id": "api",
+                    "label": "API Service",
+                    "resource_keys": ["Deployment/api"],
+                    "downstream": [],
+                }
+            ],
+        }
+        changes = [
+            UnifiedChange(
+                source_file="manifest.yaml",
+                tool="kubernetes",
+                resource_id="Deployment/api",
+                action="modify",
+                summary="Kubernetes deployment changed.",
+            )
+        ]
+
+        result = compute_blast_radius(
+            changes, topology, "Topology validation failed because duplicate ids exist."
+        )
+
+        self.assertEqual(result.context_state, "conflicting")
+        self.assertIn("conflicting_topology", result.context_limitations)
 
     def test_compute_blast_radius_ignores_noop_and_read_changes(self) -> None:
         topology = {

--- a/tests/test_api/test_analyses.py
+++ b/tests/test_api/test_analyses.py
@@ -18,7 +18,8 @@ import models.tables as tables_module
 import services.deployment_outcome_service as deployment_outcome_service_module
 import services.project_service as project_service_module
 import services.report_service as report_service_module
-from analysis.blast_radius import BlastRadiusResult
+from analysis.blast_radius import BlastRadiusResult, ImpactNode
+from api.schemas import BlastRadiusData
 from services.analysis_service import AnalysisPersistenceError
 from services.analysis_service import AnalysisRunResult
 from analysis.rollback_planner import RollbackPlan
@@ -367,6 +368,119 @@ class AnalysesApiTests(unittest.TestCase):
         self.assertEqual(payload["data"]["advisory"]["recommendation"], "caution")
         self.assertEqual(payload["data"]["audit"]["llm_provider"], "ollama")
         self.assertEqual(payload["data"]["blast_radius"]["direct_count"], 0)
+
+    def test_blast_radius_api_schema_preserves_topology_context_fields(self) -> None:
+        blast_radius = BlastRadiusData.model_validate(
+            BlastRadiusResult(
+                affected=[
+                    ImpactNode(
+                        service_id="api",
+                        label="API Service",
+                        depth=1,
+                        dependencies=["database"],
+                        owners=["payments"],
+                    )
+                ],
+                direct_count=0,
+                transitive_count=1,
+                context_source={"type": "custom", "ref": "topology.json"},
+                freshness={"updated_at": "2026-06-08T12:00:00Z", "age_days": 1},
+                context_state="current",
+                context_limitations=[],
+            ).model_dump()
+        )
+
+        payload = blast_radius.model_dump()
+        self.assertEqual(payload["affected"][0]["dependencies"], ["database"])
+        self.assertEqual(payload["affected"][0]["owners"], ["payments"])
+        self.assertEqual(
+            payload["context_source"],
+            {"type": "custom", "ref": "topology.json"},
+        )
+        self.assertEqual(
+            payload["freshness"],
+            {"updated_at": "2026-06-08T12:00:00Z", "age_days": 1},
+        )
+        self.assertEqual(payload["context_state"], "current")
+        self.assertEqual(payload["context_limitations"], [])
+
+    def test_blast_radius_api_schema_fills_partial_context_defaults(self) -> None:
+        blast_radius = BlastRadiusData.model_validate(
+            {
+                "affected": [],
+                "direct_count": 0,
+                "transitive_count": 0,
+                "context_source": {"type": "custom"},
+                "freshness": {"updated_at": "2026-06-08T12:00:00Z"},
+            }
+        )
+
+        payload = blast_radius.model_dump()
+        self.assertEqual(payload["context_source"], {"type": "custom", "ref": None})
+        self.assertEqual(
+            payload["freshness"],
+            {"updated_at": "2026-06-08T12:00:00Z", "age_days": None},
+        )
+
+    def test_blast_radius_api_schema_drops_malformed_additive_fields(self) -> None:
+        blast_radius = BlastRadiusData.model_validate(
+            {
+                "affected": [
+                    {
+                        "service_id": "api",
+                        "label": "API Service",
+                        "depth": 0,
+                        "dependencies": None,
+                        "owners": None,
+                    }
+                ],
+                "direct_count": 1,
+                "transitive_count": 0,
+                "context_source": "legacy",
+                "freshness": "unknown",
+                "context_limitations": "legacy",
+            }
+        )
+
+        payload = blast_radius.model_dump()
+        self.assertEqual(payload["affected"][0]["dependencies"], [])
+        self.assertEqual(payload["affected"][0]["owners"], [])
+        self.assertEqual(payload["context_source"], {"type": None, "ref": None})
+        self.assertEqual(payload["freshness"], {"updated_at": None, "age_days": None})
+        self.assertEqual(payload["context_limitations"], [])
+
+    def test_blast_radius_api_schema_drops_malformed_nested_additive_fields(
+        self,
+    ) -> None:
+        blast_radius = BlastRadiusData.model_validate(
+            {
+                "affected": [],
+                "direct_count": 0,
+                "transitive_count": 0,
+                "context_source": {"type": {"kind": "custom"}, "ref": "topology.json"},
+                "freshness": {"updated_at": {"bad": "value"}, "age_days": []},
+                "context_state": {"state": "missing"},
+            }
+        )
+
+        payload = blast_radius.model_dump()
+        self.assertEqual(
+            payload["context_source"], {"type": None, "ref": "topology.json"}
+        )
+        self.assertEqual(payload["freshness"], {"updated_at": None, "age_days": None})
+        self.assertEqual(payload["context_state"], "unknown")
+
+    def test_blast_radius_api_schema_normalizes_null_context_state(self) -> None:
+        blast_radius = BlastRadiusData.model_validate(
+            {
+                "affected": [],
+                "direct_count": 0,
+                "transitive_count": 0,
+                "context_state": None,
+            }
+        )
+
+        self.assertEqual(blast_radius.model_dump()["context_state"], "unknown")
 
     def test_get_analysis_preserves_go_advisory_with_narrative_warning(self) -> None:
         parse_batch = ParseBatchResult(
@@ -1520,6 +1634,19 @@ class AnalysesApiTests(unittest.TestCase):
             payload["data"]["advisory"]["recommendation"],
         )
         self.assertIn("blast_radius", payload["data"]["persisted_report"])
+        self.assertEqual(payload["data"]["blast_radius"]["context_state"], "missing")
+        self.assertIn(
+            "missing_topology",
+            payload["data"]["blast_radius"]["context_limitations"],
+        )
+        self.assertEqual(
+            payload["data"]["blast_radius"]["context_source"],
+            {"type": None, "ref": None},
+        )
+        self.assertEqual(
+            payload["data"]["persisted_report"]["blast_radius"]["context_state"],
+            "missing",
+        )
         self.assertTrue(payload["data"]["persisted_report"]["findings"])
         self.assertTrue(payload["data"]["persisted_report"]["evidence_items"])
         self.assertEqual(

--- a/tests/test_services/test_report_service.py
+++ b/tests/test_services/test_report_service.py
@@ -3799,13 +3799,29 @@ class ReportServiceTests(unittest.TestCase):
         ]
         blast_radius = BlastRadiusResult(
             affected=[
-                ImpactNode(service_id="database", label="Database", depth=0),
-                ImpactNode(service_id="api", label="API Service", depth=1),
+                ImpactNode(
+                    service_id="database",
+                    label="Database",
+                    depth=0,
+                    dependencies=[],
+                    owners=["sre"],
+                ),
+                ImpactNode(
+                    service_id="api",
+                    label="API Service",
+                    depth=1,
+                    dependencies=["database"],
+                    owners=["payments"],
+                ),
             ],
             direct_count=1,
             transitive_count=1,
             warning=None,
             unmatched_resources=[],
+            context_source={"type": "custom", "ref": "topology.json"},
+            freshness={"updated_at": "2026-06-08T12:00:00Z", "age_days": 1},
+            context_state="current",
+            context_limitations=[],
         )
         rollback_plan = RollbackPlan(
             steps=[
@@ -3898,6 +3914,23 @@ class ReportServiceTests(unittest.TestCase):
         self.assertEqual(persisted["skills_applied"], ["git", "terraform"])
         self.assertEqual(persisted["context_completeness"]["context_score"], 0.84)
         self.assertEqual(persisted["blast_radius"]["direct_count"], 1)
+        self.assertEqual(
+            persisted["blast_radius"]["context_source"],
+            {"type": "custom", "ref": "topology.json"},
+        )
+        self.assertEqual(persisted["blast_radius"]["context_state"], "current")
+        self.assertEqual(
+            persisted["blast_radius"]["affected"][0]["owners"],
+            ["sre"],
+        )
+        self.assertEqual(
+            persisted["blast_radius"]["affected"][0]["dependencies"],
+            [],
+        )
+        self.assertEqual(
+            persisted["blast_radius"]["affected"][1]["dependencies"],
+            ["database"],
+        )
         self.assertEqual(persisted["rollback_plan"]["complexity_score"], 3)
         self.assertEqual(len(persisted["incident_matches"]), 1)
         self.assertEqual(

--- a/tests/test_services/test_topology_service.py
+++ b/tests/test_services/test_topology_service.py
@@ -91,6 +91,68 @@ class TopologyServiceTests(unittest.TestCase):
         self.assertIsNone(default_topology)
         self.assertIn("not configured", default_warning)
 
+    def test_save_topology_definition_preserves_service_ownership(self) -> None:
+        project_service_module.create_project(
+            project_key="payments",
+            display_name="Payments",
+        )
+
+        save_topology_definition(
+            json.dumps(
+                {
+                    "services": [
+                        {
+                            "id": "api",
+                            "label": "API",
+                            "resource_keys": ["Deployment/api"],
+                            "downstream": [],
+                            "owner": "payments-team",
+                            "owners": ["sre", "security"],
+                        }
+                    ]
+                }
+            ),
+            project_key="payments",
+        )
+
+        topology, warning = load_topology(project_key="payments")
+
+        self.assertIsNone(warning)
+        assert topology is not None
+        self.assertEqual(topology["services"][0]["owner"], "payments-team")
+        self.assertEqual(topology["services"][0]["owners"], ["sre", "security"])
+
+    def test_save_topology_definition_drops_malformed_singular_owner(self) -> None:
+        project_service_module.create_project(
+            project_key="payments",
+            display_name="Payments",
+        )
+
+        status = save_topology_definition(
+            json.dumps(
+                {
+                    "services": [
+                        {
+                            "id": "api",
+                            "label": "API",
+                            "resource_keys": ["Deployment/api"],
+                            "downstream": [],
+                            "owner": {"team": "payments"},
+                            "owners": ["sre", {"team": "security"}],
+                        }
+                    ]
+                }
+            ),
+            project_key="payments",
+        )
+        topology, warning = load_topology(project_key="payments")
+
+        self.assertTrue(status.warnings)
+        self.assertIn("partially parsed", warning)
+        assert topology is not None
+        self.assertNotIn("owner", topology["services"][0])
+        self.assertEqual(topology["services"][0]["owners"], ["sre"])
+
     def test_topology_imports_are_isolated_by_workspace(self) -> None:
         project_service_module.create_project(
             project_key="payments",
@@ -361,6 +423,84 @@ class TopologyServiceTests(unittest.TestCase):
         self.assertEqual(topology["services"][0]["downstream"], [])
         self.assertIn("partially parsed", warning)
 
+    def test_import_topology_source_records_malformed_singular_owner(self) -> None:
+        project_service_module.create_project(
+            project_key="payments",
+            display_name="Payments",
+        )
+        source_path = Path(self.tempdir.name) / "owner-topology.json"
+        source_path.write_text(
+            json.dumps(
+                {
+                    "services": [
+                        {
+                            "id": "api",
+                            "label": "API",
+                            "resource_keys": ["Deployment/api"],
+                            "downstream": [],
+                            "owner": {"team": "payments"},
+                        }
+                    ]
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        result = import_topology_source(
+            "custom",
+            str(source_path),
+            project_key="payments",
+        )
+        topology, warning = load_topology(project_key="payments")
+
+        self.assertEqual(len(result.partially_parsed_resources), 1)
+        self.assertIn(
+            "Owner label was malformed",
+            result.partially_parsed_resources[0].message,
+        )
+        self.assertIn("partially parsed", warning)
+        assert topology is not None
+        self.assertNotIn("owner", topology["services"][0])
+
+    def test_import_topology_source_records_malformed_owner_entries(self) -> None:
+        project_service_module.create_project(
+            project_key="payments",
+            display_name="Payments",
+        )
+        source_path = Path(self.tempdir.name) / "owner-list-topology.json"
+        source_path.write_text(
+            json.dumps(
+                {
+                    "services": [
+                        {
+                            "id": "api",
+                            "label": "API",
+                            "resource_keys": ["Deployment/api"],
+                            "downstream": [],
+                            "owners": ["sre", {"team": "security"}],
+                        }
+                    ]
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        result = import_topology_source(
+            "custom",
+            str(source_path),
+            project_key="payments",
+        )
+        topology, warning = load_topology(project_key="payments")
+
+        self.assertEqual(len(result.partially_parsed_resources), 1)
+        self.assertIn(
+            "Owner labels were malformed",
+            result.partially_parsed_resources[0].message,
+        )
+        self.assertIn("partially parsed", warning)
+        assert topology is not None
+        self.assertEqual(topology["services"][0]["owners"], ["sre"])
+
     def test_import_topology_source_warns_without_failing_for_unimplemented_source(
         self,
     ) -> None:
@@ -608,6 +748,8 @@ class TopologyServiceTests(unittest.TestCase):
         self.assertIsNone(warning)
         assert topology is not None
         self.assertEqual(topology["services"][0]["id"], "legacy-api")
+        self.assertEqual(topology["metadata"]["import"]["source_type"], "legacy-file")
+        self.assertEqual(topology["metadata"]["import"]["source_ref"], str(legacy_path))
 
     def test_get_topology_status_returns_validation_error_for_malformed_stored_payload(
         self,

--- a/tests/test_ui/test_blast_radius_panel.py
+++ b/tests/test_ui/test_blast_radius_panel.py
@@ -17,16 +17,120 @@ def blast_radius_panel_test_page() -> None:
     render_blast_radius_panel(
         BlastRadiusResult(
             affected=[
-                ImpactNode(service_id="database", label="Primary Database", depth=0),
-                ImpactNode(service_id="api", label="Payments API", depth=1),
-                ImpactNode(service_id="worker", label="Fulfillment Worker", depth=1),
+                ImpactNode(
+                    service_id="database",
+                    label="Primary Database",
+                    depth=0,
+                    dependencies=[],
+                    owners=["sre"],
+                ),
+                ImpactNode(
+                    service_id="api",
+                    label="Payments API",
+                    depth=1,
+                    dependencies=["database"],
+                    owners=["payments"],
+                ),
+                ImpactNode(
+                    service_id="worker",
+                    label="Fulfillment Worker",
+                    depth=1,
+                    dependencies=["database"],
+                    owners=["fulfillment"],
+                ),
             ],
             direct_count=1,
             transitive_count=2,
             warning=None,
             unmatched_resources=[],
+            context_source={"type": "custom", "ref": "topology.json"},
+            freshness={"updated_at": "2026-06-08T12:00:00Z", "age_days": 1},
+            context_state="current",
+            context_limitations=[],
         ),
         severity="high",
+    )
+
+
+@ui.page("/_test/blast-radius-panel-legacy")
+def blast_radius_panel_legacy_test_page() -> None:
+    render_blast_radius_panel(
+        BlastRadiusResult.model_validate(
+            {
+                "affected": [
+                    {
+                        "service_id": "api",
+                        "label": "Payments API",
+                        "depth": 0,
+                    }
+                ],
+                "direct_count": 1,
+                "transitive_count": 0,
+                "warning": None,
+                "unmatched_resources": [],
+            }
+        ),
+        severity="low",
+    )
+
+
+@ui.page("/_test/blast-radius-panel-malformed-freshness")
+def blast_radius_panel_malformed_freshness_test_page() -> None:
+    render_blast_radius_panel(
+        BlastRadiusResult(
+            affected=[],
+            direct_count=0,
+            transitive_count=0,
+            warning=None,
+            unmatched_resources=[],
+            freshness={"updated_at": "unknown", "age_days": "unknown"},
+            context_state="current",
+        ),
+        severity="low",
+    )
+
+
+@ui.page("/_test/blast-radius-panel-malformed-additive-fields")
+def blast_radius_panel_malformed_additive_fields_test_page() -> None:
+    render_blast_radius_panel(
+        BlastRadiusResult.model_validate(
+            {
+                "affected": [
+                    {
+                        "service_id": "api",
+                        "label": "Payments API",
+                        "depth": 0,
+                        "dependencies": None,
+                        "owners": None,
+                    }
+                ],
+                "direct_count": 1,
+                "transitive_count": 0,
+                "warning": None,
+                "unmatched_resources": [],
+                "context_source": {"type": {"kind": "custom"}, "ref": "topology.json"},
+                "freshness": {"updated_at": {"bad": "value"}, "age_days": []},
+                "context_state": {"state": "missing"},
+                "context_limitations": "legacy",
+            }
+        ),
+        severity="low",
+    )
+
+
+@ui.page("/_test/blast-radius-panel-negative-freshness")
+def blast_radius_panel_negative_freshness_test_page() -> None:
+    render_blast_radius_panel(
+        BlastRadiusResult(
+            affected=[],
+            direct_count=0,
+            transitive_count=0,
+            warning=None,
+            unmatched_resources=[],
+            freshness={"updated_at": "2026-06-08T12:00:00Z", "age_days": -3},
+            context_state="current",
+        ),
+        severity="low",
     )
 
 
@@ -59,7 +163,43 @@ class BlastRadiusPanelRenderingTests(unittest.TestCase):
         self.assertIn("Primary Database", response.text)
         self.assertIn("Payments API", response.text)
         self.assertIn("Fulfillment Worker", response.text)
+        self.assertIn("Owner: sre", response.text)
+        self.assertIn("Depends on: database", response.text)
+        self.assertIn("Topology source: custom · topology.json", response.text)
+        self.assertIn("Topology freshness: 1 day old", response.text)
         self.assertIn("plotly", response.text.lower())
+
+    def test_blast_radius_panel_does_not_mark_legacy_payload_missing(
+        self,
+    ) -> None:
+        response = self.client.get("/_test/blast-radius-panel-legacy")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("Payments API", response.text)
+        self.assertNotIn("Topology context: missing", response.text)
+
+    def test_blast_radius_panel_handles_malformed_freshness(self) -> None:
+        response = self.client.get("/_test/blast-radius-panel-malformed-freshness")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("Topology freshness: unknown", response.text)
+
+    def test_blast_radius_panel_handles_malformed_additive_fields(self) -> None:
+        response = self.client.get(
+            "/_test/blast-radius-panel-malformed-additive-fields"
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("Payments API", response.text)
+        self.assertIn("Topology source: unknown", response.text)
+        self.assertIn("Topology freshness: unknown", response.text)
+
+    def test_blast_radius_panel_handles_negative_freshness(self) -> None:
+        response = self.client.get("/_test/blast-radius-panel-negative-freshness")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("Topology freshness: unknown", response.text)
+        self.assertNotIn("-3 days old", response.text)
 
     def test_blast_radius_panel_uses_warning_text_for_incomplete_empty_state(
         self,

--- a/ui/components/blast_radius_graph.py
+++ b/ui/components/blast_radius_graph.py
@@ -96,6 +96,40 @@ def _plotly_figure(result: BlastRadiusResult, *, severity: str) -> dict:
     }
 
 
+def _freshness_text(result: BlastRadiusResult) -> str:
+    age_days = result.freshness.get("age_days")
+    if age_days is None:
+        return "Topology freshness: unknown"
+    try:
+        days = int(age_days)
+    except (TypeError, ValueError):
+        return "Topology freshness: unknown"
+    if days < 0:
+        return "Topology freshness: unknown"
+    if days == 0:
+        return "Topology freshness: updated today"
+    unit = "day" if days == 1 else "days"
+    return f"Topology freshness: {days} {unit} old"
+
+
+def _source_text(result: BlastRadiusResult) -> str:
+    source_type = result.context_source.get("type") or "unknown"
+    source_ref = result.context_source.get("ref")
+    if source_ref:
+        return f"Topology source: {source_type} · {source_ref}"
+    return f"Topology source: {source_type}"
+
+
+def _node_context_text(node) -> str:
+    parts = [node.label]
+    if node.owners:
+        owner_label = "Owners" if len(node.owners) > 1 else "Owner"
+        parts.append(f"{owner_label}: {', '.join(node.owners)}")
+    if node.dependencies:
+        parts.append(f"Depends on: {', '.join(node.dependencies)}")
+    return " · ".join(parts)
+
+
 def render_blast_radius_panel(result: BlastRadiusResult, *, severity: str) -> None:
     """Render a blast-radius graph plus textual equivalent."""
     register_review_accessibility()
@@ -117,3 +151,13 @@ def render_blast_radius_panel(result: BlastRadiusResult, *, severity: str) -> No
         with ui.column().classes("w-full gap-1 mt-2"):
             ui.label("Text equivalent").classes("text-xs font-semibold dw-muted")
             ui.label(direct_text).classes("text-sm dw-text")
+            ui.label(_source_text(result)).classes("text-xs dw-muted")
+            ui.label(_freshness_text(result)).classes("text-xs dw-muted")
+            if result.context_state and result.context_state != "current":
+                ui.label(f"Topology context: {result.context_state}").classes(
+                    "text-xs dw-warning-text"
+                )
+            for node in sorted(
+                result.affected, key=lambda item: (item.depth, item.label)
+            ):
+                ui.label(_node_context_text(node)).classes("text-sm dw-text")


### PR DESCRIPTION
Story 7.1 enriches blast-radius output with project-scoped topology source, freshness, context-state limitations, service ownership, and upstream dependency metadata so reviewers can judge impact from explicit context instead of opaque graph counts.

It also hardens legacy persisted payload loading so malformed additive fields and null context state do not break API/UI report rendering or contradict the documented unknown-state contract.

Constraint: Preserve local-first advisory reporting while reusing existing analysis, API, service, and NiceGUI report paths.
Rejected: Add a separate topology report model | would duplicate shared blast-radius semantics across API/UI/persistence.
Confidence: high
Scope-risk: moderate
Directive: Keep topology context normalization backward-compatible for legacy persisted blast_radius payloads.
Tested: Focused schema regressions (21 tests); direct model repro unknown/unknown; impacted analysis/API/report/docs/UI suites (101 tests); full unittest discover (472 tests, 1 skipped); Ruff check; Ruff format check; git diff --check; py_compile; Bandit on touched production files; APP_PORT=18109 npm run test:ui-review (4 passed)
Not-tested: VoiceOver screen-reader lane

## What does this PR do?

<!-- Brief description of changes -->

## Type of change
- [ ] Feature (new functionality)
- [ ] Bugfix (non-breaking fix)
- [ ] Release preparation
- [ ] Hotfix (critical production fix)
- [ ] Docs / refactor / chore

## Checklist
- [ ] I have followed the branch naming convention
- [ ] Tests pass locally (`pytest tests/ -v`)
- [ ] Linting passes (`ruff check .`)
- [ ] Docker build succeeds
- [ ] I have updated docs if needed
- [ ] No secrets or .env values committed

## Related issue
Closes #