### PR TITLE
Add Terraform state topology connector

### DIFF
--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -111,7 +111,7 @@ development_status:
 
   epic-7: in-progress
   7-1-project-scoped-topology-context: review
-  7-2-terraform-state-connector: ready-for-dev
+  7-2-terraform-state-connector: done
   7-3-kubernetes-live-state-connector: ready-for-dev
   7-4-codeowners-and-ownership-mapping: ready-for-dev
   7-5-context-graph-and-freshness-ledger: ready-for-dev

--- a/docs/project-workspaces.md
+++ b/docs/project-workspaces.md
@@ -40,7 +40,7 @@ For setup-specific modeling guidance, see the [Project Model Guide](./concepts/p
   - `deploywhisper project workspace list <project-key>`
   - `deploywhisper analyze --project <key> [--workspace <workspace>] <artifact...>` or `deploywhisper analyze --project-id <id> [--workspace-id <id>] <artifact...>` returns the same submit advisory JSON contract, including verdict, Evidence Law status, top findings, uncertainty, report schema version, and advisory posture.
   - `deploywhisper topology import --from custom --source <topology.json> --project <key>`
-  - `deploywhisper topology import --from terraform --source <state-or-uri> --project <key>`
+  - `deploywhisper topology import --from terraform --source <terraform.tfstate> --project <key>`
   - The topology import command now routes through a shared source registry and returns a normalized import result with accepted, skipped, partially parsed, and unsupported resources.
   - Project, analysis, topology import, and outcome record commands can read `DEPLOYWHISPER_PROJECT_ROLE` and `DEPLOYWHISPER_PROJECT_KEYS` for automation actors that need the same lightweight authorization behavior as API callers.
 - GitHub App integration: respects `DEPLOYWHISPER_GITHUB_PROJECT_KEY` when set; otherwise derives an owner-safe default from the full repository slug and creates it on demand. Unknown, malformed, or blank explicit override values fail fast instead of falling back to the repository-derived default.

--- a/docs/terraform-state-connector.md
+++ b/docs/terraform-state-connector.md
@@ -1,0 +1,32 @@
+## Terraform State Connector
+
+DeployWhisper can import a local Terraform state file as read-only topology context for a project or workspace. The connector normalizes managed resources and dependency edges into the same project-scoped topology graph used by blast-radius and context-completeness analysis.
+
+### Import
+
+Use a local `terraform.tfstate` file:
+
+```bash
+deploywhisper topology import --from terraform --source ./terraform.tfstate --project payments
+```
+
+For workspace-scoped context:
+
+```bash
+deploywhisper topology import --from terraform --source ./terraform.tfstate --project payments --workspace prod
+```
+
+The import stores normalized resource identities and relationships only. Raw Terraform state JSON and full resource attributes are not persisted.
+
+### What Is Mapped
+
+- Managed Terraform resources become topology services keyed by Terraform address, such as `aws_db_instance.primary`.
+- Resource keys include the Terraform address and stable identity fields when present, including `id`, `arn`, `name`, `resource_id`, and `self_link`.
+- Terraform state dependencies are reversed into downstream topology edges so a change to a dependency can surface dependent resources in blast-radius analysis.
+- Terraform data sources are skipped because they are not managed infrastructure resources.
+
+### Degraded States
+
+Missing, unreadable, malformed, or structurally incomplete state files return explicit import warnings and do not replace active topology context. Stale local state files still import, but the resulting context carries a warning so analysis remains deterministic while surfacing freshness limits.
+
+The connector does not contact Terraform Cloud, object storage, or provider APIs. Remote state retrieval should happen outside DeployWhisper and pass a local read-only state snapshot into the import command.

--- a/services/topology_service.py
+++ b/services/topology_service.py
@@ -732,6 +732,263 @@ def _parse_custom_source(source_ref: str) -> TopologyChangeSet:
     return _build_custom_change_set(payload)
 
 
+def _terraform_state_unavailable_change_set(
+    source_ref: str, message: str
+) -> TopologyChangeSet:
+    return TopologyChangeSet(
+        operation="noop",
+        warnings=[message],
+        unsupported_resources=[
+            TopologyImportResource(
+                resource_ref=source_ref,
+                message=message,
+            )
+        ],
+    )
+
+
+def _terraform_state_resource_address(resource: dict[str, Any]) -> str:
+    address = str(resource.get("address") or "").strip()
+    if address:
+        return address
+    resource_type = str(resource.get("type") or "").strip()
+    resource_name = str(resource.get("name") or "").strip()
+    if not resource_type or not resource_name:
+        return ""
+    prefix = str(resource.get("module") or "").strip()
+    if str(resource.get("mode") or "").strip() == "data":
+        resource_ref = f"data.{resource_type}.{resource_name}"
+    else:
+        resource_ref = f"{resource_type}.{resource_name}"
+    if prefix:
+        return f"{prefix}.{resource_ref}"
+    return resource_ref
+
+
+def _terraform_state_identity_keys(
+    address: str, resource: dict[str, Any], instances: list[Any]
+) -> list[str]:
+    keys = [address]
+    for field in ("provider", "type"):
+        value = str(resource.get(field) or "").strip()
+        if value:
+            keys.append(value)
+    for instance in instances:
+        if not isinstance(instance, dict):
+            continue
+        index_key = instance.get("index_key")
+        if index_key is not None:
+            if isinstance(index_key, str):
+                keys.append(f"{address}[{json.dumps(index_key)}]")
+            else:
+                keys.append(f"{address}[{index_key}]")
+        attributes = instance.get("attributes")
+        if not isinstance(attributes, dict):
+            continue
+        for field in ("id", "arn", "name", "resource_id", "self_link"):
+            value = attributes.get(field)
+            if isinstance(value, str) and value.strip():
+                keys.append(value.strip())
+    seen: set[str] = set()
+    unique: list[str] = []
+    for key in keys:
+        if key in seen:
+            continue
+        seen.add(key)
+        unique.append(key)
+    return unique
+
+
+def _terraform_state_dependency_refs(instances: list[Any]) -> list[str]:
+    dependencies: list[str] = []
+    for instance in instances:
+        if not isinstance(instance, dict):
+            continue
+        raw_dependencies = instance.get("dependencies", [])
+        if not isinstance(raw_dependencies, list):
+            continue
+        for dependency in raw_dependencies:
+            dependency_ref = str(dependency or "").strip()
+            if dependency_ref:
+                dependencies.append(dependency_ref)
+    return sorted(set(dependencies))
+
+
+def _terraform_state_staleness_warning(path: Path) -> str | None:
+    try:
+        modified_at = datetime.fromtimestamp(path.stat().st_mtime, UTC)
+    except OSError:
+        return None
+    if datetime.now(UTC) - modified_at <= timedelta(days=STALE_AFTER_DAYS):
+        return None
+    return f"Terraform state context is stale — state file was last modified more than {STALE_AFTER_DAYS} days ago."
+
+
+def _parse_terraform_state_source(source_ref: str) -> TopologyChangeSet:
+    path = Path(source_ref)
+    if not path.is_file():
+        return _terraform_state_unavailable_change_set(
+            source_ref,
+            "Terraform state context is unavailable because the source is not a readable local state file; no topology changes were applied.",
+        )
+    try:
+        raw_text = path.read_text(encoding="utf-8")
+    except OSError:
+        return _terraform_state_unavailable_change_set(
+            source_ref,
+            "Terraform state context is unavailable; no topology changes were applied.",
+        )
+    try:
+        payload = json.loads(raw_text)
+    except JSONDecodeError:
+        return _terraform_state_unavailable_change_set(
+            source_ref,
+            "Terraform state context is unavailable because the state file is not valid JSON; no topology changes were applied.",
+        )
+    if not isinstance(payload, dict):
+        return _terraform_state_unavailable_change_set(
+            source_ref,
+            "Terraform state context is unavailable because the state file is not a JSON object; no topology changes were applied.",
+        )
+    if "resources" not in payload:
+        return _terraform_state_unavailable_change_set(
+            source_ref,
+            "Terraform state context is unavailable because resources are missing; no topology changes were applied.",
+        )
+    resources_raw = payload.get("resources")
+    if not isinstance(resources_raw, list):
+        return _terraform_state_unavailable_change_set(
+            source_ref,
+            "Terraform state context is unavailable because resources are missing or malformed; no topology changes were applied.",
+        )
+
+    warnings: list[str] = []
+    stale_warning = _terraform_state_staleness_warning(path)
+    if stale_warning:
+        warnings.append(stale_warning)
+    services_by_id: dict[str, dict[str, Any]] = {}
+    dependency_refs_by_service: dict[str, list[str]] = {}
+    accepted_resources: list[TopologyImportResource] = []
+    partially_parsed_resources: list[TopologyImportResource] = []
+    skipped_resources: list[TopologyImportResource] = []
+
+    for index, resource in enumerate(resources_raw, start=1):
+        resource_ref = f"resources[{index}]"
+        if not isinstance(resource, dict):
+            partially_parsed_resources.append(
+                TopologyImportResource(
+                    resource_ref=resource_ref,
+                    message="Terraform state resource entry was not a JSON object and was ignored.",
+                )
+            )
+            continue
+        if str(resource.get("mode") or "managed").strip() == "data":
+            skipped_resources.append(
+                TopologyImportResource(
+                    resource_ref=_terraform_state_resource_address(resource)
+                    or resource_ref,
+                    message="Terraform data source was skipped because it is not a managed infrastructure resource.",
+                )
+            )
+            continue
+        address = _terraform_state_resource_address(resource)
+        if not address:
+            partially_parsed_resources.append(
+                TopologyImportResource(
+                    resource_ref=resource_ref,
+                    message="Terraform state resource is missing type/name identity and was ignored.",
+                )
+            )
+            continue
+        if address in services_by_id:
+            skipped_resources.append(
+                TopologyImportResource(
+                    resource_ref=address,
+                    service_id=address,
+                    message="Duplicate Terraform state resource address was skipped.",
+                )
+            )
+            continue
+        instances = resource.get("instances", [])
+        if not isinstance(instances, list):
+            partially_parsed_resources.append(
+                TopologyImportResource(
+                    resource_ref=address,
+                    service_id=address,
+                    message="Terraform state resource instances were malformed and were ignored.",
+                )
+            )
+            instances = []
+        resource_keys = _terraform_state_identity_keys(address, resource, instances)
+        services_by_id[address] = {
+            "id": address,
+            "label": address,
+            "resource_keys": resource_keys,
+            "downstream": [],
+        }
+        dependency_refs_by_service[address] = _terraform_state_dependency_refs(
+            instances
+        )
+        accepted_resources.append(
+            TopologyImportResource(
+                resource_ref=address,
+                service_id=address,
+                message="Terraform state resource was mapped into the topology graph.",
+            )
+        )
+
+    service_ids = set(services_by_id)
+    for service_id, dependency_refs in dependency_refs_by_service.items():
+        for dependency_ref in dependency_refs:
+            if dependency_ref not in service_ids:
+                partially_parsed_resources.append(
+                    TopologyImportResource(
+                        resource_ref=f"{service_id}->{dependency_ref}",
+                        service_id=service_id,
+                        message=(
+                            f"Terraform dependency '{dependency_ref}' could not be resolved "
+                            "inside the state and was dropped."
+                        ),
+                    )
+                )
+                continue
+            services_by_id[dependency_ref]["downstream"].append(service_id)
+
+    services = []
+    for service_id in sorted(services_by_id):
+        service = dict(services_by_id[service_id])
+        service["downstream"] = sorted(set(service["downstream"]))
+        services.append(service)
+
+    if partially_parsed_resources:
+        warnings.append(
+            "Terraform state import partially parsed one or more resources; malformed entries or unresolved relationships were skipped."
+        )
+    if skipped_resources:
+        warnings.append(
+            "Terraform state import skipped data sources or duplicate resources while preserving managed infrastructure context."
+        )
+    if not accepted_resources and resources_raw:
+        warnings.append(
+            "Terraform state import did not produce any valid managed resources to apply."
+        )
+        return TopologyChangeSet(
+            operation="noop",
+            warnings=warnings,
+            skipped_resources=skipped_resources,
+            partially_parsed_resources=partially_parsed_resources,
+        )
+
+    return TopologyChangeSet(
+        operation="replace",
+        services=services,
+        warnings=warnings,
+        accepted_resources=accepted_resources,
+        skipped_resources=skipped_resources,
+        partially_parsed_resources=partially_parsed_resources,
+    )
+
+
 def _build_custom_change_set(payload: dict[str, Any]) -> TopologyChangeSet:
     services_raw = payload.get("services", [])
     if not isinstance(services_raw, list):
@@ -931,7 +1188,7 @@ def _build_unimplemented_source_handler(source_type: str) -> TopologySourceHandl
 
 TOPOLOGY_SOURCE_REGISTRY: dict[str, TopologySourceHandler] = {
     "custom": _parse_custom_source,
-    "terraform": _build_unimplemented_source_handler("terraform"),
+    "terraform": _parse_terraform_state_source,
     "cloudformation": _build_unimplemented_source_handler("cloudformation"),
     "kubernetes": _build_unimplemented_source_handler("kubernetes"),
     "ansible": _build_unimplemented_source_handler("ansible"),

--- a/services/topology_service.py
+++ b/services/topology_service.py
@@ -937,10 +937,15 @@ def _parse_terraform_state_source(source_ref: str) -> TopologyChangeSet:
             )
         )
 
-    service_ids = set(services_by_id)
+    resource_key_to_service_id = {
+        resource_key: service_id
+        for service_id, service in services_by_id.items()
+        for resource_key in service["resource_keys"]
+    }
     for service_id, dependency_refs in dependency_refs_by_service.items():
         for dependency_ref in dependency_refs:
-            if dependency_ref not in service_ids:
+            dependency_service_id = resource_key_to_service_id.get(dependency_ref)
+            if dependency_service_id is None:
                 partially_parsed_resources.append(
                     TopologyImportResource(
                         resource_ref=f"{service_id}->{dependency_ref}",
@@ -952,7 +957,7 @@ def _parse_terraform_state_source(source_ref: str) -> TopologyChangeSet:
                     )
                 )
                 continue
-            services_by_id[dependency_ref]["downstream"].append(service_id)
+            services_by_id[dependency_service_id]["downstream"].append(service_id)
 
     services = []
     for service_id in sorted(services_by_id):

--- a/tests/test_services/test_topology_service.py
+++ b/tests/test_services/test_topology_service.py
@@ -17,7 +17,9 @@ import models.database as database_module
 import models.tables as tables_module
 import services.project_service as project_service_module
 import services.settings_service as settings_service_module
+from analysis.blast_radius import compute_blast_radius
 from models.database import SessionLocal
+from parsers.base import UnifiedChange
 from services.topology_service import (
     check_topology_drift,
     get_topology_status,
@@ -523,6 +525,265 @@ class TopologyServiceTests(unittest.TestCase):
         self.assertIn("terraform", result.warnings[0].lower())
         self.assertIsNone(topology)
         self.assertIn("not configured", warning)
+
+    def test_import_topology_source_reads_terraform_state_relationships(self) -> None:
+        project_service_module.create_project(
+            project_key="payments",
+            display_name="Payments",
+        )
+        state_path = Path(self.tempdir.name) / "terraform.tfstate"
+        state_path.write_text(
+            json.dumps(
+                {
+                    "version": 4,
+                    "terraform_version": "1.8.5",
+                    "serial": 42,
+                    "lineage": "state-lineage",
+                    "resources": [
+                        {
+                            "mode": "managed",
+                            "type": "aws_db_instance",
+                            "name": "primary",
+                            "provider": 'provider["registry.terraform.io/hashicorp/aws"]',
+                            "instances": [
+                                {
+                                    "attributes": {
+                                        "id": "db-123",
+                                        "arn": "arn:aws:rds:us-east-1:111122223333:db:primary",
+                                    }
+                                }
+                            ],
+                        },
+                        {
+                            "mode": "managed",
+                            "type": "aws_ecs_service",
+                            "name": "api",
+                            "instances": [
+                                {
+                                    "dependencies": ["aws_db_instance.primary"],
+                                    "attributes": {"id": "svc-123", "name": "api"},
+                                }
+                            ],
+                        },
+                    ],
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        result = import_topology_source(
+            "terraform",
+            str(state_path),
+            project_key="payments",
+        )
+        topology, warning = load_topology(project_key="payments")
+
+        self.assertTrue(result.applied)
+        self.assertEqual(
+            sorted(result.diff.added_services),
+            ["aws_db_instance.primary", "aws_ecs_service.api"],
+        )
+        self.assertIsNone(warning)
+        assert topology is not None
+        service_by_id = {service["id"]: service for service in topology["services"]}
+        self.assertEqual(
+            service_by_id["aws_db_instance.primary"]["downstream"],
+            ["aws_ecs_service.api"],
+        )
+        self.assertIn(
+            "arn:aws:rds:us-east-1:111122223333:db:primary",
+            service_by_id["aws_db_instance.primary"]["resource_keys"],
+        )
+        self.assertIn(
+            "aws_db_instance.primary",
+            service_by_id["aws_db_instance.primary"]["resource_keys"],
+        )
+        self.assertEqual(
+            topology["metadata"]["import"]["source_type"],
+            "terraform",
+        )
+        blast_radius = compute_blast_radius(
+            [
+                UnifiedChange(
+                    source_file="plan.json",
+                    tool="terraform",
+                    resource_id="aws_db_instance.primary",
+                    action="modify",
+                    summary="Terraform changed the database.",
+                )
+            ],
+            topology,
+            warning,
+        )
+        self.assertEqual(blast_radius.context_source["type"], "terraform")
+        self.assertEqual(blast_radius.direct_count, 1)
+        self.assertEqual(blast_radius.transitive_count, 1)
+        self.assertEqual(
+            [node.service_id for node in blast_radius.affected],
+            ["aws_db_instance.primary", "aws_ecs_service.api"],
+        )
+
+    def test_import_topology_source_warns_without_failing_for_missing_terraform_state(
+        self,
+    ) -> None:
+        project_service_module.create_project(
+            project_key="payments",
+            display_name="Payments",
+        )
+        missing_path = Path(self.tempdir.name) / "missing.tfstate"
+
+        result = import_topology_source(
+            "terraform",
+            str(missing_path),
+            project_key="payments",
+        )
+        topology, warning = load_topology(project_key="payments")
+
+        self.assertFalse(result.applied)
+        self.assertEqual(result.accepted_resources, [])
+        self.assertIn("unavailable", " ".join(result.warnings).lower())
+        self.assertIsNone(topology)
+        self.assertIn("not configured", warning)
+
+    def test_import_topology_source_warns_without_replacing_for_missing_resources(
+        self,
+    ) -> None:
+        project_service_module.create_project(
+            project_key="payments",
+            display_name="Payments",
+        )
+        source_path = Path(self.tempdir.name) / "baseline-topology.json"
+        source_path.write_text(
+            json.dumps(
+                {
+                    "services": [
+                        {
+                            "id": "api",
+                            "label": "API",
+                            "resource_keys": ["aws_ecs_service.api"],
+                            "downstream": [],
+                        }
+                    ]
+                }
+            ),
+            encoding="utf-8",
+        )
+        import_topology_source("custom", str(source_path), project_key="payments")
+        state_path = Path(self.tempdir.name) / "malformed.tfstate"
+        state_path.write_text(
+            json.dumps({"version": 4, "serial": 1}),
+            encoding="utf-8",
+        )
+
+        result = import_topology_source(
+            "terraform",
+            str(state_path),
+            project_key="payments",
+        )
+        topology, warning = load_topology(project_key="payments")
+
+        self.assertFalse(result.applied)
+        self.assertIn("resources", " ".join(result.warnings).lower())
+        assert topology is not None
+        self.assertEqual(
+            [service["id"] for service in topology["services"]],
+            ["api"],
+        )
+        self.assertIsNone(warning)
+
+    def test_import_topology_source_matches_for_each_plan_addresses(self) -> None:
+        project_service_module.create_project(
+            project_key="payments",
+            display_name="Payments",
+        )
+        state_path = Path(self.tempdir.name) / "foreach.tfstate"
+        state_path.write_text(
+            json.dumps(
+                {
+                    "version": 4,
+                    "serial": 1,
+                    "resources": [
+                        {
+                            "mode": "managed",
+                            "type": "aws_instance",
+                            "name": "web",
+                            "instances": [
+                                {
+                                    "index_key": "blue",
+                                    "attributes": {"id": "i-blue"},
+                                }
+                            ],
+                        }
+                    ],
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        result = import_topology_source(
+            "terraform",
+            str(state_path),
+            project_key="payments",
+        )
+        topology, warning = load_topology(project_key="payments")
+
+        self.assertTrue(result.applied)
+        assert topology is not None
+        service = topology["services"][0]
+        self.assertIn('aws_instance.web["blue"]', service["resource_keys"])
+        blast_radius = compute_blast_radius(
+            [
+                UnifiedChange(
+                    source_file="plan.json",
+                    tool="terraform",
+                    resource_id='aws_instance.web["blue"]',
+                    action="modify",
+                    summary="Terraform changed an indexed instance.",
+                )
+            ],
+            topology,
+            warning,
+        )
+        self.assertEqual(blast_radius.direct_count, 1)
+        self.assertEqual(blast_radius.unmatched_resources, [])
+
+    def test_import_topology_source_warns_for_stale_terraform_state(self) -> None:
+        project_service_module.create_project(
+            project_key="payments",
+            display_name="Payments",
+        )
+        state_path = Path(self.tempdir.name) / "stale.tfstate"
+        state_path.write_text(
+            json.dumps(
+                {
+                    "version": 4,
+                    "serial": 1,
+                    "resources": [
+                        {
+                            "mode": "managed",
+                            "type": "aws_lambda_function",
+                            "name": "worker",
+                            "instances": [{"attributes": {"id": "worker"}}],
+                        }
+                    ],
+                }
+            ),
+            encoding="utf-8",
+        )
+        stale_timestamp = datetime(2025, 1, 1, tzinfo=UTC).timestamp()
+        os.utime(state_path, (stale_timestamp, stale_timestamp))
+
+        result = import_topology_source(
+            "terraform",
+            str(state_path),
+            project_key="payments",
+        )
+        topology, warning = load_topology(project_key="payments")
+
+        self.assertTrue(result.applied)
+        self.assertIn("stale", " ".join(result.warnings).lower())
+        self.assertIsNotNone(topology)
+        self.assertIn("stale", warning)
 
     def test_check_topology_drift_reports_added_removed_and_modified_resources(
         self,

--- a/tests/test_services/test_topology_service.py
+++ b/tests/test_services/test_topology_service.py
@@ -747,6 +747,82 @@ class TopologyServiceTests(unittest.TestCase):
         self.assertEqual(blast_radius.direct_count, 1)
         self.assertEqual(blast_radius.unmatched_resources, [])
 
+    def test_import_topology_source_resolves_indexed_dependency_refs(self) -> None:
+        project_service_module.create_project(
+            project_key="payments",
+            display_name="Payments",
+        )
+        state_path = Path(self.tempdir.name) / "indexed-dependency.tfstate"
+        state_path.write_text(
+            json.dumps(
+                {
+                    "version": 4,
+                    "serial": 1,
+                    "resources": [
+                        {
+                            "mode": "managed",
+                            "type": "aws_db_instance",
+                            "name": "primary",
+                            "instances": [
+                                {
+                                    "index_key": "blue",
+                                    "attributes": {"id": "db-blue"},
+                                }
+                            ],
+                        },
+                        {
+                            "mode": "managed",
+                            "type": "aws_ecs_service",
+                            "name": "api",
+                            "instances": [
+                                {
+                                    "dependencies": ['aws_db_instance.primary["blue"]'],
+                                    "attributes": {"id": "svc-api"},
+                                }
+                            ],
+                        },
+                    ],
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        result = import_topology_source(
+            "terraform",
+            str(state_path),
+            project_key="payments",
+        )
+        topology, warning = load_topology(project_key="payments")
+
+        self.assertTrue(result.applied)
+        self.assertEqual(result.partially_parsed_resources, [])
+        self.assertIsNone(warning)
+        assert topology is not None
+        service_by_id = {service["id"]: service for service in topology["services"]}
+        self.assertEqual(
+            service_by_id["aws_db_instance.primary"]["downstream"],
+            ["aws_ecs_service.api"],
+        )
+        blast_radius = compute_blast_radius(
+            [
+                UnifiedChange(
+                    source_file="plan.json",
+                    tool="terraform",
+                    resource_id='aws_db_instance.primary["blue"]',
+                    action="modify",
+                    summary="Terraform changed an indexed database.",
+                )
+            ],
+            topology,
+            warning,
+        )
+        self.assertEqual(blast_radius.direct_count, 1)
+        self.assertEqual(blast_radius.transitive_count, 1)
+        self.assertEqual(
+            [node.service_id for node in blast_radius.affected],
+            ["aws_db_instance.primary", "aws_ecs_service.api"],
+        )
+
     def test_import_topology_source_warns_for_stale_terraform_state(self) -> None:
         project_service_module.create_project(
             project_key="payments",


### PR DESCRIPTION
## Summary
- add a read-only local Terraform state connector for topology imports
- map managed resources, identity keys, and dependency edges into blast-radius context
- handle unavailable/malformed/stale state without blocking deterministic analysis
- fix review findings for missing resources and for_each plan-address matching

## Validation
- ./.venv/bin/python -m unittest tests.test_services.test_topology_service -q
- ./.venv/bin/ruff check .
- ./.venv/bin/ruff format --check .
- ./.venv/bin/python -m unittest discover -q
- bash scripts/ci-local.sh

UI validation not applicable: no UI route/component/browser behavior changed.