### PR TITLE
Story 7.3: Kubernetes live-state connector

### DIFF
--- a/README.md
+++ b/README.md
@@ -527,6 +527,7 @@ Project documentation currently lives in a few places:
 - [Implementation Readiness Report](./_bmad-output/planning-artifacts/implementation-readiness-report-2026-05-01.md)
 - [Project Model Guide](./docs/concepts/project-model.md)
 - [Project Workspaces](./docs/project-workspaces.md)
+- [Kubernetes Live-State Connector](./docs/kubernetes-live-state-connector.md)
 - [Evidence Model Foundation](./docs/evidence-model.md)
 - [CI Guide](./docs/ci.md)
 - [CI Secrets Checklist](./docs/ci-secrets-checklist.md)

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -1,5 +1,5 @@
 # generated: 2026-05-01
-# last_updated: 2026-06-09
+# last_updated: 2026-06-10
 # project: deploywhisper
 # project_key: NOKEY
 # tracking_system: file-system
@@ -35,7 +35,7 @@
 # - Dev moves story to review, then runs code-review
 
 generated: 2026-05-01
-last_updated: 2026-06-09
+last_updated: 2026-06-10
 project: deploywhisper
 project_key: NOKEY
 tracking_system: file-system
@@ -112,7 +112,7 @@ development_status:
   epic-7: in-progress
   7-1-project-scoped-topology-context: review
   7-2-terraform-state-connector: done
-  7-3-kubernetes-live-state-connector: ready-for-dev
+  7-3-kubernetes-live-state-connector: done
   7-4-codeowners-and-ownership-mapping: ready-for-dev
   7-5-context-graph-and-freshness-ledger: ready-for-dev
   epic-7-retrospective: optional

--- a/analysis/blast_radius.py
+++ b/analysis/blast_radius.py
@@ -310,6 +310,38 @@ def _service_resource_keys(service: dict) -> list[str]:
     ]
 
 
+def _change_resource_ids(change: UnifiedChange) -> list[str]:
+    resource_ids = [change.resource_id]
+    aliases = change.metadata.get("resource_aliases", [])
+    if isinstance(aliases, list):
+        resource_ids.extend(str(alias).strip() for alias in aliases)
+    seen: set[str] = set()
+    unique: list[str] = []
+    for resource_id in resource_ids:
+        if not resource_id or resource_id in seen:
+            continue
+        seen.add(resource_id)
+        unique.append(resource_id)
+    return unique
+
+
+def _matched_service_ids_for_change(
+    change: UnifiedChange,
+    resource_to_service_ids: dict[str, list[str]],
+) -> list[str]:
+    exact_matches = resource_to_service_ids.get(change.resource_id, [])
+    if exact_matches:
+        return exact_matches
+
+    alias_matches: list[str] = []
+    for resource_id in _change_resource_ids(change)[1:]:
+        alias_matches.extend(resource_to_service_ids.get(resource_id, []))
+    unique_alias_matches = sorted(set(alias_matches))
+    if len(unique_alias_matches) == 1:
+        return unique_alias_matches
+    return []
+
+
 def compute_blast_radius(
     changes: list[UnifiedChange],
     topology: dict | None,
@@ -385,7 +417,9 @@ def compute_blast_radius(
     unmatched_resources: list[str] = []
 
     for change in mutating_changes:
-        matched_service_ids = resource_to_service_ids.get(change.resource_id, [])
+        matched_service_ids = _matched_service_ids_for_change(
+            change, resource_to_service_ids
+        )
         if not matched_service_ids:
             unmatched_resources.append(change.resource_id)
         for service_id in matched_service_ids:

--- a/docs/kubernetes-live-state-connector.md
+++ b/docs/kubernetes-live-state-connector.md
@@ -1,0 +1,41 @@
+## Kubernetes Live-State Connector
+
+DeployWhisper can import optional read-only Kubernetes live-state context for a project or workspace. The connector shells out to the local `kubectl` already configured by the operator, reads supported object summaries, and normalizes them into the same topology graph used by blast-radius and context-completeness analysis.
+
+### Import
+
+Use the active Kubernetes context:
+
+```bash
+deploywhisper topology import --from kubernetes --source current-context --project payments
+```
+
+Use a named Kubernetes context:
+
+```bash
+deploywhisper topology import --from kubernetes --source context:prod-cluster --project payments
+```
+
+For workspace-scoped context:
+
+```bash
+deploywhisper topology import --from kubernetes --source context:prod-cluster --project payments --workspace prod
+```
+
+The import stores normalized object identities, namespace relationships, service selectors, and workload-to-service edges only. Raw Kubernetes API output, full object metadata, and `managedFields` are not persisted.
+
+### What Is Mapped
+
+- Namespaces become topology services keyed as `Namespace/<name>`.
+- Workloads become topology services keyed as `Deployment/<namespace>/<name>`, `StatefulSet/<namespace>/<name>`, or `DaemonSet/<namespace>/<name>`.
+- Kubernetes Services become topology services keyed as `Service/<namespace>/<name>`.
+- Resource keys use namespace-aware refs such as `Deployment/payments/api`; parsed manifests only match live-state objects when the manifest declares the same namespace. Namespace-less manifests remain unscoped because the effective apply namespace can come from CLI flags, Helm/Kustomize, or kubeconfig state outside the file.
+- Namespace nodes point downstream to mapped workloads and services in that namespace.
+- Service selectors are matched against workload template labels; matching workloads point downstream to the selecting Service so blast-radius analysis can surface live service impact.
+- Import timestamps and topology metadata provide freshness signals for reports and drift checks.
+
+### Degraded States
+
+Missing `kubectl`, source-context resolution failures, total command timeout, or complete live-state read failure produce explicit Kubernetes live-state context TODO warnings and do not replace active topology context. Partial per-resource failures preserve successfully read live context with warnings, and an empty successful snapshot clears stale topology for that project or workspace. The connector timeout is bounded to keep deterministic analysis from blocking on cluster access.
+
+The connector does not store kubeconfig content, tokens, raw API responses, or provider credentials. Kubernetes access should be configured outside DeployWhisper through the operator's local `kubectl` environment.

--- a/docs/project-workspaces.md
+++ b/docs/project-workspaces.md
@@ -41,6 +41,7 @@ For setup-specific modeling guidance, see the [Project Model Guide](./concepts/p
   - `deploywhisper analyze --project <key> [--workspace <workspace>] <artifact...>` or `deploywhisper analyze --project-id <id> [--workspace-id <id>] <artifact...>` returns the same submit advisory JSON contract, including verdict, Evidence Law status, top findings, uncertainty, report schema version, and advisory posture.
   - `deploywhisper topology import --from custom --source <topology.json> --project <key>`
   - `deploywhisper topology import --from terraform --source <terraform.tfstate> --project <key>`
+  - `deploywhisper topology import --from kubernetes --source <current-context|context:name> --project <key>`
   - The topology import command now routes through a shared source registry and returns a normalized import result with accepted, skipped, partially parsed, and unsupported resources.
   - Project, analysis, topology import, and outcome record commands can read `DEPLOYWHISPER_PROJECT_ROLE` and `DEPLOYWHISPER_PROJECT_KEYS` for automation actors that need the same lightweight authorization behavior as API callers.
 - GitHub App integration: respects `DEPLOYWHISPER_GITHUB_PROJECT_KEY` when set; otherwise derives an owner-safe default from the full repository slug and creates it on demand. Unknown, malformed, or blank explicit override values fail fast instead of falling back to the repository-derived default.

--- a/parsers/kubernetes_parser.py
+++ b/parsers/kubernetes_parser.py
@@ -17,7 +17,15 @@ def parse_kubernetes(name: str, raw_content: bytes | None) -> list[UnifiedChange
         kind = document.get("kind", "Resource")
         metadata = document.get("metadata", {}) or {}
         resource_name = metadata.get("name", "unnamed")
-        resource_id = f"{kind}/{resource_name}"
+        namespace = str(metadata.get("namespace") or "").strip()
+        if namespace:
+            resource_id = f"{kind}/{namespace}/{resource_name}"
+        else:
+            resource_id = f"{kind}/{resource_name}"
+        legacy_resource_id = f"{kind}/{resource_name}"
+        metadata_payload = {}
+        if resource_id != legacy_resource_id:
+            metadata_payload["resource_aliases"] = [legacy_resource_id]
         changes.append(
             UnifiedChange(
                 change_id=build_change_id(
@@ -31,6 +39,7 @@ def parse_kubernetes(name: str, raw_content: bytes | None) -> list[UnifiedChange
                     f"Kubernetes {kind} {resource_name} supplied as a standalone manifest; "
                     "previous cluster state is unknown, so the delta cannot be confirmed."
                 ),
+                metadata=metadata_payload,
             )
         )
     return changes

--- a/services/analysis_service.py
+++ b/services/analysis_service.py
@@ -345,6 +345,18 @@ def _incident_score(incident_index_size: int) -> float:
     return min(incident_index_size / 10, 1.0)
 
 
+def _unique_texts(values: list[str]) -> list[str]:
+    unique: list[str] = []
+    seen: set[str] = set()
+    for value in values:
+        normalized = str(value or "").strip()
+        if not normalized or normalized in seen:
+            continue
+        seen.add(normalized)
+        unique.append(normalized)
+    return unique
+
+
 def _context_confidence_level(context_score: float) -> str:
     if context_score >= 0.85:
         return "high"
@@ -357,6 +369,7 @@ def _context_todos(
     *,
     evidence_success_rate: float,
     topology_freshness_days: int | None,
+    topology_warnings: list[str] | None = None,
     incident_index_size: int,
     parser_success_rate: float,
     include_topology_context: bool = True,
@@ -370,6 +383,10 @@ def _context_todos(
             )
         elif topology_freshness_days > STALE_AFTER_DAYS:
             todos.append("Refresh stale topology context for this project/workspace.")
+        if _has_kubernetes_live_state_todo(topology_warnings):
+            todos.append(
+                "Resolve Kubernetes live-state context TODOs before relying on topology context."
+            )
     if include_incident_context and incident_index_size == 0:
         todos.append("Import relevant incident history for this project/workspace.")
     if parser_success_rate < 1.0:
@@ -384,32 +401,101 @@ def _context_uncertainty(
     context_score: float,
     evidence_success_rate: float,
     topology_freshness_days: int | None,
+    topology_warnings: list[str] | None = None,
     incident_index_size: int,
     parser_success_rate: float,
     include_topology_context: bool = True,
     include_incident_context: bool = True,
 ) -> str | None:
-    if context_score < 0.7:
-        return (
-            "Insufficient context: missing parser coverage, evidence coverage, "
-            "or enabled project context prevents a confident "
-            "low-risk verdict."
-        )
     weak_signals: list[str] = []
     if include_topology_context:
         if topology_freshness_days is None:
             weak_signals.append("topology context is unavailable")
         elif topology_freshness_days > STALE_AFTER_DAYS:
             weak_signals.append("topology context is stale")
+        if _has_kubernetes_live_state_todo(topology_warnings):
+            weak_signals.append("Kubernetes live-state context has unresolved TODOs")
+        elif _has_kubernetes_live_state_degradation(topology_warnings):
+            weak_signals.append("Kubernetes live-state context is degraded")
     if include_incident_context and incident_index_size == 0:
         weak_signals.append("incident history is unavailable")
     if parser_success_rate < 1.0:
         weak_signals.append("parser coverage is partial")
     if evidence_success_rate < 1.0:
         weak_signals.append("evidence coverage is partial")
+    if context_score < 0.7:
+        message = (
+            "Insufficient context: missing parser coverage, evidence coverage, "
+            "or enabled project context prevents a confident low-risk verdict."
+        )
+        if weak_signals:
+            message += " Weak signals: " + "; ".join(weak_signals) + "."
+        return message
     if not weak_signals:
         return None
     return "Uncertainty: " + "; ".join(weak_signals) + "."
+
+
+def _has_kubernetes_live_state_todo(warnings: list[str] | None) -> bool:
+    return any(
+        "kubernetes live-state context todo" in str(warning).lower()
+        for warning in warnings or []
+    )
+
+
+def _has_kubernetes_live_state_degradation(warnings: list[str] | None) -> bool:
+    degradation_markers = (
+        "kubernetes live-state context todo",
+        "kubernetes live-state import partially parsed",
+        "kubernetes live-state import did not produce any supported resources",
+        "kubernetes live-state import did not produce any non-namespace resources",
+    )
+    return any(
+        any(marker in str(warning).lower() for marker in degradation_markers)
+        for warning in warnings or []
+    )
+
+
+def _is_kubernetes_topology_payload(payload: object) -> bool:
+    if not isinstance(payload, dict):
+        return False
+    metadata = payload.get("metadata", {})
+    if not isinstance(metadata, dict):
+        return False
+    import_metadata = metadata.get("import", {})
+    if not isinstance(import_metadata, dict):
+        return False
+    return str(import_metadata.get("source_type") or "").strip() == "kubernetes"
+
+
+def _has_usable_topology_payload(payload: object) -> bool:
+    if not isinstance(payload, dict):
+        return False
+    services = payload.get("services", [])
+    if not isinstance(services, list):
+        return False
+    for service in services:
+        if not isinstance(service, dict):
+            continue
+        service_id = str(service.get("id") or "").strip()
+        resource_keys = service.get("resource_keys", [])
+        resource_key_texts = (
+            [
+                str(resource_key).strip()
+                for resource_key in resource_keys
+                if str(resource_key).strip()
+            ]
+            if isinstance(resource_keys, list)
+            else []
+        )
+        if service_id and not service_id.startswith("Namespace/"):
+            return True
+        if any(
+            resource_key and not resource_key.startswith("Namespace/")
+            for resource_key in resource_key_texts
+        ):
+            return True
+    return False
 
 
 def _evidence_success_rate(
@@ -458,6 +544,9 @@ def _build_context_completeness(
     include_incident_context: bool = True,
 ) -> ContextCompleteness:
     topology_last_imported_at = None
+    topology_warnings: list[str] = []
+    topology_payload_is_usable = False
+    topology_payload_is_kubernetes = False
     if include_topology_context:
         topology_status = get_topology_status(
             project_id=project_id,
@@ -465,7 +554,23 @@ def _build_context_completeness(
             workspace_id=workspace_id,
             workspace_key=workspace_key,
         )
+        topology_payload = getattr(topology_status, "payload", None)
         topology_last_imported_at = topology_status.updated_at
+        topology_warnings = list(getattr(topology_status, "warnings", []) or [])
+        topology_payload_is_usable = _has_usable_topology_payload(topology_payload)
+        topology_payload_is_kubernetes = _is_kubernetes_topology_payload(
+            topology_payload
+        )
+        topology_drift = getattr(topology_status, "drift", None)
+        topology_drift_warnings = list(getattr(topology_drift, "warnings", []) or [])
+        if getattr(
+            topology_drift, "status", None
+        ) == "unavailable" and _has_kubernetes_live_state_degradation(
+            topology_drift_warnings
+        ):
+            topology_warnings = _unique_texts(
+                topology_warnings + topology_drift_warnings
+            )
     topology_freshness_days = _topology_freshness_days(topology_last_imported_at)
     if not include_incident_context or (project_id is None and project_key is None):
         incident_index_size = 0
@@ -502,7 +607,14 @@ def _build_context_completeness(
         (evidence_success_rate, 0.20),
     ]
     if include_topology_context:
-        weighted_scores.append((_freshness_score(topology_freshness_days), 0.25))
+        topology_score = _freshness_score(topology_freshness_days)
+        if topology_payload_is_kubernetes and not topology_payload_is_usable:
+            topology_score = 0.0
+        if _has_kubernetes_live_state_degradation(topology_warnings):
+            topology_score = (
+                0.0 if not topology_payload_is_usable else min(topology_score, 0.5)
+            )
+        weighted_scores.append((topology_score, 0.25))
     if include_incident_context:
         weighted_scores.append((_incident_score(incident_index_size), 0.20))
     total_weight = sum(weight for _, weight in weighted_scores) or 1.0
@@ -514,6 +626,7 @@ def _build_context_completeness(
     context_todos = _context_todos(
         evidence_success_rate=evidence_success_rate,
         topology_freshness_days=topology_freshness_days,
+        topology_warnings=topology_warnings,
         incident_index_size=incident_index_size,
         parser_success_rate=raw_parser_success_rate,
         include_topology_context=include_topology_context,
@@ -541,6 +654,7 @@ def _build_context_completeness(
             context_score=raw_context_score,
             evidence_success_rate=evidence_success_rate,
             topology_freshness_days=topology_freshness_days,
+            topology_warnings=topology_warnings,
             incident_index_size=incident_index_size,
             parser_success_rate=raw_parser_success_rate,
             include_topology_context=include_topology_context,

--- a/services/topology_service.py
+++ b/services/topology_service.py
@@ -3,9 +3,11 @@
 from __future__ import annotations
 
 import json
+import subprocess
 from datetime import UTC, datetime, timedelta
 from json import JSONDecodeError
 from pathlib import Path
+from time import monotonic
 from typing import Any, Callable, Literal
 
 from pydantic import BaseModel, Field
@@ -25,6 +27,16 @@ from services.settings_service import get_topology_drift_check_interval_hours
 
 STALE_AFTER_DAYS = 30
 TOPOLOGY_DRIFT_ALERT_THRESHOLD_PERCENT = 10.0
+KUBERNETES_LIVE_STATE_TIMEOUT_SECONDS = 10
+KUBERNETES_LIVE_STATE_RESOURCES = (
+    ("namespaces", False),
+    ("services", True),
+    ("deployments", True),
+    ("statefulsets", True),
+    ("daemonsets", True),
+)
+KUBERNETES_WORKLOAD_KINDS = {"Deployment", "StatefulSet", "DaemonSet"}
+KUBERNETES_NAMESPACED_KINDS = {"Service", *KUBERNETES_WORKLOAD_KINDS}
 
 
 class TopologyImportError(ValueError):
@@ -326,6 +338,169 @@ def _drift_setting_key(
     return f"topology_drift_status::{project['id']}::{workspace['id']}"
 
 
+def _source_status_setting_key(
+    project: dict[str, Any], workspace: dict[str, Any] | None = None
+) -> str:
+    if workspace is None:
+        return f"topology_source_status::{project['id']}"
+    return f"topology_source_status::{project['id']}::{workspace['id']}"
+
+
+def _save_topology_source_status(
+    *,
+    project: dict[str, Any],
+    workspace: dict[str, Any] | None,
+    source_type: str,
+    source_ref: str,
+    warnings: list[str],
+    replace_existing: bool = False,
+) -> None:
+    entry = {
+        "source_type": source_type,
+        "source_ref": source_ref,
+        "checked_at": _current_timestamp(),
+        "warnings": _unique_messages(warnings),
+    }
+    entries: list[dict[str, Any]] = []
+    if not replace_existing:
+        existing_payload = _load_topology_source_status(project, workspace)
+        entries = [
+            existing_entry
+            for existing_entry in _source_status_entries(existing_payload)
+            if (
+                str(existing_entry.get("source_type") or "").strip(),
+                str(existing_entry.get("source_ref") or "").strip(),
+            )
+            != (source_type, source_ref)
+        ]
+    entries.append(entry)
+    payload = {**entry, "entries": entries}
+    with SessionLocal() as session:
+        upsert_setting(
+            session,
+            key=_source_status_setting_key(project, workspace),
+            value=json.dumps(payload),
+        )
+
+
+def _load_topology_source_status(
+    project: dict[str, Any], workspace: dict[str, Any] | None = None
+) -> dict[str, Any] | None:
+    with SessionLocal() as session:
+        record = get_setting(session, _source_status_setting_key(project, workspace))
+    if record is None:
+        return None
+    try:
+        payload = json.loads(record.value)
+    except JSONDecodeError:
+        return None
+    if not isinstance(payload, dict):
+        return None
+    return payload
+
+
+def _source_status_entries(
+    source_status: dict[str, Any] | None,
+) -> list[dict[str, Any]]:
+    if source_status is None:
+        return []
+    entries = source_status.get("entries")
+    if not isinstance(entries, list):
+        entries = [source_status]
+    normalized_entries = []
+    for entry in entries:
+        if isinstance(entry, dict):
+            normalized_entries.append(entry)
+    return normalized_entries
+
+
+def _source_status_matches_payload(
+    source_status: dict[str, Any] | None, payload: dict[str, Any] | None
+) -> bool:
+    if source_status is None or payload is None:
+        return False
+    import_metadata = _import_metadata(payload)
+    source_type = str(source_status.get("source_type") or "").strip()
+    active_source_type = str(import_metadata.get("source_type") or "").strip()
+    if source_type != active_source_type:
+        checked_at = _parse_iso_datetime(str(source_status.get("checked_at") or ""))
+        active_updated_at = _parse_iso_datetime(str(payload.get("updated_at") or ""))
+        return (
+            checked_at is not None
+            and active_updated_at is not None
+            and checked_at >= active_updated_at
+        )
+    source_ref = str(source_status.get("source_ref") or "").strip()
+    active_source_ref = str(import_metadata.get("source_ref") or "").strip()
+    requested_source_ref = str(
+        import_metadata.get("requested_source_ref") or ""
+    ).strip()
+    if (
+        source_type == "kubernetes"
+        and active_source_type == "kubernetes"
+        and source_ref == "current-context"
+        and requested_source_ref == "current-context"
+    ):
+        return True
+    return source_ref == active_source_ref
+
+
+def _has_kubernetes_live_state_todo_warnings(warnings: list[str] | None) -> bool:
+    return any(
+        "kubernetes live-state context todo" in str(warning).lower()
+        for warning in warnings or []
+    )
+
+
+def _has_kubernetes_live_state_degradation_warnings(
+    warnings: list[str] | None,
+) -> bool:
+    degradation_markers = (
+        "kubernetes live-state context todo",
+        "kubernetes live-state import partially parsed",
+        "kubernetes live-state import did not produce any supported resources",
+        "kubernetes live-state import did not produce any non-namespace resources",
+    )
+    return any(
+        any(marker in str(warning).lower() for marker in degradation_markers)
+        for warning in warnings or []
+    )
+
+
+def _source_status_warnings(source_status: dict[str, Any] | None) -> list[str]:
+    if source_status is None:
+        return []
+    warnings: list[str] = []
+    for entry in _source_status_entries(source_status):
+        entry_warnings = entry.get("warnings", [])
+        if isinstance(entry_warnings, list):
+            warnings.extend(str(item) for item in entry_warnings)
+    return _unique_messages(warnings)
+
+
+def _load_topology_source_status_warnings(
+    project: dict[str, Any],
+    workspace: dict[str, Any] | None = None,
+    *,
+    active_payload: dict[str, Any] | None = None,
+    require_active_match: bool = False,
+) -> list[str]:
+    source_status = _load_topology_source_status(project, workspace)
+    entries = _source_status_entries(source_status)
+    if require_active_match:
+        entries = [
+            entry
+            for entry in entries
+            if _source_status_matches_payload(entry, active_payload)
+        ]
+    warnings: list[str] = []
+    for entry in entries:
+        entry_warnings = entry.get("warnings", [])
+        if isinstance(entry_warnings, list):
+            warnings.extend(str(item) for item in entry_warnings)
+    return _unique_messages(warnings)
+
+
 def _parse_iso_datetime(value: str | None) -> datetime | None:
     if not value:
         return None
@@ -361,6 +536,18 @@ def _load_cached_topology_drift(
     if not isinstance(payload, dict):
         return None
     return TopologyDriftStatus(**payload)
+
+
+def _cached_drift_matches_source(
+    cached_status: TopologyDriftStatus | None,
+    source_type: str | None,
+    source_ref: str | None,
+) -> bool:
+    if cached_status is None or not source_type or not source_ref:
+        return False
+    cached_source_type = str(cached_status.source_type or "").strip()
+    cached_source_ref = str(cached_status.source_ref or "").strip()
+    return cached_source_type == source_type and cached_source_ref == source_ref
 
 
 def _save_topology_drift(
@@ -433,10 +620,29 @@ def _build_drift_status(
 
 
 def run_due_topology_drift_checks() -> list[TopologyDriftStatus]:
-    """Run due topology drift checks for every known project."""
+    """Run due topology drift checks for every known project/workspace scope."""
     drift_statuses: list[TopologyDriftStatus] = []
-    for project in list_projects():
-        drift_statuses.append(check_topology_drift(project_id=project.id))
+    project_ids = {project.id for project in list_projects()}
+    topology_scopes: set[tuple[int, int | None]] = {
+        (project_id, None) for project_id in project_ids
+    }
+    with SessionLocal() as session:
+        rows = (
+            session.query(TopologyVersion.project_id, TopologyVersion.workspace_id)
+            .distinct()
+            .all()
+        )
+    for project_id, workspace_id in rows:
+        if project_id not in project_ids:
+            continue
+        topology_scopes.add((project_id, workspace_id))
+    for project_id, workspace_id in sorted(
+        topology_scopes,
+        key=lambda scope: (scope[0], -1 if scope[1] is None else scope[1]),
+    ):
+        drift_statuses.append(
+            check_topology_drift(project_id=project_id, workspace_id=workspace_id)
+        )
     return drift_statuses
 
 
@@ -812,6 +1018,636 @@ def _terraform_state_dependency_refs(instances: list[Any]) -> list[str]:
             if dependency_ref:
                 dependencies.append(dependency_ref)
     return sorted(set(dependencies))
+
+
+def _kubernetes_live_state_unavailable_change_set(
+    source_ref: str, message: str, warnings: list[str] | None = None
+) -> TopologyChangeSet:
+    normalized_warnings = _unique_messages(warnings or [message])
+    return TopologyChangeSet(
+        operation="noop",
+        warnings=normalized_warnings,
+        unsupported_resources=[
+            TopologyImportResource(
+                resource_ref=source_ref,
+                message=message,
+            )
+        ],
+    )
+
+
+def _kubernetes_source_ref_error(source_ref: str) -> str | None:
+    normalized = str(source_ref or "").strip()
+    if normalized == "current-context":
+        return None
+    if (
+        normalized.startswith("context:")
+        and normalized.removeprefix("context:").strip()
+    ):
+        return None
+    return (
+        "Kubernetes live-state context TODO: source must be 'current-context' "
+        "or 'context:<name>'; no topology changes were applied."
+    )
+
+
+def _kubernetes_context_from_source_ref(source_ref: str) -> str | None:
+    normalized = str(source_ref or "").strip()
+    if normalized == "current-context":
+        return None
+    return normalized.removeprefix("context:").strip()
+
+
+def _resolve_kubernetes_import_source_ref(
+    source_ref: str,
+    *,
+    deadline: float | None = None,
+) -> tuple[str, list[str]]:
+    normalized = str(source_ref or "").strip()
+    if normalized != "current-context":
+        return source_ref, []
+
+    remaining_seconds = (
+        KUBERNETES_LIVE_STATE_TIMEOUT_SECONDS
+        if deadline is None
+        else deadline - monotonic()
+    )
+    if remaining_seconds <= 0:
+        return (
+            normalized,
+            [
+                "Kubernetes live-state context TODO: resolving the current Kubernetes "
+                f"context timed out after {KUBERNETES_LIVE_STATE_TIMEOUT_SECONDS} seconds; "
+                "no topology changes were applied."
+            ],
+        )
+    try:
+        completed = subprocess.run(
+            ["kubectl", "config", "current-context"],
+            check=True,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            timeout=remaining_seconds,
+        )
+    except FileNotFoundError:
+        return normalized, [_kubernetes_context_todo_message(normalized)]
+    except OSError:
+        return (
+            normalized,
+            [
+                "Kubernetes live-state context TODO: kubectl could not be executed; "
+                "no topology changes were applied."
+            ],
+        )
+    except subprocess.TimeoutExpired:
+        return (
+            normalized,
+            [
+                "Kubernetes live-state context TODO: resolving the current Kubernetes "
+                f"context timed out after {KUBERNETES_LIVE_STATE_TIMEOUT_SECONDS} seconds; "
+                "no topology changes were applied."
+            ],
+        )
+    except UnicodeDecodeError:
+        return (
+            normalized,
+            [
+                "Kubernetes live-state context TODO: kubectl current-context output "
+                "was not valid UTF-8; no topology changes were applied."
+            ],
+        )
+    except subprocess.CalledProcessError:
+        return (
+            normalized,
+            [
+                "Kubernetes live-state context TODO: current Kubernetes context could "
+                "not be resolved; no topology changes were applied."
+            ],
+        )
+
+    context_name = completed.stdout.strip()
+    if not context_name:
+        return (
+            normalized,
+            [
+                "Kubernetes live-state context TODO: current Kubernetes context was "
+                "empty; no topology changes were applied."
+            ],
+        )
+    return f"context:{context_name}", []
+
+
+def _kubernetes_resource_access_todo_message(source_ref: str, resource: str) -> str:
+    return (
+        "Kubernetes live-state context TODO: cluster access is unavailable for "
+        f"'{source_ref}' resource '{resource}'; that resource kind was skipped."
+    )
+
+
+def _is_kubernetes_authorization_failure(
+    exc: subprocess.CalledProcessError,
+) -> bool:
+    stderr = exc.stderr
+    if isinstance(stderr, bytes):
+        stderr_text = stderr.decode("utf-8", errors="replace")
+    else:
+        stderr_text = str(stderr or "")
+    normalized = stderr_text.lower()
+    return any(
+        marker in normalized
+        for marker in (
+            "forbidden",
+            "cannot list",
+            "permission denied",
+            "unauthorized",
+        )
+    )
+
+
+def _kubernetes_get_args(
+    base_args: list[str],
+    resource: str,
+    *,
+    all_namespaces: bool,
+    namespace: str | None = None,
+) -> list[str]:
+    args = [*base_args, "get", resource]
+    if namespace:
+        args.extend(["-n", namespace])
+    elif all_namespaces:
+        args.append("-A")
+    args.extend(["-o", "json"])
+    return args
+
+
+def _kubernetes_namespace_names(items: list[Any]) -> list[str]:
+    names: list[str] = []
+    seen: set[str] = set()
+    for item in items:
+        if not isinstance(item, dict):
+            continue
+        name = str(_kubernetes_metadata(item).get("name") or "").strip()
+        if not name or name in seen:
+            continue
+        seen.add(name)
+        names.append(name)
+    return names
+
+
+def _read_kubernetes_live_state(
+    source_ref: str,
+    *,
+    deadline: float | None = None,
+) -> tuple[str | None, list[str]]:
+    source_ref_error = _kubernetes_source_ref_error(source_ref)
+    if source_ref_error:
+        return None, [source_ref_error]
+
+    base_args = ["kubectl"]
+    context_name = _kubernetes_context_from_source_ref(source_ref)
+    if context_name:
+        base_args.extend(["--context", context_name])
+
+    items: list[Any] = []
+    warnings: list[str] = []
+    successful_reads = 0
+    namespace_names: list[str] = []
+    if deadline is None:
+        deadline = monotonic() + KUBERNETES_LIVE_STATE_TIMEOUT_SECONDS
+    for resource, is_namespaced in KUBERNETES_LIVE_STATE_RESOURCES:
+        attempts: list[tuple[bool, str | None]] = (
+            [(True, None)] if is_namespaced else [(False, None)]
+        )
+        attempt_index = 0
+        while attempt_index < len(attempts):
+            all_namespaces, namespace = attempts[attempt_index]
+            attempt_index += 1
+            remaining_seconds = deadline - monotonic()
+            if remaining_seconds <= 0:
+                warnings.append(
+                    "Kubernetes live-state context TODO: cluster access timed out after "
+                    f"{KUBERNETES_LIVE_STATE_TIMEOUT_SECONDS} seconds for '{source_ref}' "
+                    f"before reading resource '{resource}'; that resource kind was skipped."
+                )
+                break
+            args = _kubernetes_get_args(
+                base_args,
+                resource,
+                all_namespaces=all_namespaces,
+                namespace=namespace,
+            )
+            try:
+                completed = subprocess.run(
+                    args,
+                    check=True,
+                    capture_output=True,
+                    text=True,
+                    encoding="utf-8",
+                    timeout=remaining_seconds,
+                )
+            except FileNotFoundError:
+                if successful_reads > 0:
+                    warnings.append(
+                        "Kubernetes live-state context TODO: kubectl could not be "
+                        f"executed while reading resource '{resource}'; that resource "
+                        "kind was skipped."
+                    )
+                    return json.dumps({"items": items}), _unique_messages(warnings)
+                return None, [_kubernetes_context_todo_message(source_ref)]
+            except OSError:
+                if successful_reads > 0:
+                    warnings.append(
+                        "Kubernetes live-state context TODO: kubectl could not be "
+                        f"executed while reading resource '{resource}'; that resource "
+                        "kind was skipped."
+                    )
+                    return json.dumps({"items": items}), _unique_messages(warnings)
+                return (
+                    None,
+                    [
+                        "Kubernetes live-state context TODO: kubectl could not be executed; "
+                        "no topology changes were applied."
+                    ],
+                )
+            except subprocess.TimeoutExpired:
+                warnings.append(
+                    "Kubernetes live-state context TODO: cluster access timed out after "
+                    f"{KUBERNETES_LIVE_STATE_TIMEOUT_SECONDS} seconds for '{source_ref}' "
+                    f"resource '{resource}'; that resource kind was skipped."
+                )
+                break
+            except UnicodeDecodeError:
+                warnings.append(
+                    "Kubernetes live-state context TODO: kubectl output was not valid UTF-8 "
+                    f"for resource '{resource}'; that resource kind was skipped."
+                )
+                break
+            except subprocess.CalledProcessError as exc:
+                if all_namespaces and is_namespaced:
+                    if not _is_kubernetes_authorization_failure(exc):
+                        warnings.append(
+                            _kubernetes_resource_access_todo_message(
+                                source_ref, resource
+                            )
+                        )
+                        break
+                    warnings.append(
+                        "Kubernetes live-state context TODO: all-namespaces access is "
+                        f"unavailable for '{source_ref}' resource '{resource}'."
+                    )
+                    if namespace_names:
+                        attempts.extend((False, name) for name in namespace_names)
+                    else:
+                        warnings.append(
+                            "Kubernetes live-state context TODO: namespace-scoped "
+                            f"fallback is unavailable for '{source_ref}' resource "
+                            f"'{resource}' because no readable namespaces were found; "
+                            "that resource kind was skipped."
+                        )
+                    continue
+                if namespace:
+                    warnings.append(
+                        "Kubernetes live-state context TODO: namespace-scoped access "
+                        f"is unavailable for '{source_ref}' resource '{resource}' "
+                        f"in namespace '{namespace}'; that namespace was skipped."
+                    )
+                    continue
+                warnings.append(
+                    _kubernetes_resource_access_todo_message(source_ref, resource)
+                )
+                break
+
+            try:
+                payload = json.loads(completed.stdout)
+            except JSONDecodeError:
+                warnings.append(
+                    "Kubernetes live-state context TODO: kubectl returned invalid JSON "
+                    f"for resource '{resource}'; that resource kind was skipped."
+                )
+                break
+            if not isinstance(payload, dict):
+                warnings.append(
+                    "Kubernetes live-state context TODO: kubectl output was not a JSON "
+                    f"object for resource '{resource}'; that resource kind was skipped."
+                )
+                break
+            resource_items = payload.get("items", [])
+            if not isinstance(resource_items, list):
+                warnings.append(
+                    "Kubernetes live-state context TODO: kubectl output did not include "
+                    f"an items list for resource '{resource}'; that resource kind was skipped."
+                )
+                break
+            successful_reads += 1
+            if resource == "namespaces":
+                namespace_names = _kubernetes_namespace_names(resource_items)
+            items.extend(resource_items)
+
+    if successful_reads == 0:
+        return None, warnings or [_kubernetes_context_todo_message(source_ref)]
+    return json.dumps({"items": items}), _unique_messages(warnings)
+
+
+def _kubernetes_context_todo_message(source_ref: str) -> str:
+    return (
+        "Kubernetes live-state context TODO: cluster access is unavailable for "
+        f"'{source_ref}'; no topology changes were applied."
+    )
+
+
+def _kubernetes_metadata(item: dict[str, Any]) -> dict[str, Any]:
+    metadata = item.get("metadata", {})
+    if not isinstance(metadata, dict):
+        return {}
+    return metadata
+
+
+def _kubernetes_resource_ref(kind: str, namespace: str, name: str) -> str:
+    if kind == "Namespace":
+        return f"Namespace/{name}"
+    if namespace:
+        return f"{kind}/{namespace}/{name}"
+    return f"{kind}/{name}"
+
+
+def _kubernetes_short_resource_ref(kind: str, name: str) -> str:
+    return f"{kind}/{name}"
+
+
+def _kubernetes_selector_key(namespace: str, selector: dict[str, str]) -> str:
+    selector_text = ",".join(f"{key}={selector[key]}" for key in sorted(selector))
+    if namespace:
+        return f"selector:{namespace}:{selector_text}"
+    return f"selector:{selector_text}"
+
+
+def _kubernetes_string_map(value: Any) -> dict[str, str]:
+    if not isinstance(value, dict):
+        return {}
+    mapped: dict[str, str] = {}
+    for key, raw_value in value.items():
+        key_text = str(key or "").strip()
+        value_text = str(raw_value or "").strip()
+        if key_text and value_text:
+            mapped[key_text] = value_text
+    return mapped
+
+
+def _kubernetes_workload_labels(item: dict[str, Any]) -> dict[str, str]:
+    spec = item.get("spec", {})
+    if not isinstance(spec, dict):
+        return {}
+    template = spec.get("template", {})
+    if not isinstance(template, dict):
+        return {}
+    metadata = template.get("metadata", {})
+    if not isinstance(metadata, dict):
+        return {}
+    return _kubernetes_string_map(metadata.get("labels", {}))
+
+
+def _kubernetes_selector(item: dict[str, Any], kind: str) -> dict[str, str]:
+    spec = item.get("spec", {})
+    if not isinstance(spec, dict):
+        return {}
+    selector = spec.get("selector", {})
+    if kind == "Service":
+        return _kubernetes_string_map(selector)
+    if not isinstance(selector, dict):
+        return {}
+    return _kubernetes_string_map(selector.get("matchLabels", {}))
+
+
+def _kubernetes_selector_matches(
+    selector: dict[str, str], labels: dict[str, str]
+) -> bool:
+    if not selector:
+        return False
+    return all(labels.get(key) == value for key, value in selector.items())
+
+
+def _parse_kubernetes_live_state_source(
+    source_ref: str,
+    *,
+    deadline: float | None = None,
+) -> TopologyChangeSet:
+    raw_text, read_warnings = _read_kubernetes_live_state(
+        source_ref,
+        deadline=deadline,
+    )
+    if raw_text is None:
+        warnings = read_warnings or [_kubernetes_context_todo_message(source_ref)]
+        return _kubernetes_live_state_unavailable_change_set(
+            source_ref,
+            warnings[0],
+            warnings,
+        )
+    try:
+        payload = json.loads(raw_text)
+    except JSONDecodeError:
+        return _kubernetes_live_state_unavailable_change_set(
+            source_ref,
+            "Kubernetes live-state context TODO: kubectl returned invalid JSON; no topology changes were applied.",
+        )
+    if not isinstance(payload, dict):
+        return _kubernetes_live_state_unavailable_change_set(
+            source_ref,
+            "Kubernetes live-state context TODO: kubectl output was not a JSON object; no topology changes were applied.",
+        )
+    items = payload.get("items", [])
+    if not isinstance(items, list):
+        return _kubernetes_live_state_unavailable_change_set(
+            source_ref,
+            "Kubernetes live-state context TODO: kubectl output did not include an items list; no topology changes were applied.",
+        )
+
+    services_by_id: dict[str, dict[str, Any]] = {}
+    accepted_resources: list[TopologyImportResource] = []
+    partially_parsed_resources: list[TopologyImportResource] = []
+    skipped_resources: list[TopologyImportResource] = []
+    workloads: list[dict[str, Any]] = []
+    cluster_services: list[dict[str, Any]] = []
+
+    for index, item in enumerate(items, start=1):
+        item_ref = f"items[{index}]"
+        if not isinstance(item, dict):
+            partially_parsed_resources.append(
+                TopologyImportResource(
+                    resource_ref=item_ref,
+                    message="Kubernetes live-state item was not a JSON object and was ignored.",
+                )
+            )
+            continue
+        kind = str(item.get("kind") or "").strip()
+        metadata = _kubernetes_metadata(item)
+        name = str(metadata.get("name") or "").strip()
+        namespace = str(metadata.get("namespace") or "").strip()
+        if not kind or not name:
+            partially_parsed_resources.append(
+                TopologyImportResource(
+                    resource_ref=item_ref,
+                    message="Kubernetes live-state item is missing kind/name identity and was ignored.",
+                )
+            )
+            continue
+        if kind in KUBERNETES_NAMESPACED_KINDS and not namespace:
+            partially_parsed_resources.append(
+                TopologyImportResource(
+                    resource_ref=_kubernetes_resource_ref(kind, "", name),
+                    message=(
+                        "Kubernetes live-state namespaced object is missing "
+                        "metadata.namespace and was ignored."
+                    ),
+                )
+            )
+            continue
+        if kind not in {"Namespace", "Service", *KUBERNETES_WORKLOAD_KINDS}:
+            skipped_resources.append(
+                TopologyImportResource(
+                    resource_ref=_kubernetes_resource_ref(kind, namespace, name),
+                    message="Kubernetes object kind was skipped because it is not mapped by this connector.",
+                )
+            )
+            continue
+
+        resource_ref = _kubernetes_resource_ref(kind, namespace, name)
+        if resource_ref in services_by_id:
+            skipped_resources.append(
+                TopologyImportResource(
+                    resource_ref=resource_ref,
+                    service_id=resource_ref,
+                    message="Duplicate Kubernetes live-state object was skipped.",
+                )
+            )
+            continue
+
+        resource_keys = [resource_ref]
+        if kind == "Namespace":
+            resource_keys.append(_kubernetes_short_resource_ref(kind, name))
+        api_version = str(item.get("apiVersion") or "").strip()
+        if api_version:
+            resource_keys.append(f"{api_version}/{resource_ref}")
+        selector = _kubernetes_selector(item, kind)
+        if selector:
+            resource_keys.append(_kubernetes_selector_key(namespace, selector))
+
+        seen_keys: set[str] = set()
+        unique_keys: list[str] = []
+        for resource_key in resource_keys:
+            if resource_key in seen_keys:
+                continue
+            seen_keys.add(resource_key)
+            unique_keys.append(resource_key)
+
+        services_by_id[resource_ref] = {
+            "id": resource_ref,
+            "label": resource_ref,
+            "resource_keys": unique_keys,
+            "downstream": [],
+        }
+        accepted_resources.append(
+            TopologyImportResource(
+                resource_ref=resource_ref,
+                service_id=resource_ref,
+                message="Kubernetes live-state object was mapped into the topology graph.",
+            )
+        )
+        if kind in KUBERNETES_WORKLOAD_KINDS:
+            workloads.append(
+                {
+                    "service_id": resource_ref,
+                    "namespace": namespace,
+                    "labels": _kubernetes_workload_labels(item),
+                }
+            )
+        elif kind == "Service":
+            cluster_services.append(
+                {
+                    "service_id": resource_ref,
+                    "namespace": namespace,
+                    "selector": selector,
+                }
+            )
+
+    for service_id, service in services_by_id.items():
+        if service_id.startswith("Namespace/"):
+            namespace = service_id.removeprefix("Namespace/")
+            service["downstream"].extend(
+                target_id
+                for target_id in services_by_id
+                if target_id != service_id
+                and target_id.split("/", maxsplit=2)[1] == namespace
+            )
+
+    for cluster_service in cluster_services:
+        selector = cluster_service["selector"]
+        if not selector:
+            continue
+        for workload in workloads:
+            if cluster_service["namespace"] != workload["namespace"]:
+                continue
+            if _kubernetes_selector_matches(selector, workload["labels"]):
+                services_by_id[workload["service_id"]]["downstream"].append(
+                    cluster_service["service_id"]
+                )
+
+    normalized_services = []
+    for service_id in sorted(services_by_id):
+        service = dict(services_by_id[service_id])
+        service["downstream"] = sorted(set(service["downstream"]))
+        normalized_services.append(service)
+
+    warnings: list[str] = list(read_warnings)
+    if partially_parsed_resources:
+        warnings.append(
+            "Kubernetes live-state import partially parsed one or more objects; malformed entries were skipped."
+        )
+    if skipped_resources:
+        warnings.append(
+            "Kubernetes live-state import skipped unsupported or duplicate objects while preserving supported context."
+        )
+    if not accepted_resources:
+        warnings.append(
+            "Kubernetes live-state import did not produce any supported resources to apply."
+        )
+        if not items and not read_warnings:
+            return TopologyChangeSet(
+                operation="replace",
+                services=[],
+                warnings=warnings,
+                skipped_resources=skipped_resources,
+                partially_parsed_resources=partially_parsed_resources,
+            )
+        return TopologyChangeSet(
+            operation="noop",
+            warnings=warnings,
+            skipped_resources=skipped_resources,
+            partially_parsed_resources=partially_parsed_resources,
+        )
+
+    if not any(
+        not item.resource_ref.startswith("Namespace/") for item in accepted_resources
+    ):
+        warnings.append(
+            "Kubernetes live-state import did not produce any non-namespace resources to apply."
+        )
+        return TopologyChangeSet(
+            operation="noop",
+            warnings=warnings,
+            accepted_resources=accepted_resources,
+            skipped_resources=skipped_resources,
+            partially_parsed_resources=partially_parsed_resources,
+        )
+
+    return TopologyChangeSet(
+        operation="replace",
+        services=normalized_services,
+        warnings=warnings,
+        accepted_resources=accepted_resources,
+        skipped_resources=skipped_resources,
+        partially_parsed_resources=partially_parsed_resources,
+    )
 
 
 def _terraform_state_staleness_warning(path: Path) -> str | None:
@@ -1195,7 +2031,7 @@ TOPOLOGY_SOURCE_REGISTRY: dict[str, TopologySourceHandler] = {
     "custom": _parse_custom_source,
     "terraform": _parse_terraform_state_source,
     "cloudformation": _build_unimplemented_source_handler("cloudformation"),
-    "kubernetes": _build_unimplemented_source_handler("kubernetes"),
+    "kubernetes": _parse_kubernetes_live_state_source,
     "ansible": _build_unimplemented_source_handler("ansible"),
 }
 
@@ -1234,29 +2070,31 @@ def _build_payload_from_change_set(
     change_set: TopologyChangeSet,
     source_type: str,
     source_ref: str,
+    requested_source_ref: str | None = None,
 ) -> dict[str, Any]:
+    import_metadata: dict[str, Any] = {
+        "source_type": source_type,
+        "source_ref": source_ref,
+        "warnings": change_set.warnings,
+        "accepted_resources": [
+            item.model_dump() for item in change_set.accepted_resources
+        ],
+        "skipped_resources": [
+            item.model_dump() for item in change_set.skipped_resources
+        ],
+        "partially_parsed_resources": [
+            item.model_dump() for item in change_set.partially_parsed_resources
+        ],
+        "unsupported_resources": [
+            item.model_dump() for item in change_set.unsupported_resources
+        ],
+    }
+    if requested_source_ref:
+        import_metadata["requested_source_ref"] = requested_source_ref
     return {
         "updated_at": _current_timestamp(),
         "services": change_set.services,
-        "metadata": {
-            "import": {
-                "source_type": source_type,
-                "source_ref": source_ref,
-                "warnings": change_set.warnings,
-                "accepted_resources": [
-                    item.model_dump() for item in change_set.accepted_resources
-                ],
-                "skipped_resources": [
-                    item.model_dump() for item in change_set.skipped_resources
-                ],
-                "partially_parsed_resources": [
-                    item.model_dump() for item in change_set.partially_parsed_resources
-                ],
-                "unsupported_resources": [
-                    item.model_dump() for item in change_set.unsupported_resources
-                ],
-            }
-        },
+        "metadata": {"import": import_metadata},
     }
 
 
@@ -1304,10 +2142,7 @@ def _persist_topology_payload(
             )
         )
         session.commit()
-    return get_topology_status(
-        project_id=int(project["id"]),
-        workspace_id=int(workspace["id"]) if workspace is not None else None,
-    )
+    return _build_topology_status(payload, path=topology_path, exists=True)
 
 
 def _canonical_service(service: dict[str, Any]) -> dict[str, Any]:
@@ -1423,7 +2258,11 @@ def check_topology_drift(
     source_ref = str(import_metadata.get("source_ref") or "").strip() or None
     cached_status = _load_cached_topology_drift(project, workspace)
 
-    if not force and not _is_drift_check_due(cached_status, interval_hours):
+    if (
+        not force
+        and _cached_drift_matches_source(cached_status, source_type, source_ref)
+        and not _is_drift_check_due(cached_status, interval_hours)
+    ):
         return cached_status or _build_drift_status(
             status="unavailable",
             interval_hours=interval_hours,
@@ -1488,6 +2327,22 @@ def check_topology_drift(
                 source_type=source_type,
                 source_ref=source_ref,
                 warnings=[str(exc)],
+            ),
+            workspace,
+        )
+
+    if source_type == "kubernetes" and (
+        _has_kubernetes_live_state_todo_warnings(change_set.warnings)
+        or bool(change_set.partially_parsed_resources)
+    ):
+        return _save_topology_drift(
+            project,
+            _build_drift_status(
+                status="unavailable",
+                interval_hours=interval_hours,
+                source_type=source_type,
+                source_ref=source_ref,
+                warnings=change_set.warnings,
             ),
             workspace,
         )
@@ -1569,23 +2424,43 @@ def get_topology_status(
         project, workspace
     )
     if status_override is not None and payload is None:
+        status_override.warnings = _unique_messages(
+            list(status_override.warnings)
+            + _load_topology_source_status_warnings(project, workspace)
+        )
         return status_override
     if payload is None:
+        source_status_warnings = _load_topology_source_status_warnings(
+            project, workspace
+        )
         if bool(project.get("is_default")):
             legacy_status = _read_legacy_topology_status()
             if legacy_status is not None:
+                legacy_status.warnings = _unique_messages(
+                    list(legacy_status.warnings) + source_status_warnings
+                )
                 return legacy_status
         return TopologyStatus(
             path=str(topology_path),
             exists=False,
             warnings=[
                 "Blast radius may be incomplete — service topology is not configured."
-            ],
+            ]
+            + source_status_warnings,
         )
     status = _build_topology_status(payload, path=topology_path, exists=True)
     status.drift = check_topology_drift(
         project_id=int(project["id"]),
         workspace_id=int(workspace["id"]) if workspace is not None else None,
+    )
+    status.warnings = _unique_messages(
+        list(status.warnings)
+        + _load_topology_source_status_warnings(
+            project,
+            workspace,
+            active_payload=payload,
+            require_active_match=True,
+        )
     )
     return status
 
@@ -1621,13 +2496,55 @@ def import_topology_source(
         else None
     )
     previous_payload, _, _ = _load_latest_topology_payload(project, workspace)
-    change_set = _lookup_source_handler(normalized_source_type)(source_ref)
+    resolved_source_ref = source_ref
+    source_ref_warnings: list[str] = []
+    kubernetes_deadline: float | None = None
+    if normalized_source_type == "kubernetes":
+        kubernetes_deadline = monotonic() + KUBERNETES_LIVE_STATE_TIMEOUT_SECONDS
+        resolved_source_ref, source_ref_warnings = (
+            _resolve_kubernetes_import_source_ref(
+                source_ref,
+                deadline=kubernetes_deadline,
+            )
+        )
+    if source_ref_warnings:
+        change_set = _kubernetes_live_state_unavailable_change_set(
+            resolved_source_ref,
+            source_ref_warnings[0],
+            source_ref_warnings,
+        )
+    elif normalized_source_type == "kubernetes":
+        change_set = _parse_kubernetes_live_state_source(
+            resolved_source_ref,
+            deadline=kubernetes_deadline,
+        )
+    else:
+        change_set = _lookup_source_handler(normalized_source_type)(resolved_source_ref)
     warnings = list(change_set.warnings)
 
     if change_set.operation == "noop":
+        if normalized_source_type == "kubernetes":
+            _save_topology_source_status(
+                project=project,
+                workspace=workspace,
+                source_type=normalized_source_type,
+                source_ref=resolved_source_ref,
+                warnings=warnings,
+            )
+            _save_topology_drift(
+                project,
+                _build_drift_status(
+                    status="unavailable",
+                    interval_hours=get_topology_drift_check_interval_hours(),
+                    source_type=normalized_source_type,
+                    source_ref=resolved_source_ref,
+                    warnings=warnings,
+                ),
+                workspace,
+            )
         return _build_import_result(
             source_type=normalized_source_type,
-            source_ref=source_ref,
+            source_ref=resolved_source_ref,
             applied=False,
             change_set=change_set,
             before_payload=previous_payload,
@@ -1638,7 +2555,13 @@ def import_topology_source(
     payload = _build_payload_from_change_set(
         change_set=change_set,
         source_type=normalized_source_type,
-        source_ref=source_ref,
+        source_ref=resolved_source_ref,
+        requested_source_ref=(
+            "current-context"
+            if normalized_source_type == "kubernetes"
+            and str(source_ref or "").strip() == "current-context"
+            else None
+        ),
     )
     status = _persist_topology_payload(
         payload,
@@ -1646,10 +2569,46 @@ def import_topology_source(
         workspace=workspace,
         source_type=normalized_source_type,
     )
-    warnings.extend(status.warnings)
+    _save_topology_source_status(
+        project=project,
+        workspace=workspace,
+        source_type=normalized_source_type,
+        source_ref=resolved_source_ref,
+        warnings=[],
+        replace_existing=normalized_source_type != "kubernetes",
+    )
+    _save_topology_drift(
+        project,
+        _build_drift_status(
+            status=(
+                "unavailable"
+                if normalized_source_type == "kubernetes"
+                and _has_kubernetes_live_state_degradation_warnings(warnings)
+                else "up_to_date"
+            ),
+            interval_hours=get_topology_drift_check_interval_hours(),
+            source_type=normalized_source_type,
+            source_ref=resolved_source_ref,
+            total_resource_count=len(_resource_snapshot(status.payload or {})),
+            warnings=warnings,
+        ),
+        workspace,
+    )
+    if (
+        normalized_source_type == "kubernetes"
+        and str(source_ref or "").strip() == "current-context"
+        and resolved_source_ref != "current-context"
+    ):
+        _save_topology_source_status(
+            project=project,
+            workspace=workspace,
+            source_type=normalized_source_type,
+            source_ref="current-context",
+            warnings=[],
+        )
     return _build_import_result(
         source_type=normalized_source_type,
-        source_ref=source_ref,
+        source_ref=resolved_source_ref,
         applied=True,
         change_set=change_set,
         before_payload=previous_payload,
@@ -1694,7 +2653,7 @@ def save_topology_definition(
     change_set = _build_custom_change_set(payload)
 
     try:
-        return _persist_topology_payload(
+        status = _persist_topology_payload(
             _build_payload_from_change_set(
                 change_set=change_set,
                 source_type="manual",
@@ -1704,6 +2663,19 @@ def save_topology_definition(
             workspace=workspace,
             source_type="manual",
         )
+        _save_topology_source_status(
+            project=project,
+            workspace=workspace,
+            source_type="manual",
+            source_ref="inline://manual-topology",
+            warnings=[],
+            replace_existing=True,
+        )
+        status = get_topology_status(
+            project_id=int(project["id"]),
+            workspace_id=int(workspace["id"]) if workspace is not None else None,
+        )
+        return status
     except TopologyImportError as exc:
         raise ValueError(exc.message) from exc
 

--- a/tests/test_analysis/test_blast_radius.py
+++ b/tests/test_analysis/test_blast_radius.py
@@ -100,6 +100,79 @@ class BlastRadiusTests(unittest.TestCase):
 
         self.assertEqual(result.freshness["age_days"], 1)
 
+    def test_compute_blast_radius_prefers_exact_match_over_legacy_alias(
+        self,
+    ) -> None:
+        topology = {
+            "services": [
+                {
+                    "id": "api-payments",
+                    "label": "Payments API",
+                    "resource_keys": ["Deployment/payments/api"],
+                    "downstream": [],
+                },
+                {
+                    "id": "api-legacy",
+                    "label": "Legacy API",
+                    "resource_keys": ["Deployment/api"],
+                    "downstream": [],
+                },
+            ]
+        }
+        changes = [
+            UnifiedChange(
+                source_file="deployment.yaml",
+                tool="kubernetes",
+                resource_id="Deployment/payments/api",
+                action="modify",
+                summary="Deployment changed.",
+                metadata={"resource_aliases": ["Deployment/api"]},
+            )
+        ]
+
+        result = compute_blast_radius(changes, topology)
+
+        self.assertEqual(result.direct_count, 1)
+        self.assertEqual(
+            [node.service_id for node in result.affected], ["api-payments"]
+        )
+
+    def test_compute_blast_radius_ignores_ambiguous_legacy_alias(
+        self,
+    ) -> None:
+        topology = {
+            "services": [
+                {
+                    "id": "api-a",
+                    "label": "API A",
+                    "resource_keys": ["Deployment/api"],
+                    "downstream": [],
+                },
+                {
+                    "id": "api-b",
+                    "label": "API B",
+                    "resource_keys": ["Deployment/api"],
+                    "downstream": [],
+                },
+            ]
+        }
+        changes = [
+            UnifiedChange(
+                source_file="deployment.yaml",
+                tool="kubernetes",
+                resource_id="Deployment/payments/api",
+                action="modify",
+                summary="Deployment changed.",
+                metadata={"resource_aliases": ["Deployment/api"]},
+            )
+        ]
+
+        result = compute_blast_radius(changes, topology)
+
+        self.assertEqual(result.direct_count, 0)
+        self.assertEqual(result.affected, [])
+        self.assertEqual(result.unmatched_resources, ["Deployment/payments/api"])
+
     def test_compute_blast_radius_drops_malformed_owner_values(self) -> None:
         topology = {
             "services": [

--- a/tests/test_parsers/test_kubernetes_parser.py
+++ b/tests/test_parsers/test_kubernetes_parser.py
@@ -24,6 +24,36 @@ provisioner: efs.csi.aws.com
         self.assertEqual(changes[0].action, "apply")
         self.assertIn("previous cluster state is unknown", changes[0].summary)
 
+    def test_parse_kubernetes_includes_namespace_when_manifest_declares_one(
+        self,
+    ) -> None:
+        raw = b"""apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: api
+  namespace: payments
+"""
+
+        changes = parse_kubernetes("deployment.yaml", raw)
+
+        self.assertEqual(len(changes), 1)
+        self.assertEqual(changes[0].resource_id, "Deployment/payments/api")
+
+    def test_parse_kubernetes_leaves_namespace_less_manifest_unscoped(
+        self,
+    ) -> None:
+        raw = b"""apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: api
+"""
+
+        changes = parse_kubernetes("deployment.yaml", raw)
+
+        self.assertEqual(len(changes), 1)
+        self.assertEqual(changes[0].resource_id, "Deployment/api")
+        self.assertNotIn("resource_aliases", changes[0].metadata)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_services/test_analysis_service.py
+++ b/tests/test_services/test_analysis_service.py
@@ -630,6 +630,314 @@ class AnalysisServiceTests(unittest.TestCase):
             context.context_todos,
         )
 
+    def test_build_context_completeness_surfaces_kubernetes_live_state_todos(
+        self,
+    ) -> None:
+        batch = ParseBatchResult(
+            files=[
+                ParsedFileResult(
+                    file_name="deployment.yaml",
+                    tool="kubernetes",
+                    status="parsed",
+                    changes=[],
+                )
+            ]
+        )
+
+        with patch(
+            "services.analysis_service.get_topology_status",
+            return_value=SimpleNamespace(
+                updated_at="2026-06-09T00:00:00Z",
+                warnings=[
+                    "Kubernetes live-state context TODO: cluster access is unavailable."
+                ],
+            ),
+        ):
+            context = build_analysis_artifacts.__globals__[
+                "_build_context_completeness"
+            ](batch, include_incident_context=False)
+
+        self.assertLess(context.context_score, 0.7)
+        self.assertEqual(context.confidence_level, "low")
+        self.assertTrue(context.insufficient_context)
+        self.assertIn(
+            "Resolve Kubernetes live-state context TODOs before relying on topology context.",
+            context.context_todos,
+        )
+        self.assertIn("Kubernetes live-state", context.uncertainty)
+
+    def test_build_context_completeness_keeps_partial_kubernetes_context_usable(
+        self,
+    ) -> None:
+        batch = ParseBatchResult(
+            files=[
+                ParsedFileResult(
+                    file_name="deployment.yaml",
+                    tool="kubernetes",
+                    status="parsed",
+                    changes=[],
+                )
+            ]
+        )
+
+        with patch(
+            "services.analysis_service.get_topology_status",
+            return_value=SimpleNamespace(
+                updated_at="2026-06-09T00:00:00Z",
+                payload={
+                    "services": [
+                        {
+                            "id": "Deployment/payments/api",
+                            "resource_keys": ["Deployment/payments/api"],
+                            "downstream": [],
+                        }
+                    ]
+                },
+                warnings=[
+                    "Kubernetes live-state context TODO: all-namespaces access is unavailable for 'context:prod' resource 'deployments'."
+                ],
+            ),
+        ):
+            context = build_analysis_artifacts.__globals__[
+                "_build_context_completeness"
+            ](batch, include_incident_context=False)
+
+        self.assertGreaterEqual(context.context_score, 0.7)
+        self.assertLess(context.context_score, 1.0)
+        self.assertEqual(context.confidence_level, "medium")
+        self.assertFalse(context.insufficient_context)
+        self.assertIn(
+            "Resolve Kubernetes live-state context TODOs before relying on topology context.",
+            context.context_todos,
+        )
+        self.assertIn("Kubernetes live-state", context.uncertainty)
+
+    def test_build_context_completeness_uses_kubernetes_drift_todos(
+        self,
+    ) -> None:
+        batch = ParseBatchResult(
+            files=[
+                ParsedFileResult(
+                    file_name="deployment.yaml",
+                    tool="kubernetes",
+                    status="parsed",
+                    changes=[],
+                )
+            ]
+        )
+
+        with patch(
+            "services.analysis_service.get_topology_status",
+            return_value=SimpleNamespace(
+                updated_at="2026-06-09T00:00:00Z",
+                payload={
+                    "services": [
+                        {
+                            "id": "Deployment/payments/api",
+                            "resource_keys": ["Deployment/payments/api"],
+                            "downstream": [],
+                        }
+                    ]
+                },
+                warnings=[],
+                drift=SimpleNamespace(
+                    status="unavailable",
+                    warnings=[
+                        "Kubernetes live-state context TODO: cluster access is unavailable for 'context:prod'."
+                    ],
+                ),
+            ),
+        ):
+            context = build_analysis_artifacts.__globals__[
+                "_build_context_completeness"
+            ](batch, include_incident_context=False)
+
+        self.assertLess(context.context_score, 1.0)
+        self.assertEqual(context.confidence_level, "medium")
+        self.assertIn(
+            "Resolve Kubernetes live-state context TODOs before relying on topology context.",
+            context.context_todos,
+        )
+        self.assertIn("Kubernetes live-state", context.uncertainty)
+
+    def test_build_context_completeness_uses_malformed_kubernetes_drift_warnings(
+        self,
+    ) -> None:
+        batch = ParseBatchResult(
+            files=[
+                ParsedFileResult(
+                    file_name="deployment.yaml",
+                    tool="kubernetes",
+                    status="parsed",
+                    changes=[],
+                )
+            ]
+        )
+
+        with patch(
+            "services.analysis_service.get_topology_status",
+            return_value=SimpleNamespace(
+                updated_at="2026-06-09T00:00:00Z",
+                payload={
+                    "services": [
+                        {
+                            "id": "Deployment/payments/api",
+                            "resource_keys": ["Deployment/payments/api"],
+                            "downstream": [],
+                        }
+                    ]
+                },
+                warnings=[],
+                drift=SimpleNamespace(
+                    status="unavailable",
+                    warnings=[
+                        "Kubernetes live-state import partially parsed one or more objects; malformed entries were skipped."
+                    ],
+                ),
+            ),
+        ):
+            context = build_analysis_artifacts.__globals__[
+                "_build_context_completeness"
+            ](batch, include_incident_context=False)
+
+        self.assertLess(context.context_score, 1.0)
+        self.assertEqual(context.confidence_level, "medium")
+        self.assertIn("Kubernetes live-state", context.uncertainty)
+
+    def test_build_context_completeness_does_not_degrade_for_unsupported_kind_skips(
+        self,
+    ) -> None:
+        batch = ParseBatchResult(
+            files=[
+                ParsedFileResult(
+                    file_name="deployment.yaml",
+                    tool="kubernetes",
+                    status="parsed",
+                    changes=[],
+                )
+            ]
+        )
+
+        with patch(
+            "services.analysis_service.get_topology_status",
+            return_value=SimpleNamespace(
+                updated_at="2026-06-09T00:00:00Z",
+                payload={
+                    "metadata": {
+                        "import": {
+                            "source_type": "kubernetes",
+                            "source_ref": "context:prod",
+                        }
+                    },
+                    "services": [
+                        {
+                            "id": "Deployment/payments/api",
+                            "resource_keys": ["Deployment/payments/api"],
+                            "downstream": [],
+                        }
+                    ],
+                },
+                warnings=[
+                    "Kubernetes live-state import skipped unsupported or duplicate objects while preserving supported context."
+                ],
+            ),
+        ):
+            context = build_analysis_artifacts.__globals__[
+                "_build_context_completeness"
+            ](batch, include_incident_context=False)
+
+        self.assertEqual(context.context_score, 1.0)
+        self.assertEqual(context.confidence_level, "high")
+        self.assertIsNone(context.uncertainty)
+
+    def test_build_context_completeness_treats_namespace_only_kubernetes_context_as_unusable(
+        self,
+    ) -> None:
+        batch = ParseBatchResult(
+            files=[
+                ParsedFileResult(
+                    file_name="namespace.yaml",
+                    tool="kubernetes",
+                    status="parsed",
+                    changes=[],
+                )
+            ]
+        )
+
+        with patch(
+            "services.analysis_service.get_topology_status",
+            return_value=SimpleNamespace(
+                updated_at="2026-06-09T00:00:00Z",
+                payload={
+                    "services": [
+                        {
+                            "id": "Namespace/payments",
+                            "resource_keys": ["Namespace/payments"],
+                            "downstream": [],
+                        }
+                    ]
+                },
+                warnings=[
+                    "Kubernetes live-state context TODO: all-namespaces access is unavailable for 'context:prod' resource 'deployments'."
+                ],
+            ),
+        ):
+            context = build_analysis_artifacts.__globals__[
+                "_build_context_completeness"
+            ](batch, include_incident_context=False)
+
+        self.assertLess(context.context_score, 0.7)
+        self.assertEqual(context.confidence_level, "low")
+        self.assertTrue(context.insufficient_context)
+        self.assertIn(
+            "Resolve Kubernetes live-state context TODOs before relying on topology context.",
+            context.context_todos,
+        )
+
+    def test_build_context_completeness_treats_namespace_only_kubernetes_context_without_todos_as_unusable(
+        self,
+    ) -> None:
+        batch = ParseBatchResult(
+            files=[
+                ParsedFileResult(
+                    file_name="namespace.yaml",
+                    tool="kubernetes",
+                    status="parsed",
+                    changes=[],
+                )
+            ]
+        )
+
+        with patch(
+            "services.analysis_service.get_topology_status",
+            return_value=SimpleNamespace(
+                updated_at="2026-06-09T00:00:00Z",
+                payload={
+                    "metadata": {
+                        "import": {
+                            "source_type": "kubernetes",
+                            "source_ref": "context:prod",
+                        }
+                    },
+                    "services": [
+                        {
+                            "id": "Namespace/payments",
+                            "resource_keys": ["Namespace/payments"],
+                            "downstream": [],
+                        }
+                    ],
+                },
+                warnings=[],
+            ),
+        ):
+            context = build_analysis_artifacts.__globals__[
+                "_build_context_completeness"
+            ](batch, include_incident_context=False)
+
+        self.assertLess(context.context_score, 0.7)
+        self.assertEqual(context.confidence_level, "low")
+        self.assertTrue(context.insufficient_context)
+
     def test_build_context_completeness_counts_distinct_evidence_coverage(
         self,
     ) -> None:
@@ -1195,7 +1503,10 @@ class AnalysisServiceTests(unittest.TestCase):
         inferred = artifacts.findings[1]
         self.assertFalse(inferred.deterministic)
         self.assertAlmostEqual(inferred.confidence, 0.73)
-        self.assertGreater(artifacts.assessment.context_completeness.context_score, 0.7)
+        self.assertGreaterEqual(
+            artifacts.assessment.context_completeness.context_score,
+            0.7,
+        )
 
     def test_build_analysis_artifacts_reduces_context_score_for_stale_topology(
         self,

--- a/tests/test_services/test_topology_service.py
+++ b/tests/test_services/test_topology_service.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import os
+import subprocess
 import tempfile
 import unittest
 from datetime import UTC, datetime
@@ -20,6 +21,7 @@ import services.settings_service as settings_service_module
 from analysis.blast_radius import compute_blast_radius
 from models.database import SessionLocal
 from parsers.base import UnifiedChange
+from parsers.kubernetes_parser import parse_kubernetes
 from services.topology_service import (
     check_topology_drift,
     get_topology_status,
@@ -32,6 +34,27 @@ from services.topology_service import (
 
 def _fresh_topology_timestamp() -> str:
     return datetime.now(UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def _kubectl_live_state_side_effect(
+    resources_by_name: dict[str, list[dict]],
+):
+    def side_effect(args: list[str], **_: object) -> subprocess.CompletedProcess:
+        resource = args[args.index("get") + 1]
+        return subprocess.CompletedProcess(
+            args=args,
+            returncode=0,
+            stdout=json.dumps(
+                {
+                    "apiVersion": "v1",
+                    "kind": "List",
+                    "items": resources_by_name.get(resource, []),
+                }
+            ),
+            stderr="",
+        )
+
+    return side_effect
 
 
 class TopologyServiceTests(unittest.TestCase):
@@ -526,6 +549,1651 @@ class TopologyServiceTests(unittest.TestCase):
         self.assertIsNone(topology)
         self.assertIn("not configured", warning)
 
+    def test_import_topology_source_reads_kubernetes_live_state_relationships(
+        self,
+    ) -> None:
+        project_service_module.create_project(
+            project_key="payments",
+            display_name="Payments",
+        )
+        live_state = {
+            "apiVersion": "v1",
+            "kind": "List",
+            "items": [
+                {
+                    "apiVersion": "v1",
+                    "kind": "Namespace",
+                    "metadata": {
+                        "name": "payments",
+                        "resourceVersion": "10",
+                        "managedFields": [{"manager": "kubectl"}],
+                    },
+                },
+                {
+                    "apiVersion": "apps/v1",
+                    "kind": "Deployment",
+                    "metadata": {
+                        "name": "api",
+                        "namespace": "payments",
+                        "resourceVersion": "20",
+                    },
+                    "spec": {
+                        "selector": {"matchLabels": {"app": "api"}},
+                        "template": {
+                            "metadata": {"labels": {"app": "api", "tier": "frontend"}}
+                        },
+                    },
+                },
+                {
+                    "apiVersion": "v1",
+                    "kind": "Service",
+                    "metadata": {
+                        "name": "api",
+                        "namespace": "payments",
+                        "resourceVersion": "30",
+                    },
+                    "spec": {"selector": {"app": "api"}},
+                },
+            ],
+        }
+
+        with patch("services.topology_service.subprocess.run") as run:
+            run.side_effect = _kubectl_live_state_side_effect(
+                {
+                    "namespaces": [live_state["items"][0]],
+                    "deployments": [live_state["items"][1]],
+                    "services": [live_state["items"][2]],
+                }
+            )
+
+            result = import_topology_source(
+                "kubernetes",
+                "context:prod",
+                project_key="payments",
+            )
+
+        topology, warning = load_topology(project_key="payments")
+
+        self.assertTrue(result.applied)
+        self.assertIsNone(warning)
+        self.assertGreaterEqual(run.call_count, 1)
+        namespace_args = run.call_args_list[0].args[0]
+        service_args = run.call_args_list[1].args[0]
+        self.assertEqual(namespace_args[:4], ["kubectl", "--context", "prod", "get"])
+        self.assertEqual(namespace_args[4:], ["namespaces", "-o", "json"])
+        self.assertEqual(service_args[:4], ["kubectl", "--context", "prod", "get"])
+        self.assertEqual(service_args[4:], ["services", "-A", "-o", "json"])
+        assert topology is not None
+        self.assertEqual(topology["metadata"]["import"]["source_type"], "kubernetes")
+        self.assertIn("updated_at", topology)
+        self.assertNotIn("managedFields", json.dumps(topology))
+        service_by_id = {service["id"]: service for service in topology["services"]}
+        self.assertEqual(
+            service_by_id["Namespace/payments"]["downstream"],
+            ["Deployment/payments/api", "Service/payments/api"],
+        )
+        self.assertEqual(
+            service_by_id["Deployment/payments/api"]["downstream"],
+            ["Service/payments/api"],
+        )
+        self.assertNotIn(
+            "Deployment/api",
+            service_by_id["Deployment/payments/api"]["resource_keys"],
+        )
+        self.assertNotIn(
+            "Namespace/payments",
+            service_by_id["Deployment/payments/api"]["resource_keys"],
+        )
+        self.assertFalse(
+            any(
+                resource_key.startswith("resourceVersion:")
+                for service in topology["services"]
+                for resource_key in service["resource_keys"]
+            )
+        )
+        self.assertIn(
+            "selector:payments:app=api",
+            service_by_id["Service/payments/api"]["resource_keys"],
+        )
+        changes = parse_kubernetes(
+            "deployment.yaml",
+            b"""apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: api
+  namespace: payments
+""",
+        )
+        blast_radius = compute_blast_radius(changes, topology, warning)
+        self.assertEqual(blast_radius.context_source["type"], "kubernetes")
+        self.assertEqual(blast_radius.freshness["updated_at"], topology["updated_at"])
+        self.assertIsInstance(blast_radius.freshness["age_days"], int)
+        self.assertEqual(blast_radius.direct_count, 1)
+        self.assertEqual(blast_radius.transitive_count, 1)
+        self.assertEqual(
+            [node.service_id for node in blast_radius.affected],
+            ["Deployment/payments/api", "Service/payments/api"],
+        )
+
+    def test_import_topology_source_matches_namespaced_kubernetes_manifest_once(
+        self,
+    ) -> None:
+        project_service_module.create_project(
+            project_key="payments",
+            display_name="Payments",
+        )
+        live_state = {
+            "apiVersion": "v1",
+            "kind": "List",
+            "items": [
+                {
+                    "apiVersion": "apps/v1",
+                    "kind": "Deployment",
+                    "metadata": {"name": "api", "namespace": "payments"},
+                    "spec": {"template": {"metadata": {"labels": {"app": "api"}}}},
+                },
+                {
+                    "apiVersion": "v1",
+                    "kind": "Service",
+                    "metadata": {"name": "api", "namespace": "payments"},
+                    "spec": {"selector": {"app": "api"}},
+                },
+                {
+                    "apiVersion": "apps/v1",
+                    "kind": "Deployment",
+                    "metadata": {"name": "api", "namespace": "staging"},
+                    "spec": {"template": {"metadata": {"labels": {"app": "api"}}}},
+                },
+                {
+                    "apiVersion": "v1",
+                    "kind": "Service",
+                    "metadata": {"name": "api", "namespace": "staging"},
+                    "spec": {"selector": {"app": "api"}},
+                },
+            ],
+        }
+
+        with patch("services.topology_service.subprocess.run") as run:
+            run.side_effect = _kubectl_live_state_side_effect(
+                {
+                    "deployments": [live_state["items"][0], live_state["items"][2]],
+                    "services": [live_state["items"][1], live_state["items"][3]],
+                }
+            )
+            import_topology_source(
+                "kubernetes",
+                "context:prod",
+                project_key="payments",
+            )
+        topology, warning = load_topology(project_key="payments")
+        changes = parse_kubernetes(
+            "deployment.yaml",
+            b"""apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: api
+  namespace: payments
+""",
+        )
+
+        blast_radius = compute_blast_radius(changes, topology, warning)
+
+        self.assertEqual(changes[0].resource_id, "Deployment/payments/api")
+        self.assertEqual(blast_radius.direct_count, 1)
+        self.assertEqual(blast_radius.transitive_count, 1)
+        self.assertEqual(
+            [node.service_id for node in blast_radius.affected],
+            ["Deployment/payments/api", "Service/payments/api"],
+        )
+
+    def test_import_topology_source_leaves_namespace_less_manifest_unmatched(
+        self,
+    ) -> None:
+        project_service_module.create_project(
+            project_key="payments",
+            display_name="Payments",
+        )
+        live_state = {
+            "apiVersion": "v1",
+            "kind": "List",
+            "items": [
+                {
+                    "apiVersion": "apps/v1",
+                    "kind": "Deployment",
+                    "metadata": {"name": "api", "namespace": "default"},
+                    "spec": {"template": {"metadata": {"labels": {"app": "api"}}}},
+                },
+                {
+                    "apiVersion": "v1",
+                    "kind": "Service",
+                    "metadata": {"name": "api", "namespace": "default"},
+                    "spec": {"selector": {"app": "api"}},
+                },
+                {
+                    "apiVersion": "apps/v1",
+                    "kind": "Deployment",
+                    "metadata": {"name": "api", "namespace": "staging"},
+                    "spec": {"template": {"metadata": {"labels": {"app": "api"}}}},
+                },
+                {
+                    "apiVersion": "v1",
+                    "kind": "Service",
+                    "metadata": {"name": "api", "namespace": "staging"},
+                    "spec": {"selector": {"app": "api"}},
+                },
+            ],
+        }
+
+        with patch("services.topology_service.subprocess.run") as run:
+            run.side_effect = _kubectl_live_state_side_effect(
+                {
+                    "deployments": [live_state["items"][0], live_state["items"][2]],
+                    "services": [live_state["items"][1], live_state["items"][3]],
+                }
+            )
+            import_topology_source(
+                "kubernetes",
+                "context:prod",
+                project_key="payments",
+            )
+        topology, warning = load_topology(project_key="payments")
+        changes = parse_kubernetes(
+            "deployment.yaml",
+            b"""apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: api
+""",
+        )
+
+        blast_radius = compute_blast_radius(changes, topology, warning)
+
+        self.assertEqual(changes[0].resource_id, "Deployment/api")
+        self.assertEqual(blast_radius.direct_count, 0)
+        self.assertEqual(blast_radius.transitive_count, 0)
+        self.assertEqual(blast_radius.affected, [])
+        self.assertEqual(blast_radius.unmatched_resources, ["Deployment/api"])
+        self.assertIn("no topology mapping", blast_radius.warning.lower())
+
+    def test_import_topology_source_matches_namespace_manifest_through_namespace_node(
+        self,
+    ) -> None:
+        project_service_module.create_project(
+            project_key="payments",
+            display_name="Payments",
+        )
+        live_state = {
+            "apiVersion": "v1",
+            "kind": "List",
+            "items": [
+                {
+                    "apiVersion": "v1",
+                    "kind": "Namespace",
+                    "metadata": {"name": "payments"},
+                },
+                {
+                    "apiVersion": "apps/v1",
+                    "kind": "Deployment",
+                    "metadata": {"name": "api", "namespace": "payments"},
+                    "spec": {"template": {"metadata": {"labels": {"app": "api"}}}},
+                },
+                {
+                    "apiVersion": "v1",
+                    "kind": "Service",
+                    "metadata": {"name": "api", "namespace": "payments"},
+                    "spec": {"selector": {"app": "api"}},
+                },
+            ],
+        }
+
+        with patch("services.topology_service.subprocess.run") as run:
+            run.side_effect = _kubectl_live_state_side_effect(
+                {
+                    "namespaces": [live_state["items"][0]],
+                    "deployments": [live_state["items"][1]],
+                    "services": [live_state["items"][2]],
+                }
+            )
+            import_topology_source(
+                "kubernetes",
+                "context:prod",
+                project_key="payments",
+            )
+        topology, warning = load_topology(project_key="payments")
+        changes = parse_kubernetes(
+            "namespace.yaml",
+            b"""apiVersion: v1
+kind: Namespace
+metadata:
+  name: payments
+""",
+        )
+
+        blast_radius = compute_blast_radius(changes, topology, warning)
+
+        self.assertEqual(changes[0].resource_id, "Namespace/payments")
+        self.assertEqual(blast_radius.direct_count, 1)
+        self.assertEqual(blast_radius.transitive_count, 2)
+        self.assertEqual(
+            [(node.service_id, node.depth) for node in blast_radius.affected],
+            [
+                ("Namespace/payments", 0),
+                ("Deployment/payments/api", 1),
+                ("Service/payments/api", 1),
+            ],
+        )
+
+    def test_kubernetes_parser_alias_matches_legacy_custom_topology_key(self) -> None:
+        topology = {
+            "metadata": {"import": {"source_type": "custom", "source_ref": "legacy"}},
+            "updated_at": _fresh_topology_timestamp(),
+            "services": [
+                {
+                    "id": "api",
+                    "label": "API",
+                    "resource_keys": ["Deployment/api"],
+                    "downstream": [],
+                }
+            ],
+        }
+        changes = parse_kubernetes(
+            "deployment.yaml",
+            b"""apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: api
+  namespace: payments
+""",
+        )
+
+        blast_radius = compute_blast_radius(changes, topology)
+
+        self.assertEqual(changes[0].resource_id, "Deployment/payments/api")
+        self.assertEqual(changes[0].metadata["resource_aliases"], ["Deployment/api"])
+        self.assertEqual(blast_radius.direct_count, 1)
+        self.assertEqual([node.service_id for node in blast_radius.affected], ["api"])
+
+    def test_import_topology_source_resolves_current_context_source_ref(self) -> None:
+        project_service_module.create_project(
+            project_key="payments",
+            display_name="Payments",
+        )
+        deployment = {
+            "apiVersion": "apps/v1",
+            "kind": "Deployment",
+            "metadata": {"name": "api", "namespace": "payments"},
+            "spec": {"template": {"metadata": {"labels": {"app": "api"}}}},
+        }
+
+        def side_effect(args: list[str], **_: object) -> subprocess.CompletedProcess:
+            if args == ["kubectl", "config", "current-context"]:
+                return subprocess.CompletedProcess(
+                    args=args,
+                    returncode=0,
+                    stdout="prod\n",
+                    stderr="",
+                )
+            resource = args[args.index("get") + 1]
+            return subprocess.CompletedProcess(
+                args=args,
+                returncode=0,
+                stdout=json.dumps(
+                    {
+                        "apiVersion": "v1",
+                        "kind": "List",
+                        "items": [deployment] if resource == "deployments" else [],
+                    }
+                ),
+                stderr="",
+            )
+
+        with patch("services.topology_service.subprocess.run") as run:
+            run.side_effect = side_effect
+            result = import_topology_source(
+                "kubernetes",
+                "current-context",
+                project_key="payments",
+            )
+
+        topology, _ = load_topology(project_key="payments")
+
+        self.assertTrue(result.applied)
+        self.assertEqual(result.source_ref, "context:prod")
+        assert topology is not None
+        self.assertEqual(topology["metadata"]["import"]["source_ref"], "context:prod")
+        get_args = run.call_args_list[1].args[0]
+        self.assertEqual(get_args[:3], ["kubectl", "--context", "prod"])
+
+    def test_import_topology_source_current_context_uses_one_timeout_budget(
+        self,
+    ) -> None:
+        project_service_module.create_project(
+            project_key="payments",
+            display_name="Payments",
+        )
+        command_timeouts: list[float] = []
+
+        def side_effect(
+            args: list[str], **kwargs: object
+        ) -> subprocess.CompletedProcess:
+            command_timeouts.append(float(kwargs["timeout"]))
+            if args == ["kubectl", "config", "current-context"]:
+                return subprocess.CompletedProcess(
+                    args=args,
+                    returncode=0,
+                    stdout="prod\n",
+                    stderr="",
+                )
+            raise FileNotFoundError("kubectl")
+
+        with (
+            patch("services.topology_service.subprocess.run", side_effect=side_effect),
+            patch(
+                "services.topology_service.monotonic",
+                side_effect=[100.0, 100.0, 109.0],
+            ),
+        ):
+            result = import_topology_source(
+                "kubernetes",
+                "current-context",
+                project_key="payments",
+            )
+
+        self.assertFalse(result.applied)
+        self.assertEqual(command_timeouts[0], 10.0)
+        self.assertLessEqual(command_timeouts[1], 1.0)
+
+    def test_import_topology_source_preserves_topology_when_current_context_resolver_fails(
+        self,
+    ) -> None:
+        failure_cases = [
+            FileNotFoundError("kubectl"),
+            OSError("kubectl"),
+            subprocess.TimeoutExpired("kubectl", timeout=10),
+            UnicodeDecodeError("utf-8", b"\xff", 0, 1, "invalid"),
+            subprocess.CalledProcessError(1, ["kubectl"]),
+            subprocess.CompletedProcess(
+                args=["kubectl", "config", "current-context"],
+                returncode=0,
+                stdout="\n",
+                stderr="",
+            ),
+        ]
+        baseline = json.dumps(
+            {
+                "services": [
+                    {
+                        "id": "api",
+                        "label": "API",
+                        "resource_keys": ["Deployment/api"],
+                        "downstream": [],
+                    }
+                ]
+            }
+        )
+
+        for index, failure in enumerate(failure_cases):
+            project_key = f"resolver-{index}"
+            project_service_module.create_project(
+                project_key=project_key,
+                display_name=f"Resolver {index}",
+            )
+            save_topology_definition(baseline, project_key=project_key)
+
+            with self.subTest(failure=type(failure).__name__, index=index):
+                with patch("services.topology_service.subprocess.run") as run:
+                    if isinstance(failure, subprocess.CompletedProcess):
+                        run.return_value = failure
+                    else:
+                        run.side_effect = failure
+                    result = import_topology_source(
+                        "kubernetes",
+                        "current-context",
+                        project_key=project_key,
+                    )
+
+                topology, warning = load_topology(project_key=project_key)
+
+                self.assertFalse(result.applied)
+                assert warning is not None
+                self.assertIn("kubernetes live-state context todo", warning.lower())
+                assert topology is not None
+                self.assertEqual(
+                    [service["id"] for service in topology["services"]], ["api"]
+                )
+
+    def test_current_context_refresh_failure_warns_existing_resolved_topology(
+        self,
+    ) -> None:
+        project_service_module.create_project(
+            project_key="payments",
+            display_name="Payments",
+        )
+        deployment = {
+            "apiVersion": "apps/v1",
+            "kind": "Deployment",
+            "metadata": {"name": "api", "namespace": "payments"},
+            "spec": {"template": {"metadata": {"labels": {"app": "api"}}}},
+        }
+
+        def successful_resolve(
+            args: list[str], **_: object
+        ) -> subprocess.CompletedProcess:
+            if args == ["kubectl", "config", "current-context"]:
+                return subprocess.CompletedProcess(
+                    args=args,
+                    returncode=0,
+                    stdout="prod\n",
+                    stderr="",
+                )
+            resource = args[args.index("get") + 1]
+            return subprocess.CompletedProcess(
+                args=args,
+                returncode=0,
+                stdout=json.dumps(
+                    {
+                        "apiVersion": "v1",
+                        "kind": "List",
+                        "items": [deployment] if resource == "deployments" else [],
+                    }
+                ),
+                stderr="",
+            )
+
+        with patch("services.topology_service.subprocess.run") as run:
+            run.side_effect = successful_resolve
+            baseline = import_topology_source(
+                "kubernetes",
+                "current-context",
+                project_key="payments",
+            )
+
+        with patch("services.topology_service.subprocess.run") as run:
+            run.side_effect = subprocess.TimeoutExpired("kubectl", timeout=10)
+            refresh = import_topology_source(
+                "kubernetes",
+                "current-context",
+                project_key="payments",
+            )
+
+        status = get_topology_status(project_key="payments")
+
+        self.assertTrue(baseline.applied)
+        self.assertEqual(baseline.source_ref, "context:prod")
+        self.assertFalse(refresh.applied)
+        self.assertEqual(
+            status.payload["metadata"]["import"]["source_ref"], "context:prod"
+        )
+        self.assertIn(
+            "kubernetes live-state context todo",
+            " ".join(status.warnings).lower(),
+        )
+
+    def test_current_context_failure_does_not_warn_unrelated_explicit_context(
+        self,
+    ) -> None:
+        project_service_module.create_project(
+            project_key="payments",
+            display_name="Payments",
+        )
+        deployment = {
+            "apiVersion": "apps/v1",
+            "kind": "Deployment",
+            "metadata": {"name": "api", "namespace": "payments"},
+            "spec": {"template": {"metadata": {"labels": {"app": "api"}}}},
+        }
+
+        with patch("services.topology_service.subprocess.run") as run:
+            run.side_effect = _kubectl_live_state_side_effect(
+                {"deployments": [deployment]}
+            )
+            baseline = import_topology_source(
+                "kubernetes",
+                "context:staging",
+                project_key="payments",
+            )
+
+        with patch("services.topology_service.subprocess.run") as run:
+            run.side_effect = subprocess.TimeoutExpired("kubectl", timeout=10)
+            refresh = import_topology_source(
+                "kubernetes",
+                "current-context",
+                project_key="payments",
+            )
+
+        status = get_topology_status(project_key="payments")
+
+        self.assertTrue(baseline.applied)
+        self.assertEqual(baseline.source_ref, "context:staging")
+        self.assertFalse(refresh.applied)
+        self.assertEqual(
+            status.payload["metadata"]["import"]["source_ref"], "context:staging"
+        )
+        self.assertNotIn(
+            "kubernetes live-state context todo",
+            " ".join(status.warnings).lower(),
+        )
+
+    def test_current_context_warning_survives_unrelated_context_probe(
+        self,
+    ) -> None:
+        project_service_module.create_project(
+            project_key="payments",
+            display_name="Payments",
+        )
+        deployment = {
+            "apiVersion": "apps/v1",
+            "kind": "Deployment",
+            "metadata": {"name": "api", "namespace": "payments"},
+            "spec": {"template": {"metadata": {"labels": {"app": "api"}}}},
+        }
+
+        def successful_resolve(
+            args: list[str], **_: object
+        ) -> subprocess.CompletedProcess:
+            if args == ["kubectl", "config", "current-context"]:
+                return subprocess.CompletedProcess(
+                    args=args,
+                    returncode=0,
+                    stdout="prod\n",
+                    stderr="",
+                )
+            resource = args[args.index("get") + 1]
+            return subprocess.CompletedProcess(
+                args=args,
+                returncode=0,
+                stdout=json.dumps(
+                    {
+                        "apiVersion": "v1",
+                        "kind": "List",
+                        "items": [deployment] if resource == "deployments" else [],
+                    }
+                ),
+                stderr="",
+            )
+
+        with patch("services.topology_service.subprocess.run") as run:
+            run.side_effect = successful_resolve
+            baseline = import_topology_source(
+                "kubernetes",
+                "current-context",
+                project_key="payments",
+            )
+
+        with patch("services.topology_service.subprocess.run") as run:
+            run.side_effect = subprocess.TimeoutExpired("kubectl", timeout=10)
+            refresh = import_topology_source(
+                "kubernetes",
+                "current-context",
+                project_key="payments",
+            )
+
+        with patch("services.topology_service.subprocess.run") as run:
+            run.side_effect = FileNotFoundError("kubectl")
+            unrelated_probe = import_topology_source(
+                "kubernetes",
+                "context:staging",
+                project_key="payments",
+            )
+
+        status = get_topology_status(project_key="payments")
+        joined_warnings = " ".join(status.warnings).lower()
+
+        self.assertTrue(baseline.applied)
+        self.assertFalse(refresh.applied)
+        self.assertFalse(unrelated_probe.applied)
+        self.assertIn("resolving the current kubernetes context", joined_warnings)
+        self.assertNotIn("context:staging", joined_warnings)
+
+    def test_import_topology_source_warns_without_replacing_for_unavailable_kubernetes(
+        self,
+    ) -> None:
+        project_service_module.create_project(
+            project_key="payments",
+            display_name="Payments",
+        )
+        source_path = Path(self.tempdir.name) / "baseline-topology.json"
+        source_path.write_text(
+            json.dumps(
+                {
+                    "services": [
+                        {
+                            "id": "api",
+                            "label": "API",
+                            "resource_keys": ["Deployment/api"],
+                            "downstream": [],
+                        }
+                    ]
+                }
+            ),
+            encoding="utf-8",
+        )
+        import_topology_source("custom", str(source_path), project_key="payments")
+
+        with patch("services.topology_service.subprocess.run") as run:
+            run.side_effect = FileNotFoundError("kubectl")
+            result = import_topology_source(
+                "kubernetes",
+                "context:prod",
+                project_key="payments",
+            )
+
+        topology, warning = load_topology(project_key="payments")
+
+        self.assertFalse(result.applied)
+        self.assertIn("todo", " ".join(result.warnings).lower())
+        self.assertEqual(result.accepted_resources, [])
+        self.assertEqual(len(result.unsupported_resources), 1)
+        assert topology is not None
+        self.assertEqual([service["id"] for service in topology["services"]], ["api"])
+        assert warning is not None
+        self.assertIn("kubernetes live-state context todo", warning.lower())
+
+    def test_save_topology_definition_clears_cached_kubernetes_live_state_warning(
+        self,
+    ) -> None:
+        project_service_module.create_project(
+            project_key="payments",
+            display_name="Payments",
+        )
+
+        with patch("services.topology_service.subprocess.run") as run:
+            run.side_effect = FileNotFoundError("kubectl")
+            import_topology_source(
+                "kubernetes",
+                "context:prod",
+                project_key="payments",
+            )
+
+        _, warning = load_topology(project_key="payments")
+        assert warning is not None
+        self.assertIn("kubernetes live-state context todo", warning.lower())
+
+        save_topology_definition(
+            json.dumps(
+                {
+                    "services": [
+                        {
+                            "id": "api",
+                            "label": "API",
+                            "resource_keys": ["Deployment/api"],
+                            "downstream": [],
+                        }
+                    ]
+                }
+            ),
+            project_key="payments",
+        )
+
+        _, warning = load_topology(project_key="payments")
+
+        if warning is not None:
+            self.assertNotIn("kubernetes live-state context todo", warning.lower())
+
+    def test_import_topology_source_warns_for_invalid_kubernetes_source_ref(
+        self,
+    ) -> None:
+        project_service_module.create_project(
+            project_key="payments",
+            display_name="Payments",
+        )
+
+        with patch("services.topology_service.subprocess.run") as run:
+            result = import_topology_source(
+                "kubernetes",
+                "context:",
+                project_key="payments",
+            )
+
+        topology, warning = load_topology(project_key="payments")
+
+        self.assertFalse(result.applied)
+        self.assertEqual(run.call_count, 0)
+        self.assertIn("context:<name>", " ".join(result.warnings))
+        self.assertIsNone(topology)
+        assert warning is not None
+        self.assertIn("kubernetes live-state context todo", warning.lower())
+
+    def test_import_topology_source_warns_for_kubernetes_timeout(self) -> None:
+        project_service_module.create_project(
+            project_key="payments",
+            display_name="Payments",
+        )
+
+        with patch("services.topology_service.subprocess.run") as run:
+            run.side_effect = subprocess.TimeoutExpired("kubectl", timeout=10)
+            result = import_topology_source(
+                "kubernetes",
+                "context:prod",
+                project_key="payments",
+            )
+
+        topology, warning = load_topology(project_key="payments")
+
+        self.assertFalse(result.applied)
+        self.assertIn("todo", " ".join(result.warnings).lower())
+        self.assertIn("timed out", " ".join(result.warnings).lower())
+        self.assertEqual(result.accepted_resources, [])
+        self.assertIsNone(topology)
+        self.assertIn("not configured", warning)
+        assert warning is not None
+        self.assertIn("kubernetes live-state context todo", warning.lower())
+
+    def test_import_topology_source_warns_for_kubernetes_os_error(self) -> None:
+        project_service_module.create_project(
+            project_key="payments",
+            display_name="Payments",
+        )
+
+        with patch("services.topology_service.subprocess.run") as run:
+            run.side_effect = PermissionError("kubectl")
+            result = import_topology_source(
+                "kubernetes",
+                "context:prod",
+                project_key="payments",
+            )
+
+        topology, warning = load_topology(project_key="payments")
+
+        self.assertFalse(result.applied)
+        self.assertIn("todo", " ".join(result.warnings).lower())
+        self.assertIn("could not be executed", " ".join(result.warnings).lower())
+        self.assertEqual(result.accepted_resources, [])
+        self.assertIsNone(topology)
+        assert warning is not None
+        self.assertIn("kubernetes live-state context todo", warning.lower())
+
+    def test_import_topology_source_warns_for_kubernetes_decode_error(self) -> None:
+        project_service_module.create_project(
+            project_key="payments",
+            display_name="Payments",
+        )
+
+        with patch("services.topology_service.subprocess.run") as run:
+            run.side_effect = UnicodeDecodeError("utf-8", b"\xff", 0, 1, "invalid")
+            result = import_topology_source(
+                "kubernetes",
+                "context:prod",
+                project_key="payments",
+            )
+
+        topology, warning = load_topology(project_key="payments")
+
+        self.assertFalse(result.applied)
+        self.assertIn("todo", " ".join(result.warnings).lower())
+        self.assertIn("utf-8", " ".join(result.warnings).lower())
+        self.assertEqual(result.accepted_resources, [])
+        self.assertIsNone(topology)
+        assert warning is not None
+        self.assertIn("kubernetes live-state context todo", warning.lower())
+
+    def test_import_topology_source_partially_skips_live_state_missing_namespace(
+        self,
+    ) -> None:
+        project_service_module.create_project(
+            project_key="payments",
+            display_name="Payments",
+        )
+        source_path = Path(self.tempdir.name) / "baseline-topology.json"
+        source_path.write_text(
+            json.dumps(
+                {
+                    "services": [
+                        {
+                            "id": "api",
+                            "label": "API",
+                            "resource_keys": ["Deployment/api"],
+                            "downstream": [],
+                        }
+                    ]
+                }
+            ),
+            encoding="utf-8",
+        )
+        import_topology_source("custom", str(source_path), project_key="payments")
+        namespace = {
+            "apiVersion": "v1",
+            "kind": "Namespace",
+            "metadata": {"name": "payments"},
+        }
+        malformed_deployment = {
+            "apiVersion": "apps/v1",
+            "kind": "Deployment",
+            "metadata": {"name": "api"},
+            "spec": {"template": {"metadata": {"labels": {"app": "api"}}}},
+        }
+
+        with patch("services.topology_service.subprocess.run") as run:
+            run.side_effect = _kubectl_live_state_side_effect(
+                {
+                    "namespaces": [namespace],
+                    "deployments": [malformed_deployment],
+                }
+            )
+            result = import_topology_source(
+                "kubernetes",
+                "context:prod",
+                project_key="payments",
+            )
+
+        topology, warning = load_topology(project_key="payments")
+
+        self.assertFalse(result.applied)
+        self.assertIn("partially parsed", " ".join(result.warnings).lower())
+        self.assertEqual(
+            [item.resource_ref for item in result.partially_parsed_resources],
+            ["Deployment/api"],
+        )
+        assert topology is not None
+        self.assertEqual([service["id"] for service in topology["services"]], ["api"])
+        self.assertNotIn("Deployment/default/api", json.dumps(topology))
+        assert warning is not None
+        self.assertIn("partially parsed", warning.lower())
+
+    def test_import_topology_source_preserves_partial_kubernetes_rbac_context(
+        self,
+    ) -> None:
+        project_service_module.create_project(
+            project_key="payments",
+            display_name="Payments",
+        )
+        deployment = {
+            "apiVersion": "apps/v1",
+            "kind": "Deployment",
+            "metadata": {"name": "api", "namespace": "payments"},
+            "spec": {"template": {"metadata": {"labels": {"app": "api"}}}},
+        }
+
+        def side_effect(args: list[str], **_: object) -> subprocess.CompletedProcess:
+            resource = args[args.index("get") + 1]
+            if resource == "namespaces":
+                raise subprocess.CalledProcessError(1, args)
+            return subprocess.CompletedProcess(
+                args=args,
+                returncode=0,
+                stdout=json.dumps(
+                    {
+                        "apiVersion": "v1",
+                        "kind": "List",
+                        "items": [deployment] if resource == "deployments" else [],
+                    }
+                ),
+                stderr="",
+            )
+
+        with patch("services.topology_service.subprocess.run") as run:
+            run.side_effect = side_effect
+            result = import_topology_source(
+                "kubernetes",
+                "context:prod",
+                project_key="payments",
+            )
+
+        topology, warning = load_topology(project_key="payments")
+
+        self.assertTrue(result.applied)
+        self.assertIn("namespaces", " ".join(result.warnings))
+        assert topology is not None
+        self.assertEqual(
+            [service["id"] for service in topology["services"]],
+            ["Deployment/payments/api"],
+        )
+        assert warning is not None
+        self.assertIn("cluster access is unavailable", warning.lower())
+
+    def test_import_topology_source_preserves_mid_scan_launcher_failure_context(
+        self,
+    ) -> None:
+        project_service_module.create_project(
+            project_key="payments",
+            display_name="Payments",
+        )
+        deployment = {
+            "apiVersion": "apps/v1",
+            "kind": "Deployment",
+            "metadata": {"name": "api", "namespace": "payments"},
+            "spec": {"template": {"metadata": {"labels": {"app": "api"}}}},
+        }
+
+        def side_effect(args: list[str], **_: object) -> subprocess.CompletedProcess:
+            resource = args[args.index("get") + 1]
+            if resource == "statefulsets":
+                raise FileNotFoundError("kubectl")
+            return subprocess.CompletedProcess(
+                args=args,
+                returncode=0,
+                stdout=json.dumps(
+                    {
+                        "apiVersion": "v1",
+                        "kind": "List",
+                        "items": [deployment] if resource == "deployments" else [],
+                    }
+                ),
+                stderr="",
+            )
+
+        with patch("services.topology_service.subprocess.run") as run:
+            run.side_effect = side_effect
+            result = import_topology_source(
+                "kubernetes",
+                "context:prod",
+                project_key="payments",
+            )
+
+        topology, warning = load_topology(project_key="payments")
+
+        self.assertTrue(result.applied)
+        self.assertIn("kubectl", " ".join(result.warnings).lower())
+        assert topology is not None
+        self.assertEqual(
+            [service["id"] for service in topology["services"]],
+            ["Deployment/payments/api"],
+        )
+        assert warning is not None
+        self.assertIn("kubectl", warning.lower())
+
+    def test_import_topology_source_does_not_fallback_for_non_rbac_all_namespace_error(
+        self,
+    ) -> None:
+        project_service_module.create_project(
+            project_key="payments",
+            display_name="Payments",
+        )
+        source_path = Path(self.tempdir.name) / "baseline-topology.json"
+        source_path.write_text(
+            json.dumps(
+                {
+                    "services": [
+                        {
+                            "id": "api",
+                            "label": "API",
+                            "resource_keys": ["Deployment/api"],
+                            "downstream": [],
+                        }
+                    ]
+                }
+            ),
+            encoding="utf-8",
+        )
+        import_topology_source("custom", str(source_path), project_key="payments")
+        namespace = {
+            "apiVersion": "v1",
+            "kind": "Namespace",
+            "metadata": {"name": "payments"},
+        }
+        deployment = {
+            "apiVersion": "apps/v1",
+            "kind": "Deployment",
+            "metadata": {"name": "api", "namespace": "payments"},
+            "spec": {"template": {"metadata": {"labels": {"app": "api"}}}},
+        }
+
+        def side_effect(args: list[str], **_: object) -> subprocess.CompletedProcess:
+            resource = args[args.index("get") + 1]
+            if resource == "deployments" and "-A" in args:
+                raise subprocess.CalledProcessError(
+                    1,
+                    args,
+                    stderr="dial tcp 10.0.0.1:443: i/o timeout",
+                )
+            items = []
+            if resource == "namespaces":
+                items = [namespace]
+            elif resource == "deployments":
+                items = [deployment]
+            return subprocess.CompletedProcess(
+                args=args,
+                returncode=0,
+                stdout=json.dumps(
+                    {
+                        "apiVersion": "v1",
+                        "kind": "List",
+                        "items": items,
+                    }
+                ),
+                stderr="",
+            )
+
+        with patch("services.topology_service.subprocess.run") as run:
+            run.side_effect = side_effect
+            result = import_topology_source(
+                "kubernetes",
+                "context:prod",
+                project_key="payments",
+            )
+
+        topology, warning = load_topology(project_key="payments")
+
+        self.assertFalse(result.applied)
+        self.assertIn("cluster access is unavailable", " ".join(result.warnings))
+        assert topology is not None
+        self.assertEqual([service["id"] for service in topology["services"]], ["api"])
+        assert warning is not None
+        self.assertIn("cluster access is unavailable", warning.lower())
+
+    def test_import_topology_source_does_not_run_immediate_kubernetes_drift_read(
+        self,
+    ) -> None:
+        project_service_module.create_project(
+            project_key="payments",
+            display_name="Payments",
+        )
+        deployment = {
+            "apiVersion": "apps/v1",
+            "kind": "Deployment",
+            "metadata": {"name": "api", "namespace": "payments"},
+            "spec": {"template": {"metadata": {"labels": {"app": "api"}}}},
+        }
+
+        with patch("services.topology_service.subprocess.run") as run:
+            run.side_effect = _kubectl_live_state_side_effect(
+                {"deployments": [deployment]}
+            )
+            result = import_topology_source(
+                "kubernetes",
+                "context:prod",
+                project_key="payments",
+            )
+
+        get_calls = [
+            call.args[0] for call in run.call_args_list if "get" in call.args[0]
+        ]
+
+        self.assertTrue(result.applied)
+        self.assertEqual(len(get_calls), 5)
+
+    def test_import_topology_source_retries_namespaced_access_after_all_namespaces_rbac(
+        self,
+    ) -> None:
+        project_service_module.create_project(
+            project_key="payments",
+            display_name="Payments",
+        )
+        deployment = {
+            "apiVersion": "apps/v1",
+            "kind": "Deployment",
+            "metadata": {"name": "api", "namespace": "payments"},
+            "spec": {"template": {"metadata": {"labels": {"app": "api"}}}},
+        }
+        namespace = {
+            "apiVersion": "v1",
+            "kind": "Namespace",
+            "metadata": {"name": "payments"},
+        }
+
+        def side_effect(args: list[str], **_: object) -> subprocess.CompletedProcess:
+            resource = args[args.index("get") + 1]
+            if resource == "deployments" and "-A" in args:
+                raise subprocess.CalledProcessError(
+                    1,
+                    args,
+                    stderr="Error from server (Forbidden): deployments is forbidden",
+                )
+            items = []
+            if resource == "namespaces":
+                items = [namespace]
+            elif resource == "deployments":
+                items = [deployment]
+            return subprocess.CompletedProcess(
+                args=args,
+                returncode=0,
+                stdout=json.dumps(
+                    {
+                        "apiVersion": "v1",
+                        "kind": "List",
+                        "items": items,
+                    }
+                ),
+                stderr="",
+            )
+
+        with patch("services.topology_service.subprocess.run") as run:
+            run.side_effect = side_effect
+            result = import_topology_source(
+                "kubernetes",
+                "context:prod",
+                project_key="payments",
+            )
+
+        topology, warning = load_topology(project_key="payments")
+        deployment_calls = [
+            call.args[0]
+            for call in run.call_args_list
+            if call.args[0][call.args[0].index("get") + 1] == "deployments"
+        ]
+
+        self.assertTrue(result.applied)
+        self.assertEqual(deployment_calls[0][4:], ["deployments", "-A", "-o", "json"])
+        self.assertEqual(
+            deployment_calls[1][4:],
+            ["deployments", "-n", "payments", "-o", "json"],
+        )
+        self.assertIn("all-namespaces access", " ".join(result.warnings))
+        assert topology is not None
+        self.assertEqual(
+            [service["id"] for service in topology["services"]],
+            ["Deployment/payments/api", "Namespace/payments"],
+        )
+        assert warning is not None
+        self.assertIn("all-namespaces access", warning)
+
+    def test_import_topology_source_failed_kubernetes_probe_marks_cached_drift_unavailable(
+        self,
+    ) -> None:
+        project_service_module.create_project(
+            project_key="payments",
+            display_name="Payments",
+        )
+        deployment = {
+            "apiVersion": "apps/v1",
+            "kind": "Deployment",
+            "metadata": {"name": "api", "namespace": "payments"},
+            "spec": {"template": {"metadata": {"labels": {"app": "api"}}}},
+        }
+
+        with patch("services.topology_service.subprocess.run") as run:
+            run.side_effect = _kubectl_live_state_side_effect(
+                {"deployments": [deployment]}
+            )
+            import_topology_source(
+                "kubernetes",
+                "context:prod",
+                project_key="payments",
+            )
+
+        initial_status = get_topology_status(project_key="payments")
+        assert initial_status.drift is not None
+        self.assertEqual(initial_status.drift.status, "up_to_date")
+
+        with patch("services.topology_service.subprocess.run") as run:
+            run.side_effect = FileNotFoundError("kubectl")
+            failed_result = import_topology_source(
+                "kubernetes",
+                "context:prod",
+                project_key="payments",
+            )
+
+        status = get_topology_status(project_key="payments")
+
+        self.assertFalse(failed_result.applied)
+        self.assertIsNotNone(status.drift)
+        assert status.drift is not None
+        self.assertEqual(status.drift.status, "unavailable")
+        self.assertIn("Kubernetes live-state", " ".join(status.drift.warnings))
+
+    def test_import_topology_source_continues_namespace_fallback_after_forbidden_namespace(
+        self,
+    ) -> None:
+        project_service_module.create_project(
+            project_key="payments",
+            display_name="Payments",
+        )
+        namespaces = [
+            {
+                "apiVersion": "v1",
+                "kind": "Namespace",
+                "metadata": {"name": "restricted"},
+            },
+            {
+                "apiVersion": "v1",
+                "kind": "Namespace",
+                "metadata": {"name": "payments"},
+            },
+        ]
+        deployment = {
+            "apiVersion": "apps/v1",
+            "kind": "Deployment",
+            "metadata": {"name": "api", "namespace": "payments"},
+            "spec": {"template": {"metadata": {"labels": {"app": "api"}}}},
+        }
+
+        def side_effect(args: list[str], **_: object) -> subprocess.CompletedProcess:
+            resource = args[args.index("get") + 1]
+            if resource == "deployments" and "-A" in args:
+                raise subprocess.CalledProcessError(
+                    1,
+                    args,
+                    stderr="Error from server (Forbidden): deployments is forbidden",
+                )
+            if resource == "deployments" and "restricted" in args:
+                raise subprocess.CalledProcessError(1, args)
+            items = []
+            if resource == "namespaces":
+                items = namespaces
+            elif resource == "deployments" and "payments" in args:
+                items = [deployment]
+            return subprocess.CompletedProcess(
+                args=args,
+                returncode=0,
+                stdout=json.dumps(
+                    {
+                        "apiVersion": "v1",
+                        "kind": "List",
+                        "items": items,
+                    }
+                ),
+                stderr="",
+            )
+
+        with patch("services.topology_service.subprocess.run") as run:
+            run.side_effect = side_effect
+            result = import_topology_source(
+                "kubernetes",
+                "context:prod",
+                project_key="payments",
+            )
+
+        topology, warning = load_topology(project_key="payments")
+        deployment_calls = [
+            call.args[0]
+            for call in run.call_args_list
+            if call.args[0][call.args[0].index("get") + 1] == "deployments"
+        ]
+
+        self.assertTrue(result.applied)
+        self.assertEqual(
+            [args[4:] for args in deployment_calls[:3]],
+            [
+                ["deployments", "-A", "-o", "json"],
+                ["deployments", "-n", "restricted", "-o", "json"],
+                ["deployments", "-n", "payments", "-o", "json"],
+            ],
+        )
+        self.assertIn("namespace 'restricted'", " ".join(result.warnings))
+        assert topology is not None
+        self.assertIn(
+            "Deployment/payments/api",
+            [service["id"] for service in topology["services"]],
+        )
+        assert warning is not None
+        self.assertIn("namespace 'restricted'", warning)
+
+    def test_import_topology_source_success_clears_previous_kubernetes_todo_from_result(
+        self,
+    ) -> None:
+        project_service_module.create_project(
+            project_key="payments",
+            display_name="Payments",
+        )
+
+        with patch("services.topology_service.subprocess.run") as run:
+            run.side_effect = FileNotFoundError("kubectl")
+            failed_result = import_topology_source(
+                "kubernetes",
+                "context:prod",
+                project_key="payments",
+            )
+
+        self.assertFalse(failed_result.applied)
+        self.assertIn(
+            "kubernetes live-state context todo",
+            " ".join(failed_result.warnings).lower(),
+        )
+
+        namespace = {
+            "apiVersion": "v1",
+            "kind": "Namespace",
+            "metadata": {"name": "payments"},
+        }
+        deployment = {
+            "apiVersion": "apps/v1",
+            "kind": "Deployment",
+            "metadata": {"name": "api", "namespace": "payments"},
+            "spec": {"template": {"metadata": {"labels": {"app": "api"}}}},
+        }
+
+        with patch("services.topology_service.subprocess.run") as run:
+            run.side_effect = _kubectl_live_state_side_effect(
+                {
+                    "namespaces": [namespace],
+                    "deployments": [deployment],
+                }
+            )
+            result = import_topology_source(
+                "kubernetes",
+                "context:prod",
+                project_key="payments",
+            )
+
+        _, warning = load_topology(project_key="payments")
+
+        self.assertTrue(result.applied)
+        self.assertNotIn(
+            "kubernetes live-state context todo", " ".join(result.warnings).lower()
+        )
+        if warning is not None:
+            self.assertNotIn("kubernetes live-state context todo", warning.lower())
+
+    def test_get_topology_status_ignores_cached_kubernetes_todos_for_other_source_ref(
+        self,
+    ) -> None:
+        project_service_module.create_project(
+            project_key="payments",
+            display_name="Payments",
+        )
+        deployment = {
+            "apiVersion": "apps/v1",
+            "kind": "Deployment",
+            "metadata": {"name": "api", "namespace": "payments"},
+            "spec": {"template": {"metadata": {"labels": {"app": "api"}}}},
+        }
+
+        with patch("services.topology_service.subprocess.run") as run:
+            run.side_effect = _kubectl_live_state_side_effect(
+                {"deployments": [deployment]}
+            )
+            import_topology_source(
+                "kubernetes",
+                "context:prod",
+                project_key="payments",
+            )
+
+        with patch("services.topology_service.subprocess.run") as run:
+            run.side_effect = FileNotFoundError("kubectl")
+            failed_result = import_topology_source(
+                "kubernetes",
+                "context:staging",
+                project_key="payments",
+            )
+            status = get_topology_status(project_key="payments")
+
+        self.assertFalse(failed_result.applied)
+        self.assertEqual(
+            status.payload["metadata"]["import"]["source_ref"],
+            "context:prod",
+        )
+        joined_warnings = " ".join(status.warnings).lower()
+        self.assertNotIn("context:staging", joined_warnings)
+        self.assertNotIn("kubernetes live-state context todo", joined_warnings)
+
+    def test_get_topology_status_ignores_cached_kubernetes_todos_after_custom_import(
+        self,
+    ) -> None:
+        project_service_module.create_project(
+            project_key="payments",
+            display_name="Payments",
+        )
+
+        with patch("services.topology_service.subprocess.run") as run:
+            run.side_effect = FileNotFoundError("kubectl")
+            failed_result = import_topology_source(
+                "kubernetes",
+                "context:prod",
+                project_key="payments",
+            )
+
+        source_path = Path(self.tempdir.name) / "custom-after-kubernetes.json"
+        source_path.write_text(
+            json.dumps(
+                {
+                    "services": [
+                        {
+                            "id": "api",
+                            "label": "API",
+                            "resource_keys": ["Deployment/api"],
+                            "downstream": [],
+                        }
+                    ]
+                }
+            ),
+            encoding="utf-8",
+        )
+        import_topology_source("custom", str(source_path), project_key="payments")
+
+        status = get_topology_status(project_key="payments")
+
+        self.assertFalse(failed_result.applied)
+        self.assertEqual(status.payload["metadata"]["import"]["source_type"], "custom")
+        joined_warnings = " ".join(status.warnings).lower()
+        self.assertNotIn("kubernetes live-state context todo", joined_warnings)
+
+    def test_import_topology_source_preserves_topology_when_partial_empty_read_fails(
+        self,
+    ) -> None:
+        project_service_module.create_project(
+            project_key="payments",
+            display_name="Payments",
+        )
+        source_path = Path(self.tempdir.name) / "baseline-topology.json"
+        source_path.write_text(
+            json.dumps(
+                {
+                    "services": [
+                        {
+                            "id": "api",
+                            "label": "API",
+                            "resource_keys": ["Deployment/api"],
+                            "downstream": [],
+                        }
+                    ]
+                }
+            ),
+            encoding="utf-8",
+        )
+        import_topology_source("custom", str(source_path), project_key="payments")
+
+        def side_effect(args: list[str], **_: object) -> subprocess.CompletedProcess:
+            resource = args[args.index("get") + 1]
+            if resource == "services" and "-A" in args:
+                raise subprocess.CalledProcessError(1, args)
+            return subprocess.CompletedProcess(
+                args=args,
+                returncode=0,
+                stdout=json.dumps({"apiVersion": "v1", "kind": "List", "items": []}),
+                stderr="",
+            )
+
+        with patch("services.topology_service.subprocess.run") as run:
+            run.side_effect = side_effect
+            result = import_topology_source(
+                "kubernetes",
+                "context:prod",
+                project_key="payments",
+            )
+
+        topology, warning = load_topology(project_key="payments")
+
+        self.assertFalse(result.applied)
+        self.assertIn("cluster access is unavailable", " ".join(result.warnings))
+        assert topology is not None
+        self.assertEqual([service["id"] for service in topology["services"]], ["api"])
+        assert warning is not None
+        self.assertIn("cluster access is unavailable", warning)
+
+    def test_import_topology_source_empty_stderr_all_namespace_failure_is_not_rbac(
+        self,
+    ) -> None:
+        project_service_module.create_project(
+            project_key="payments",
+            display_name="Payments",
+        )
+        namespace = {
+            "apiVersion": "v1",
+            "kind": "Namespace",
+            "metadata": {"name": "payments"},
+        }
+        deployment = {
+            "apiVersion": "apps/v1",
+            "kind": "Deployment",
+            "metadata": {"name": "api", "namespace": "payments"},
+            "spec": {"template": {"metadata": {"labels": {"app": "api"}}}},
+        }
+
+        def side_effect(args: list[str], **_: object) -> subprocess.CompletedProcess:
+            resource = args[args.index("get") + 1]
+            if resource == "deployments" and "-A" in args:
+                raise subprocess.CalledProcessError(1, args, stderr="")
+            items = [namespace] if resource == "namespaces" else []
+            if resource == "deployments" and "-n" in args:
+                items = [deployment]
+            return subprocess.CompletedProcess(
+                args=args,
+                returncode=0,
+                stdout=json.dumps(
+                    {
+                        "apiVersion": "v1",
+                        "kind": "List",
+                        "items": items,
+                    }
+                ),
+                stderr="",
+            )
+
+        with patch("services.topology_service.subprocess.run") as run:
+            run.side_effect = side_effect
+            result = import_topology_source(
+                "kubernetes",
+                "context:prod",
+                project_key="payments",
+            )
+
+        self.assertFalse(result.applied)
+        joined_warnings = " ".join(result.warnings)
+        self.assertIn("cluster access is unavailable", joined_warnings)
+        self.assertNotIn("all-namespaces access", joined_warnings)
+
+    def test_import_topology_source_empty_kubernetes_snapshot_clears_stale_topology(
+        self,
+    ) -> None:
+        project_service_module.create_project(
+            project_key="payments",
+            display_name="Payments",
+        )
+        source_path = Path(self.tempdir.name) / "baseline-topology.json"
+        source_path.write_text(
+            json.dumps(
+                {
+                    "services": [
+                        {
+                            "id": "api",
+                            "label": "API",
+                            "resource_keys": ["Deployment/api"],
+                            "downstream": [],
+                        }
+                    ]
+                }
+            ),
+            encoding="utf-8",
+        )
+        import_topology_source("custom", str(source_path), project_key="payments")
+
+        with patch("services.topology_service.subprocess.run") as run:
+            run.side_effect = _kubectl_live_state_side_effect({})
+            result = import_topology_source(
+                "kubernetes",
+                "context:prod",
+                project_key="payments",
+            )
+
+        topology, warning = load_topology(project_key="payments")
+
+        self.assertTrue(result.applied)
+        assert topology is not None
+        self.assertEqual(topology["services"], [])
+        self.assertIn("did not produce", " ".join(result.warnings))
+        assert warning is not None
+        self.assertIn("did not produce", warning)
+
     def test_import_topology_source_reads_terraform_state_relationships(self) -> None:
         project_service_module.create_project(
             project_key="payments",
@@ -928,6 +2596,134 @@ class TopologyServiceTests(unittest.TestCase):
         assert status.drift is not None
         self.assertEqual(status.drift.status, "drifted")
 
+    def test_check_topology_drift_marks_partial_kubernetes_reread_unavailable(
+        self,
+    ) -> None:
+        project_service_module.create_project(
+            project_key="payments",
+            display_name="Payments",
+        )
+        namespace = {
+            "apiVersion": "v1",
+            "kind": "Namespace",
+            "metadata": {"name": "payments"},
+        }
+        deployment = {
+            "apiVersion": "apps/v1",
+            "kind": "Deployment",
+            "metadata": {"name": "api", "namespace": "payments"},
+            "spec": {"template": {"metadata": {"labels": {"app": "api"}}}},
+        }
+
+        with patch("services.topology_service.subprocess.run") as run:
+            run.side_effect = _kubectl_live_state_side_effect(
+                {
+                    "namespaces": [namespace],
+                    "deployments": [deployment],
+                }
+            )
+            imported = import_topology_source(
+                "kubernetes",
+                "context:prod",
+                project_key="payments",
+            )
+
+        def partial_reread(args: list[str], **_: object) -> subprocess.CompletedProcess:
+            resource = args[args.index("get") + 1]
+            if resource == "deployments" and "-A" in args:
+                raise subprocess.CalledProcessError(
+                    1,
+                    args,
+                    stderr="Error from server (Forbidden): deployments is forbidden",
+                )
+            items = []
+            if resource == "namespaces":
+                items = [namespace]
+            elif resource == "deployments":
+                items = [deployment]
+            return subprocess.CompletedProcess(
+                args=args,
+                returncode=0,
+                stdout=json.dumps(
+                    {
+                        "apiVersion": "v1",
+                        "kind": "List",
+                        "items": items,
+                    }
+                ),
+                stderr="",
+            )
+
+        with patch("services.topology_service.subprocess.run") as run:
+            run.side_effect = partial_reread
+            drift = check_topology_drift(project_key="payments", force=True)
+
+        self.assertTrue(imported.applied)
+        self.assertEqual(drift.status, "unavailable")
+        self.assertFalse(drift.alert)
+        self.assertEqual(drift.added_resources, [])
+        self.assertEqual(drift.removed_resources, [])
+        self.assertIn("all-namespaces access", " ".join(drift.warnings))
+
+    def test_check_topology_drift_marks_malformed_partial_kubernetes_reread_unavailable(
+        self,
+    ) -> None:
+        project_service_module.create_project(
+            project_key="payments",
+            display_name="Payments",
+        )
+        deployment = {
+            "apiVersion": "apps/v1",
+            "kind": "Deployment",
+            "metadata": {"name": "api", "namespace": "payments"},
+            "spec": {"template": {"metadata": {"labels": {"app": "api"}}}},
+        }
+        malformed_statefulset = {
+            "apiVersion": "apps/v1",
+            "kind": "StatefulSet",
+            "metadata": {"name": "db"},
+            "spec": {"template": {"metadata": {"labels": {"app": "db"}}}},
+        }
+
+        with patch("services.topology_service.subprocess.run") as run:
+            run.side_effect = _kubectl_live_state_side_effect(
+                {"deployments": [deployment]}
+            )
+            imported = import_topology_source(
+                "kubernetes",
+                "context:prod",
+                project_key="payments",
+            )
+
+        def partial_reread(args: list[str], **_: object) -> subprocess.CompletedProcess:
+            resource = args[args.index("get") + 1]
+            items = []
+            if resource == "deployments":
+                items = [deployment]
+            elif resource == "statefulsets":
+                items = [malformed_statefulset]
+            return subprocess.CompletedProcess(
+                args=args,
+                returncode=0,
+                stdout=json.dumps(
+                    {
+                        "apiVersion": "v1",
+                        "kind": "List",
+                        "items": items,
+                    }
+                ),
+                stderr="",
+            )
+
+        with patch("services.topology_service.subprocess.run") as run:
+            run.side_effect = partial_reread
+            drift = check_topology_drift(project_key="payments", force=True)
+
+        self.assertTrue(imported.applied)
+        self.assertEqual(drift.status, "unavailable")
+        self.assertFalse(drift.alert)
+        self.assertIn("partially parsed", " ".join(drift.warnings).lower())
+
     def test_get_topology_status_runs_due_scheduled_drift_check_by_default(
         self,
     ) -> None:
@@ -989,6 +2785,52 @@ class TopologyServiceTests(unittest.TestCase):
 
         self.assertEqual(drift.status, "unavailable")
         self.assertFalse(drift.alert)
+        self.assertIn("manual", " ".join(drift.warnings).lower())
+
+    def test_check_topology_drift_ignores_cached_status_after_source_changes(
+        self,
+    ) -> None:
+        project_service_module.create_project(
+            project_key="payments",
+            display_name="Payments",
+        )
+        source_path = Path(self.tempdir.name) / "cached-source-topology.json"
+        source_path.write_text(
+            json.dumps(
+                {
+                    "services": [
+                        {
+                            "id": "api",
+                            "label": "API",
+                            "resource_keys": ["Deployment/api"],
+                            "downstream": [],
+                        }
+                    ]
+                }
+            ),
+            encoding="utf-8",
+        )
+        import_topology_source("custom", str(source_path), project_key="payments")
+        save_topology_definition(
+            json.dumps(
+                {
+                    "services": [
+                        {
+                            "id": "manual-api",
+                            "label": "Manual API",
+                            "resource_keys": ["Deployment/manual-api"],
+                            "downstream": [],
+                        }
+                    ]
+                }
+            ),
+            project_key="payments",
+        )
+
+        drift = check_topology_drift(project_key="payments")
+
+        self.assertEqual(drift.status, "unavailable")
+        self.assertEqual(drift.source_type, "manual")
         self.assertIn("manual", " ".join(drift.warnings).lower())
 
     def test_run_due_topology_drift_checks_updates_projects_with_due_imports(
@@ -1058,6 +2900,87 @@ class TopologyServiceTests(unittest.TestCase):
         self.assertEqual(status.drift.status, "drifted")
         self.assertEqual(status.drift.added_resources, ["Deployment/worker"])
 
+    def test_run_due_topology_drift_checks_updates_workspace_imports(
+        self,
+    ) -> None:
+        project = project_service_module.create_project(
+            project_key="payments",
+            display_name="Payments",
+        )
+        workspace = project_service_module.create_workspace(
+            project_key="payments",
+            workspace_key="prod",
+            display_name="Production",
+        )
+        source_path = Path(self.tempdir.name) / "workspace-drift-topology.json"
+        source_path.write_text(
+            json.dumps(
+                {
+                    "services": [
+                        {
+                            "id": "api",
+                            "label": "API",
+                            "resource_keys": ["Deployment/api"],
+                            "downstream": [],
+                        }
+                    ]
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        import_topology_source(
+            "custom",
+            str(source_path),
+            project_key="payments",
+            workspace_key="prod",
+        )
+        source_path.write_text(
+            json.dumps(
+                {
+                    "services": [
+                        {
+                            "id": "api",
+                            "label": "API",
+                            "resource_keys": ["Deployment/api"],
+                            "downstream": ["worker"],
+                        },
+                        {
+                            "id": "worker",
+                            "label": "Worker",
+                            "resource_keys": ["Deployment/worker"],
+                            "downstream": [],
+                        },
+                    ]
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        with SessionLocal() as session:
+            cached_drift = session.get(
+                tables_module.AppSetting,
+                f"topology_drift_status::{project.id}::{workspace.id}",
+            )
+            assert cached_drift is not None
+            cached_payload = json.loads(cached_drift.value)
+            cached_payload["checked_at"] = "2026-04-01T00:00:00Z"
+            cached_payload["next_check_at"] = "2026-04-02T00:00:00Z"
+            cached_drift.value = json.dumps(cached_payload)
+            session.commit()
+
+        run_due_topology_drift_checks()
+        with SessionLocal() as session:
+            cached_drift = session.get(
+                tables_module.AppSetting,
+                f"topology_drift_status::{project.id}::{workspace.id}",
+            )
+            assert cached_drift is not None
+            cached_payload = json.loads(cached_drift.value)
+
+        self.assertEqual(cached_payload["status"], "drifted")
+        self.assertEqual(cached_payload["added_resources"], ["Deployment/worker"])
+
     def test_load_topology_imports_legacy_file_into_default_project(self) -> None:
         legacy_path = Path(self.tempdir.name) / "legacy-topology.json"
         legacy_path.write_text(
@@ -1110,6 +3033,41 @@ class TopologyServiceTests(unittest.TestCase):
         self.assertTrue(status.exists)
         self.assertIn(
             "stored topology JSON is invalid", " ".join(status.blocking_errors)
+        )
+
+    def test_get_topology_status_merges_cached_kubernetes_todos_for_invalid_payload(
+        self,
+    ) -> None:
+        project = project_service_module.create_project(
+            project_key="payments",
+            display_name="Payments",
+        )
+        with patch("services.topology_service.subprocess.run") as run:
+            run.side_effect = FileNotFoundError("kubectl")
+            import_topology_source(
+                "kubernetes",
+                "context:prod",
+                project_key="payments",
+            )
+        with SessionLocal() as session:
+            session.add(
+                tables_module.TopologyVersion(
+                    project_id=project.id,
+                    source_type="kubernetes",
+                    payload_json="{bad json",
+                )
+            )
+            session.commit()
+
+        status = get_topology_status(project_id=project.id)
+
+        self.assertTrue(status.exists)
+        self.assertIn(
+            "stored topology JSON is invalid", " ".join(status.blocking_errors)
+        )
+        self.assertIn(
+            "kubernetes live-state context todo",
+            " ".join(status.warnings).lower(),
         )
 
     def test_save_topology_definition_aborts_default_project_write_when_legacy_mirror_fails(


### PR DESCRIPTION
## Summary
- Adds the optional read-only Kubernetes live-state topology connector backed by local kubectl.
- Maps namespaces, services, and common workload controllers into project/workspace-scoped topology context with namespace-aware matching.
- Surfaces unavailable or degraded cluster access as TODO/context-confidence signals instead of silent certainty.
- Updates operator docs and Story 7.3 sprint tracking.

## Validation
- BMad code review rerun: clean, no new findings.
- ./.venv/bin/python -m unittest -q tests.test_services.test_topology_service tests.test_services.test_analysis_service tests.test_parsers.test_kubernetes_parser tests.test_analysis.test_blast_radius: 142 tests passed.
- UI validation not applicable: no UI route, NiceGUI component, rendered report/history/dashboard surface, browser interaction, keyboard behavior, or accessibility semantics changed.