### PR TITLE
Story 7.4 CODEOWNERS ownership mapping

### DIFF
--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -1,5 +1,5 @@
 # generated: 2026-05-01
-# last_updated: 2026-06-10
+# last_updated: 2026-06-12
 # project: deploywhisper
 # project_key: NOKEY
 # tracking_system: file-system
@@ -35,7 +35,7 @@
 # - Dev moves story to review, then runs code-review
 
 generated: 2026-05-01
-last_updated: 2026-06-10
+last_updated: 2026-06-12
 project: deploywhisper
 project_key: NOKEY
 tracking_system: file-system
@@ -113,7 +113,7 @@ development_status:
   7-1-project-scoped-topology-context: review
   7-2-terraform-state-connector: done
   7-3-kubernetes-live-state-connector: done
-  7-4-codeowners-and-ownership-mapping: ready-for-dev
+  7-4-codeowners-and-ownership-mapping: review
   7-5-context-graph-and-freshness-ledger: ready-for-dev
   epic-7-retrospective: optional
 

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -1,5 +1,5 @@
 # generated: 2026-05-01
-# last_updated: 2026-06-12
+# last_updated: 2026-06-15
 # project: deploywhisper
 # project_key: NOKEY
 # tracking_system: file-system
@@ -35,7 +35,7 @@
 # - Dev moves story to review, then runs code-review
 
 generated: 2026-05-01
-last_updated: 2026-06-12
+last_updated: 2026-06-15
 project: deploywhisper
 project_key: NOKEY
 tracking_system: file-system
@@ -113,7 +113,7 @@ development_status:
   7-1-project-scoped-topology-context: review
   7-2-terraform-state-connector: done
   7-3-kubernetes-live-state-connector: done
-  7-4-codeowners-and-ownership-mapping: review
+  7-4-codeowners-and-ownership-mapping: done
   7-5-context-graph-and-freshness-ledger: ready-for-dev
   epic-7-retrospective: optional
 

--- a/api/routes/analyses.py
+++ b/api/routes/analyses.py
@@ -37,6 +37,7 @@ from services.intake_service import (
     trusted_artifact_path_binding_is_ambiguous,
     trusted_artifact_path_matches_filename,
     trusted_relative_artifact_path,
+    untrusted_upload_filename,
     uniquify_artifact_names,
 )
 from services.report_service import REPORT_SCHEMA_VERSION
@@ -420,7 +421,9 @@ async def _read_upload_files_with_limit(
             chunks.extend(chunk)
             remaining -= len(chunk)
         artifact_name = (
-            trusted_paths[index] if trusted_paths else upload.filename or "artifact.bin"
+            trusted_paths[index]
+            if trusted_paths
+            else untrusted_upload_filename(upload.filename)
         )
         buffered.append((artifact_name, bytes(chunks)))
 

--- a/api/routes/analyses.py
+++ b/api/routes/analyses.py
@@ -34,6 +34,9 @@ from services.analysis_service import (
 from services.intake_service import (
     MAX_TOTAL_UPLOAD_BYTES,
     build_pending_analysis,
+    trusted_artifact_path_binding_is_ambiguous,
+    trusted_artifact_path_matches_filename,
+    trusted_relative_artifact_path,
     uniquify_artifact_names,
 )
 from services.report_service import REPORT_SCHEMA_VERSION
@@ -361,11 +364,40 @@ def require_share_management_token(
 
 async def _read_upload_files_with_limit(
     files: list[UploadFile],
+    artifact_paths: list[str] | str | None = None,
 ) -> list[tuple[str, bytes]]:
     remaining = MAX_TOTAL_UPLOAD_BYTES
     buffered: list[tuple[str, bytes]] = []
+    trusted_paths = _trusted_artifact_paths(artifact_paths, expected_count=len(files))
+    if trusted_paths:
+        for index, upload in enumerate(files):
+            if not trusted_artifact_path_matches_filename(
+                trusted_paths[index],
+                upload.filename,
+            ):
+                raise ApiError(
+                    status_code=400,
+                    code="artifact_path_mismatch",
+                    message=(
+                        "artifact_paths entries must be provided in the same order "
+                        "as the uploaded files and their filenames must match."
+                    ),
+                )
+        if trusted_artifact_path_binding_is_ambiguous(
+            trusted_paths,
+            [upload.filename for upload in files],
+        ):
+            raise ApiError(
+                status_code=400,
+                code="artifact_path_ambiguous",
+                message=(
+                    "artifact_paths cannot safely bind duplicate path metadata. "
+                    "For duplicate basenames, include each trusted repo-relative "
+                    "path in the matching upload filename."
+                ),
+            )
 
-    for upload in files:
+    for index, upload in enumerate(files):
         file_size = getattr(upload, "size", None)
         if isinstance(file_size, int) and file_size > remaining:
             raise ApiError(
@@ -387,9 +419,48 @@ async def _read_upload_files_with_limit(
                 )
             chunks.extend(chunk)
             remaining -= len(chunk)
-        buffered.append((upload.filename or "artifact.bin", bytes(chunks)))
+        artifact_name = (
+            trusted_paths[index] if trusted_paths else upload.filename or "artifact.bin"
+        )
+        buffered.append((artifact_name, bytes(chunks)))
 
     return uniquify_artifact_names(buffered)
+
+
+def _trusted_artifact_paths(
+    artifact_paths: list[str] | str | None,
+    *,
+    expected_count: int | None = None,
+) -> list[str]:
+    if artifact_paths is None:
+        return []
+    if isinstance(artifact_paths, str):
+        values = [artifact_paths]
+    else:
+        values = list(artifact_paths)
+    if expected_count is not None and len(values) != expected_count:
+        raise ApiError(
+            status_code=400,
+            code="artifact_path_mismatch",
+            message=(
+                "artifact_paths must include exactly one trusted relative path "
+                "for each uploaded file."
+            ),
+        )
+    trusted_paths: list[str] = []
+    for value in values:
+        trusted_path = trusted_relative_artifact_path(value)
+        if trusted_path is None:
+            raise ApiError(
+                status_code=400,
+                code="invalid_artifact_path",
+                message=(
+                    "artifact_paths entries must be safe repo-relative paths "
+                    "without absolute, traversal, drive-root, or reserved segments."
+                ),
+            )
+        trusted_paths.append(trusted_path)
+    return trusted_paths
 
 
 @router.get(
@@ -549,6 +620,10 @@ async def create_analysis(
         default=None,
         description="Optional project-local workspace/environment key for the analysis.",
     ),
+    artifact_paths: list[str] | None = Form(
+        default=None,
+        description="Optional trusted relative artifact path per uploaded file for directory-scoped ownership matching.",
+    ),
     trigger_type: str | None = Header(
         default=None, alias="X-DeployWhisper-Trigger-Type"
     ),
@@ -615,7 +690,7 @@ async def create_analysis(
             raise _project_scope_forbidden_error() from exc
         raise _project_api_error(exc) from exc
 
-    raw_files = await _read_upload_files_with_limit(files)
+    raw_files = await _read_upload_files_with_limit(files, artifact_paths)
     pending_analysis = build_pending_analysis(raw_files)
     if pending_analysis.ready_count == 0:
         raise ApiError(

--- a/api/schemas.py
+++ b/api/schemas.py
@@ -2,11 +2,20 @@
 
 from __future__ import annotations
 
+import math
 from typing import Any, Literal
 
 from config import settings
 from evidence.models import FindingEvidenceClassification
-from pydantic import BaseModel, Field, computed_field, model_validator
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    ValidationError,
+    computed_field,
+    field_validator,
+    model_validator,
+)
 
 from services.confidence_ledger import (
     EvidenceLawStatus,
@@ -96,6 +105,21 @@ DeployRecommendation = Literal["go", "caution", "no-go"]
 RollbackComplexity = Literal["low", "medium", "high"]
 DeploymentOutcomeLabel = Literal["success", "failure", "rolled_back"]
 DeploymentOutcomeInputLabel = Literal["success", "failure", "rolled_back", "rollback"]
+OwnerSignalScope = Literal["file", "service"]
+
+
+def _validate_non_empty_strings(values: list[str]) -> list[str]:
+    cleaned: list[str] = []
+    seen: set[str] = set()
+    for value in values:
+        text = str(value).strip()
+        if not text:
+            raise ValueError("List values must be non-empty strings.")
+        if text in seen:
+            continue
+        seen.add(text)
+        cleaned.append(text)
+    return cleaned
 
 
 class IntakeItem(BaseModel):
@@ -432,6 +456,19 @@ class PersistedReportData(BaseModel):
         description="Durable artifact identity/status fallback retained outside manifest JSON",
     )
     audit: AuditMetadataData
+
+    @model_validator(mode="before")
+    @classmethod
+    def normalize_context_completeness_payload(cls, data: Any) -> Any:
+        if not isinstance(data, dict):
+            return data
+        normalized = dict(data)
+        context_payload = normalized.get("context_completeness")
+        normalized["context_completeness"] = _known_context_fields_payload(
+            context_payload,
+            ContextCompletenessData,
+        )
+        return normalized
 
 
 class AnalysisReportData(PersistedReportData):
@@ -823,32 +860,101 @@ class EvidenceItemData(BaseModel):
     )
 
 
+class OwnerSignalData(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    scope: OwnerSignalScope = Field(..., description="Ownership signal scope")
+    subject: str = Field(
+        ..., min_length=1, description="Owned file, service, or resource subject"
+    )
+    owners: list[str] = Field(
+        default_factory=list, description="Owners identified for this subject"
+    )
+    source: str = Field(..., min_length=1, description="Ownership source type")
+    source_ref: str | None = Field(
+        default=None, min_length=1, description="Source file or topology reference"
+    )
+    matched_pattern: str | None = Field(
+        default=None,
+        min_length=1,
+        description="CODEOWNERS pattern that matched the subject",
+    )
+    resource_id: str | None = Field(
+        default=None,
+        min_length=1,
+        description="Changed resource linked to the signal",
+    )
+    service_id: str | None = Field(
+        default=None,
+        min_length=1,
+        description="Topology service identifier linked to the signal",
+    )
+    escalation_hint: str = Field(
+        ..., min_length=1, description="Reviewer-facing escalation guidance"
+    )
+
+    @field_validator("owners")
+    @classmethod
+    def _validate_owners(cls, value: list[str]) -> list[str]:
+        return _validate_non_empty_strings(value)
+
+
 class ContextCompletenessData(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
     topology_freshness_days: int | None = Field(
-        default=None, description="Age in days of the topology snapshot when available"
+        default=None,
+        ge=0,
+        description="Age in days of the topology snapshot when available",
     )
     topology_last_imported_at: str | None = Field(
         default=None,
         description="ISO timestamp for the last imported topology snapshot when available",
     )
     incident_index_size: int = Field(
-        default=0, description="Number of incidents available for similarity matching"
+        default=0,
+        ge=0,
+        description="Number of incidents available for similarity matching",
+    )
+    incident_index_version: str | None = Field(
+        default=None,
+        min_length=1,
+        description="Incident index version used for context",
+    )
+    incident_index_last_indexed_at: str | None = Field(
+        default=None,
+        min_length=1,
+        description="ISO timestamp for the incident index snapshot when available",
+    )
+    incident_index_freshness_status: str | None = Field(
+        default=None,
+        min_length=1,
+        description="Freshness status for the incident index snapshot",
     )
     evidence_success_rate: float = Field(
         default=1.0,
         ge=0.0,
         le=1.0,
+        allow_inf_nan=False,
         description="Fraction of material changes represented by evidence items",
     )
     parser_success_rate: float = Field(
-        default=1.0, description="Fraction of analyzed files parsed successfully"
+        default=1.0,
+        ge=0.0,
+        le=1.0,
+        allow_inf_nan=False,
+        description="Fraction of analyzed files parsed successfully",
     )
     parser_success_by_tool: dict[str, float] = Field(
         default_factory=dict,
         description="Per-tool parser success rates between 0 and 1",
     )
     context_score: float = Field(
-        default=1.0, description="Aggregate context completeness score between 0 and 1"
+        default=1.0,
+        ge=0.0,
+        le=1.0,
+        allow_inf_nan=False,
+        description="Aggregate context completeness score between 0 and 1",
     )
     confidence_level: Literal["high", "medium", "low"] = Field(
         default="high",
@@ -869,6 +975,53 @@ class ContextCompletenessData(BaseModel):
         default=False,
         description="Whether analysis context was explicitly marked partial upstream",
     )
+    owner_signals: list[OwnerSignalData] = Field(
+        default_factory=list,
+        description="File and service ownership signals for analyzed changes",
+    )
+    escalation_hints: list[str] = Field(
+        default_factory=list,
+        description="Reviewer-facing ownership escalation hints",
+    )
+    ownership_unmapped_subjects: list[str] = Field(
+        default_factory=list,
+        description="Analyzed files, resources, or services missing ownership data",
+    )
+
+    @field_validator("escalation_hints", "ownership_unmapped_subjects")
+    @classmethod
+    def _validate_ownership_strings(cls, value: list[str]) -> list[str]:
+        return _validate_non_empty_strings(value)
+
+    @field_validator("evidence_success_rate", "parser_success_rate", "context_score")
+    @classmethod
+    def _validate_unit_float(cls, value: float) -> float:
+        if not math.isfinite(value) or not 0.0 <= value <= 1.0:
+            raise ValueError("value must be a finite number between 0 and 1")
+        return value
+
+    @field_validator("parser_success_by_tool")
+    @classmethod
+    def _validate_parser_success_by_tool(
+        cls, value: dict[str, float]
+    ) -> dict[str, float]:
+        normalized: dict[str, float] = {}
+        for tool, rate in value.items():
+            tool_name = str(tool).strip()
+            if not tool_name:
+                raise ValueError("parser success tool names must be non-empty")
+            try:
+                numeric_rate = float(rate)
+            except (TypeError, ValueError) as exc:
+                raise ValueError(
+                    "parser success rates must be finite numbers between 0 and 1"
+                ) from exc
+            if not math.isfinite(numeric_rate) or not 0.0 <= numeric_rate <= 1.0:
+                raise ValueError(
+                    "parser success rates must be finite numbers between 0 and 1"
+                )
+            normalized[tool_name] = numeric_rate
+        return normalized
 
 
 class AssessmentData(BaseModel):
@@ -1473,6 +1626,274 @@ def _copy_payload_list(items: Any, schema_type: type[BaseModel]) -> list[BaseMod
     return [_copy_payload(item, schema_type) for item in items]
 
 
+def _known_model_fields_payload(payload: Any, schema_type: type[BaseModel]) -> dict:
+    if not isinstance(payload, dict):
+        return {}
+    return {
+        key: value for key, value in payload.items() if key in schema_type.model_fields
+    }
+
+
+def _degraded_context_payload() -> dict[str, Any]:
+    return {
+        "context_score": 0.0,
+        "confidence_level": "low",
+        "insufficient_context": True,
+        "uncertainty": "Context completeness payload was unavailable or unreadable.",
+        "context_todos": [
+            "Regenerate this report to restore context completeness metadata."
+        ],
+    }
+
+
+def _context_string_list(value: Any) -> list[str]:
+    if not isinstance(value, list):
+        return []
+    try:
+        return _validate_non_empty_strings(value)
+    except ValueError:
+        return []
+
+
+def _salvaged_context_string_list(value: Any) -> tuple[list[str], bool]:
+    if not isinstance(value, list):
+        return [], value is not None
+    cleaned: list[str] = []
+    seen: set[str] = set()
+    dropped = False
+    for item in value:
+        if not isinstance(item, str):
+            dropped = True
+            continue
+        text = item.strip()
+        if not text:
+            dropped = True
+            continue
+        if text in seen:
+            continue
+        seen.add(text)
+        cleaned.append(text)
+    return cleaned, dropped
+
+
+def _mark_context_ownership_payload_partial(payload: dict[str, Any]) -> dict[str, Any]:
+    marked = dict(payload)
+    try:
+        marked["context_score"] = min(float(marked.get("context_score", 1.0)), 0.69)
+    except (TypeError, ValueError):
+        marked["context_score"] = 0.69
+    marked["confidence_level"] = "low"
+    marked["insufficient_context"] = True
+    marked["partial_context"] = True
+    warning = "Ownership context payload was partially unreadable."
+    uncertainty = str(marked.get("uncertainty") or "").strip()
+    marked["uncertainty"] = f"{uncertainty} {warning}".strip()
+    todos, _ = _salvaged_context_string_list(marked.get("context_todos"))
+    ownership_todo = "Regenerate this report to restore ownership context metadata."
+    if ownership_todo not in todos:
+        todos.append(ownership_todo)
+    marked["context_todos"] = todos
+    return marked
+
+
+def _owner_signal_escalation_hint(payload: dict[str, Any]) -> str | None:
+    scope = str(payload.get("scope") or "").strip()
+    subject = str(payload.get("subject") or "").strip()
+    owners = _context_string_list(payload.get("owners"))
+    if scope not in {"file", "service"} or not subject or not owners:
+        return None
+    owner_text = ", ".join(owners)
+    if scope == "service":
+        return f"Escalate service review for {subject} to {owner_text}."
+    return f"Escalate file review for {subject} to {owner_text}."
+
+
+def _salvaged_ownership_context_payload(payload: dict[str, Any]) -> dict[str, Any]:
+    salvaged = dict(payload)
+    dropped_ownership_data = False
+    raw_owner_signals = salvaged.get("owner_signals")
+    if isinstance(raw_owner_signals, list):
+        owner_signals: list[dict[str, Any]] = []
+        for item in raw_owner_signals:
+            filtered = _known_model_fields_payload(item, OwnerSignalData)
+            if not filtered:
+                continue
+            if "owners" in filtered:
+                cleaned_owners, dropped_owners = _salvaged_context_string_list(
+                    filtered.get("owners")
+                )
+                if dropped_owners:
+                    dropped_ownership_data = True
+                if cleaned_owners:
+                    filtered["owners"] = cleaned_owners
+            if not filtered.get("escalation_hint"):
+                hint = _owner_signal_escalation_hint(filtered)
+                if hint is not None:
+                    filtered["escalation_hint"] = hint
+            try:
+                owner_signals.append(
+                    OwnerSignalData.model_validate(filtered).model_dump(mode="json")
+                )
+            except ValidationError:
+                continue
+        dropped_ownership_data = dropped_ownership_data or len(owner_signals) != len(
+            raw_owner_signals
+        )
+        salvaged["owner_signals"] = owner_signals
+    else:
+        dropped_ownership_data = "owner_signals" in salvaged
+        salvaged.pop("owner_signals", None)
+    for field_name in ("escalation_hints", "ownership_unmapped_subjects"):
+        if field_name in salvaged:
+            values = salvaged[field_name]
+            salvaged_values, dropped_values = _salvaged_context_string_list(values)
+            if dropped_values:
+                dropped_ownership_data = True
+            salvaged[field_name] = salvaged_values
+    if dropped_ownership_data:
+        return _mark_context_ownership_payload_partial(salvaged)
+    return salvaged
+
+
+def _coerce_optional_context_string(value: Any) -> str | None:
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text or None
+
+
+def _coerce_context_float(value: Any, default: float) -> float:
+    if value is None:
+        return default
+    try:
+        numeric_value = float(value)
+    except (TypeError, ValueError):
+        return default
+    if not math.isfinite(numeric_value):
+        return default
+    return numeric_value
+
+
+def _coerce_context_int(value: Any, default: int) -> int:
+    try:
+        numeric_value = int(value)
+    except (TypeError, ValueError):
+        return default
+    if numeric_value < 0:
+        return default
+    return numeric_value
+
+
+def _coerce_optional_context_int(value: Any) -> int | None:
+    if value is None:
+        return None
+    try:
+        numeric_value = int(value)
+    except (TypeError, ValueError):
+        return None
+    if numeric_value < 0:
+        return None
+    return numeric_value
+
+
+def _coerce_context_unit_float(
+    value: Any,
+    *,
+    default: float,
+    invalid_default: float = 0.0,
+) -> float:
+    if value is None:
+        return default
+    try:
+        numeric_value = float(value)
+    except (TypeError, ValueError):
+        return invalid_default
+    if not math.isfinite(numeric_value):
+        return invalid_default
+    return min(max(numeric_value, 0.0), 1.0)
+
+
+def _salvaged_context_completeness_payload(payload: dict[str, Any]) -> dict[str, Any]:
+    salvaged = _salvaged_ownership_context_payload(payload)
+    normalized = dict(salvaged)
+    normalized["topology_freshness_days"] = _coerce_optional_context_int(
+        normalized.get("topology_freshness_days")
+    )
+    for field_name in (
+        "topology_last_imported_at",
+        "incident_index_version",
+        "incident_index_last_indexed_at",
+        "incident_index_freshness_status",
+        "uncertainty",
+    ):
+        normalized[field_name] = _coerce_optional_context_string(
+            normalized.get(field_name)
+        )
+    normalized["incident_index_size"] = _coerce_context_int(
+        normalized.get("incident_index_size"),
+        0,
+    )
+    normalized["evidence_success_rate"] = _coerce_context_unit_float(
+        normalized.get("evidence_success_rate"),
+        default=1.0,
+    )
+    normalized["parser_success_rate"] = _coerce_context_unit_float(
+        normalized.get("parser_success_rate"),
+        default=1.0,
+    )
+    parser_success_by_tool = normalized.get("parser_success_by_tool")
+    normalized["parser_success_by_tool"] = (
+        {
+            str(tool).strip(): _coerce_context_unit_float(rate, default=1.0)
+            for tool, rate in parser_success_by_tool.items()
+            if str(tool).strip()
+        }
+        if isinstance(parser_success_by_tool, dict)
+        else {}
+    )
+    normalized["context_score"] = _coerce_context_unit_float(
+        normalized.get("context_score"),
+        default=1.0,
+        invalid_default=1.0,
+    )
+    if normalized.get("confidence_level") not in {"high", "medium", "low"}:
+        normalized["confidence_level"] = "low"
+    normalized["context_todos"] = _context_string_list(normalized.get("context_todos"))
+    if not isinstance(normalized.get("insufficient_context"), bool):
+        normalized["insufficient_context"] = True
+    if not isinstance(normalized.get("partial_context"), bool):
+        normalized["partial_context"] = False
+    return _mark_context_ownership_payload_partial(normalized)
+
+
+def _known_context_fields_payload(
+    payload: Any,
+    schema_type: type[BaseModel],
+) -> dict:
+    if not isinstance(payload, dict):
+        return _degraded_context_payload()
+    known_payload = _known_model_fields_payload(payload, schema_type)
+    if not known_payload:
+        return _degraded_context_payload()
+    try:
+        return schema_type.model_validate(known_payload).model_dump(mode="json")
+    except ValidationError:
+        if schema_type is ContextCompletenessData:
+            ownership_fields = {
+                "owner_signals",
+                "escalation_hints",
+                "ownership_unmapped_subjects",
+            }
+            if ownership_fields.intersection(known_payload):
+                try:
+                    return schema_type.model_validate(
+                        _salvaged_context_completeness_payload(known_payload)
+                    ).model_dump(mode="json")
+                except ValidationError:
+                    pass
+        return _degraded_context_payload()
+
+
 def build_analysis_run_data(
     *,
     intake: PendingAnalysis,
@@ -1486,8 +1907,16 @@ def build_analysis_run_data(
     rollback_plan = result.rollback_plan
     narrative = result.narrative
     persisted_report = result.persisted_report
+    raw_context_payload = persisted_report.get("context_completeness")
     persisted_context = ContextCompletenessData.model_validate(
-        persisted_report.get("context_completeness", {})
+        _known_context_fields_payload(
+            raw_context_payload,
+            ContextCompletenessData,
+        )
+    )
+    persisted_report_payload = dict(persisted_report)
+    persisted_report_payload["context_completeness"] = persisted_context.model_dump(
+        mode="json"
     )
 
     return AnalysisRunData(
@@ -1578,5 +2007,5 @@ def build_analysis_run_data(
         narrative=_copy_model(narrative, NarrativeData),
         advisory=_copy_model(advisory, AdvisorySummaryData),
         share_summary=_copy_model(share_summary, ShareSummaryData),
-        persisted_report=PersistedReportData.model_validate(persisted_report),
+        persisted_report=PersistedReportData.model_validate(persisted_report_payload),
     )

--- a/cli/analyze.py
+++ b/cli/analyze.py
@@ -53,8 +53,11 @@ from services.project_service import list_projects, list_workspaces
 from services.project_service import require_project_permission
 from services.project_service import resolve_project_reference
 from services.intake_service import (
+    EXTERNAL_ARTIFACT_PREFIX,
     MAX_TOTAL_UPLOAD_BYTES,
+    artifact_name_has_traversal,
     build_pending_analysis,
+    normalize_artifact_name,
     uniquify_artifact_names,
 )
 from services.report_service import (
@@ -198,11 +201,96 @@ def _require_cli_analysis_project_permission(
     return True
 
 
+def _codeowners_root_for_cli_path(path: Path) -> Path | None:
+    if path.name != "CODEOWNERS":
+        return None
+    parent = path.parent
+    if parent.name in {".github", "docs"}:
+        return parent.parent
+    return parent
+
+
+def _infer_cli_artifact_roots(paths: list[Path]) -> tuple[Path, ...]:
+    roots: set[Path] = set()
+    for path in paths:
+        try:
+            resolved_path = path.resolve()
+        except OSError:
+            continue
+        root = _codeowners_root_for_cli_path(resolved_path)
+        if root is None:
+            continue
+        roots.add(root)
+    return tuple(sorted(roots, key=lambda root: str(root)))
+
+
+def _unique_cli_root_prefixes(roots: tuple[Path, ...]) -> dict[Path, str]:
+    prefix_counts: dict[str, int] = {}
+    prefixes: dict[Path, str] = {}
+    for root in roots:
+        candidate = normalize_artifact_name(root.name or "project")
+        prefix_counts.setdefault(candidate, 0)
+        prefix = candidate
+        while prefix in prefixes.values():
+            prefix_counts[candidate] += 1
+            prefix = f"{candidate}#{prefix_counts[candidate] + 1}"
+        prefixes[root] = prefix
+    return prefixes
+
+
+def _cli_artifact_roots_by_specificity(roots: tuple[Path, ...]) -> tuple[Path, ...]:
+    return tuple(sorted(roots, key=lambda root: (-len(root.parts), str(root))))
+
+
+def _cli_artifact_name(
+    *,
+    raw_path: str,
+    path: Path,
+    artifact_roots: tuple[Path, ...],
+    root_prefixes: dict[Path, str],
+) -> str:
+    if not path.is_absolute():
+        if artifact_name_has_traversal(raw_path):
+            return normalize_artifact_name(raw_path)
+        try:
+            resolved_path = path.resolve()
+        except OSError:
+            return normalize_artifact_name(raw_path)
+        for artifact_root in _cli_artifact_roots_by_specificity(artifact_roots):
+            try:
+                relative_name = normalize_artifact_name(
+                    str(resolved_path.relative_to(artifact_root))
+                )
+            except ValueError:
+                continue
+            if len(artifact_roots) == 1:
+                return relative_name
+            return f"{root_prefixes[artifact_root]}/{relative_name}"
+        if artifact_roots:
+            return f"{EXTERNAL_ARTIFACT_PREFIX}/{normalize_artifact_name(path.name or 'artifact.bin')}"
+        return normalize_artifact_name(raw_path)
+    for artifact_root in _cli_artifact_roots_by_specificity(artifact_roots):
+        try:
+            relative_name = normalize_artifact_name(
+                str(path.resolve().relative_to(artifact_root))
+            )
+        except (OSError, ValueError):
+            continue
+        if len(artifact_roots) == 1:
+            return relative_name
+        return f"{root_prefixes[artifact_root]}/{relative_name}"
+    if artifact_roots:
+        return f"{EXTERNAL_ARTIFACT_PREFIX}/{normalize_artifact_name(path.name or 'artifact.bin')}"
+    return path.name or "artifact.bin"
+
+
 def _load_artifacts(paths: list[str]) -> list[tuple[str, bytes]]:
     artifacts: list[tuple[str, bytes]] = []
     running_total = 0
-    for raw_path in paths:
-        path = Path(raw_path)
+    artifact_paths = [(raw_path, Path(raw_path)) for raw_path in paths]
+    artifact_roots = _infer_cli_artifact_roots([path for _, path in artifact_paths])
+    root_prefixes = _unique_cli_root_prefixes(artifact_roots)
+    for raw_path, path in artifact_paths:
         try:
             file_size = path.stat().st_size
             running_total += file_size
@@ -215,7 +303,13 @@ def _load_artifacts(paths: list[str]) -> list[tuple[str, bytes]]:
                         )
                     )
                 )
-            artifacts.append((path.name, path.read_bytes()))
+            artifact_name = _cli_artifact_name(
+                raw_path=raw_path,
+                path=path,
+                artifact_roots=artifact_roots,
+                root_prefixes=root_prefixes,
+            )
+            artifacts.append((artifact_name, path.read_bytes()))
         except OSError as exc:
             raise ValueError(
                 json.dumps(
@@ -228,7 +322,10 @@ def _load_artifacts(paths: list[str]) -> list[tuple[str, bytes]]:
             ) from exc
     return [
         (str(name), bytes(raw_content or b""))
-        for name, raw_content in uniquify_artifact_names(artifacts)
+        for name, raw_content in uniquify_artifact_names(
+            artifacts,
+            allow_external_prefix=True,
+        )
     ]
 
 

--- a/docs/schemas/report-v2.md
+++ b/docs/schemas/report-v2.md
@@ -512,11 +512,16 @@ artifact path such as `.github/CODEOWNERS` or
 `services/payments/plan.json`; absolute paths, drive-root paths, traversal
 segments, and reserved internal prefixes are rejected.
 
+When two uploaded files share the same basename, the multipart filename must
+also carry the matching repo-relative path for each file. This lets the server
+prove that `artifact_paths` values were bound to the intended file parts instead
+of relying on positional order alone.
+
 ```bash
 curl -F project_key=payments \
-  -F files=@.github/CODEOWNERS \
+  -F 'files=@.github/CODEOWNERS;filename=.github/CODEOWNERS' \
   -F artifact_paths=.github/CODEOWNERS \
-  -F files=@services/payments/plan.json \
+  -F 'files=@services/payments/plan.json;filename=services/payments/plan.json' \
   -F artifact_paths=services/payments/plan.json \
   http://127.0.0.1:8080/api/v1/analyses
 ```

--- a/docs/schemas/report-v2.md
+++ b/docs/schemas/report-v2.md
@@ -231,10 +231,40 @@ without storing raw plan internals in a separate contract.
       "Import or refresh topology context for this project/workspace.",
       "Import relevant incident history for this project/workspace.",
       "Review evidence extraction gaps for supported artifacts.",
-      "Review parser errors and resubmit supported artifacts."
+      "Review parser errors and resubmit supported artifacts.",
+      "Add CODEOWNERS or ownership mapping for analyzed files/resources."
     ],
     "insufficient_context": true,
-    "partial_context": true
+    "partial_context": true,
+    "owner_signals": [
+      {
+        "scope": "file",
+        "subject": "services/payments/plan.json",
+        "owners": ["@payments-sre"],
+        "source": "CODEOWNERS",
+        "source_ref": ".github/CODEOWNERS",
+        "matched_pattern": "/services/payments/",
+        "resource_id": null,
+        "service_id": null,
+        "escalation_hint": "Escalate file review for services/payments/plan.json to @payments-sre."
+      },
+      {
+        "scope": "service",
+        "subject": "Payments API",
+        "owners": ["@payments-runtime"],
+        "source": "topology",
+        "source_ref": "topology.json",
+        "matched_pattern": null,
+        "resource_id": "aws_security_group.payments",
+        "service_id": "payments-api",
+        "escalation_hint": "Escalate service review for Payments API to @payments-runtime."
+      }
+    ],
+    "escalation_hints": [
+      "Escalate file review for services/payments/plan.json to @payments-sre.",
+      "Escalate service review for Payments API to @payments-runtime."
+    ],
+    "ownership_unmapped_subjects": []
   },
   "blast_radius": {
     "affected": [
@@ -454,6 +484,49 @@ non-current states. Current labels include `missing_topology`, `stale_topology`,
 treat unrecognized future labels as additional incomplete-context signals rather
 than failing report parsing.
 
+### Ownership context
+
+`context_completeness.owner_signals` is a point-in-time ownership snapshot for
+the analyzed files and mapped services/resources. File signals come from the
+last matching `CODEOWNERS` rule in the analyzed submission's uploaded
+`CODEOWNERS` source; DeployWhisper does not fall back to its own repository
+checkout for analyzed-project ownership. Service signals come from topology
+ownership fields when a changed resource maps to a service. Each signal carries
+owners, source metadata, and an `escalation_hint` that report consumers can
+render directly for reviewer routing.
+
+When no file or service ownership can be found for analyzed subjects,
+`context_completeness.context_todos` includes
+`Add CODEOWNERS or ownership mapping for analyzed files/resources.`, and
+`ownership_unmapped_subjects` lists the files or services that need owner data.
+
+#### Request-side ownership setup
+
+Directory-scoped ownership depends on preserving repo-relative artifact paths
+for every submitted file. Upload `.github/CODEOWNERS`, `CODEOWNERS`, or
+`docs/CODEOWNERS` with the analyzed artifacts from the same repository root.
+
+API multipart clients should send one `artifact_paths` form value for each
+`files` part, in the same order. Each value must be a safe repo-relative
+artifact path such as `.github/CODEOWNERS` or
+`services/payments/plan.json`; absolute paths, drive-root paths, traversal
+segments, and reserved internal prefixes are rejected.
+
+```bash
+curl -F project_key=payments \
+  -F files=@.github/CODEOWNERS \
+  -F artifact_paths=.github/CODEOWNERS \
+  -F files=@services/payments/plan.json \
+  -F artifact_paths=services/payments/plan.json \
+  http://127.0.0.1:8080/api/v1/analyses
+```
+
+CLI analysis preserves relative paths when files are submitted from a common
+repository root, so run it from the target checkout or pass paths that share the
+same root. For the dashboard, prefer directory upload when analyzing a tree; the
+browser supplies repo-relative artifact paths so directory-scoped CODEOWNERS
+rules can match.
+
 ### Analysis run incident and pattern matches
 
 Live API/CLI analysis responses and persisted report retrieval payloads include
@@ -485,6 +558,7 @@ must not be presented as organization-specific incident history.
 - submission manifest payloads that record accepted, excluded, failed, partial, sensitive, provenance, and redaction status
 - durable submission manifest fallback identity/status metadata for malformed-manifest recovery
 - parser-normalized change metadata for Terraform plan JSON format and Terraform versions, module paths, replacement paths, unknown-after-apply fields, redacted fields, and unsupported resource/change/plan fields
+- ownership owner signals, escalation hints, and missing-ownership context TODOs
 
 Story 2.6 added report-level confidence, context uncertainty, evidence coverage,
 context TODOs, and insufficient-context signals as additive `v2` fields. Story

--- a/evidence/models.py
+++ b/evidence/models.py
@@ -10,6 +10,7 @@ from pydantic import BaseModel, ConfigDict, Field, field_validator, model_valida
 RiskSeverity = Literal["low", "medium", "high", "critical"]
 DeployRecommendation = Literal["go", "caution", "no-go"]
 ContextConfidenceLevel = Literal["high", "medium", "low"]
+OwnerSignalScope = Literal["file", "service"]
 EvidenceSourceType = Literal[
     "artifact",
     "topology",
@@ -86,6 +87,9 @@ class ContextCompleteness(BaseModel):
     context_todos: list[str] = Field(default_factory=list)
     insufficient_context: bool = Field(default=False)
     partial_context: bool = Field(default=False)
+    owner_signals: list["OwnerSignal"] = Field(default_factory=list)
+    escalation_hints: list[str] = Field(default_factory=list)
+    ownership_unmapped_subjects: list[str] = Field(default_factory=list)
 
     @field_validator("parser_success_by_tool")
     @classmethod
@@ -110,6 +114,37 @@ class ContextCompleteness(BaseModel):
     @field_validator("context_todos")
     @classmethod
     def _validate_context_todos(cls, value: list[str]) -> list[str]:
+        return _validate_string_list(value)
+
+    @field_validator("escalation_hints")
+    @classmethod
+    def _validate_escalation_hints(cls, value: list[str]) -> list[str]:
+        return _validate_string_list(value)
+
+    @field_validator("ownership_unmapped_subjects")
+    @classmethod
+    def _validate_ownership_unmapped_subjects(cls, value: list[str]) -> list[str]:
+        return _validate_string_list(value)
+
+
+class OwnerSignal(BaseModel):
+    """Reviewer-facing ownership hint captured with report context."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    scope: OwnerSignalScope
+    subject: str = Field(..., min_length=1)
+    owners: list[str] = Field(default_factory=list)
+    source: str = Field(..., min_length=1)
+    source_ref: str | None = Field(default=None, min_length=1)
+    matched_pattern: str | None = Field(default=None, min_length=1)
+    resource_id: str | None = Field(default=None, min_length=1)
+    service_id: str | None = Field(default=None, min_length=1)
+    escalation_hint: str = Field(..., min_length=1)
+
+    @field_validator("owners")
+    @classmethod
+    def _validate_owners(cls, value: list[str]) -> list[str]:
         return _validate_string_list(value)
 
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "description": "Dev-only browser and screen-reader verification for DeployWhisper UI flows.",
   "scripts": {
     "setup:ui-review": "npx @guidepup/setup",
-    "test:ui-review": "playwright test tests/e2e/report_review.keyboard.spec.js",
+    "test:ui-review": "playwright test tests/e2e/report_review.keyboard.spec.js && playwright test tests/e2e/dashboard_deploy_review_upload.spec.js",
     "test:ui-review:voiceover": "playwright test tests/e2e/report_review.voiceover.spec.js --project=webkit"
   },
   "devDependencies": {

--- a/services/analysis_service.py
+++ b/services/analysis_service.py
@@ -43,6 +43,11 @@ from services.settings_service import resolve_provider_runtime
 from services.submission_manifest import SubmissionManifest, build_submission_manifest
 from services.incident_service import get_incident_index_snapshot
 from services.confidence_ledger import EvidenceLawStatus, evidence_law_status
+from services.ownership_service import (
+    CodeownersSource,
+    build_ownership_context,
+    uploaded_codeowners_sources,
+)
 from services.topology_service import (
     STALE_AFTER_DAYS,
     get_topology_status,
@@ -404,6 +409,7 @@ def _context_uncertainty(
     topology_warnings: list[str] | None = None,
     incident_index_size: int,
     parser_success_rate: float,
+    ownership_unmapped_subjects: list[str] | tuple[str, ...] = (),
     include_topology_context: bool = True,
     include_incident_context: bool = True,
 ) -> str | None:
@@ -423,10 +429,12 @@ def _context_uncertainty(
         weak_signals.append("parser coverage is partial")
     if evidence_success_rate < 1.0:
         weak_signals.append("evidence coverage is partial")
+    if ownership_unmapped_subjects:
+        weak_signals.append("ownership mapping is incomplete")
     if context_score < 0.7:
         message = (
             "Insufficient context: missing parser coverage, evidence coverage, "
-            "or enabled project context prevents a confident low-risk verdict."
+            "ownership mapping, or enabled project context prevents a confident low-risk verdict."
         )
         if weak_signals:
             message += " Weak signals: " + "; ".join(weak_signals) + "."
@@ -542,6 +550,8 @@ def _build_context_completeness(
     workspace_key: str | None = None,
     include_topology_context: bool = True,
     include_incident_context: bool = True,
+    topology: dict | None = None,
+    codeowners_sources: tuple[CodeownersSource, ...] = (),
 ) -> ContextCompleteness:
     topology_last_imported_at = None
     topology_warnings: list[str] = []
@@ -622,6 +632,12 @@ def _build_context_completeness(
         1.0,
         sum(score * weight for score, weight in weighted_scores) / total_weight,
     )
+    ownership_topology = topology if include_topology_context else None
+    ownership_context = build_ownership_context(
+        parse_batch,
+        topology=ownership_topology,
+        codeowners_sources=codeowners_sources,
+    )
     context_score = round(raw_context_score, 2)
     context_todos = _context_todos(
         evidence_success_rate=evidence_success_rate,
@@ -632,6 +648,7 @@ def _build_context_completeness(
         include_topology_context=include_topology_context,
         include_incident_context=include_incident_context,
     )
+    context_todos = _unique_texts(context_todos + list(ownership_context.context_todos))
     return ContextCompleteness(
         topology_freshness_days=topology_freshness_days,
         topology_last_imported_at=topology_last_imported_at,
@@ -657,11 +674,15 @@ def _build_context_completeness(
             topology_warnings=topology_warnings,
             incident_index_size=incident_index_size,
             parser_success_rate=raw_parser_success_rate,
+            ownership_unmapped_subjects=ownership_context.unmapped_subjects,
             include_topology_context=include_topology_context,
             include_incident_context=include_incident_context,
         ),
         context_todos=context_todos,
         insufficient_context=raw_context_score < 0.7,
+        owner_signals=list(ownership_context.owner_signals),
+        escalation_hints=list(ownership_context.escalation_hints),
+        ownership_unmapped_subjects=list(ownership_context.unmapped_subjects),
     )
 
 
@@ -675,6 +696,8 @@ def build_context_completeness(
     workspace_key: str | None = None,
     include_topology_context: bool = True,
     include_incident_context: bool = True,
+    topology: dict | None = None,
+    codeowners_sources: tuple[CodeownersSource, ...] = (),
 ) -> ContextCompleteness:
     """Build the shared context-completeness signal for analysis callers."""
 
@@ -687,6 +710,8 @@ def build_context_completeness(
         workspace_key=workspace_key,
         include_topology_context=include_topology_context,
         include_incident_context=include_incident_context,
+        topology=topology,
+        codeowners_sources=codeowners_sources,
     )
 
 
@@ -1282,6 +1307,7 @@ def build_analysis_artifacts(
     partial_context = parse_batch.has_partial_context or (
         submission_manifest.partial_analysis
     )
+    codeowners_sources = uploaded_codeowners_sources(files)
     analysis_raw_files = _raw_files_for_parse_batch(files, parse_batch)
     evidence_items = extract_batch_evidence(
         parse_batch,
@@ -1318,6 +1344,8 @@ def build_analysis_artifacts(
         workspace_key=workspace_key,
         include_topology_context=include_topology_context,
         include_incident_context=include_incident_context,
+        topology=topology,
+        codeowners_sources=codeowners_sources,
     )
     assessment = apply_context_uncertainty(assessment)
     findings = build_findings(

--- a/services/intake_service.py
+++ b/services/intake_service.py
@@ -18,6 +18,185 @@ SENSITIVE_FILE_MARKERS = {
     "credentials",
 }
 MAX_TOTAL_UPLOAD_BYTES = 50_000_000
+UNSAFE_ARTIFACT_PREFIX = "__unsafe_path__"
+EXTERNAL_ARTIFACT_PREFIX = "__external_path__"
+
+
+def artifact_name_has_traversal(original_name: str) -> bool:
+    """Return whether the submitted name contains parent traversal segments."""
+    return any(
+        part.strip() == ".."
+        for part in str(original_name or "").replace("\\", "/").split("/")
+    )
+
+
+def artifact_name_is_traversal_normalized(name: str) -> bool:
+    normalized = str(name or "").replace("\\", "/").strip().lstrip("/")
+    normalized_lower = normalized.lower()
+    unsafe_prefix = UNSAFE_ARTIFACT_PREFIX.lower()
+    return normalized_lower == unsafe_prefix or normalized_lower.startswith(
+        f"{unsafe_prefix}/"
+    )
+
+
+def artifact_name_is_ownership_untrusted(name: str) -> bool:
+    normalized = str(name or "").replace("\\", "/").strip().lstrip("/")
+    normalized_lower = normalized.lower()
+    for prefix in (UNSAFE_ARTIFACT_PREFIX, EXTERNAL_ARTIFACT_PREFIX):
+        prefix_lower = prefix.lower()
+        if normalized_lower == prefix_lower or normalized_lower.startswith(
+            f"{prefix_lower}/"
+        ):
+            return True
+    return False
+
+
+def _is_drive_relative_segment(value: str) -> bool:
+    return len(value) >= 2 and value[0].isalpha() and value[1] == ":"
+
+
+def trusted_relative_artifact_path(value: object) -> str | None:
+    """Return normalized trusted browser/API relative path metadata, if valid."""
+    if not isinstance(value, str):
+        return None
+    normalized = value.replace("\\", "/").strip()
+    if not normalized or normalized.startswith("/"):
+        return None
+    reserved_prefixes = {
+        UNSAFE_ARTIFACT_PREFIX.lower(),
+        EXTERNAL_ARTIFACT_PREFIX.lower(),
+    }
+    parts: list[str] = []
+    for raw_part in normalized.split("/"):
+        part = raw_part.strip()
+        if not part or part == ".":
+            continue
+        if (
+            part == ".."
+            or part.endswith(":")
+            or _is_drive_relative_segment(part)
+            or part.lower() in reserved_prefixes
+        ):
+            return None
+        parts.append(part)
+    if not parts:
+        return None
+    return "/".join(parts)
+
+
+def trusted_artifact_path_matches_filename(
+    artifact_path: str,
+    filename: object,
+) -> bool:
+    """Return whether trusted path metadata can be bound to this upload filename."""
+    trusted_path = trusted_relative_artifact_path(artifact_path)
+    if trusted_path is None:
+        return False
+    filename_text = str(filename or "").replace("\\", "/").strip()
+    if not filename_text:
+        return False
+    trusted_filename = trusted_relative_artifact_path(filename_text)
+    if trusted_filename is not None and "/" in trusted_filename:
+        return trusted_filename == trusted_path
+    if trusted_filename is None and "/" in filename_text:
+        return False
+    filename_leaf = filename_text.rsplit("/", maxsplit=1)[-1]
+    return trusted_path.rsplit("/", maxsplit=1)[-1] == filename_leaf
+
+
+def _filename_leaf(filename: object) -> str | None:
+    filename_text = str(filename or "").replace("\\", "/").strip()
+    if not filename_text:
+        return None
+    filename_leaf = filename_text.rsplit("/", maxsplit=1)[-1].strip()
+    return filename_leaf or None
+
+
+def trusted_artifact_path_binding_is_ambiguous(
+    artifact_paths: Iterable[str],
+    filenames: Iterable[object],
+) -> bool:
+    """Return whether path metadata cannot be unambiguously paired to uploads."""
+    trusted_paths: list[str] = []
+    for artifact_path in artifact_paths:
+        trusted_path = trusted_relative_artifact_path(artifact_path)
+        if trusted_path is None:
+            return False
+        trusted_paths.append(trusted_path)
+
+    filename_paths: list[str | None] = []
+    filename_leaves: list[str] = []
+    for filename in filenames:
+        filename_leaf = _filename_leaf(filename)
+        if filename_leaf is None:
+            return False
+        filename_leaves.append(filename_leaf)
+        filename_text = str(filename or "").replace("\\", "/").strip()
+        trusted_filename = trusted_relative_artifact_path(filename_text)
+        filename_paths.append(
+            trusted_filename
+            if trusted_filename is not None and "/" in trusted_filename
+            else None
+        )
+
+    if len(set(trusted_paths)) != len(trusted_paths):
+        return True
+
+    path_leaves = [path.rsplit("/", maxsplit=1)[-1] for path in trusted_paths]
+    duplicate_path_leaves = {
+        leaf for leaf in path_leaves if path_leaves.count(leaf) > 1
+    }
+    duplicate_filename_leaves = {
+        leaf for leaf in filename_leaves if filename_leaves.count(leaf) > 1
+    }
+    if not duplicate_path_leaves and not duplicate_filename_leaves:
+        return False
+
+    for trusted_path, filename_path in zip(trusted_paths, filename_paths, strict=False):
+        if trusted_path.rsplit("/", maxsplit=1)[-1] in duplicate_path_leaves:
+            if filename_path != trusted_path:
+                return True
+    return False
+
+
+def normalize_artifact_name(
+    original_name: str, *, allow_external_prefix: bool = False
+) -> str:
+    """Return a safe relative artifact name while preserving useful directories."""
+    normalized = str(original_name or "").replace("\\", "/").strip()
+    clean_segments = [
+        part.strip() for part in normalized.split("/") if part.strip() and part != "."
+    ]
+    absolute_or_host_path = normalized.startswith("/") or (
+        bool(clean_segments)
+        and (
+            clean_segments[0].endswith(":")
+            or _is_drive_relative_segment(clean_segments[0])
+        )
+    )
+    has_traversal = artifact_name_has_traversal(normalized)
+    unsafe_prefixes = {UNSAFE_ARTIFACT_PREFIX.lower()}
+    if not allow_external_prefix:
+        unsafe_prefixes.add(EXTERNAL_ARTIFACT_PREFIX.lower())
+    has_reserved_unsafe_prefix = any(
+        part.strip().lower() in unsafe_prefixes for part in normalized.split("/")
+    )
+    parts: list[str] = []
+    for part in normalized.split("/"):
+        segment = part.strip()
+        if not segment or segment == ".":
+            continue
+        if segment == "..":
+            continue
+        if segment.endswith(":") or _is_drive_relative_segment(segment):
+            continue
+        if segment.lower() in unsafe_prefixes:
+            continue
+        parts.append(segment)
+    safe_name = "/".join(parts) or "artifact.bin"
+    if absolute_or_host_path or has_traversal or has_reserved_unsafe_prefix:
+        return f"{UNSAFE_ARTIFACT_PREFIX}/{safe_name}"
+    return safe_name
 
 
 def is_sensitive_file(name: str) -> bool:
@@ -34,20 +213,27 @@ def uniquify_artifact_names(
     files: Iterable[tuple[str, bytes | None]],
     *,
     existing_names: Iterable[str] = (),
+    allow_external_prefix: bool = False,
 ) -> list[tuple[str, bytes | None]]:
     used_names: set[str] = set(existing_names)
     duplicate_counts: dict[str, int] = {}
     normalized: list[tuple[str, bytes | None]] = []
 
     for original_name, raw_content in files:
-        candidate = Path(original_name).name or "artifact.bin"
+        candidate = normalize_artifact_name(
+            original_name,
+            allow_external_prefix=allow_external_prefix,
+        )
         duplicate_counts.setdefault(candidate, 0)
         unique_name = candidate
         while unique_name in used_names:
             duplicate_counts[candidate] += 1
-            base = Path(candidate).stem or "artifact"
-            suffix = Path(candidate).suffix
-            unique_name = f"{base}#{duplicate_counts[candidate] + 1}{suffix}"
+            path = Path(candidate)
+            base = path.stem or "artifact"
+            suffix = path.suffix
+            leaf = f"{base}#{duplicate_counts[candidate] + 1}{suffix}"
+            parent = str(path.parent)
+            unique_name = leaf if parent == "." else f"{parent}/{leaf}"
         used_names.add(unique_name)
         normalized.append((unique_name, raw_content))
     return normalized

--- a/services/intake_service.py
+++ b/services/intake_service.py
@@ -104,6 +104,31 @@ def trusted_artifact_path_matches_filename(
     return trusted_path.rsplit("/", maxsplit=1)[-1] == filename_leaf
 
 
+def untrusted_upload_filename(filename: object) -> str:
+    """Return a safe artifact name for uploads without trusted path metadata."""
+    filename_text = str(filename or "").replace("\\", "/").strip()
+    filename_leaf = filename_text.rsplit("/", maxsplit=1)[-1].strip()
+    if "/" in filename_text:
+        reserved_prefixes = {
+            UNSAFE_ARTIFACT_PREFIX.lower(),
+            EXTERNAL_ARTIFACT_PREFIX.lower(),
+        }
+        safe_parts = [
+            part.strip()
+            for part in filename_text.split("/")
+            if part.strip()
+            and part.strip() not in {".", ".."}
+            and not part.strip().endswith(":")
+            and not _is_drive_relative_segment(part.strip())
+            and part.strip().lower() not in reserved_prefixes
+        ]
+        safe_name = "/".join(safe_parts) or filename_leaf or "artifact.bin"
+        return f"{UNSAFE_ARTIFACT_PREFIX}/{safe_name}"
+    if filename_leaf == "CODEOWNERS":
+        return f"{UNSAFE_ARTIFACT_PREFIX}/{filename_leaf}"
+    return filename_leaf or "artifact.bin"
+
+
 def _filename_leaf(filename: object) -> str | None:
     filename_text = str(filename or "").replace("\\", "/").strip()
     if not filename_text:

--- a/services/ownership_service.py
+++ b/services/ownership_service.py
@@ -86,12 +86,17 @@ def _normalized_subject(path: str) -> str:
 def _untrusted_display_subject(subject: str) -> str:
     normalized = _normalized_subject(subject)
     normalized_lower = normalized.lower()
-    for prefix in (UNSAFE_ARTIFACT_PREFIX, EXTERNAL_ARTIFACT_PREFIX):
+    labels_by_prefix = {
+        UNSAFE_ARTIFACT_PREFIX: "untrusted upload",
+        EXTERNAL_ARTIFACT_PREFIX: "external artifact",
+    }
+    for prefix, label in labels_by_prefix.items():
         prefix_lower = prefix.lower()
         if normalized_lower == prefix_lower:
-            return "unknown-file"
+            return f"{label}: unknown-file"
         if normalized_lower.startswith(f"{prefix_lower}/"):
-            return normalized[len(prefix) + 1 :] or "unknown-file"
+            display_subject = normalized[len(prefix) + 1 :] or "unknown-file"
+            return f"{label}: {display_subject}"
     return normalized or "unknown-file"
 
 

--- a/services/ownership_service.py
+++ b/services/ownership_service.py
@@ -1,0 +1,771 @@
+"""Ownership context helpers for reports."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from fnmatch import fnmatchcase
+import re
+from typing import Any
+
+from evidence.models import OwnerSignal
+from parsers.base import ParseBatchResult, UnifiedChange, is_non_mutating_action
+from services.intake_service import (
+    artifact_name_has_traversal,
+    artifact_name_is_ownership_untrusted,
+    artifact_name_is_traversal_normalized,
+)
+
+CODEOWNERS_LOOKUP_ORDER = (".github/CODEOWNERS", "CODEOWNERS", "docs/CODEOWNERS")
+CODEOWNERS_MAX_BYTES = 3_000_000
+OWNERSHIP_CONTEXT_TODO = (
+    "Add CODEOWNERS or ownership mapping for analyzed files/resources."
+)
+HANDLE_OWNER_PATTERN = re.compile(
+    r"^@[A-Za-z0-9](?:[A-Za-z0-9-]{0,37}[A-Za-z0-9])?"
+    r"(?:/[A-Za-z0-9](?:[A-Za-z0-9-]{0,98}[A-Za-z0-9])?)?$"
+)
+EMAIL_OWNER_PATTERN = re.compile(r"^[^@\s]+@[^@\s]+\.[^@\s.,;:!?]+$")
+TOPOLOGY_OWNER_LABEL_PATTERN = re.compile(
+    r"^[A-Za-z0-9](?:[A-Za-z0-9._/ -]{0,126}[A-Za-z0-9])?$"
+)
+
+
+@dataclass(frozen=True)
+class CodeownersMatch:
+    owners: tuple[str, ...]
+    pattern: str
+    source_ref: str
+
+
+@dataclass(frozen=True)
+class OwnershipContext:
+    owner_signals: tuple[OwnerSignal, ...]
+    escalation_hints: tuple[str, ...]
+    unmapped_subjects: tuple[str, ...]
+    context_todos: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class CodeownersSource:
+    source_ref: str
+    content: str
+    readable: bool = True
+    root_prefix: str = ""
+
+
+@dataclass(frozen=True)
+class _CodeownersRule:
+    pattern: str
+    owners: tuple[str, ...]
+    source_ref: str
+    root_prefix: str
+
+
+def _clean_texts(values: list[Any]) -> list[str]:
+    cleaned: list[str] = []
+    seen: set[str] = set()
+    for value in values:
+        text = str(value or "").strip()
+        if not text or text in seen:
+            continue
+        seen.add(text)
+        cleaned.append(text)
+    return cleaned
+
+
+def _normalized_subject(path: str) -> str:
+    normalized = str(path or "").strip().replace("\\", "/")
+    while normalized.startswith("./"):
+        normalized = normalized[2:]
+    return normalized.lstrip("/")
+
+
+def _is_codeowners_source(name: str) -> bool:
+    return _codeowners_lookup_match(name) is not None
+
+
+def _codeowners_lookup_match(name: str) -> tuple[str, str] | None:
+    normalized = _normalized_subject(name)
+    for source_ref in CODEOWNERS_LOOKUP_ORDER:
+        if normalized == source_ref:
+            return source_ref, ""
+    for source_ref in sorted(CODEOWNERS_LOOKUP_ORDER, key=len, reverse=True):
+        suffix = f"/{source_ref}"
+        if normalized.endswith(suffix):
+            root_prefix = normalized[: -len(suffix)].strip("/")
+            if root_prefix:
+                return source_ref, root_prefix
+    return None
+
+
+def _decode_codeowners_content(raw_content: bytes | str | None) -> str | None:
+    if raw_content is None:
+        return None
+    if isinstance(raw_content, str):
+        return raw_content.removeprefix("\ufeff")
+    try:
+        return raw_content.decode("utf-8-sig")
+    except UnicodeDecodeError:
+        return None
+
+
+def _split_codeowners_rule(line: str) -> tuple[str, list[str]] | None:
+    pattern_chars: list[str] = []
+    index = 0
+    while index < len(line):
+        char = line[index]
+        if char == "\\" and index + 1 < len(line):
+            next_char = line[index + 1]
+            pattern_chars.append(" " if next_char == " " else next_char)
+            index += 2
+            continue
+        if char.isspace():
+            pattern = "".join(pattern_chars).strip()
+            owners = line[index:].split()
+            return (pattern, owners) if pattern else None
+        pattern_chars.append(char)
+        index += 1
+    pattern = "".join(pattern_chars).strip()
+    return (pattern, []) if pattern else None
+
+
+def _strip_codeowners_comment(line: str) -> str:
+    escaped = False
+    chars: list[str] = []
+    for char in line:
+        if char == "#" and not escaped:
+            break
+        chars.append(char)
+        escaped = char == "\\" and not escaped
+        if char != "\\":
+            escaped = False
+    return "".join(chars).strip()
+
+
+def _valid_owner_token(owner: str) -> bool:
+    if HANDLE_OWNER_PATTERN.match(owner):
+        return True
+    return EMAIL_OWNER_PATTERN.match(owner) is not None
+
+
+def _codeowners_source_key(source_ref: str, root_prefix: str) -> str:
+    return f"{root_prefix}\0{source_ref}"
+
+
+def uploaded_codeowners_sources(
+    files: list[tuple[str, bytes | str | None]],
+) -> tuple[CodeownersSource, ...]:
+    """Extract uploaded CODEOWNERS content using GitHub's lookup order."""
+    by_ref: dict[str, CodeownersSource] = {}
+    for name, raw_content in files:
+        if (
+            artifact_name_has_traversal(name)
+            or artifact_name_is_traversal_normalized(name)
+            or artifact_name_is_ownership_untrusted(name)
+        ):
+            continue
+        lookup_match = _codeowners_lookup_match(name)
+        if lookup_match is None:
+            continue
+        source_ref, root_prefix = lookup_match
+        source_key = _codeowners_source_key(source_ref, root_prefix)
+        if source_key in by_ref:
+            continue
+        content = _decode_codeowners_content(raw_content)
+        if content is None:
+            by_ref[source_key] = CodeownersSource(
+                source_ref=_normalized_subject(name),
+                content="",
+                readable=False,
+                root_prefix=root_prefix,
+            )
+            continue
+        readable = len(content.encode("utf-8")) <= CODEOWNERS_MAX_BYTES
+        by_ref[source_key] = CodeownersSource(
+            source_ref=_normalized_subject(name),
+            content=content if readable else "",
+            readable=readable,
+            root_prefix=root_prefix,
+        )
+    root_prefixes = sorted({source.root_prefix for source in by_ref.values()})
+    sources: list[CodeownersSource] = []
+    for root_prefix in root_prefixes:
+        for source_ref in CODEOWNERS_LOOKUP_ORDER:
+            source = by_ref.get(_codeowners_source_key(source_ref, root_prefix))
+            if source is not None:
+                sources.append(source)
+                break
+    if "" in root_prefixes:
+        rootless_sources = [source for source in sources if source.root_prefix == ""]
+        prefixed_sources = [source for source in sources if source.root_prefix != ""]
+        return tuple(rootless_sources + prefixed_sources)
+    return tuple(sources)
+
+
+def _load_codeowners_rules(
+    sources: tuple[CodeownersSource, ...] = (),
+) -> list[_CodeownersRule]:
+    rules: list[_CodeownersRule] = []
+    seen_roots: set[str] = set()
+    for source in sources:
+        root_key = _normalized_subject(source.root_prefix)
+        if root_key in seen_roots:
+            continue
+        seen_roots.add(root_key)
+        if (
+            not source.readable
+            or len(source.content.encode("utf-8")) > CODEOWNERS_MAX_BYTES
+        ):
+            continue
+        for line in source.content.splitlines():
+            stripped = _strip_codeowners_comment(line)
+            if not stripped or stripped.startswith("#"):
+                continue
+            parsed = _split_codeowners_rule(stripped)
+            if parsed is None:
+                continue
+            pattern, owners = parsed
+            if _unsupported_codeowners_pattern(pattern):
+                continue
+            cleaned_owners = _clean_texts(owners)
+            if cleaned_owners and not all(
+                _valid_owner_token(owner) for owner in cleaned_owners
+            ):
+                continue
+            rules.append(
+                _CodeownersRule(
+                    pattern=pattern,
+                    owners=tuple(cleaned_owners),
+                    source_ref=source.source_ref,
+                    root_prefix=source.root_prefix,
+                )
+            )
+    return rules
+
+
+def _unsupported_codeowners_pattern(pattern: str) -> bool:
+    return pattern.startswith("!")
+
+
+def _split_path(path: str) -> list[str]:
+    return [part for part in path.split("/") if part]
+
+
+def _segment_match(pattern_segment: str, subject_segment: str) -> bool:
+    return fnmatchcase(subject_segment, pattern_segment)
+
+
+def _segments_match(
+    pattern_segments: list[str],
+    subject_segments: list[str],
+) -> bool:
+    if not pattern_segments:
+        return not subject_segments
+    pattern_head, *pattern_tail = pattern_segments
+    if pattern_head == "**":
+        return any(
+            _segments_match(pattern_tail, subject_segments[index:])
+            for index in range(len(subject_segments) + 1)
+        )
+    if not subject_segments:
+        return False
+    return _segment_match(pattern_head, subject_segments[0]) and _segments_match(
+        pattern_tail,
+        subject_segments[1:],
+    )
+
+
+def _collapse_globstar_directory_segments(pattern_segments: list[str]) -> list[str]:
+    collapsed: list[str] = []
+    for index, segment in enumerate(pattern_segments):
+        if segment == "**" and index < len(pattern_segments) - 1:
+            continue
+        collapsed.append(segment)
+    return collapsed
+
+
+def _directory_segments_match(
+    pattern_segments: list[str],
+    subject_segments: list[str],
+) -> bool:
+    if len(subject_segments) < len(pattern_segments):
+        return False
+    return _segments_match(pattern_segments, subject_segments[: len(pattern_segments)])
+
+
+def _path_pattern_matches(
+    pattern_segments: list[str],
+    subject_segments: list[str],
+    *,
+    directory_match: bool,
+) -> bool:
+    if _segments_match(pattern_segments, subject_segments):
+        return True
+    collapsed_segments = _collapse_globstar_directory_segments(pattern_segments)
+    if collapsed_segments != pattern_segments and _segments_match(
+        collapsed_segments,
+        subject_segments,
+    ):
+        return True
+    if directory_match:
+        return _directory_segments_match(pattern_segments, subject_segments)
+    return False
+
+
+def _pattern_matches(pattern: str, subject: str) -> bool:
+    normalized_subject = _normalized_subject(subject)
+    if pattern == "*":
+        return True
+    normalized_pattern = pattern.strip().replace("\\", "/")
+    if not normalized_pattern:
+        return False
+    anchored = normalized_pattern.startswith("/")
+    directory_pattern = normalized_pattern.endswith("/")
+    normalized_pattern = normalized_pattern.strip("/")
+    subject_segments = _split_path(normalized_subject)
+    pattern_segments = _split_path(normalized_pattern)
+    if not pattern_segments:
+        return False
+    has_slash = "/" in normalized_pattern
+    has_glob = any(marker in normalized_pattern for marker in "*?[")
+    if anchored and not has_slash:
+        if directory_pattern or not has_glob:
+            return _directory_segments_match(pattern_segments, subject_segments)
+        return len(subject_segments) == 1 and _segment_match(
+            pattern_segments[0],
+            subject_segments[0],
+        )
+
+    if not has_slash:
+        if directory_pattern or not has_glob:
+            return any(
+                _directory_segments_match(pattern_segments, subject_segments[index:])
+                for index in range(len(subject_segments))
+            )
+        return fnmatchcase(
+            normalized_subject.rsplit("/", maxsplit=1)[-1], normalized_pattern
+        )
+
+    directory_match = directory_pattern or pattern_segments[-1] == "**"
+    if anchored:
+        return _path_pattern_matches(
+            pattern_segments,
+            subject_segments,
+            directory_match=directory_match,
+        )
+
+    return _path_pattern_matches(
+        pattern_segments,
+        subject_segments,
+        directory_match=directory_match,
+    )
+
+
+def _match_codeowners(
+    subject: str,
+    rules: list[_CodeownersRule],
+    *,
+    prefixed_roots: tuple[str, ...] = (),
+) -> CodeownersMatch | None:
+    matched: CodeownersMatch | None = None
+    for rule in rules:
+        if not rule.root_prefix and _subject_is_under_prefixed_root(
+            subject,
+            prefixed_roots,
+        ):
+            continue
+        relative_subject = _subject_for_rule(subject, rule.root_prefix)
+        if relative_subject is not None and _pattern_matches(
+            rule.pattern, relative_subject
+        ):
+            matched = CodeownersMatch(
+                owners=rule.owners,
+                pattern=rule.pattern,
+                source_ref=rule.source_ref,
+            )
+    return matched
+
+
+def _subject_is_under_prefixed_root(
+    subject: str, prefixed_roots: tuple[str, ...]
+) -> bool:
+    normalized_subject = _normalized_subject(subject)
+    for root in prefixed_roots:
+        normalized_root = _normalized_subject(root)
+        if not normalized_root:
+            continue
+        if normalized_subject == normalized_root or normalized_subject.startswith(
+            f"{normalized_root}/"
+        ):
+            return True
+    return False
+
+
+def _subject_for_rule(subject: str, root_prefix: str) -> str | None:
+    normalized_subject = _normalized_subject(subject)
+    normalized_prefix = _normalized_subject(root_prefix)
+    if not normalized_prefix:
+        return normalized_subject
+    if normalized_subject == normalized_prefix:
+        return ""
+    prefix = f"{normalized_prefix}/"
+    if normalized_subject.startswith(prefix):
+        return normalized_subject[len(prefix) :]
+    return None
+
+
+def _service_owners(service: dict[str, Any]) -> list[str]:
+    owners: list[str] = []
+    owner = service.get("owner")
+    if isinstance(owner, str):
+        owners.append(owner)
+    raw_owners = service.get("owners")
+    if isinstance(raw_owners, list):
+        owners.extend(value for value in raw_owners if isinstance(value, str))
+    return [
+        owner
+        for owner in _clean_texts(owners)
+        if _valid_owner_token(owner) or TOPOLOGY_OWNER_LABEL_PATTERN.fullmatch(owner)
+    ]
+
+
+def _topology_source_ref(topology: dict[str, Any] | None) -> str | None:
+    if not isinstance(topology, dict):
+        return None
+    metadata = topology.get("metadata")
+    if not isinstance(metadata, dict):
+        return None
+    import_metadata = metadata.get("import")
+    if not isinstance(import_metadata, dict):
+        return None
+    source_ref = str(import_metadata.get("source_ref") or "").strip()
+    return source_ref or None
+
+
+def _resource_aliases(change: UnifiedChange) -> list[str]:
+    aliases = change.metadata.get("resource_aliases", [])
+    if not isinstance(aliases, list):
+        return []
+    return _clean_texts(aliases)
+
+
+def _services_by_resource(
+    topology: dict[str, Any] | None,
+) -> dict[str, list[dict[str, Any]]]:
+    if not isinstance(topology, dict):
+        return {}
+    services = topology.get("services")
+    if not isinstance(services, list):
+        return {}
+    by_resource: dict[str, list[dict[str, Any]]] = {}
+    for service in services:
+        if not isinstance(service, dict):
+            continue
+        resource_keys = service.get("resource_keys")
+        if not isinstance(resource_keys, list):
+            continue
+        for resource_key in _clean_texts(resource_keys):
+            by_resource.setdefault(resource_key, []).append(service)
+    return by_resource
+
+
+def _matched_services_for_change(
+    change: UnifiedChange,
+    services_by_resource: dict[str, list[dict[str, Any]]],
+) -> list[tuple[str, dict[str, Any]]]:
+    exact_matches = services_by_resource.get(change.resource_id, [])
+    if exact_matches:
+        if _services_resolve_to_one_owner_context(exact_matches):
+            return _unique_service_matches(
+                [(change.resource_id, service) for service in exact_matches]
+            )
+        return []
+
+    alias_matches: list[tuple[str, dict[str, Any]]] = []
+    for resource_id in _resource_aliases(change):
+        for service in services_by_resource.get(resource_id, []):
+            alias_matches.append((resource_id, service))
+    if _services_resolve_to_one_owner_context(
+        [service for _, service in alias_matches]
+    ):
+        return _unique_service_matches(alias_matches)
+    return []
+
+
+def _has_service_candidates_for_change(
+    change: UnifiedChange,
+    services_by_resource: dict[str, list[dict[str, Any]]],
+) -> bool:
+    if services_by_resource.get(change.resource_id):
+        return True
+    return any(
+        services_by_resource.get(resource_id)
+        for resource_id in _resource_aliases(change)
+    )
+
+
+def _service_label(service: dict[str, Any]) -> str:
+    label = str(service.get("label") or "").strip()
+    if label:
+        return label
+    return str(service.get("id") or "").strip()
+
+
+def _service_id(service: dict[str, Any]) -> str | None:
+    service_id = str(service.get("id") or "").strip()
+    return service_id or None
+
+
+def _service_identity(service: dict[str, Any]) -> str:
+    return _service_id(service) or _service_label(service)
+
+
+def _service_owner_signature(service: dict[str, Any]) -> tuple[str, ...]:
+    return tuple(sorted(_service_owners(service)))
+
+
+def _services_resolve_to_one_owner_context(services: list[dict[str, Any]]) -> bool:
+    signatures_by_identity: dict[str, set[tuple[str, ...]]] = {}
+    owner_signatures: set[tuple[str, ...]] = set()
+    for service in services:
+        identity = _service_identity(service)
+        if not identity:
+            return False
+        owner_signatures.add(_service_owner_signature(service))
+        signatures_by_identity.setdefault(identity, set()).add(
+            _service_owner_signature(service)
+        )
+    if len(owner_signatures) == 1 and next(iter(owner_signatures), ()):
+        return True
+    return len(signatures_by_identity) == 1 and all(
+        len(signatures) == 1 for signatures in signatures_by_identity.values()
+    )
+
+
+def _unique_service_matches(
+    matches: list[tuple[str, dict[str, Any]]],
+) -> list[tuple[str, dict[str, Any]]]:
+    unique: list[tuple[str, dict[str, Any]]] = []
+    seen: set[tuple[str, str]] = set()
+    for resource_id, service in matches:
+        service_key = _service_id(service) or _service_label(service)
+        key = (resource_id, service_key)
+        if key in seen:
+            continue
+        seen.add(key)
+        unique.append((resource_id, service))
+    return unique
+
+
+def _change_ownership_subject(
+    change: UnifiedChange,
+    *,
+    fallback_file_name: str,
+) -> str:
+    resource_id = str(change.resource_id or "").strip()
+    if resource_id:
+        return resource_id
+    source_file = str(change.source_file or "").strip()
+    if source_file:
+        return f"{source_file}:unknown-resource"
+    file_name = str(fallback_file_name or "").strip()
+    if file_name:
+        return f"{file_name}:unknown-resource"
+    return "unknown-resource"
+
+
+def _file_signal(subject: str, match: CodeownersMatch) -> OwnerSignal:
+    owners = list(match.owners)
+    hint = f"Escalate file review for {subject} to {', '.join(owners)}."
+    return OwnerSignal(
+        scope="file",
+        subject=subject,
+        owners=owners,
+        source="CODEOWNERS",
+        source_ref=match.source_ref,
+        matched_pattern=match.pattern,
+        escalation_hint=hint,
+    )
+
+
+def _service_signal(
+    *,
+    service: dict[str, Any],
+    resource_id: str,
+    source_ref: str | None,
+) -> OwnerSignal | None:
+    owners = _service_owners(service)
+    if not owners:
+        return None
+    subject = _service_label(service)
+    if not subject:
+        return None
+    hint = f"Escalate service review for {subject} to {', '.join(owners)}."
+    return OwnerSignal(
+        scope="service",
+        subject=subject,
+        owners=owners,
+        source="topology",
+        source_ref=source_ref,
+        resource_id=resource_id,
+        service_id=_service_id(service),
+        escalation_hint=hint,
+    )
+
+
+def _dedupe_signals(signals: list[OwnerSignal]) -> list[OwnerSignal]:
+    unique: list[OwnerSignal] = []
+    seen: set[tuple[Any, ...]] = set()
+    for signal in signals:
+        key = (
+            signal.scope,
+            signal.subject,
+            tuple(signal.owners),
+            signal.source,
+            signal.source_ref,
+            signal.resource_id,
+            signal.service_id,
+        )
+        if key in seen:
+            continue
+        seen.add(key)
+        unique.append(signal)
+    return unique
+
+
+def build_ownership_context(
+    parse_batch: ParseBatchResult,
+    *,
+    topology: dict[str, Any] | None = None,
+    codeowners_sources: tuple[CodeownersSource, ...] = (),
+) -> OwnershipContext:
+    """Build deterministic ownership hints for analyzed files and resources."""
+    rules = _load_codeowners_rules(codeowners_sources)
+    prefixed_roots = tuple(
+        _clean_texts([source.root_prefix for source in codeowners_sources])
+    )
+    signals: list[OwnerSignal] = []
+    unmapped_subjects: list[str] = []
+    file_owned_subjects: set[str] = set()
+    file_unmapped_candidates: set[str] = set()
+    unknown_file_candidates: set[str] = set()
+    files_with_service_ownership: set[str] = set()
+    files_with_unresolved_changes: set[str] = set()
+    files_with_mutating_changes: set[str] = set()
+
+    analyzed_files = [
+        file_result
+        for file_result in parse_batch.files
+        if file_result.status == "failed"
+        or (file_result.status == "parsed" and file_result.changes)
+    ]
+    for file_result in analyzed_files:
+        subject = _normalized_subject(file_result.file_name)
+        if not subject:
+            if file_result.status == "failed":
+                unmapped_subjects.append("unknown-file")
+            else:
+                unknown_file_candidates.add(subject)
+            continue
+        if artifact_name_is_ownership_untrusted(subject):
+            if file_result.status == "failed":
+                unmapped_subjects.append(subject)
+            continue
+        match = _match_codeowners(subject, rules, prefixed_roots=prefixed_roots)
+        if match is None or not match.owners:
+            file_unmapped_candidates.add(subject)
+            continue
+        signals.append(_file_signal(subject, match))
+        file_owned_subjects.add(subject)
+
+    services_by_resource = _services_by_resource(topology)
+    topology_source_ref = _topology_source_ref(topology)
+    parsed_files = [
+        file_result
+        for file_result in analyzed_files
+        if file_result.status == "parsed" and file_result.changes
+    ]
+    for file_result in parsed_files:
+        for change in file_result.changes:
+            if is_non_mutating_action(change.action):
+                continue
+            files_with_mutating_changes.add(_normalized_subject(file_result.file_name))
+            matched_services = _matched_services_for_change(
+                change, services_by_resource
+            )
+            if not matched_services:
+                if (
+                    not _has_service_candidates_for_change(change, services_by_resource)
+                    and _normalized_subject(file_result.file_name)
+                    in file_owned_subjects
+                ):
+                    continue
+                unmapped_subjects.append(
+                    _change_ownership_subject(
+                        change,
+                        fallback_file_name=file_result.file_name,
+                    )
+                )
+                files_with_unresolved_changes.add(
+                    _normalized_subject(file_result.file_name)
+                )
+                continue
+            for resource_id, service in matched_services:
+                signal = _service_signal(
+                    service=service,
+                    resource_id=resource_id,
+                    source_ref=topology_source_ref,
+                )
+                if signal is None:
+                    subject = _service_label(service) or _change_ownership_subject(
+                        change,
+                        fallback_file_name=file_result.file_name,
+                    )
+                    unmapped_subjects.append(subject)
+                    files_with_unresolved_changes.add(
+                        _normalized_subject(file_result.file_name)
+                    )
+                    continue
+                signals.append(signal)
+                files_with_service_ownership.add(
+                    _normalized_subject(file_result.file_name)
+                )
+
+    parsed_file_subjects = {
+        _normalized_subject(file_result.file_name) for file_result in parsed_files
+    }
+    for subject in sorted(file_unmapped_candidates):
+        if (
+            subject in parsed_file_subjects
+            and subject not in files_with_mutating_changes
+        ):
+            continue
+        if (
+            subject in parsed_file_subjects
+            and subject in files_with_service_ownership
+            and subject not in files_with_unresolved_changes
+        ):
+            continue
+        unmapped_subjects.append(subject)
+    for subject in sorted(unknown_file_candidates):
+        if (
+            subject in files_with_service_ownership
+            and subject not in files_with_unresolved_changes
+        ):
+            continue
+        if subject in files_with_unresolved_changes:
+            continue
+        unmapped_subjects.append("unknown-file")
+
+    unique_signals = _dedupe_signals(signals)
+    escalation_hints = tuple(
+        _clean_texts([signal.escalation_hint for signal in unique_signals])
+    )
+    unique_unmapped = tuple(_clean_texts(unmapped_subjects))
+    todos = (OWNERSHIP_CONTEXT_TODO,) if unique_unmapped else ()
+    return OwnershipContext(
+        owner_signals=tuple(unique_signals),
+        escalation_hints=escalation_hints,
+        unmapped_subjects=unique_unmapped,
+        context_todos=todos,
+    )

--- a/services/ownership_service.py
+++ b/services/ownership_service.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections import Counter
 from dataclasses import dataclass
 from fnmatch import fnmatchcase
 import re
@@ -10,6 +11,8 @@ from typing import Any
 from evidence.models import OwnerSignal
 from parsers.base import ParseBatchResult, UnifiedChange, is_non_mutating_action
 from services.intake_service import (
+    EXTERNAL_ARTIFACT_PREFIX,
+    UNSAFE_ARTIFACT_PREFIX,
     artifact_name_has_traversal,
     artifact_name_is_ownership_untrusted,
     artifact_name_is_traversal_normalized,
@@ -78,6 +81,18 @@ def _normalized_subject(path: str) -> str:
     while normalized.startswith("./"):
         normalized = normalized[2:]
     return normalized.lstrip("/")
+
+
+def _untrusted_display_subject(subject: str) -> str:
+    normalized = _normalized_subject(subject)
+    normalized_lower = normalized.lower()
+    for prefix in (UNSAFE_ARTIFACT_PREFIX, EXTERNAL_ARTIFACT_PREFIX):
+        prefix_lower = prefix.lower()
+        if normalized_lower == prefix_lower:
+            return "unknown-file"
+        if normalized_lower.startswith(f"{prefix_lower}/"):
+            return normalized[len(prefix) + 1 :] or "unknown-file"
+    return normalized or "unknown-file"
 
 
 def _is_codeowners_source(name: str) -> bool:
@@ -669,7 +684,7 @@ def build_ownership_context(
                 unknown_file_candidates.add(subject)
             continue
         if artifact_name_is_ownership_untrusted(subject):
-            unmapped_subjects.append(subject)
+            unmapped_subjects.append(_untrusted_display_subject(subject))
             if file_result.status != "failed":
                 untrusted_file_unmapped_candidates.add(subject)
             continue
@@ -765,11 +780,18 @@ def build_ownership_context(
         and subject not in files_with_unresolved_changes
     }
     if cleared_untrusted_subjects:
-        unmapped_subjects = [
-            subject
-            for subject in unmapped_subjects
-            if subject not in cleared_untrusted_subjects
-        ]
+        cleared_subject_counts = Counter(cleared_untrusted_subjects)
+        cleared_subject_counts.update(
+            _untrusted_display_subject(subject)
+            for subject in cleared_untrusted_subjects
+        )
+        retained_unmapped_subjects: list[str] = []
+        for subject in unmapped_subjects:
+            if cleared_subject_counts[subject] > 0:
+                cleared_subject_counts[subject] -= 1
+                continue
+            retained_unmapped_subjects.append(subject)
+        unmapped_subjects = retained_unmapped_subjects
 
     unique_signals = _dedupe_signals(signals)
     escalation_hints = tuple(

--- a/services/ownership_service.py
+++ b/services/ownership_service.py
@@ -648,6 +648,7 @@ def build_ownership_context(
     unmapped_subjects: list[str] = []
     file_owned_subjects: set[str] = set()
     file_unmapped_candidates: set[str] = set()
+    untrusted_file_unmapped_candidates: set[str] = set()
     unknown_file_candidates: set[str] = set()
     files_with_service_ownership: set[str] = set()
     files_with_unresolved_changes: set[str] = set()
@@ -668,8 +669,9 @@ def build_ownership_context(
                 unknown_file_candidates.add(subject)
             continue
         if artifact_name_is_ownership_untrusted(subject):
-            if file_result.status == "failed":
-                unmapped_subjects.append(subject)
+            unmapped_subjects.append(subject)
+            if file_result.status != "failed":
+                untrusted_file_unmapped_candidates.add(subject)
             continue
         match = _match_codeowners(subject, rules, prefixed_roots=prefixed_roots)
         if match is None or not match.owners:
@@ -756,6 +758,18 @@ def build_ownership_context(
         if subject in files_with_unresolved_changes:
             continue
         unmapped_subjects.append("unknown-file")
+    cleared_untrusted_subjects = {
+        subject
+        for subject in untrusted_file_unmapped_candidates
+        if subject in files_with_service_ownership
+        and subject not in files_with_unresolved_changes
+    }
+    if cleared_untrusted_subjects:
+        unmapped_subjects = [
+            subject
+            for subject in unmapped_subjects
+            if subject not in cleared_untrusted_subjects
+        ]
 
     unique_signals = _dedupe_signals(signals)
     escalation_hints = tuple(

--- a/tests/e2e/dashboard_deploy_review_upload.spec.js
+++ b/tests/e2e/dashboard_deploy_review_upload.spec.js
@@ -1,4 +1,6 @@
 const path = require("path");
+const fs = require("fs");
+const os = require("os");
 const { test, expect } = require("@playwright/test");
 
 test.describe("dashboard deploy review upload", () => {
@@ -37,14 +39,26 @@ test.describe("dashboard deploy review upload", () => {
       .first()
       .elementHandle();
     expect(fileInput).not.toBeNull();
+    await expect(page.locator('input[type="file"]').first()).not.toHaveAttribute(
+      "webkitdirectory",
+      "",
+    );
 
     await page.waitForTimeout(6500);
+    const uploadRequest = page.waitForRequest(
+      (request) =>
+        request.method() === "POST" &&
+        request.url().includes("/_deploywhisper/dashboard-upload/"),
+    );
     await fileInput.setInputFiles(
       path.join(
         process.cwd(),
         "samples/ui-demo-infra/analysis-artifacts/kubernetes/checkout-platform.yaml",
       ),
     );
+    const uploadBody = (await uploadRequest).postData() || "";
+    expect(uploadBody).toContain('name="artifact_paths"');
+    expect(uploadBody).toContain("checkout-platform.yaml");
 
     await expect(page.getByText("1 files", { exact: true })).toBeVisible();
     await expect(page.getByText("1 accepted", { exact: true })).toBeVisible();
@@ -97,5 +111,73 @@ test.describe("dashboard deploy review upload", () => {
           message.includes("Cannot read properties of null"),
       ),
     ).toEqual([]);
+  });
+
+  test("sends browser relative paths for directory uploads", async ({ page }) => {
+    const uploadRoot = fs.mkdtempSync(
+      path.join(os.tmpdir(), "deploywhisper-owners-"),
+    );
+    fs.mkdirSync(path.join(uploadRoot, "services/payments"), {
+      recursive: true,
+    });
+    fs.writeFileSync(
+      path.join(uploadRoot, "CODEOWNERS"),
+      "/services/payments/ @payments-sre\n",
+    );
+    fs.writeFileSync(
+      path.join(uploadRoot, "services/payments/plan.json"),
+      '{"resource_changes": [{"address": "aws_security_group.payments", "change": {"actions": ["update"]}}]}',
+    );
+
+    await page.goto("/", { waitUntil: "networkidle" });
+    await page.getByRole("button", { name: /Run Analysis/ }).click();
+    await expect(page.getByText("Deploy review", { exact: true })).toBeInViewport({
+      timeout: 15_000,
+    });
+
+    const fileInputs = page.locator('input[type="file"]');
+    await expect(fileInputs).toHaveCount(2);
+    await expect(fileInputs.nth(0)).not.toHaveAttribute("webkitdirectory", "");
+    await expect(fileInputs.nth(1)).toHaveAttribute("webkitdirectory", "");
+
+    const uploadRequest = page.waitForRequest(
+      (request) =>
+        request.method() === "POST" &&
+        request.url().includes("/_deploywhisper/dashboard-upload/"),
+    );
+    await fileInputs.nth(1).setInputFiles(uploadRoot);
+    const uploadBody = (await uploadRequest).postData() || "";
+
+    expect(uploadBody).toContain('name="artifact_paths"');
+    expect(uploadBody).toContain("CODEOWNERS");
+    expect(uploadBody).toContain("services/payments/plan.json");
+    await expect(page.getByText("2 files", { exact: true })).toBeVisible();
+    await expect(page.getByText("1 accepted", { exact: true })).toBeVisible();
+
+    const analyzeButton = page.getByRole("button", { name: /^Analyze$/ });
+    await expect(analyzeButton).toBeEnabled();
+    await analyzeButton.click();
+
+    const continueAnyway = page.getByRole("button", { name: "Continue Anyway" });
+    if (
+      await continueAnyway
+        .waitFor({ state: "visible", timeout: 15_000 })
+        .then(() => true)
+        .catch(() => false)
+    ) {
+      await continueAnyway.click();
+    }
+
+    await expect(page.getByText("0 files", { exact: true })).toBeVisible({
+      timeout: 90_000,
+    });
+    await expect(page.getByText("Ownership context").first()).toBeVisible({
+      timeout: 90_000,
+    });
+    await expect(
+      page
+        .getByText(/Owner: .*services\/payments\/plan\.json -> @payments-sre/)
+        .first(),
+    ).toBeVisible();
   });
 });

--- a/tests/e2e/dashboard_deploy_review_upload.spec.js
+++ b/tests/e2e/dashboard_deploy_review_upload.spec.js
@@ -180,4 +180,71 @@ test.describe("dashboard deploy review upload", () => {
         .first(),
     ).toBeVisible();
   });
+
+  test("renders missing ownership TODOs from dashboard directory uploads", async ({
+    page,
+  }) => {
+    const uploadRoot = fs.mkdtempSync(
+      path.join(os.tmpdir(), "deploywhisper-missing-owner-"),
+    );
+    fs.mkdirSync(path.join(uploadRoot, "services/unowned"), {
+      recursive: true,
+    });
+    fs.writeFileSync(
+      path.join(uploadRoot, "services/unowned/plan.json"),
+      '{"resource_changes": [{"address": "aws_security_group.unowned", "change": {"actions": ["update"]}}]}',
+    );
+
+    await page.goto("/", { waitUntil: "networkidle" });
+    await page.getByRole("button", { name: /Run Analysis/ }).click();
+    await expect(page.getByText("Deploy review", { exact: true })).toBeInViewport({
+      timeout: 15_000,
+    });
+
+    const fileInputs = page.locator('input[type="file"]');
+    await expect(fileInputs).toHaveCount(2);
+    await expect(fileInputs.nth(1)).toHaveAttribute("webkitdirectory", "");
+
+    const uploadRequest = page.waitForRequest(
+      (request) =>
+        request.method() === "POST" &&
+        request.url().includes("/_deploywhisper/dashboard-upload/"),
+    );
+    await fileInputs.nth(1).setInputFiles(uploadRoot);
+    const uploadBody = (await uploadRequest).postData() || "";
+
+    expect(uploadBody).toContain('name="artifact_paths"');
+    expect(uploadBody).toContain("services/unowned/plan.json");
+    await expect(page.getByText("1 files", { exact: true })).toBeVisible();
+    await expect(page.getByText("1 accepted", { exact: true })).toBeVisible();
+
+    const analyzeButton = page.getByRole("button", { name: /^Analyze$/ });
+    await expect(analyzeButton).toBeEnabled();
+    await analyzeButton.click();
+
+    const continueAnyway = page.getByRole("button", { name: "Continue Anyway" });
+    if (
+      await continueAnyway
+        .waitFor({ state: "visible", timeout: 15_000 })
+        .then(() => true)
+        .catch(() => false)
+    ) {
+      await continueAnyway.click();
+    }
+
+    await expect(page.getByText("0 files", { exact: true })).toBeVisible({
+      timeout: 90_000,
+    });
+    await expect(page.getByText("Ownership context").first()).toBeVisible({
+      timeout: 90_000,
+    });
+    await expect(
+      page
+        .getByText(/Missing owner: .*services\/unowned\/plan\.json/)
+        .first(),
+    ).toBeVisible();
+    await expect(
+      page.getByText("Add CODEOWNERS or ownership mapping").first(),
+    ).toBeVisible();
+  });
 });

--- a/tests/test_api/test_analyses.py
+++ b/tests/test_api/test_analyses.py
@@ -19,7 +19,7 @@ import services.deployment_outcome_service as deployment_outcome_service_module
 import services.project_service as project_service_module
 import services.report_service as report_service_module
 from analysis.blast_radius import BlastRadiusResult, ImpactNode
-from api.schemas import BlastRadiusData
+from api.schemas import BlastRadiusData, ContextCompletenessData, PersistedReportData
 from services.analysis_service import AnalysisPersistenceError
 from services.analysis_service import AnalysisRunResult
 from analysis.rollback_planner import RollbackPlan
@@ -34,6 +34,7 @@ from evidence.models import ContextCompleteness, EvidenceItem
 from fastapi.testclient import TestClient
 from llm.narrator import NarrativeResult
 from parsers.base import ParseBatchResult, ParsedFileResult, UnifiedChange
+from pydantic import ValidationError
 
 
 class AnalysesApiTests(unittest.TestCase):
@@ -1654,6 +1655,578 @@ class AnalysesApiTests(unittest.TestCase):
             persisted_evidence_id,
         )
         self.assertEqual(payload["data"]["persisted_report"]["id"], 2)
+
+    def test_create_analysis_preserves_ownership_context_in_api_schema(self) -> None:
+        project_service_module.create_project(
+            project_key="payments-owners",
+            display_name="Payments Owners",
+        )
+        persisted_report = dict(self.persisted)
+        persisted_report["context_completeness"] = {
+            **dict(persisted_report["context_completeness"]),
+            "incident_index_version": "incidents:unknown",
+            "incident_index_last_indexed_at": "2026-05-25T00:00:00Z",
+            "incident_index_freshness_status": "current",
+            "owner_signals": [
+                {
+                    "scope": "file",
+                    "subject": "services/payments/plan.json",
+                    "owners": ["@payments-sre"],
+                    "source": "CODEOWNERS",
+                    "source_ref": ".github/CODEOWNERS",
+                    "matched_pattern": "/services/payments/",
+                    "resource_id": None,
+                    "service_id": None,
+                    "escalation_hint": "Escalate file review for services/payments/plan.json to @payments-sre.",
+                }
+            ],
+            "escalation_hints": [
+                "Escalate file review for services/payments/plan.json to @payments-sre."
+            ],
+            "ownership_unmapped_subjects": ["aws_security_group.unmapped"],
+        }
+
+        with patch(
+            "api.routes.analyses.analyze_uploaded_files",
+            return_value=self._analysis_result_with_persisted_report(persisted_report),
+        ):
+            response = self.client.post(
+                "/api/v1/analyses",
+                files={"files": ("plan.json", b'{"resource_changes": []}')},
+                data={"project_key": "payments-owners"},
+            )
+
+        self.assertEqual(response.status_code, 200)
+        context = response.json()["data"]["assessment"]["context_completeness"]
+        self.assertEqual(context["incident_index_version"], "incidents:unknown")
+        self.assertEqual(
+            context["incident_index_last_indexed_at"],
+            "2026-05-25T00:00:00Z",
+        )
+        self.assertEqual(context["incident_index_freshness_status"], "current")
+        self.assertEqual(context["owner_signals"][0]["owners"], ["@payments-sre"])
+        self.assertEqual(
+            context["escalation_hints"],
+            ["Escalate file review for services/payments/plan.json to @payments-sre."],
+        )
+        self.assertEqual(
+            context["ownership_unmapped_subjects"],
+            ["aws_security_group.unmapped"],
+        )
+        self.assertEqual(
+            context,
+            response.json()["data"]["persisted_report"]["context_completeness"],
+        )
+
+    def test_create_analysis_uses_trusted_relative_artifact_paths_for_api_uploads(
+        self,
+    ) -> None:
+        project_service_module.create_project(
+            project_key="payments-api-paths",
+            display_name="Payments API Paths",
+        )
+        persisted_report = dict(self.persisted)
+
+        with patch(
+            "api.routes.analyses.analyze_uploaded_files",
+            return_value=self._analysis_result_with_persisted_report(persisted_report),
+        ) as analyze_uploaded_files:
+            response = self.client.post(
+                "/api/v1/analyses",
+                files=[
+                    ("files", ("CODEOWNERS", b"/services/payments/ @payments-sre")),
+                    ("files", ("plan.json", b'{"resource_changes": []}')),
+                ],
+                data={
+                    "project_key": "payments-api-paths",
+                    "artifact_paths": [
+                        ".github/CODEOWNERS",
+                        "services/payments/plan.json",
+                    ],
+                },
+            )
+
+        self.assertEqual(response.status_code, 200)
+        raw_files = analyze_uploaded_files.call_args.args[0]
+        self.assertEqual(
+            [name for name, _ in raw_files],
+            [".github/CODEOWNERS", "services/payments/plan.json"],
+        )
+
+    def test_create_analysis_rejects_mismatched_artifact_paths_for_api_uploads(
+        self,
+    ) -> None:
+        project_service_module.create_project(
+            project_key="payments-api-path-mismatch",
+            display_name="Payments API Path Mismatch",
+        )
+
+        with patch("api.routes.analyses.analyze_uploaded_files") as analyze_mock:
+            response = self.client.post(
+                "/api/v1/analyses",
+                files=[
+                    ("files", ("CODEOWNERS", b"/services/payments/ @payments-sre")),
+                    ("files", ("plan.json", b'{"resource_changes": []}')),
+                ],
+                data={
+                    "project_key": "payments-api-path-mismatch",
+                    "artifact_paths": [".github/CODEOWNERS"],
+                },
+            )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.json()["error"]["code"], "artifact_path_mismatch")
+        analyze_mock.assert_not_called()
+
+    def test_create_analysis_rejects_reordered_artifact_paths_for_api_uploads(
+        self,
+    ) -> None:
+        project_service_module.create_project(
+            project_key="payments-api-path-reorder",
+            display_name="Payments API Path Reorder",
+        )
+
+        with patch("api.routes.analyses.analyze_uploaded_files") as analyze_mock:
+            response = self.client.post(
+                "/api/v1/analyses",
+                files=[
+                    ("files", ("CODEOWNERS", b"/services/payments/ @payments-sre")),
+                    ("files", ("plan.json", b'{"resource_changes": []}')),
+                ],
+                data={
+                    "project_key": "payments-api-path-reorder",
+                    "artifact_paths": [
+                        "services/payments/plan.json",
+                        ".github/CODEOWNERS",
+                    ],
+                },
+            )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.json()["error"]["code"], "artifact_path_mismatch")
+        analyze_mock.assert_not_called()
+
+    def test_create_analysis_supports_duplicate_artifact_path_filenames(
+        self,
+    ) -> None:
+        project_service_module.create_project(
+            project_key="payments-api-path-duplicate",
+            display_name="Payments API Path Duplicate",
+        )
+        persisted_report = dict(self.persisted)
+
+        with patch("api.routes.analyses.analyze_uploaded_files") as analyze_mock:
+            analyze_mock.return_value = self._analysis_result_with_persisted_report(
+                persisted_report
+            )
+            response = self.client.post(
+                "/api/v1/analyses",
+                files=[
+                    (
+                        "files",
+                        (
+                            "services/payments/plan.json",
+                            b'{"resource_changes": []}',
+                        ),
+                    ),
+                    (
+                        "files",
+                        (
+                            "services/billing/plan.json",
+                            b'{"resource_changes": []}',
+                        ),
+                    ),
+                ],
+                data={
+                    "project_key": "payments-api-path-duplicate",
+                    "artifact_paths": [
+                        "services/payments/plan.json",
+                        "services/billing/plan.json",
+                    ],
+                },
+            )
+
+        self.assertEqual(response.status_code, 200)
+        raw_files = analyze_mock.call_args.args[0]
+        self.assertEqual(
+            [name for name, _ in raw_files],
+            ["services/payments/plan.json", "services/billing/plan.json"],
+        )
+
+    def test_create_analysis_rejects_duplicate_basenames_without_path_binding(
+        self,
+    ) -> None:
+        project_service_module.create_project(
+            project_key="payments-api-path-duplicate-bare",
+            display_name="Payments API Path Duplicate Bare",
+        )
+
+        with patch("api.routes.analyses.analyze_uploaded_files") as analyze_mock:
+            response = self.client.post(
+                "/api/v1/analyses",
+                files=[
+                    ("files", ("plan.json", b'{"resource_changes": []}')),
+                    ("files", ("plan.json", b'{"resource_changes": []}')),
+                ],
+                data={
+                    "project_key": "payments-api-path-duplicate-bare",
+                    "artifact_paths": [
+                        "services/payments/plan.json",
+                        "services/billing/plan.json",
+                    ],
+                },
+            )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.json()["error"]["code"], "artifact_path_ambiguous")
+        analyze_mock.assert_not_called()
+
+    def test_create_analysis_rejects_duplicate_artifact_paths_for_api_uploads(
+        self,
+    ) -> None:
+        project_service_module.create_project(
+            project_key="payments-api-path-exact-duplicate",
+            display_name="Payments API Path Exact Duplicate",
+        )
+
+        with patch("api.routes.analyses.analyze_uploaded_files") as analyze_mock:
+            response = self.client.post(
+                "/api/v1/analyses",
+                files=[
+                    ("files", ("plan.json", b'{"resource_changes": []}')),
+                    ("files", ("plan.json", b'{"resource_changes": []}')),
+                ],
+                data={
+                    "project_key": "payments-api-path-exact-duplicate",
+                    "artifact_paths": [
+                        "services/payments/plan.json",
+                        "services/payments/plan.json",
+                    ],
+                },
+            )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.json()["error"]["code"], "artifact_path_ambiguous")
+        analyze_mock.assert_not_called()
+
+    def test_create_analysis_rejects_invalid_artifact_paths_at_request_layer(
+        self,
+    ) -> None:
+        project_service_module.create_project(
+            project_key="payments-api-path-invalid",
+            display_name="Payments API Path Invalid",
+        )
+
+        invalid_values = (
+            "/Users/alice/repo/services/payments/plan.json",
+            "services/../payments/plan.json",
+            "__unsafe_path__/services/payments/plan.json",
+            "__external_path__/services/payments/plan.json",
+        )
+        for artifact_path in invalid_values:
+            with self.subTest(artifact_path=artifact_path):
+                with patch(
+                    "api.routes.analyses.analyze_uploaded_files"
+                ) as analyze_mock:
+                    response = self.client.post(
+                        "/api/v1/analyses",
+                        files=[
+                            ("files", ("plan.json", b'{"resource_changes": []}')),
+                        ],
+                        data={
+                            "project_key": "payments-api-path-invalid",
+                            "artifact_paths": [artifact_path],
+                        },
+                    )
+
+                self.assertEqual(response.status_code, 400)
+                self.assertEqual(
+                    response.json()["error"]["code"],
+                    "invalid_artifact_path",
+                )
+                analyze_mock.assert_not_called()
+
+    def test_context_completeness_api_schema_rejects_invalid_scalar_values(
+        self,
+    ) -> None:
+        invalid_payloads = (
+            {"topology_freshness_days": -1},
+            {"incident_index_size": -1},
+            {"parser_success_rate": float("nan")},
+            {"parser_success_rate": -0.1},
+            {"parser_success_by_tool": {"terraform": float("inf")}},
+            {"parser_success_by_tool": {"terraform": 1.2}},
+            {"context_score": float("-inf")},
+            {"context_score": -0.1},
+        )
+        for payload in invalid_payloads:
+            with self.subTest(payload=payload):
+                with self.assertRaises(ValidationError):
+                    ContextCompletenessData.model_validate(payload)
+
+    def test_persisted_report_salvages_nonfinite_and_negative_context_scalars(
+        self,
+    ) -> None:
+        persisted_report = dict(self.persisted)
+        persisted_report["context_completeness"] = {
+            **dict(persisted_report["context_completeness"]),
+            "topology_freshness_days": -7,
+            "incident_index_size": -3,
+            "evidence_success_rate": float("nan"),
+            "parser_success_rate": float("inf"),
+            "parser_success_by_tool": {"terraform": -0.2, "kubernetes": float("nan")},
+            "context_score": float("-inf"),
+            "confidence_level": "medium",
+            "owner_signals": [
+                {
+                    "scope": "file",
+                    "subject": "services/payments/plan.json",
+                    "owners": ["@payments-sre"],
+                    "source": "CODEOWNERS",
+                    "source_ref": ".github/CODEOWNERS",
+                    "escalation_hint": "Escalate file review for services/payments/plan.json to @payments-sre.",
+                }
+            ],
+        }
+
+        report = PersistedReportData.model_validate(persisted_report)
+
+        self.assertIsNone(report.context_completeness.topology_freshness_days)
+        self.assertEqual(report.context_completeness.incident_index_size, 0)
+        self.assertEqual(report.context_completeness.evidence_success_rate, 0.0)
+        self.assertEqual(report.context_completeness.parser_success_rate, 0.0)
+        self.assertEqual(
+            report.context_completeness.parser_success_by_tool,
+            {"terraform": 0.0, "kubernetes": 0.0},
+        )
+        self.assertEqual(report.context_completeness.context_score, 0.69)
+        self.assertEqual(report.context_completeness.confidence_level, "low")
+        self.assertTrue(report.context_completeness.insufficient_context)
+        self.assertTrue(report.context_completeness.partial_context)
+        self.assertEqual(len(report.context_completeness.owner_signals), 1)
+
+    def test_context_completeness_api_schema_rejects_malformed_owner_signals(
+        self,
+    ) -> None:
+        with self.assertRaises(ValidationError):
+            ContextCompletenessData.model_validate(
+                {
+                    "owner_signals": [
+                        {
+                            "scope": "file",
+                            "subject": "",
+                            "owners": [""],
+                            "source": "",
+                            "escalation_hint": "",
+                        }
+                    ],
+                    "escalation_hints": [""],
+                    "ownership_unmapped_subjects": [""],
+                }
+            )
+        with self.assertRaises(ValidationError):
+            ContextCompletenessData.model_validate(
+                {
+                    "owner_signals": [
+                        {
+                            "scope": "file",
+                            "subject": "services/payments/plan.json",
+                            "owners": ["@payments-sre"],
+                            "source": "CODEOWNERS",
+                            "escalation_hint": "Escalate file review to @payments-sre.",
+                            "unexpected": "not allowed",
+                        }
+                    ],
+                    "unexpected_context": "not allowed",
+                }
+            )
+
+    def test_persisted_report_degrades_malformed_context_payload(self) -> None:
+        malformed_contexts = (
+            "oops",
+            {"future_context_field": "unknown"},
+            {"context_score": "oops"},
+        )
+        for malformed_context in malformed_contexts:
+            persisted_report = dict(self.persisted)
+            persisted_report["context_completeness"] = malformed_context
+
+            report = PersistedReportData.model_validate(persisted_report)
+
+            self.assertEqual(report.context_completeness.context_score, 0.0)
+            self.assertEqual(report.context_completeness.confidence_level, "low")
+            self.assertTrue(report.context_completeness.insufficient_context)
+            self.assertIn(
+                "Context completeness payload was unavailable or unreadable.",
+                report.context_completeness.uncertainty,
+            )
+
+    def test_persisted_report_degrades_missing_context_payload(self) -> None:
+        persisted_report = dict(self.persisted)
+        persisted_report.pop("context_completeness", None)
+
+        report = PersistedReportData.model_validate(persisted_report)
+
+        self.assertEqual(report.context_completeness.context_score, 0.0)
+        self.assertEqual(report.context_completeness.confidence_level, "low")
+        self.assertTrue(report.context_completeness.insufficient_context)
+        self.assertIn(
+            "Context completeness payload was unavailable or unreadable.",
+            report.context_completeness.uncertainty,
+        )
+
+    def test_persisted_report_salvages_malformed_ownership_context_fields(
+        self,
+    ) -> None:
+        persisted_report = dict(self.persisted)
+        persisted_report["context_completeness"] = {
+            **dict(persisted_report["context_completeness"]),
+            "context_score": 0.84,
+            "confidence_level": "medium",
+            "owner_signals": [
+                {
+                    "scope": "file",
+                    "subject": "services/payments/plan.json",
+                    "owners": ["@payments-sre", "", {"handle": "@fake-owner"}],
+                    "source": "CODEOWNERS",
+                    "source_ref": ".github/CODEOWNERS",
+                    "unexpected": "not allowed",
+                },
+                {
+                    "scope": "file",
+                    "subject": "",
+                    "owners": ["@broken"],
+                    "source": "CODEOWNERS",
+                    "escalation_hint": "Broken owner signal.",
+                },
+            ],
+            "context_todos": ["Review missing ownership before deploy.", "", 42],
+            "escalation_hints": [
+                "Escalate service review for Payments API to @payments-runtime.",
+                "",
+                {"hint": "fake escalation"},
+            ],
+            "ownership_unmapped_subjects": [
+                "aws_security_group.unmapped",
+                "",
+                123,
+            ],
+        }
+
+        report = PersistedReportData.model_validate(persisted_report)
+
+        self.assertEqual(report.context_completeness.context_score, 0.69)
+        self.assertEqual(report.context_completeness.confidence_level, "low")
+        self.assertTrue(report.context_completeness.insufficient_context)
+        self.assertTrue(report.context_completeness.partial_context)
+        self.assertIn(
+            "Ownership context payload was partially unreadable.",
+            report.context_completeness.uncertainty,
+        )
+        self.assertIn(
+            "Regenerate this report to restore ownership context metadata.",
+            report.context_completeness.context_todos,
+        )
+        self.assertEqual(len(report.context_completeness.owner_signals), 1)
+        self.assertEqual(
+            report.context_completeness.owner_signals[0].owners,
+            ["@payments-sre"],
+        )
+        self.assertEqual(
+            report.context_completeness.owner_signals[0].escalation_hint,
+            "Escalate file review for services/payments/plan.json to @payments-sre.",
+        )
+        self.assertIn(
+            "Review missing ownership before deploy.",
+            report.context_completeness.context_todos,
+        )
+        self.assertEqual(
+            report.context_completeness.escalation_hints,
+            ["Escalate service review for Payments API to @payments-runtime."],
+        )
+        self.assertEqual(
+            report.context_completeness.ownership_unmapped_subjects,
+            ["aws_security_group.unmapped"],
+        )
+
+    def test_persisted_report_marks_partial_when_owner_entries_are_cleaned(
+        self,
+    ) -> None:
+        persisted_report = dict(self.persisted)
+        persisted_report["context_completeness"] = {
+            **dict(persisted_report["context_completeness"]),
+            "context_score": 0.84,
+            "confidence_level": "medium",
+            "owner_signals": [
+                {
+                    "scope": "file",
+                    "subject": "services/payments/plan.json",
+                    "owners": ["@payments-sre", ""],
+                    "source": "CODEOWNERS",
+                    "source_ref": ".github/CODEOWNERS",
+                }
+            ],
+        }
+
+        report = PersistedReportData.model_validate(persisted_report)
+
+        self.assertEqual(report.context_completeness.context_score, 0.69)
+        self.assertEqual(report.context_completeness.confidence_level, "low")
+        self.assertTrue(report.context_completeness.insufficient_context)
+        self.assertTrue(report.context_completeness.partial_context)
+        self.assertEqual(len(report.context_completeness.owner_signals), 1)
+        self.assertEqual(
+            report.context_completeness.owner_signals[0].owners,
+            ["@payments-sre"],
+        )
+        self.assertIn(
+            "Regenerate this report to restore ownership context metadata.",
+            report.context_completeness.context_todos,
+        )
+
+    def test_persisted_report_salvages_ownership_when_scalar_context_is_malformed(
+        self,
+    ) -> None:
+        persisted_report = dict(self.persisted)
+        persisted_report["context_completeness"] = {
+            **dict(persisted_report["context_completeness"]),
+            "context_score": "oops",
+            "confidence_level": "medium",
+            "owner_signals": [
+                {
+                    "scope": "file",
+                    "subject": "services/payments/plan.json",
+                    "owners": ["@payments-sre"],
+                    "source": "CODEOWNERS",
+                    "source_ref": ".github/CODEOWNERS",
+                    "escalation_hint": "Escalate file review for services/payments/plan.json to @payments-sre.",
+                }
+            ],
+            "escalation_hints": [
+                "Escalate file review for services/payments/plan.json to @payments-sre."
+            ],
+            "ownership_unmapped_subjects": ["aws_security_group.unmapped"],
+        }
+
+        report = PersistedReportData.model_validate(persisted_report)
+
+        self.assertEqual(report.context_completeness.context_score, 0.69)
+        self.assertEqual(report.context_completeness.confidence_level, "low")
+        self.assertTrue(report.context_completeness.insufficient_context)
+        self.assertTrue(report.context_completeness.partial_context)
+        self.assertEqual(len(report.context_completeness.owner_signals), 1)
+        self.assertEqual(
+            report.context_completeness.owner_signals[0].owners,
+            ["@payments-sre"],
+        )
+        self.assertEqual(
+            report.context_completeness.escalation_hints,
+            ["Escalate file review for services/payments/plan.json to @payments-sre."],
+        )
+        self.assertEqual(
+            report.context_completeness.ownership_unmapped_subjects,
+            ["aws_security_group.unmapped"],
+        )
 
     def test_create_analysis_preserves_go_advisory_with_narrative_warning(
         self,

--- a/tests/test_api/test_analyses.py
+++ b/tests/test_api/test_analyses.py
@@ -1753,6 +1753,91 @@ class AnalysesApiTests(unittest.TestCase):
             [".github/CODEOWNERS", "services/payments/plan.json"],
         )
 
+    def test_create_analysis_does_not_trust_pathlike_filenames_without_metadata(
+        self,
+    ) -> None:
+        project_service_module.create_project(
+            project_key="payments-api-untrusted-paths",
+            display_name="Payments API Untrusted Paths",
+        )
+        persisted_report = dict(self.persisted)
+
+        with patch(
+            "api.routes.analyses.analyze_uploaded_files",
+            return_value=self._analysis_result_with_persisted_report(persisted_report),
+        ) as analyze_uploaded_files:
+            response = self.client.post(
+                "/api/v1/analyses",
+                files=[
+                    (
+                        "files",
+                        (
+                            ".github/CODEOWNERS",
+                            b"/services/payments/ @payments-sre",
+                        ),
+                    ),
+                    (
+                        "files",
+                        (
+                            "services/payments/plan.json",
+                            b'{"resource_changes": []}',
+                        ),
+                    ),
+                ],
+                data={"project_key": "payments-api-untrusted-paths"},
+            )
+
+        self.assertEqual(response.status_code, 200)
+        raw_files = analyze_uploaded_files.call_args.args[0]
+        self.assertEqual(
+            [name for name, _ in raw_files],
+            [
+                "__unsafe_path__/.github/CODEOWNERS",
+                "__unsafe_path__/services/payments/plan.json",
+            ],
+        )
+
+    def test_create_analysis_does_not_trust_bare_codeowners_without_metadata(
+        self,
+    ) -> None:
+        project_service_module.create_project(
+            project_key="payments-api-untrusted-codeowners",
+            display_name="Payments API Untrusted CODEOWNERS",
+        )
+        persisted_report = dict(self.persisted)
+
+        with patch(
+            "api.routes.analyses.analyze_uploaded_files",
+            return_value=self._analysis_result_with_persisted_report(persisted_report),
+        ) as analyze_uploaded_files:
+            response = self.client.post(
+                "/api/v1/analyses",
+                files=[
+                    (
+                        "files",
+                        (
+                            "CODEOWNERS",
+                            b"/services/payments/ @payments-sre",
+                        ),
+                    ),
+                    (
+                        "files",
+                        (
+                            "plan.json",
+                            b'{"resource_changes": []}',
+                        ),
+                    ),
+                ],
+                data={"project_key": "payments-api-untrusted-codeowners"},
+            )
+
+        self.assertEqual(response.status_code, 200)
+        raw_files = analyze_uploaded_files.call_args.args[0]
+        self.assertEqual(
+            [name for name, _ in raw_files],
+            ["__unsafe_path__/CODEOWNERS", "plan.json"],
+        )
+
     def test_create_analysis_rejects_mismatched_artifact_paths_for_api_uploads(
         self,
     ) -> None:

--- a/tests/test_cli/test_analyze.py
+++ b/tests/test_cli/test_analyze.py
@@ -208,7 +208,7 @@ class AnalyzeCliTests(unittest.TestCase):
         self.assertEqual(context.owner_signals, ())
         self.assertEqual(
             context.unmapped_subjects,
-            (f"{EXTERNAL_ARTIFACT_PREFIX}/plan.json", "aws_s3_bucket.external"),
+            ("external artifact: plan.json", "aws_s3_bucket.external"),
         )
 
     def test_load_artifacts_preserves_multiple_absolute_codeowners_roots(

--- a/tests/test_cli/test_analyze.py
+++ b/tests/test_cli/test_analyze.py
@@ -21,11 +21,16 @@ import services.analysis_service as analysis_service_module
 import services.project_service as project_service_module
 from analysis.incident_matcher import IncidentMatch
 from analysis.risk_scorer import RiskAssessment, RiskContributor
-from cli.analyze import main
+from cli.analyze import _load_artifacts, main
 from importlib import reload
 from integrations.github.init_service import GitHubInitOptions, GitHubInitResult
 from llm.narrator import NarrativeResult
-from parsers.base import ParseBatchResult, ParsedFileResult
+from parsers.base import ParseBatchResult, ParsedFileResult, UnifiedChange
+from services.intake_service import EXTERNAL_ARTIFACT_PREFIX
+from services.ownership_service import (
+    build_ownership_context,
+    uploaded_codeowners_sources,
+)
 from services.benchmark_runner_service import BenchmarkRunResult, BenchmarkRunSummary
 from services.skill_installer_service import InstalledSkillEntry, SkillInstallResult
 from services.skill_registry_service import SkillRegistryEntry
@@ -55,6 +60,252 @@ class AnalyzeCliTests(unittest.TestCase):
         os.environ.pop("DATABASE_URL", None)
         os.environ.pop("APP_BASE_URL", None)
         self.tempdir.cleanup()
+
+    def test_load_artifacts_preserves_relative_paths_for_common_parent(self) -> None:
+        repo = Path(self.tempdir.name) / "repo"
+        codeowners_path = repo / ".github" / "CODEOWNERS"
+        plan_path = repo / "services" / "payments" / "plan.json"
+        codeowners_path.parent.mkdir(parents=True)
+        plan_path.parent.mkdir(parents=True)
+        codeowners_path.write_text(
+            "/services/payments/ @payments-sre", encoding="utf-8"
+        )
+        plan_path.write_text('{"resource_changes": []}', encoding="utf-8")
+
+        artifacts = _load_artifacts([str(codeowners_path), str(plan_path)])
+
+        self.assertEqual(
+            [name for name, _ in artifacts],
+            [".github/CODEOWNERS", "services/payments/plan.json"],
+        )
+
+    def test_load_artifacts_preserves_mixed_relative_codeowners_absolute_artifact(
+        self,
+    ) -> None:
+        repo = Path(self.tempdir.name) / "repo"
+        codeowners_path = repo / ".github" / "CODEOWNERS"
+        plan_path = repo / "services" / "payments" / "plan.json"
+        codeowners_path.parent.mkdir(parents=True)
+        plan_path.parent.mkdir(parents=True)
+        codeowners_path.write_text(
+            "/services/payments/ @payments-sre", encoding="utf-8"
+        )
+        plan_path.write_text('{"resource_changes": []}', encoding="utf-8")
+
+        cwd = Path.cwd()
+        try:
+            os.chdir(repo)
+            artifacts = _load_artifacts([".github/CODEOWNERS", str(plan_path)])
+        finally:
+            os.chdir(cwd)
+
+        self.assertEqual(
+            [name for name, _ in artifacts],
+            [".github/CODEOWNERS", "services/payments/plan.json"],
+        )
+
+    def test_load_artifacts_preserves_mixed_absolute_codeowners_relative_artifact(
+        self,
+    ) -> None:
+        repo = Path(self.tempdir.name) / "repo"
+        codeowners_path = repo / ".github" / "CODEOWNERS"
+        plan_path = repo / "services" / "payments" / "plan.json"
+        codeowners_path.parent.mkdir(parents=True)
+        plan_path.parent.mkdir(parents=True)
+        codeowners_path.write_text(
+            "/services/payments/ @payments-sre", encoding="utf-8"
+        )
+        plan_path.write_text('{"resource_changes": []}', encoding="utf-8")
+
+        cwd = Path.cwd()
+        try:
+            os.chdir(repo.parent)
+            artifacts = _load_artifacts(
+                [str(codeowners_path), "repo/services/payments/plan.json"]
+            )
+        finally:
+            os.chdir(cwd)
+
+        self.assertEqual(
+            [name for name, _ in artifacts],
+            [".github/CODEOWNERS", "services/payments/plan.json"],
+        )
+
+    def test_load_artifacts_preserves_single_relative_path(self) -> None:
+        repo = Path(self.tempdir.name) / "repo"
+        plan_path = repo / "services" / "payments" / "plan.json"
+        plan_path.parent.mkdir(parents=True)
+        plan_path.write_text('{"resource_changes": []}', encoding="utf-8")
+
+        cwd = Path.cwd()
+        try:
+            os.chdir(repo.parent)
+            artifacts = _load_artifacts(["repo/services/payments/plan.json"])
+        finally:
+            os.chdir(cwd)
+
+        self.assertEqual(
+            [name for name, _ in artifacts],
+            ["repo/services/payments/plan.json"],
+        )
+
+    def test_load_artifacts_uses_basenames_for_unrelated_absolute_paths(self) -> None:
+        first_root = Path(self.tempdir.name) / "repo-a"
+        second_root = Path(self.tempdir.name) / "repo-b"
+        first_path = first_root / "services" / "payments" / "plan.json"
+        second_path = second_root / "services" / "billing" / "plan.json"
+        first_path.parent.mkdir(parents=True)
+        second_path.parent.mkdir(parents=True)
+        first_path.write_text('{"resource_changes": []}', encoding="utf-8")
+        second_path.write_text('{"resource_changes": []}', encoding="utf-8")
+
+        artifacts = _load_artifacts([str(first_path), str(second_path)])
+
+        self.assertEqual([name for name, _ in artifacts], ["plan.json", "plan#2.json"])
+
+    def test_load_artifacts_marks_out_of_root_absolute_paths_when_codeowners_present(
+        self,
+    ) -> None:
+        repo = Path(self.tempdir.name) / "repo"
+        external = Path(self.tempdir.name) / "external"
+        codeowners_path = repo / ".github" / "CODEOWNERS"
+        plan_path = external / "plan.json"
+        codeowners_path.parent.mkdir(parents=True)
+        plan_path.parent.mkdir(parents=True)
+        codeowners_path.write_text("*.json @root-owner", encoding="utf-8")
+        plan_path.write_text('{"resource_changes": []}', encoding="utf-8")
+
+        artifacts = _load_artifacts([str(codeowners_path), str(plan_path)])
+        artifact_names = [name for name, _ in artifacts]
+
+        self.assertEqual(
+            artifact_names,
+            [".github/CODEOWNERS", f"{EXTERNAL_ARTIFACT_PREFIX}/plan.json"],
+        )
+        parse_batch = ParseBatchResult(
+            files=[
+                ParsedFileResult(
+                    file_name=artifact_names[1],
+                    tool="terraform",
+                    status="parsed",
+                    changes=[
+                        UnifiedChange(
+                            source_file=artifact_names[1],
+                            tool="terraform",
+                            resource_id="aws_s3_bucket.external",
+                            action="create",
+                            summary="Terraform creates an external bucket.",
+                        )
+                    ],
+                )
+            ]
+        )
+        context = build_ownership_context(
+            parse_batch,
+            codeowners_sources=uploaded_codeowners_sources(artifacts),
+        )
+
+        self.assertEqual(context.owner_signals, ())
+        self.assertEqual(
+            context.unmapped_subjects,
+            (f"{EXTERNAL_ARTIFACT_PREFIX}/plan.json", "aws_s3_bucket.external"),
+        )
+
+    def test_load_artifacts_preserves_multiple_absolute_codeowners_roots(
+        self,
+    ) -> None:
+        repo_a = Path(self.tempdir.name) / "repo-a"
+        repo_b = Path(self.tempdir.name) / "repo-b"
+        repo_a_codeowners = repo_a / ".github" / "CODEOWNERS"
+        repo_b_codeowners = repo_b / ".github" / "CODEOWNERS"
+        repo_a_plan = repo_a / "services" / "payments" / "plan.json"
+        repo_b_plan = repo_b / "services" / "billing" / "plan.json"
+        for path in (repo_a_codeowners, repo_b_codeowners, repo_a_plan, repo_b_plan):
+            path.parent.mkdir(parents=True, exist_ok=True)
+        repo_a_codeowners.write_text(
+            "/services/payments/ @payments-sre", encoding="utf-8"
+        )
+        repo_b_codeowners.write_text(
+            "/services/billing/ @billing-sre", encoding="utf-8"
+        )
+        repo_a_plan.write_text('{"resource_changes": []}', encoding="utf-8")
+        repo_b_plan.write_text('{"resource_changes": []}', encoding="utf-8")
+
+        artifacts = _load_artifacts(
+            [
+                str(repo_a_codeowners),
+                str(repo_a_plan),
+                str(repo_b_codeowners),
+                str(repo_b_plan),
+            ]
+        )
+
+        self.assertEqual(
+            [name for name, _ in artifacts],
+            [
+                "repo-a/.github/CODEOWNERS",
+                "repo-a/services/payments/plan.json",
+                "repo-b/.github/CODEOWNERS",
+                "repo-b/services/billing/plan.json",
+            ],
+        )
+
+    def test_load_artifacts_prefers_nested_codeowners_root_for_nested_repo(
+        self,
+    ) -> None:
+        repo = Path(self.tempdir.name) / "repo"
+        nested_repo = repo / "services" / "payments"
+        root_codeowners = repo / ".github" / "CODEOWNERS"
+        nested_codeowners = nested_repo / "CODEOWNERS"
+        nested_plan = nested_repo / "plan.json"
+        for path in (root_codeowners, nested_codeowners, nested_plan):
+            path.parent.mkdir(parents=True, exist_ok=True)
+        root_codeowners.write_text("/services/payments/ @platform", encoding="utf-8")
+        nested_codeowners.write_text("*.json @payments-sre", encoding="utf-8")
+        nested_plan.write_text(
+            '{"resource_changes": [{"address": "aws_security_group.payments", "change": {"actions": ["update"]}}]}',
+            encoding="utf-8",
+        )
+
+        artifacts = _load_artifacts(
+            [str(root_codeowners), str(nested_codeowners), str(nested_plan)]
+        )
+        artifact_names = [name for name, _ in artifacts]
+
+        self.assertEqual(
+            artifact_names,
+            [
+                "repo/.github/CODEOWNERS",
+                "payments/CODEOWNERS",
+                "payments/plan.json",
+            ],
+        )
+        parse_batch = ParseBatchResult(
+            files=[
+                ParsedFileResult(
+                    file_name=artifact_names[2],
+                    tool="terraform",
+                    status="parsed",
+                    changes=[
+                        UnifiedChange(
+                            source_file=artifact_names[2],
+                            tool="terraform",
+                            resource_id="aws_security_group.payments",
+                            action="modify",
+                            summary="Terraform modifies a payments security group.",
+                        )
+                    ],
+                )
+            ]
+        )
+        context = build_ownership_context(
+            parse_batch,
+            codeowners_sources=uploaded_codeowners_sources(artifacts),
+        )
+
+        self.assertEqual(len(context.owner_signals), 1)
+        self.assertEqual(context.owner_signals[0].owners, ["@payments-sre"])
+        self.assertEqual(context.owner_signals[0].source, "CODEOWNERS")
 
     def test_skills_command_uses_shared_custom_skill_registry(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:

--- a/tests/test_docs/test_report_schema_documentation.py
+++ b/tests/test_docs/test_report_schema_documentation.py
@@ -36,6 +36,9 @@ class ReportSchemaDocumentationTests(unittest.TestCase):
             '"evidence_items"',
             '"report_schema_versions"',
             '"context_completeness"',
+            '"owner_signals"',
+            '"escalation_hints"',
+            '"ownership_unmapped_subjects"',
             '"narrative_available"',
             '"narrative_degraded"',
             '"narrative_failure_notice"',
@@ -53,6 +56,19 @@ class ReportSchemaDocumentationTests(unittest.TestCase):
 
         self.assertIn("share-summary payload `version` remains `v1`", content)
         self.assertIn("additive fields are compatible", content)
+
+    def test_report_v2_guide_documents_ownership_request_setup(self) -> None:
+        content = REPORT_SCHEMA_GUIDE.read_text(encoding="utf-8").lower()
+
+        for phrase in (
+            "request-side ownership setup",
+            "`artifact_paths`",
+            "repo-relative artifact paths",
+            ".github/codeowners",
+            "directory upload",
+        ):
+            with self.subTest(phrase=phrase):
+                self.assertIn(phrase, content)
 
 
 if __name__ == "__main__":

--- a/tests/test_models/test_evidence_models.py
+++ b/tests/test_models/test_evidence_models.py
@@ -49,6 +49,9 @@ class EvidenceModelTests(unittest.TestCase):
                 "context_todos": ["Refresh Kubernetes context."],
                 "insufficient_context": False,
                 "partial_context": False,
+                "owner_signals": [],
+                "escalation_hints": [],
+                "ownership_unmapped_subjects": [],
             },
         )
 

--- a/tests/test_services/test_analysis_service.py
+++ b/tests/test_services/test_analysis_service.py
@@ -2022,7 +2022,9 @@ class AnalysisServiceTests(unittest.TestCase):
                         "plan.json",
                         b'{"resource_changes": [{"address": "aws_security_group.main", "change": {"actions": ["update"]}}]}',
                     )
-                ]
+                ],
+                include_topology_context=False,
+                include_incident_context=False,
             )
 
         self.assertEqual(len(artifacts.findings), 2)

--- a/tests/test_services/test_analysis_service.py
+++ b/tests/test_services/test_analysis_service.py
@@ -23,11 +23,14 @@ from services.analysis_service import (
     analyze_uploaded_files,
     build_advisory_summary,
     build_analysis_artifacts,
+    build_context_completeness,
     build_share_summary,
     evaluate_parse_batch,
     resolve_analysis_project_scope,
     ShareSummaryJsonPayload,
 )
+from services.intake_service import uniquify_artifact_names
+from services.ownership_service import CodeownersSource
 
 
 def _incident_snapshot(count: int = 0) -> dict:
@@ -370,6 +373,529 @@ class AnalysisServiceTests(unittest.TestCase):
             "public-ingress-wide-open",
         )
         self.assertTrue(artifacts.incident_matches[0].verification_guidance)
+
+    def test_build_analysis_artifacts_adds_owner_signals_from_codeowners_and_topology(
+        self,
+    ) -> None:
+        assessment = RiskAssessment(
+            score=42,
+            severity="medium",
+            recommendation="caution",
+            top_risk="Terraform changed the payments security group.",
+            contributors=[],
+            interaction_risks=[],
+            partial_context=False,
+            warnings=[],
+        )
+        topology = {
+            "updated_at": "2026-06-08T12:00:00Z",
+            "metadata": {
+                "import": {
+                    "source_type": "custom",
+                    "source_ref": "topology.json",
+                    "warnings": [],
+                }
+            },
+            "services": [
+                {
+                    "id": "payments-api",
+                    "label": "Payments API",
+                    "resource_keys": ["aws_security_group.payments"],
+                    "downstream": [],
+                    "owners": ["@payments-runtime"],
+                }
+            ],
+        }
+        with (
+            patch(
+                "services.analysis_service.load_topology",
+                return_value=(topology, None),
+            ),
+            patch(
+                "services.analysis_service.get_topology_status",
+                return_value=SimpleNamespace(
+                    updated_at="2026-06-08T12:00:00Z",
+                    payload=topology,
+                    warnings=[],
+                ),
+            ),
+            patch(
+                "services.analysis_service.get_incident_index_snapshot",
+                return_value=_incident_snapshot(2),
+            ),
+            patch(
+                "services.analysis_service.evaluate_parse_batch",
+                return_value=assessment,
+            ),
+            patch(
+                "services.analysis_service.generate_narrative",
+                return_value=NarrativeResult(
+                    opening_sentence="CAUTION: review the payments change.",
+                    explanation="The deployment should be reviewed.",
+                    guidance=[],
+                    degraded=False,
+                    warnings=[],
+                ),
+            ),
+            patch("services.analysis_service.find_incident_matches", return_value=[]),
+        ):
+            artifacts = build_analysis_artifacts(
+                [
+                    (
+                        "CODEOWNERS",
+                        "\n".join(
+                            [
+                                "* @platform",
+                                "/services/payments/ @payments-sre @payments-dev",
+                            ]
+                        ).encode(),
+                    ),
+                    (
+                        "services/payments/plan.json",
+                        b'{"resource_changes": [{"address": "aws_security_group.payments", "change": {"actions": ["update"]}}]}',
+                    ),
+                ],
+                project_id=123,
+            )
+
+        context = artifacts.assessment.context_completeness
+        owner_signals = [signal.model_dump() for signal in context.owner_signals]
+        self.assertIn(
+            {
+                "scope": "file",
+                "subject": "services/payments/plan.json",
+                "owners": ["@payments-sre", "@payments-dev"],
+                "source": "CODEOWNERS",
+                "source_ref": "CODEOWNERS",
+                "matched_pattern": "/services/payments/",
+                "resource_id": None,
+                "service_id": None,
+                "escalation_hint": "Escalate file review for services/payments/plan.json to @payments-sre, @payments-dev.",
+            },
+            owner_signals,
+        )
+        self.assertIn(
+            {
+                "scope": "service",
+                "subject": "Payments API",
+                "owners": ["@payments-runtime"],
+                "source": "topology",
+                "source_ref": "topology.json",
+                "matched_pattern": None,
+                "resource_id": "aws_security_group.payments",
+                "service_id": "payments-api",
+                "escalation_hint": "Escalate service review for Payments API to @payments-runtime.",
+            },
+            owner_signals,
+        )
+        self.assertIn(
+            "Escalate file review for services/payments/plan.json to @payments-sre, @payments-dev.",
+            context.escalation_hints,
+        )
+        self.assertNotIn(
+            "Add CODEOWNERS or ownership mapping for analyzed files/resources.",
+            context.context_todos,
+        )
+
+    def test_build_analysis_artifacts_preserves_owner_signals_after_intake_paths(
+        self,
+    ) -> None:
+        assessment = RiskAssessment(
+            score=42,
+            severity="medium",
+            recommendation="caution",
+            top_risk="Terraform changed the payments security group.",
+            contributors=[],
+            interaction_risks=[],
+            partial_context=False,
+            warnings=[],
+        )
+        with (
+            patch("services.analysis_service.load_topology", return_value=(None, None)),
+            patch(
+                "services.analysis_service.get_topology_status",
+                return_value=SimpleNamespace(
+                    updated_at=None,
+                    payload=None,
+                    warnings=[],
+                ),
+            ),
+            patch(
+                "services.analysis_service.get_incident_index_snapshot",
+                return_value=_incident_snapshot(0),
+            ),
+            patch(
+                "services.analysis_service.evaluate_parse_batch",
+                return_value=assessment,
+            ),
+            patch(
+                "services.analysis_service.generate_narrative",
+                return_value=NarrativeResult(
+                    opening_sentence="CAUTION: review the payments change.",
+                    explanation="The deployment should be reviewed.",
+                    guidance=[],
+                    degraded=False,
+                    warnings=[],
+                ),
+            ),
+            patch("services.analysis_service.find_incident_matches", return_value=[]),
+        ):
+            artifacts = build_analysis_artifacts(
+                uniquify_artifact_names(
+                    [
+                        (
+                            "repo/.github/CODEOWNERS",
+                            b"/services/payments/ @payments-sre",
+                        ),
+                        (
+                            "repo/services/payments/plan.json",
+                            b'{"resource_changes": [{"address": "aws_security_group.payments", "change": {"actions": ["update"]}}]}',
+                        ),
+                    ]
+                ),
+                project_id=123,
+            )
+
+        context = artifacts.assessment.context_completeness
+        self.assertIn(
+            {
+                "scope": "file",
+                "subject": "repo/services/payments/plan.json",
+                "owners": ["@payments-sre"],
+                "source": "CODEOWNERS",
+                "source_ref": "repo/.github/CODEOWNERS",
+                "matched_pattern": "/services/payments/",
+                "resource_id": None,
+                "service_id": None,
+                "escalation_hint": "Escalate file review for repo/services/payments/plan.json to @payments-sre.",
+            },
+            [signal.model_dump() for signal in context.owner_signals],
+        )
+
+    def test_codeowners_file_owner_prevents_missing_resource_ownership_downgrade(
+        self,
+    ) -> None:
+        assessment = RiskAssessment(
+            score=24,
+            severity="low",
+            recommendation="go",
+            top_risk="Terraform changed a security group.",
+            contributors=[],
+            interaction_risks=[],
+            partial_context=False,
+            warnings=[],
+        )
+        topology = {
+            "updated_at": "2026-06-08T12:00:00Z",
+            "metadata": {
+                "import": {
+                    "source_type": "custom",
+                    "source_ref": "topology.json",
+                    "warnings": [],
+                }
+            },
+            "services": [
+                {
+                    "id": "unrelated-api",
+                    "label": "Unrelated API",
+                    "resource_keys": ["aws_security_group.unrelated"],
+                    "owners": ["@platform-runtime"],
+                }
+            ],
+        }
+
+        with (
+            patch(
+                "services.analysis_service.load_topology",
+                return_value=(topology, None),
+            ),
+            patch(
+                "services.analysis_service.get_topology_status",
+                return_value=SimpleNamespace(
+                    updated_at="2026-06-08T12:00:00Z",
+                    payload=topology,
+                    warnings=[],
+                ),
+            ),
+            patch(
+                "services.analysis_service.get_incident_index_snapshot",
+                return_value=_incident_snapshot(2),
+            ),
+            patch(
+                "services.analysis_service.evaluate_parse_batch",
+                return_value=assessment,
+            ),
+            patch(
+                "services.analysis_service.generate_narrative",
+                return_value=NarrativeResult(
+                    opening_sentence="GO: review the security group update.",
+                    explanation="The deployment was analyzed.",
+                    guidance=[],
+                    degraded=False,
+                    warnings=[],
+                ),
+            ),
+            patch("services.analysis_service.find_incident_matches", return_value=[]),
+        ):
+            artifacts = build_analysis_artifacts(
+                [
+                    (
+                        "CODEOWNERS",
+                        b"/services/payments/ @payments-sre",
+                    ),
+                    (
+                        "services/payments/plan.json",
+                        b'{"resource_changes": [{"address": "aws_security_group.payments", "change": {"actions": ["update"]}}]}',
+                    ),
+                ],
+                project_id=123,
+            )
+
+        context = artifacts.assessment.context_completeness
+        self.assertEqual([signal.scope for signal in context.owner_signals], ["file"])
+        self.assertEqual(context.owner_signals[0].owners, ["@payments-sre"])
+        self.assertEqual(context.ownership_unmapped_subjects, [])
+        self.assertNotIn(
+            "Add CODEOWNERS or ownership mapping for analyzed files/resources.",
+            context.context_todos,
+        )
+        self.assertGreaterEqual(context.context_score, 0.7)
+        self.assertFalse(context.insufficient_context)
+
+    def test_topology_owner_prevents_missing_file_ownership_downgrade(
+        self,
+    ) -> None:
+        assessment = RiskAssessment(
+            score=24,
+            severity="low",
+            recommendation="go",
+            top_risk="Terraform security group changed.",
+            contributors=[],
+            interaction_risks=[],
+            partial_context=False,
+            warnings=[],
+        )
+        topology = {
+            "updated_at": "2026-06-08T12:00:00Z",
+            "metadata": {
+                "import": {
+                    "source_type": "custom",
+                    "source_ref": "topology.json",
+                    "warnings": [],
+                }
+            },
+            "services": [
+                {
+                    "id": "payments-api",
+                    "label": "Payments API",
+                    "resource_keys": ["aws_security_group.payments"],
+                    "owners": ["@payments-runtime"],
+                }
+            ],
+        }
+
+        with (
+            patch(
+                "services.analysis_service.load_topology",
+                return_value=(topology, None),
+            ),
+            patch(
+                "services.analysis_service.get_topology_status",
+                return_value=SimpleNamespace(
+                    updated_at="2026-06-08T12:00:00Z",
+                    payload=topology,
+                    warnings=[],
+                ),
+            ),
+            patch(
+                "services.analysis_service.get_incident_index_snapshot",
+                return_value=_incident_snapshot(2),
+            ),
+            patch(
+                "services.analysis_service.evaluate_parse_batch",
+                return_value=assessment,
+            ),
+            patch(
+                "services.analysis_service.generate_narrative",
+                return_value=NarrativeResult(
+                    opening_sentence="GO: review the deployment update.",
+                    explanation="The deployment was analyzed.",
+                    guidance=[],
+                    degraded=False,
+                    warnings=[],
+                ),
+            ),
+            patch("services.analysis_service.find_incident_matches", return_value=[]),
+        ):
+            artifacts = build_analysis_artifacts(
+                [
+                    (
+                        "services/payments/plan.json",
+                        (
+                            b'{"resource_changes": [{"address": '
+                            b'"aws_security_group.payments", "change": '
+                            b'{"actions": ["update"]}}]}'
+                        ),
+                    )
+                ],
+                project_id=123,
+            )
+
+        context = artifacts.assessment.context_completeness
+        self.assertEqual(
+            [signal.scope for signal in context.owner_signals], ["service"]
+        )
+        self.assertEqual(context.owner_signals[0].owners, ["@payments-runtime"])
+        self.assertEqual(context.ownership_unmapped_subjects, [])
+        self.assertNotIn(
+            "Add CODEOWNERS or ownership mapping for analyzed files/resources.",
+            context.context_todos,
+        )
+        self.assertGreaterEqual(context.context_score, 0.7)
+        self.assertFalse(context.insufficient_context)
+
+    def test_build_analysis_artifacts_adds_context_todo_when_ownership_missing(
+        self,
+    ) -> None:
+        assessment = RiskAssessment(
+            score=24,
+            severity="low",
+            recommendation="go",
+            top_risk="Terraform changed a security group.",
+            contributors=[],
+            interaction_risks=[],
+            partial_context=False,
+            warnings=[],
+        )
+        topology = {
+            "updated_at": "2026-06-08T12:00:00Z",
+            "metadata": {
+                "import": {
+                    "source_type": "custom",
+                    "source_ref": "topology.json",
+                    "warnings": [],
+                }
+            },
+            "services": [
+                {
+                    "id": "payments-api",
+                    "label": "Payments API",
+                    "resource_keys": ["aws_security_group.payments"],
+                    "downstream": [],
+                }
+            ],
+        }
+
+        with (
+            patch(
+                "services.analysis_service.load_topology",
+                return_value=(topology, None),
+            ),
+            patch(
+                "services.analysis_service.get_topology_status",
+                return_value=SimpleNamespace(
+                    updated_at="2026-06-08T12:00:00Z",
+                    payload=topology,
+                    warnings=[],
+                ),
+            ),
+            patch(
+                "services.analysis_service.get_incident_index_snapshot",
+                return_value=_incident_snapshot(2),
+            ),
+            patch(
+                "services.analysis_service.evaluate_parse_batch",
+                return_value=assessment,
+            ),
+            patch(
+                "services.analysis_service.generate_narrative",
+                return_value=NarrativeResult(
+                    opening_sentence="GO: review the security group update.",
+                    explanation="The deployment was analyzed.",
+                    guidance=[],
+                    degraded=False,
+                    warnings=[],
+                ),
+            ),
+            patch("services.analysis_service.find_incident_matches", return_value=[]),
+        ):
+            artifacts = build_analysis_artifacts(
+                [
+                    (
+                        "services/payments/plan.json",
+                        b'{"resource_changes": [{"address": "aws_security_group.payments", "change": {"actions": ["update"]}}]}',
+                    )
+                ],
+                project_id=123,
+            )
+
+        context = artifacts.assessment.context_completeness
+        self.assertEqual(context.owner_signals, [])
+        self.assertIn(
+            "Add CODEOWNERS or ownership mapping for analyzed files/resources.",
+            context.context_todos,
+        )
+        self.assertIn(
+            "services/payments/plan.json",
+            context.ownership_unmapped_subjects,
+        )
+        self.assertIn("Payments API", context.ownership_unmapped_subjects)
+        self.assertEqual(context.context_score, 0.84)
+        self.assertEqual(context.confidence_level, "medium")
+        self.assertFalse(context.insufficient_context)
+        self.assertIn("ownership mapping is incomplete", context.uncertainty)
+
+    def test_build_context_completeness_suppresses_service_ownership_when_topology_disabled(
+        self,
+    ) -> None:
+        parse_batch = ParseBatchResult(
+            files=[
+                ParsedFileResult(
+                    file_name="services/payments/plan.json",
+                    tool="terraform",
+                    status="parsed",
+                    changes=[
+                        UnifiedChange(
+                            source_file="services/payments/plan.json",
+                            tool="terraform",
+                            resource_id="aws_security_group.payments",
+                            action="modify",
+                            summary="Terraform changed a payments security group.",
+                        )
+                    ],
+                )
+            ]
+        )
+        topology = {
+            "services": [
+                {
+                    "id": "payments-api",
+                    "label": "Payments API",
+                    "resource_keys": ["aws_security_group.payments"],
+                    "owners": ["@payments-runtime"],
+                }
+            ]
+        }
+        context = build_context_completeness(
+            parse_batch,
+            include_topology_context=False,
+            include_incident_context=False,
+            topology=topology,
+            codeowners_sources=(
+                CodeownersSource(
+                    source_ref="CODEOWNERS",
+                    content="/services/payments/ @payments-sre",
+                ),
+            ),
+        )
+
+        self.assertEqual([signal.scope for signal in context.owner_signals], ["file"])
+        self.assertEqual(context.owner_signals[0].owners, ["@payments-sre"])
+        self.assertNotIn(
+            "aws_security_group.payments",
+            context.ownership_unmapped_subjects,
+        )
+        self.assertNotIn("Payments API", context.ownership_unmapped_subjects)
 
     def _share_report_payload(self) -> dict:
         return {

--- a/tests/test_services/test_intake_service.py
+++ b/tests/test_services/test_intake_service.py
@@ -5,9 +5,15 @@ from __future__ import annotations
 import unittest
 
 from services.intake_service import (
+    EXTERNAL_ARTIFACT_PREFIX,
+    UNSAFE_ARTIFACT_PREFIX,
     build_pending_analysis,
     detect_tool_type,
     is_sensitive_file,
+    normalize_artifact_name,
+    trusted_artifact_path_binding_is_ambiguous,
+    trusted_artifact_path_matches_filename,
+    trusted_relative_artifact_path,
     uniquify_artifact_names,
 )
 from parsers.base import ParseBatchResult, ParseIssue, ParsedFileResult, UnifiedChange
@@ -89,6 +95,129 @@ Outputs:
             ]
         )
         self.assertEqual([name for name, _ in files], ["plan.json", "plan#2.json"])
+
+    def test_uniquify_artifact_names_preserves_safe_relative_paths(self) -> None:
+        files = uniquify_artifact_names(
+            [
+                ("repo/services/payments/plan.json", b"first"),
+                ("repo/services/payments/plan.json", b"second"),
+                ("../repo/./CODEOWNERS", b"owners"),
+                ("repo/../CODEOWNERS", b"root owners"),
+            ]
+        )
+
+        self.assertEqual(
+            [name for name, _ in files],
+            [
+                "repo/services/payments/plan.json",
+                "repo/services/payments/plan#2.json",
+                f"{UNSAFE_ARTIFACT_PREFIX}/repo/CODEOWNERS",
+                f"{UNSAFE_ARTIFACT_PREFIX}/repo/CODEOWNERS#2",
+            ],
+        )
+
+    def test_normalize_artifact_name_removes_unsafe_path_segments(self) -> None:
+        self.assertEqual(
+            normalize_artifact_name("../C:/repo/./services\\plan.json"),
+            f"{UNSAFE_ARTIFACT_PREFIX}/repo/services/plan.json",
+        )
+        self.assertEqual(
+            normalize_artifact_name("repo/../CODEOWNERS"),
+            f"{UNSAFE_ARTIFACT_PREFIX}/repo/CODEOWNERS",
+        )
+        self.assertEqual(
+            normalize_artifact_name(f"{UNSAFE_ARTIFACT_PREFIX}/CODEOWNERS"),
+            f"{UNSAFE_ARTIFACT_PREFIX}/CODEOWNERS",
+        )
+        self.assertEqual(
+            normalize_artifact_name("/Users/alice/repo/.github/CODEOWNERS"),
+            f"{UNSAFE_ARTIFACT_PREFIX}/Users/alice/repo/.github/CODEOWNERS",
+        )
+        self.assertEqual(
+            normalize_artifact_name("C:\\Users\\alice\\repo\\.github\\CODEOWNERS"),
+            f"{UNSAFE_ARTIFACT_PREFIX}/Users/alice/repo/.github/CODEOWNERS",
+        )
+        self.assertEqual(
+            normalize_artifact_name("./C:/Users/alice/repo/.github/CODEOWNERS"),
+            f"{UNSAFE_ARTIFACT_PREFIX}/Users/alice/repo/.github/CODEOWNERS",
+        )
+        self.assertEqual(
+            normalize_artifact_name("C:repo/services/payments/plan.json"),
+            f"{UNSAFE_ARTIFACT_PREFIX}/services/payments/plan.json",
+        )
+        self.assertEqual(
+            normalize_artifact_name("__UNSAFE_PATH__/CODEOWNERS"),
+            f"{UNSAFE_ARTIFACT_PREFIX}/CODEOWNERS",
+        )
+        self.assertEqual(
+            normalize_artifact_name(f"{EXTERNAL_ARTIFACT_PREFIX}/plan.json"),
+            f"{UNSAFE_ARTIFACT_PREFIX}/plan.json",
+        )
+        self.assertEqual(normalize_artifact_name(""), "artifact.bin")
+
+    def test_trusted_relative_artifact_path_canonicalizes_safe_metadata(
+        self,
+    ) -> None:
+        self.assertEqual(
+            trusted_relative_artifact_path("./repo/./services/payments/plan.json"),
+            "repo/services/payments/plan.json",
+        )
+
+    def test_trusted_relative_artifact_path_rejects_host_and_reserved_metadata(
+        self,
+    ) -> None:
+        unsafe_values = [
+            "./C:/Users/alice/repo/.github/CODEOWNERS",
+            "C:repo/services/plan.json",
+            "repo/C:/services/plan.json",
+            f"{UNSAFE_ARTIFACT_PREFIX}/CODEOWNERS",
+            f"{EXTERNAL_ARTIFACT_PREFIX}/plan.json",
+        ]
+
+        self.assertEqual(
+            [trusted_relative_artifact_path(value) for value in unsafe_values],
+            [None, None, None, None, None],
+        )
+
+    def test_trusted_artifact_path_rejects_traversal_filename_leaf_match(
+        self,
+    ) -> None:
+        self.assertFalse(
+            trusted_artifact_path_matches_filename(
+                "services/payments/plan.json",
+                "../payments/plan.json",
+            )
+        )
+
+    def test_duplicate_basename_bindings_require_full_path_filename_proof(
+        self,
+    ) -> None:
+        paths = ["services/payments/plan.json", "services/billing/plan.json"]
+
+        self.assertTrue(
+            trusted_artifact_path_binding_is_ambiguous(
+                paths, ["plan.json", "plan.json"]
+            )
+        )
+        self.assertFalse(trusted_artifact_path_binding_is_ambiguous(paths, paths))
+        self.assertTrue(
+            trusted_artifact_path_binding_is_ambiguous(
+                paths,
+                ["services/billing/plan.json", "services/payments/plan.json"],
+            )
+        )
+        self.assertTrue(
+            trusted_artifact_path_matches_filename(
+                "services/payments/plan.json",
+                "services/payments/plan.json",
+            )
+        )
+        self.assertFalse(
+            trusted_artifact_path_matches_filename(
+                "services/payments/plan.json",
+                "services/billing/plan.json",
+            )
+        )
 
     def test_pending_analysis_preserves_duplicate_file_names_after_uniquifying(
         self,

--- a/tests/test_services/test_intake_service.py
+++ b/tests/test_services/test_intake_service.py
@@ -15,6 +15,7 @@ from services.intake_service import (
     trusted_artifact_path_matches_filename,
     trusted_relative_artifact_path,
     uniquify_artifact_names,
+    untrusted_upload_filename,
 )
 from parsers.base import ParseBatchResult, ParseIssue, ParsedFileResult, UnifiedChange
 from services.submission_manifest import build_submission_manifest
@@ -187,6 +188,32 @@ Outputs:
                 "services/payments/plan.json",
                 "../payments/plan.json",
             )
+        )
+
+    def test_untrusted_upload_filename_taints_pathlike_codeowners(self) -> None:
+        self.assertEqual(
+            untrusted_upload_filename(".github/CODEOWNERS"),
+            f"{UNSAFE_ARTIFACT_PREFIX}/.github/CODEOWNERS",
+        )
+        self.assertEqual(
+            untrusted_upload_filename("repo/docs/CODEOWNERS"),
+            f"{UNSAFE_ARTIFACT_PREFIX}/repo/docs/CODEOWNERS",
+        )
+        self.assertEqual(
+            untrusted_upload_filename("CODEOWNERS"),
+            f"{UNSAFE_ARTIFACT_PREFIX}/CODEOWNERS",
+        )
+        self.assertEqual(
+            untrusted_upload_filename("services/payments/plan.json"),
+            f"{UNSAFE_ARTIFACT_PREFIX}/services/payments/plan.json",
+        )
+        self.assertEqual(
+            untrusted_upload_filename("../services/payments/plan.json"),
+            f"{UNSAFE_ARTIFACT_PREFIX}/services/payments/plan.json",
+        )
+        self.assertEqual(
+            untrusted_upload_filename("repo/__external_path__/plan.json"),
+            f"{UNSAFE_ARTIFACT_PREFIX}/repo/plan.json",
         )
 
     def test_duplicate_basename_bindings_require_full_path_filename_proof(

--- a/tests/test_services/test_ownership_service.py
+++ b/tests/test_services/test_ownership_service.py
@@ -12,7 +12,7 @@ from services.ownership_service import (
     build_ownership_context,
     uploaded_codeowners_sources,
 )
-from services.intake_service import uniquify_artifact_names
+from services.intake_service import untrusted_upload_filename, uniquify_artifact_names
 
 
 class OwnershipServiceTests(unittest.TestCase):
@@ -197,6 +197,32 @@ class OwnershipServiceTests(unittest.TestCase):
         )
 
         sources = uploaded_codeowners_sources(files)
+
+        self.assertEqual(sources, ())
+
+    def test_pathlike_untrusted_codeowners_filename_is_not_trusted(self) -> None:
+        sources = uploaded_codeowners_sources(
+            [
+                (
+                    untrusted_upload_filename(".github/CODEOWNERS"),
+                    b"* @spoofed-owner",
+                ),
+                ("repo/services/payments/plan.json", b"{}"),
+            ]
+        )
+
+        self.assertEqual(sources, ())
+
+    def test_bare_untrusted_codeowners_filename_is_not_trusted(self) -> None:
+        sources = uploaded_codeowners_sources(
+            [
+                (
+                    untrusted_upload_filename("CODEOWNERS"),
+                    b"* @spoofed-owner",
+                ),
+                ("services/payments/plan.json", b"{}"),
+            ]
+        )
 
         self.assertEqual(sources, ())
 
@@ -892,6 +918,101 @@ class OwnershipServiceTests(unittest.TestCase):
         self.assertEqual(context.owner_signals[0].owners, ["@payments-runtime"])
         self.assertEqual(context.unmapped_subjects, ())
         self.assertEqual(context.context_todos, ())
+
+    def test_untrusted_pathlike_file_unmapped_subject_hides_internal_marker(
+        self,
+    ) -> None:
+        artifact_name = untrusted_upload_filename("services/payments/plan.json")
+        parse_batch = ParseBatchResult(
+            files=[
+                ParsedFileResult(
+                    file_name=artifact_name,
+                    tool="terraform",
+                    status="parsed",
+                    changes=[
+                        UnifiedChange(
+                            source_file=artifact_name,
+                            tool="terraform",
+                            resource_id="aws_security_group.payments",
+                            action="modify",
+                            summary="Terraform changed a payments security group.",
+                        )
+                    ],
+                )
+            ]
+        )
+
+        context = build_ownership_context(parse_batch)
+
+        self.assertIn("services/payments/plan.json", context.unmapped_subjects)
+        self.assertFalse(
+            any(
+                subject.startswith("__unsafe_path__/")
+                for subject in context.unmapped_subjects
+            )
+        )
+        self.assertEqual(context.context_todos, (OWNERSHIP_CONTEXT_TODO,))
+
+    def test_service_owned_untrusted_subject_keeps_matching_trusted_gap(
+        self,
+    ) -> None:
+        untrusted_artifact_name = untrusted_upload_filename(
+            "services/payments/plan.json"
+        )
+        parse_batch = ParseBatchResult(
+            files=[
+                ParsedFileResult(
+                    file_name=untrusted_artifact_name,
+                    tool="terraform",
+                    status="parsed",
+                    changes=[
+                        UnifiedChange(
+                            source_file=untrusted_artifact_name,
+                            tool="terraform",
+                            resource_id="aws_security_group.service_owned",
+                            action="modify",
+                            summary="Terraform changed a service-owned group.",
+                        )
+                    ],
+                ),
+                ParsedFileResult(
+                    file_name="services/payments/plan.json",
+                    tool="terraform",
+                    status="parsed",
+                    changes=[
+                        UnifiedChange(
+                            source_file="services/payments/plan.json",
+                            tool="terraform",
+                            resource_id="aws_security_group.unowned",
+                            action="modify",
+                            summary="Terraform changed an unowned group.",
+                        )
+                    ],
+                ),
+            ]
+        )
+        topology = {
+            "metadata": {"import": {"source_ref": "topology.yaml"}},
+            "services": [
+                {
+                    "id": "payments-api",
+                    "label": "Payments API",
+                    "resource_keys": ["aws_security_group.service_owned"],
+                    "owners": ["@payments-runtime"],
+                }
+            ],
+        }
+
+        context = build_ownership_context(parse_batch, topology=topology)
+
+        self.assertIn("services/payments/plan.json", context.unmapped_subjects)
+        self.assertFalse(
+            any(
+                subject.startswith("__unsafe_path__/")
+                for subject in context.unmapped_subjects
+            )
+        )
+        self.assertEqual(context.context_todos, (OWNERSHIP_CONTEXT_TODO,))
 
     def test_non_mutating_changes_do_not_create_missing_ownership_context(
         self,

--- a/tests/test_services/test_ownership_service.py
+++ b/tests/test_services/test_ownership_service.py
@@ -1,0 +1,1264 @@
+"""Tests for ownership context helpers."""
+
+from __future__ import annotations
+
+import unittest
+
+from parsers.base import ParseBatchResult, ParsedFileResult, UnifiedChange
+from services.ownership_service import (
+    CodeownersSource,
+    OWNERSHIP_CONTEXT_TODO,
+    _pattern_matches,
+    build_ownership_context,
+    uploaded_codeowners_sources,
+)
+from services.intake_service import uniquify_artifact_names
+
+
+class OwnershipServiceTests(unittest.TestCase):
+    def _codeowners(self, source_ref: str, content: str) -> CodeownersSource:
+        return CodeownersSource(source_ref=source_ref, content=content)
+
+    def test_codeowners_path_patterns_follow_documented_boundaries(self) -> None:
+        self.assertTrue(_pattern_matches("/*.md", "README.md"))
+        self.assertFalse(_pattern_matches("/*.md", "docs/readme.md"))
+        self.assertTrue(_pattern_matches("/docs/*.md", "docs/readme.md"))
+        self.assertFalse(_pattern_matches("/docs/*.md", "docs/sub/readme.md"))
+        self.assertTrue(_pattern_matches("docs/readme.md", "docs/readme.md"))
+        self.assertFalse(
+            _pattern_matches("docs/readme.md", "docs/readme.md/config.yaml")
+        )
+        self.assertFalse(_pattern_matches("docs/readme.md", "services/docs/readme.md"))
+        self.assertTrue(_pattern_matches("docs", "docs/readme.md"))
+        self.assertTrue(_pattern_matches("apps/", "services/apps/config.yaml"))
+        self.assertFalse(_pattern_matches("/apps/", "services/apps/config.yaml"))
+        self.assertTrue(_pattern_matches("docs/**/README.md", "docs/README.md"))
+        self.assertTrue(
+            _pattern_matches("docs/**/README.md", "docs/services/README.md")
+        )
+        self.assertTrue(_pattern_matches("[Dd]ockerfile", "Dockerfile"))
+        self.assertFalse(_pattern_matches("[Dd]ockerfile", "docs/Dockerfile/app.yaml"))
+
+    def test_codeowners_escaped_space_patterns_match_file_paths(self) -> None:
+        parse_batch = ParseBatchResult(
+            files=[
+                ParsedFileResult(
+                    file_name="docs/My File.md",
+                    tool="terraform",
+                    status="failed",
+                    changes=[],
+                )
+            ]
+        )
+
+        context = build_ownership_context(
+            parse_batch,
+            codeowners_sources=(
+                self._codeowners("CODEOWNERS", "docs/My\\ File.md @docs-team"),
+            ),
+        )
+
+        self.assertEqual(context.owner_signals[0].subject, "docs/My File.md")
+        self.assertEqual(context.owner_signals[0].owners, ["@docs-team"])
+        self.assertEqual(context.owner_signals[0].matched_pattern, "docs/My File.md")
+        self.assertEqual(context.context_todos, ())
+
+    def test_codeowners_escaped_hash_patterns_match_file_paths(self) -> None:
+        parse_batch = ParseBatchResult(
+            files=[
+                ParsedFileResult(
+                    file_name="docs/#runbook.md",
+                    tool="terraform",
+                    status="failed",
+                    changes=[],
+                )
+            ]
+        )
+
+        context = build_ownership_context(
+            parse_batch,
+            codeowners_sources=(
+                self._codeowners("CODEOWNERS", "docs/\\#runbook.md @docs-team"),
+            ),
+        )
+
+        self.assertEqual(context.owner_signals[0].subject, "docs/#runbook.md")
+        self.assertEqual(context.owner_signals[0].owners, ["@docs-team"])
+        self.assertEqual(context.context_todos, ())
+
+    def test_codeowners_utf8_bom_does_not_break_first_rule(self) -> None:
+        parse_batch = ParseBatchResult(
+            files=[
+                ParsedFileResult(
+                    file_name="services/payments/plan.json",
+                    tool="terraform",
+                    status="failed",
+                    changes=[],
+                )
+            ]
+        )
+        sources = uploaded_codeowners_sources(
+            [
+                (
+                    "CODEOWNERS",
+                    "\ufeff/services/payments/ @payments-sre".encode("utf-8"),
+                )
+            ]
+        )
+
+        context = build_ownership_context(parse_batch, codeowners_sources=sources)
+
+        self.assertEqual(context.owner_signals[0].owners, ["@payments-sre"])
+        self.assertEqual(context.context_todos, ())
+
+    def test_long_team_slug_owner_token_is_accepted(self) -> None:
+        long_team = "@platform/" + ("release-approval-team-" * 3).rstrip("-")
+        parse_batch = ParseBatchResult(
+            files=[
+                ParsedFileResult(
+                    file_name="services/payments/plan.json",
+                    tool="terraform",
+                    status="failed",
+                    changes=[],
+                )
+            ]
+        )
+
+        context = build_ownership_context(
+            parse_batch,
+            codeowners_sources=(
+                self._codeowners("CODEOWNERS", f"/services/payments/ {long_team}"),
+            ),
+        )
+
+        self.assertEqual(context.owner_signals[0].owners, [long_team])
+        self.assertEqual(context.context_todos, ())
+
+    def test_first_uploaded_codeowners_source_wins_and_inline_comments_are_ignored(
+        self,
+    ) -> None:
+        parse_batch = ParseBatchResult(
+            files=[
+                ParsedFileResult(
+                    file_name="services/payments/plan.json",
+                    tool="terraform",
+                    status="parsed",
+                    changes=[
+                        UnifiedChange(
+                            source_file="services/payments/plan.json",
+                            tool="terraform",
+                            resource_id="aws_security_group.payments",
+                            action="modify",
+                            summary="Terraform changed a payments security group.",
+                        )
+                    ],
+                )
+            ]
+        )
+        context = build_ownership_context(
+            parse_batch,
+            codeowners_sources=(
+                self._codeowners(
+                    ".github/CODEOWNERS",
+                    "\n".join(
+                        [
+                            "/services/payments/ @payments-sre # primary owner",
+                            "*.tf @terraform-owner",
+                        ]
+                    ),
+                ),
+                self._codeowners("CODEOWNERS", "/services/payments/ @wrong-owner"),
+            ),
+        )
+
+        self.assertEqual(context.owner_signals[0].owners, ["@payments-sre"])
+        self.assertEqual(context.owner_signals[0].source_ref, ".github/CODEOWNERS")
+
+    def test_uploaded_codeowners_sources_follow_lookup_order(self) -> None:
+        sources = uploaded_codeowners_sources(
+            [
+                ("CODEOWNERS", "* @root"),
+                ("docs/CODEOWNERS", "* @docs"),
+                (".github/CODEOWNERS", "* @github"),
+            ]
+        )
+
+        self.assertEqual(
+            sources,
+            (CodeownersSource(source_ref=".github/CODEOWNERS", content="* @github"),),
+        )
+
+    def test_traversal_normalized_codeowners_is_not_trusted(self) -> None:
+        files = uniquify_artifact_names(
+            [
+                ("repo/../CODEOWNERS", b"* @spoofed-owner"),
+                ("repo/services/payments/plan.json", b"{}"),
+            ]
+        )
+
+        sources = uploaded_codeowners_sources(files)
+
+        self.assertEqual(sources, ())
+
+    def test_reserved_unsafe_prefix_codeowners_is_not_trusted(self) -> None:
+        files = uniquify_artifact_names(
+            [
+                ("__unsafe_path__/CODEOWNERS", b"* @spoofed-owner"),
+                ("repo/services/payments/plan.json", b"{}"),
+            ]
+        )
+
+        sources = uploaded_codeowners_sources(files)
+
+        self.assertEqual(sources, ())
+
+    def test_reserved_external_prefix_codeowners_is_not_trusted(self) -> None:
+        sources = uploaded_codeowners_sources(
+            [
+                ("__external_path__/CODEOWNERS", b"* @spoofed-owner"),
+                ("repo/services/payments/plan.json", b"{}"),
+            ]
+        )
+
+        self.assertEqual(sources, ())
+
+    def test_prefixed_docs_codeowners_keeps_docs_lookup_semantics(self) -> None:
+        sources = uploaded_codeowners_sources(
+            [
+                ("repo/docs/CODEOWNERS", b"* @docs-owner"),
+            ]
+        )
+
+        self.assertEqual(
+            sources,
+            (
+                CodeownersSource(
+                    source_ref="repo/docs/CODEOWNERS",
+                    content="* @docs-owner",
+                    root_prefix="repo",
+                ),
+            ),
+        )
+
+    def test_uploaded_codeowners_sources_detect_prefixed_repository_root(self) -> None:
+        sources = uploaded_codeowners_sources(
+            [
+                ("repo/CODEOWNERS", "* @root"),
+                ("repo/.github/CODEOWNERS", "* @github"),
+            ]
+        )
+
+        self.assertEqual(
+            sources,
+            (
+                CodeownersSource(
+                    source_ref="repo/.github/CODEOWNERS",
+                    content="* @github",
+                    root_prefix="repo",
+                ),
+            ),
+        )
+
+    def test_prefixed_codeowners_source_matches_files_under_same_root(self) -> None:
+        parse_batch = ParseBatchResult(
+            files=[
+                ParsedFileResult(
+                    file_name="repo/services/payments/plan.json",
+                    tool="terraform",
+                    status="failed",
+                    changes=[],
+                ),
+                ParsedFileResult(
+                    file_name="other/services/payments/plan.json",
+                    tool="terraform",
+                    status="failed",
+                    changes=[],
+                ),
+            ]
+        )
+
+        context = build_ownership_context(
+            parse_batch,
+            codeowners_sources=(
+                CodeownersSource(
+                    source_ref="repo/.github/CODEOWNERS",
+                    content="/services/payments/ @payments-sre",
+                    root_prefix="repo",
+                ),
+            ),
+        )
+
+        self.assertEqual(len(context.owner_signals), 1)
+        self.assertEqual(
+            context.owner_signals[0].subject, "repo/services/payments/plan.json"
+        )
+        self.assertEqual(context.owner_signals[0].owners, ["@payments-sre"])
+        self.assertIn("other/services/payments/plan.json", context.unmapped_subjects)
+
+    def test_rootless_codeowners_does_not_fallback_for_known_prefixed_root(
+        self,
+    ) -> None:
+        parse_batch = ParseBatchResult(
+            files=[
+                ParsedFileResult(
+                    file_name="repo/services/payments/plan.json",
+                    tool="terraform",
+                    status="failed",
+                    changes=[],
+                ),
+                ParsedFileResult(
+                    file_name="services/root/plan.json",
+                    tool="terraform",
+                    status="failed",
+                    changes=[],
+                ),
+            ]
+        )
+        sources = uploaded_codeowners_sources(
+            [
+                ("CODEOWNERS", "* @root-owner"),
+                ("repo/.github/CODEOWNERS", "/services/other/ @repo-owner"),
+            ]
+        )
+
+        context = build_ownership_context(parse_batch, codeowners_sources=sources)
+
+        self.assertEqual(
+            [signal.subject for signal in context.owner_signals],
+            ["services/root/plan.json"],
+        )
+        self.assertEqual(context.owner_signals[0].owners, ["@root-owner"])
+        self.assertIn("repo/services/payments/plan.json", context.unmapped_subjects)
+
+    def test_multi_root_codeowners_sources_match_each_uploaded_root(self) -> None:
+        parse_batch = ParseBatchResult(
+            files=[
+                ParsedFileResult(
+                    file_name="repo-a/services/payments/plan.json",
+                    tool="terraform",
+                    status="failed",
+                    changes=[],
+                ),
+                ParsedFileResult(
+                    file_name="repo-b/services/billing/plan.json",
+                    tool="terraform",
+                    status="failed",
+                    changes=[],
+                ),
+            ]
+        )
+        sources = uploaded_codeowners_sources(
+            [
+                ("repo-a/.github/CODEOWNERS", "/services/payments/ @payments-sre"),
+                ("repo-b/.github/CODEOWNERS", "/services/billing/ @billing-sre"),
+            ]
+        )
+
+        context = build_ownership_context(parse_batch, codeowners_sources=sources)
+
+        self.assertEqual(
+            [signal.owners for signal in context.owner_signals],
+            [["@payments-sre"], ["@billing-sre"]],
+        )
+        self.assertEqual(context.unmapped_subjects, ())
+
+    def test_oversized_uploaded_codeowners_degrades_to_unmapped_context(self) -> None:
+        parse_batch = ParseBatchResult(
+            files=[
+                ParsedFileResult(
+                    file_name="app.js",
+                    tool="terraform",
+                    status="failed",
+                    changes=[],
+                )
+            ]
+        )
+        sources = uploaded_codeowners_sources([("CODEOWNERS", b"* @root\n" * 500_000)])
+
+        context = build_ownership_context(parse_batch, codeowners_sources=sources)
+
+        self.assertEqual(
+            sources,
+            (CodeownersSource(source_ref="CODEOWNERS", content="", readable=False),),
+        )
+        self.assertEqual(context.owner_signals, ())
+        self.assertIn("app.js", context.unmapped_subjects)
+
+    def test_invalid_higher_priority_codeowners_does_not_fall_through(self) -> None:
+        parse_batch = ParseBatchResult(
+            files=[
+                ParsedFileResult(
+                    file_name="app.js",
+                    tool="terraform",
+                    status="parsed",
+                    changes=[
+                        UnifiedChange(
+                            source_file="app.js",
+                            tool="terraform",
+                            resource_id="aws_security_group.app",
+                            action="modify",
+                            summary="Terraform changed an app security group.",
+                        )
+                    ],
+                )
+            ]
+        )
+        sources = uploaded_codeowners_sources(
+            [
+                (".github/CODEOWNERS", b"\xff"),
+                ("CODEOWNERS", "* @fallback-owner"),
+            ]
+        )
+
+        context = build_ownership_context(parse_batch, codeowners_sources=sources)
+
+        self.assertEqual(
+            sources,
+            (
+                CodeownersSource(
+                    source_ref=".github/CODEOWNERS", content="", readable=False
+                ),
+            ),
+        )
+        self.assertEqual(context.owner_signals, ())
+        self.assertIn("app.js", context.unmapped_subjects)
+        self.assertEqual(context.context_todos, (OWNERSHIP_CONTEXT_TODO,))
+
+    def test_ownership_context_does_not_read_deploywhisper_codeowners_by_default(
+        self,
+    ) -> None:
+        parse_batch = ParseBatchResult(
+            files=[
+                ParsedFileResult(
+                    file_name="services/payments/plan.json",
+                    tool="terraform",
+                    status="parsed",
+                    changes=[
+                        UnifiedChange(
+                            source_file="services/payments/plan.json",
+                            tool="terraform",
+                            resource_id="aws_security_group.payments",
+                            action="modify",
+                            summary="Terraform changed a payments security group.",
+                        )
+                    ],
+                )
+            ]
+        )
+
+        context = build_ownership_context(parse_batch)
+
+        self.assertEqual(context.owner_signals, ())
+        self.assertIn("services/payments/plan.json", context.unmapped_subjects)
+
+    def test_codeowners_bracket_patterns_match_file_paths(self) -> None:
+        parse_batch = ParseBatchResult(
+            files=[
+                ParsedFileResult(
+                    file_name="app.js",
+                    tool="terraform",
+                    status="parsed",
+                    changes=[
+                        UnifiedChange(
+                            source_file="app.js",
+                            tool="terraform",
+                            resource_id="aws_security_group.app",
+                            action="modify",
+                            summary="Terraform changed an app security group.",
+                        )
+                    ],
+                )
+            ]
+        )
+        context = build_ownership_context(
+            parse_batch,
+            codeowners_sources=(
+                self._codeowners(
+                    "CODEOWNERS",
+                    "\n".join(
+                        [
+                            "*.j[st] @js-owner",
+                            "!app.js @negated-owner",
+                        ]
+                    ),
+                ),
+            ),
+        )
+
+        self.assertEqual(context.owner_signals[0].owners, ["@js-owner"])
+        self.assertEqual(context.context_todos, ())
+
+        docker_context = build_ownership_context(
+            ParseBatchResult(
+                files=[
+                    ParsedFileResult(
+                        file_name="Dockerfile",
+                        tool="terraform",
+                        status="failed",
+                        changes=[],
+                    )
+                ]
+            ),
+            codeowners_sources=(
+                self._codeowners("CODEOWNERS", "[Dd]ockerfile @container-owner"),
+            ),
+        )
+
+        self.assertEqual(docker_context.owner_signals[0].owners, ["@container-owner"])
+        self.assertEqual(docker_context.context_todos, ())
+
+    def test_missing_service_owner_adds_todo_even_when_file_owner_exists(self) -> None:
+        parse_batch = ParseBatchResult(
+            files=[
+                ParsedFileResult(
+                    file_name="services/payments/plan.json",
+                    tool="terraform",
+                    status="parsed",
+                    changes=[
+                        UnifiedChange(
+                            source_file="services/payments/plan.json",
+                            tool="terraform",
+                            resource_id="aws_security_group.payments",
+                            action="modify",
+                            summary="Terraform changed a payments security group.",
+                        )
+                    ],
+                )
+            ]
+        )
+        topology = {
+            "services": [
+                {
+                    "id": "payments-api",
+                    "label": "Payments API",
+                    "resource_keys": ["aws_security_group.payments"],
+                    "downstream": [],
+                }
+            ]
+        }
+        context = build_ownership_context(
+            parse_batch,
+            topology=topology,
+            codeowners_sources=(
+                self._codeowners("CODEOWNERS", "/services/payments/ @payments-sre"),
+            ),
+        )
+
+        self.assertEqual([signal.scope for signal in context.owner_signals], ["file"])
+        self.assertEqual(context.unmapped_subjects, ("Payments API",))
+        self.assertEqual(context.context_todos, (OWNERSHIP_CONTEXT_TODO,))
+
+    def test_ambiguous_alias_match_adds_todo_instead_of_owner_signals(self) -> None:
+        parse_batch = ParseBatchResult(
+            files=[
+                ParsedFileResult(
+                    file_name="deployments/payments.yaml",
+                    tool="kubernetes",
+                    status="parsed",
+                    changes=[
+                        UnifiedChange(
+                            source_file="deployments/payments.yaml",
+                            tool="kubernetes",
+                            resource_id="Deployment/payments/api",
+                            action="modify",
+                            summary="Kubernetes deployment changed.",
+                            metadata={"resource_aliases": ["Deployment/api"]},
+                        )
+                    ],
+                )
+            ]
+        )
+        topology = {
+            "services": [
+                {
+                    "id": "payments-api",
+                    "label": "Payments API",
+                    "resource_keys": ["Deployment/api"],
+                    "owners": ["@payments-runtime"],
+                },
+                {
+                    "id": "billing-api",
+                    "label": "Billing API",
+                    "resource_keys": ["Deployment/api"],
+                    "owners": ["@billing-runtime"],
+                },
+            ]
+        }
+        context = build_ownership_context(parse_batch, topology=topology)
+
+        self.assertEqual(context.owner_signals, ())
+        self.assertIn("Deployment/payments/api", context.unmapped_subjects)
+        self.assertEqual(context.context_todos, (OWNERSHIP_CONTEXT_TODO,))
+
+    def test_ambiguous_exact_resource_match_adds_todo_instead_of_owner_signals(
+        self,
+    ) -> None:
+        parse_batch = ParseBatchResult(
+            files=[
+                ParsedFileResult(
+                    file_name="deployments/payments.yaml",
+                    tool="kubernetes",
+                    status="parsed",
+                    changes=[
+                        UnifiedChange(
+                            source_file="deployments/payments.yaml",
+                            tool="kubernetes",
+                            resource_id="Deployment/api",
+                            action="modify",
+                            summary="Kubernetes deployment changed.",
+                        )
+                    ],
+                )
+            ]
+        )
+        topology = {
+            "services": [
+                {
+                    "id": "payments-api",
+                    "label": "Payments API",
+                    "resource_keys": ["Deployment/api"],
+                    "owners": ["@payments-runtime"],
+                },
+                {
+                    "id": "billing-api",
+                    "label": "Billing API",
+                    "resource_keys": ["Deployment/api"],
+                    "owners": ["@billing-runtime"],
+                },
+            ]
+        }
+
+        context = build_ownership_context(parse_batch, topology=topology)
+
+        self.assertEqual(context.owner_signals, ())
+        self.assertIn("Deployment/api", context.unmapped_subjects)
+        self.assertEqual(context.context_todos, (OWNERSHIP_CONTEXT_TODO,))
+
+    def test_ambiguous_resource_stays_unmapped_with_file_owner(self) -> None:
+        parse_batch = ParseBatchResult(
+            files=[
+                ParsedFileResult(
+                    file_name="services/payments/plan.json",
+                    tool="terraform",
+                    status="parsed",
+                    changes=[
+                        UnifiedChange(
+                            source_file="services/payments/plan.json",
+                            tool="terraform",
+                            resource_id="aws_security_group.payments",
+                            action="modify",
+                            summary="Terraform changed a payments security group.",
+                        )
+                    ],
+                )
+            ]
+        )
+        topology = {
+            "services": [
+                {
+                    "id": "payments-api",
+                    "label": "Payments API",
+                    "resource_keys": ["aws_security_group.payments"],
+                    "owners": ["@payments-runtime"],
+                },
+                {
+                    "id": "billing-api",
+                    "label": "Billing API",
+                    "resource_keys": ["aws_security_group.payments"],
+                    "owners": ["@billing-runtime"],
+                },
+            ]
+        }
+
+        context = build_ownership_context(
+            parse_batch,
+            topology=topology,
+            codeowners_sources=(
+                self._codeowners("CODEOWNERS", "/services/payments/ @payments-sre"),
+            ),
+        )
+
+        self.assertEqual([signal.scope for signal in context.owner_signals], ["file"])
+        self.assertEqual(context.owner_signals[0].owners, ["@payments-sre"])
+        self.assertIn("aws_security_group.payments", context.unmapped_subjects)
+        self.assertEqual(context.context_todos, (OWNERSHIP_CONTEXT_TODO,))
+
+    def test_multiple_services_with_same_owner_emit_service_signals(self) -> None:
+        parse_batch = ParseBatchResult(
+            files=[
+                ParsedFileResult(
+                    file_name="deployments/payments.yaml",
+                    tool="kubernetes",
+                    status="parsed",
+                    changes=[
+                        UnifiedChange(
+                            source_file="deployments/payments.yaml",
+                            tool="kubernetes",
+                            resource_id="Deployment/api",
+                            action="modify",
+                            summary="Kubernetes deployment changed.",
+                        )
+                    ],
+                )
+            ]
+        )
+        topology = {
+            "services": [
+                {
+                    "id": "payments-api",
+                    "label": "Payments API",
+                    "resource_keys": ["Deployment/api"],
+                    "owners": ["@shared-runtime"],
+                },
+                {
+                    "id": "payments-worker",
+                    "label": "Payments Worker",
+                    "resource_keys": ["Deployment/api"],
+                    "owners": ["@shared-runtime"],
+                },
+            ]
+        }
+
+        context = build_ownership_context(parse_batch, topology=topology)
+
+        self.assertEqual(
+            [signal.subject for signal in context.owner_signals],
+            ["Payments API", "Payments Worker"],
+        )
+        self.assertNotIn("Deployment/api", context.unmapped_subjects)
+
+    def test_multiple_services_with_same_owner_set_ignore_owner_order(self) -> None:
+        parse_batch = ParseBatchResult(
+            files=[
+                ParsedFileResult(
+                    file_name="deployments/payments.yaml",
+                    tool="kubernetes",
+                    status="parsed",
+                    changes=[
+                        UnifiedChange(
+                            source_file="deployments/payments.yaml",
+                            tool="kubernetes",
+                            resource_id="Deployment/api",
+                            action="modify",
+                            summary="Kubernetes deployment changed.",
+                        )
+                    ],
+                )
+            ]
+        )
+        topology = {
+            "services": [
+                {
+                    "id": "payments-api",
+                    "label": "Payments API",
+                    "resource_keys": ["Deployment/api"],
+                    "owners": ["@payments-runtime", "@platform-runtime"],
+                },
+                {
+                    "id": "payments-worker",
+                    "label": "Payments Worker",
+                    "resource_keys": ["Deployment/api"],
+                    "owners": ["@platform-runtime", "@payments-runtime"],
+                },
+            ]
+        }
+
+        context = build_ownership_context(parse_batch, topology=topology)
+
+        self.assertEqual(
+            [signal.subject for signal in context.owner_signals],
+            ["Payments API", "Payments Worker"],
+        )
+        self.assertNotIn("Deployment/api", context.unmapped_subjects)
+
+    def test_topology_only_owner_satisfies_file_ownership_context(self) -> None:
+        parse_batch = ParseBatchResult(
+            files=[
+                ParsedFileResult(
+                    file_name="deployments/payments.yaml",
+                    tool="kubernetes",
+                    status="parsed",
+                    changes=[
+                        UnifiedChange(
+                            source_file="deployments/payments.yaml",
+                            tool="kubernetes",
+                            resource_id="Deployment/api",
+                            action="modify",
+                            summary="Kubernetes deployment image changed.",
+                        )
+                    ],
+                )
+            ]
+        )
+        topology = {
+            "metadata": {"import": {"source_ref": "topology.yaml"}},
+            "services": [
+                {
+                    "id": "payments-api",
+                    "label": "Payments API",
+                    "resource_keys": ["Deployment/api"],
+                    "owners": ["@payments-runtime"],
+                }
+            ],
+        }
+
+        context = build_ownership_context(parse_batch, topology=topology)
+
+        self.assertEqual(
+            [signal.scope for signal in context.owner_signals], ["service"]
+        )
+        self.assertEqual(context.owner_signals[0].owners, ["@payments-runtime"])
+        self.assertEqual(context.unmapped_subjects, ())
+        self.assertEqual(context.context_todos, ())
+
+    def test_plain_topology_owner_label_satisfies_ownership_context(self) -> None:
+        parse_batch = ParseBatchResult(
+            files=[
+                ParsedFileResult(
+                    file_name="deployments/payments.yaml",
+                    tool="kubernetes",
+                    status="parsed",
+                    changes=[
+                        UnifiedChange(
+                            source_file="deployments/payments.yaml",
+                            tool="kubernetes",
+                            resource_id="Deployment/api",
+                            action="modify",
+                            summary="Kubernetes deployment image changed.",
+                        )
+                    ],
+                )
+            ]
+        )
+        topology = {
+            "metadata": {"import": {"source_ref": "topology.yaml"}},
+            "services": [
+                {
+                    "id": "payments-api",
+                    "label": "Payments API",
+                    "resource_keys": ["Deployment/api"],
+                    "owners": ["payments-team"],
+                }
+            ],
+        }
+
+        context = build_ownership_context(parse_batch, topology=topology)
+
+        self.assertEqual(
+            [signal.scope for signal in context.owner_signals], ["service"]
+        )
+        self.assertEqual(context.owner_signals[0].owners, ["payments-team"])
+        self.assertEqual(context.unmapped_subjects, ())
+        self.assertEqual(context.context_todos, ())
+
+    def test_topology_owner_satisfies_external_artifact_ownership_context(
+        self,
+    ) -> None:
+        parse_batch = ParseBatchResult(
+            files=[
+                ParsedFileResult(
+                    file_name="__external_path__/plan.json",
+                    tool="terraform",
+                    status="parsed",
+                    changes=[
+                        UnifiedChange(
+                            source_file="__external_path__/plan.json",
+                            tool="terraform",
+                            resource_id="aws_security_group.payments",
+                            action="modify",
+                            summary="Terraform changed a payments security group.",
+                        )
+                    ],
+                )
+            ]
+        )
+        topology = {
+            "metadata": {"import": {"source_ref": "topology.yaml"}},
+            "services": [
+                {
+                    "id": "payments-api",
+                    "label": "Payments API",
+                    "resource_keys": ["aws_security_group.payments"],
+                    "owners": ["@payments-runtime"],
+                }
+            ],
+        }
+
+        context = build_ownership_context(parse_batch, topology=topology)
+
+        self.assertEqual(
+            [signal.scope for signal in context.owner_signals], ["service"]
+        )
+        self.assertEqual(context.owner_signals[0].owners, ["@payments-runtime"])
+        self.assertEqual(context.unmapped_subjects, ())
+        self.assertEqual(context.context_todos, ())
+
+    def test_non_mutating_changes_do_not_create_missing_ownership_context(
+        self,
+    ) -> None:
+        parse_batch = ParseBatchResult(
+            files=[
+                ParsedFileResult(
+                    file_name="deployments/payments.yaml",
+                    tool="kubernetes",
+                    status="parsed",
+                    changes=[
+                        UnifiedChange(
+                            source_file="deployments/payments.yaml",
+                            tool="kubernetes",
+                            resource_id="Deployment/api",
+                            action="read",
+                            summary="Kubernetes deployment was read without changes.",
+                        )
+                    ],
+                )
+            ]
+        )
+
+        context = build_ownership_context(parse_batch)
+
+        self.assertEqual(context.unmapped_subjects, ())
+        self.assertEqual(context.context_todos, ())
+
+    def test_invalid_topology_owner_tokens_do_not_emit_owner_signals(self) -> None:
+        parse_batch = ParseBatchResult(
+            files=[
+                ParsedFileResult(
+                    file_name="deployments/payments.yaml",
+                    tool="kubernetes",
+                    status="parsed",
+                    changes=[
+                        UnifiedChange(
+                            source_file="deployments/payments.yaml",
+                            tool="kubernetes",
+                            resource_id="Deployment/api",
+                            action="modify",
+                            summary="Kubernetes deployment changed.",
+                        )
+                    ],
+                )
+            ]
+        )
+        topology = {
+            "services": [
+                {
+                    "id": "payments-api",
+                    "label": "Payments API",
+                    "resource_keys": ["Deployment/api"],
+                    "owners": ["@payments-runtime."],
+                }
+            ]
+        }
+
+        context = build_ownership_context(parse_batch, topology=topology)
+
+        self.assertEqual(context.owner_signals, ())
+        self.assertIn("Payments API", context.unmapped_subjects)
+        self.assertEqual(context.context_todos, (OWNERSHIP_CONTEXT_TODO,))
+
+    def test_duplicate_service_id_with_conflicting_owners_is_unmapped(self) -> None:
+        parse_batch = ParseBatchResult(
+            files=[
+                ParsedFileResult(
+                    file_name="deployments/payments.yaml",
+                    tool="kubernetes",
+                    status="parsed",
+                    changes=[
+                        UnifiedChange(
+                            source_file="deployments/payments.yaml",
+                            tool="kubernetes",
+                            resource_id="Deployment/api",
+                            action="modify",
+                            summary="Kubernetes deployment changed.",
+                        )
+                    ],
+                )
+            ]
+        )
+        topology = {
+            "services": [
+                {
+                    "id": "payments-api",
+                    "label": "Payments API",
+                    "resource_keys": ["Deployment/api"],
+                    "owners": [],
+                },
+                {
+                    "id": "payments-api",
+                    "label": "Payments API",
+                    "resource_keys": ["Deployment/api"],
+                    "owners": ["@payments-runtime"],
+                },
+            ]
+        }
+
+        context = build_ownership_context(parse_batch, topology=topology)
+
+        self.assertEqual(context.owner_signals, ())
+        self.assertIn("Deployment/api", context.unmapped_subjects)
+        self.assertEqual(context.context_todos, (OWNERSHIP_CONTEXT_TODO,))
+
+    def test_failed_file_still_gets_file_owner_signal(self) -> None:
+        parse_batch = ParseBatchResult(
+            files=[
+                ParsedFileResult(
+                    file_name="services/payments/broken-plan.json",
+                    tool="terraform",
+                    status="failed",
+                    changes=[],
+                )
+            ]
+        )
+        context = build_ownership_context(
+            parse_batch,
+            codeowners_sources=(
+                self._codeowners("CODEOWNERS", "/services/payments/ @payments-sre"),
+            ),
+        )
+
+        self.assertEqual([signal.scope for signal in context.owner_signals], ["file"])
+        self.assertEqual(context.owner_signals[0].owners, ["@payments-sre"])
+        self.assertEqual(context.context_todos, ())
+
+    def test_empty_file_name_degrades_to_unmapped_subject(self) -> None:
+        parse_batch = ParseBatchResult(
+            files=[
+                ParsedFileResult(
+                    file_name="",
+                    tool="terraform",
+                    status="failed",
+                    changes=[],
+                )
+            ]
+        )
+
+        context = build_ownership_context(
+            parse_batch,
+            codeowners_sources=(self._codeowners("CODEOWNERS", "* @root-owner"),),
+        )
+
+        self.assertEqual(context.owner_signals, ())
+        self.assertIn("unknown-file", context.unmapped_subjects)
+
+    def test_empty_file_name_with_service_owner_does_not_add_unknown_file(
+        self,
+    ) -> None:
+        parse_batch = ParseBatchResult(
+            files=[
+                ParsedFileResult(
+                    file_name="",
+                    tool="terraform",
+                    status="parsed",
+                    changes=[
+                        UnifiedChange(
+                            source_file="",
+                            tool="terraform",
+                            resource_id="aws_security_group.payments",
+                            action="modify",
+                            summary="Terraform changed a payments security group.",
+                        )
+                    ],
+                )
+            ]
+        )
+        topology = {
+            "services": [
+                {
+                    "id": "payments-api",
+                    "label": "Payments API",
+                    "resource_keys": ["aws_security_group.payments"],
+                    "owners": ["@payments-runtime"],
+                }
+            ],
+        }
+
+        context = build_ownership_context(parse_batch, topology=topology)
+
+        self.assertEqual(
+            [signal.scope for signal in context.owner_signals], ["service"]
+        )
+        self.assertEqual(context.unmapped_subjects, ())
+        self.assertNotIn("unknown-file", context.unmapped_subjects)
+
+    def test_codeowners_file_owner_satisfies_unmatched_resource_escalation(
+        self,
+    ) -> None:
+        parse_batch = ParseBatchResult(
+            files=[
+                ParsedFileResult(
+                    file_name="services/payments/plan.json",
+                    tool="terraform",
+                    status="parsed",
+                    changes=[
+                        UnifiedChange(
+                            source_file="services/payments/plan.json",
+                            tool="terraform",
+                            resource_id="aws_security_group.unmapped",
+                            action="modify",
+                            summary="Terraform changed an unmapped security group.",
+                        )
+                    ],
+                )
+            ]
+        )
+        topology = {
+            "services": [
+                {
+                    "id": "payments-api",
+                    "label": "Payments API",
+                    "resource_keys": ["aws_security_group.payments"],
+                    "owners": ["@payments-runtime"],
+                    "downstream": [],
+                }
+            ]
+        }
+        context = build_ownership_context(
+            parse_batch,
+            topology=topology,
+            codeowners_sources=(
+                self._codeowners("CODEOWNERS", "/services/payments/ @payments-sre"),
+            ),
+        )
+
+        self.assertEqual([signal.scope for signal in context.owner_signals], ["file"])
+        self.assertEqual(context.unmapped_subjects, ())
+        self.assertEqual(context.context_todos, ())
+
+    def test_blank_resource_id_uses_codeowners_file_owner_fallback(self) -> None:
+        parse_batch = ParseBatchResult(
+            files=[
+                ParsedFileResult(
+                    file_name="services/payments/plan.json",
+                    tool="terraform",
+                    status="parsed",
+                    changes=[
+                        UnifiedChange(
+                            source_file="services/payments/plan.json",
+                            tool="terraform",
+                            resource_id=" ",
+                            action="modify",
+                            summary="Terraform changed an unnamed resource.",
+                        )
+                    ],
+                )
+            ]
+        )
+
+        context = build_ownership_context(
+            parse_batch,
+            codeowners_sources=(
+                self._codeowners("CODEOWNERS", "/services/payments/ @payments-sre"),
+            ),
+        )
+
+        self.assertEqual([signal.scope for signal in context.owner_signals], ["file"])
+        self.assertEqual(context.unmapped_subjects, ())
+        self.assertEqual(context.context_todos, ())
+
+    def test_invalid_uploaded_codeowners_degrades_to_unmapped_context(self) -> None:
+        parse_batch = ParseBatchResult(
+            files=[
+                ParsedFileResult(
+                    file_name="app.js",
+                    tool="terraform",
+                    status="parsed",
+                    changes=[
+                        UnifiedChange(
+                            source_file="app.js",
+                            tool="terraform",
+                            resource_id="aws_security_group.app",
+                            action="modify",
+                            summary="Terraform changed an app security group.",
+                        )
+                    ],
+                )
+            ]
+        )
+        sources = uploaded_codeowners_sources([("CODEOWNERS", b"\xff")])
+
+        context = build_ownership_context(parse_batch, codeowners_sources=sources)
+
+        self.assertEqual(
+            sources,
+            (CodeownersSource(source_ref="CODEOWNERS", content="", readable=False),),
+        )
+        self.assertEqual(context.owner_signals, ())
+        self.assertIn("app.js", context.unmapped_subjects)
+        self.assertEqual(context.context_todos, (OWNERSHIP_CONTEXT_TODO,))
+
+    def test_ownerless_codeowners_lines_clear_earlier_valid_matches(self) -> None:
+        parse_batch = ParseBatchResult(
+            files=[
+                ParsedFileResult(
+                    file_name="app.js",
+                    tool="terraform",
+                    status="parsed",
+                    changes=[
+                        UnifiedChange(
+                            source_file="app.js",
+                            tool="terraform",
+                            resource_id="aws_security_group.app",
+                            action="modify",
+                            summary="Terraform changed an app security group.",
+                        )
+                    ],
+                )
+            ]
+        )
+
+        context = build_ownership_context(
+            parse_batch,
+            codeowners_sources=(self._codeowners("CODEOWNERS", "* @platform\napp.js"),),
+        )
+
+        self.assertEqual(context.owner_signals, ())
+        self.assertIn("app.js", context.unmapped_subjects)
+
+    def test_invalid_codeowners_owner_tokens_are_skipped(self) -> None:
+        parse_batch = ParseBatchResult(
+            files=[
+                ParsedFileResult(
+                    file_name="app.py",
+                    tool="terraform",
+                    status="failed",
+                    changes=[],
+                ),
+                ParsedFileResult(
+                    file_name="service.yaml",
+                    tool="terraform",
+                    status="failed",
+                    changes=[],
+                ),
+                ParsedFileResult(
+                    file_name="infra.tf",
+                    tool="terraform",
+                    status="failed",
+                    changes=[],
+                ),
+            ]
+        )
+
+        context = build_ownership_context(
+            parse_batch,
+            codeowners_sources=(
+                self._codeowners(
+                    "CODEOWNERS",
+                    "\n".join(
+                        [
+                            "*.py platform-team",
+                            "*.yaml @platform bad-token",
+                            "*.tf @bad-owner.",
+                        ]
+                    ),
+                ),
+            ),
+        )
+
+        self.assertEqual(context.owner_signals, ())
+        self.assertIn("app.py", context.unmapped_subjects)
+        self.assertIn("service.yaml", context.unmapped_subjects)
+        self.assertIn("infra.tf", context.unmapped_subjects)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_services/test_ownership_service.py
+++ b/tests/test_services/test_ownership_service.py
@@ -944,7 +944,10 @@ class OwnershipServiceTests(unittest.TestCase):
 
         context = build_ownership_context(parse_batch)
 
-        self.assertIn("services/payments/plan.json", context.unmapped_subjects)
+        self.assertIn(
+            "untrusted upload: services/payments/plan.json",
+            context.unmapped_subjects,
+        )
         self.assertFalse(
             any(
                 subject.startswith("__unsafe_path__/")
@@ -1006,6 +1009,10 @@ class OwnershipServiceTests(unittest.TestCase):
         context = build_ownership_context(parse_batch, topology=topology)
 
         self.assertIn("services/payments/plan.json", context.unmapped_subjects)
+        self.assertNotIn(
+            "untrusted upload: services/payments/plan.json",
+            context.unmapped_subjects,
+        )
         self.assertFalse(
             any(
                 subject.startswith("__unsafe_path__/")

--- a/tests/test_ui/test_context_completeness_panel.py
+++ b/tests/test_ui/test_context_completeness_panel.py
@@ -271,6 +271,78 @@ class ContextCompletenessPanelRenderingTests(unittest.TestCase):
             response.text,
         )
 
+    def test_context_panel_renders_ownership_context(self) -> None:
+        @ui.page("/_test/context-panel-ownership")
+        def ownership_context_panel_test_page() -> None:
+            from ui.components.context_completeness_panel import (
+                render_context_completeness_panel,
+            )
+
+            render_context_completeness_panel(
+                {
+                    "topology_freshness_days": 0,
+                    "topology_last_imported_at": "2026-05-11T11:22:33Z",
+                    "incident_index_size": 10,
+                    "evidence_success_rate": 1.0,
+                    "parser_success_rate": 1.0,
+                    "parser_success_by_tool": {"terraform": 1.0},
+                    "context_score": 0.92,
+                    "owner_signals": [
+                        {
+                            "scope": "file",
+                            "subject": "services/payments/plan.json",
+                            "owners": ["@payments-sre"],
+                            "source": "CODEOWNERS",
+                            "source_ref": ".github/CODEOWNERS",
+                        }
+                    ],
+                    "escalation_hints": [
+                        "Escalate file review for services/payments/plan.json to @payments-sre."
+                    ],
+                    "ownership_unmapped_subjects": ["aws_security_group.unmapped"],
+                }
+            )
+
+        response = self.client.get("/_test/context-panel-ownership")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("Ownership context", response.text)
+        self.assertIn("services/payments/plan.json", response.text)
+        self.assertIn("@payments-sre", response.text)
+        self.assertIn("Escalation hints", response.text)
+        self.assertIn("Missing ownership", response.text)
+        self.assertIn("aws_security_group.unmapped", response.text)
+
+    def test_context_summary_renders_owner_signals_without_hints(self) -> None:
+        @ui.page("/_test/context-summary-ownership-only")
+        def ownership_summary_test_page() -> None:
+            from ui.components.context_completeness_panel import (
+                render_context_summary_panel,
+            )
+
+            render_context_summary_panel(
+                {
+                    "context_score": 0.92,
+                    "owner_signals": [
+                        {
+                            "scope": "file",
+                            "subject": "services/payments/plan.json",
+                            "owners": ["@payments-sre"],
+                            "source": "CODEOWNERS",
+                            "source_ref": ".github/CODEOWNERS",
+                        }
+                    ],
+                }
+            )
+
+        response = self.client.get("/_test/context-summary-ownership-only")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("Ownership context", response.text)
+        self.assertIn(
+            "Owner: services/payments/plan.json -&gt; @payments-sre", response.text
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_ui/test_upload_panel.py
+++ b/tests/test_ui/test_upload_panel.py
@@ -237,7 +237,13 @@ class UploadPanelTests(unittest.TestCase):
 
         self.assertEqual(
             [uploaded_file_artifact_name(upload) for upload in unsafe_uploads],
-            ["CODEOWNERS", "CODEOWNERS", "CODEOWNERS", "CODEOWNERS", "CODEOWNERS"],
+            [
+                "__unsafe_path__/CODEOWNERS",
+                "__unsafe_path__/CODEOWNERS",
+                "__unsafe_path__/CODEOWNERS",
+                "__unsafe_path__/CODEOWNERS",
+                "__unsafe_path__/CODEOWNERS",
+            ],
         )
 
     def test_configure_dashboard_upload_widget_sends_browser_relative_paths(
@@ -343,6 +349,116 @@ class UploadPanelTests(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "metadata is ambiguous"):
             asyncio.run(dashboard_file_uploads_from_request(request))  # type: ignore[arg-type]
 
+    def test_dashboard_upload_request_rejects_codeowners_field_paths_without_metadata(
+        self,
+    ) -> None:
+        request = FakeRequest(
+            [
+                (
+                    ".github/CODEOWNERS",
+                    FakeStarletteUpload(
+                        ".github/CODEOWNERS",
+                        content=b"/services/payments/ @payments-sre",
+                    ),
+                ),
+                (
+                    "services/payments/plan.json",
+                    FakeStarletteUpload(
+                        "services/payments/plan.json",
+                        content=b'{"resource_changes": []}',
+                    ),
+                ),
+            ]
+        )
+
+        with self.assertRaisesRegex(ValueError, "metadata must match uploaded files"):
+            asyncio.run(dashboard_file_uploads_from_request(request))  # type: ignore[arg-type]
+
+    def test_dashboard_upload_request_does_not_trust_bare_codeowners_without_metadata(
+        self,
+    ) -> None:
+        request = FakeRequest(
+            [
+                (
+                    "CODEOWNERS",
+                    FakeStarletteUpload(
+                        "CODEOWNERS",
+                        content=b"/services/payments/ @payments-sre",
+                    ),
+                ),
+                (
+                    "plan.json",
+                    FakeStarletteUpload(
+                        "plan.json",
+                        content=b'{"resource_changes": []}',
+                    ),
+                ),
+            ]
+        )
+
+        files = asyncio.run(dashboard_file_uploads_from_request(request))  # type: ignore[arg-type]
+
+        self.assertEqual(
+            [file.name for file in files],
+            ["__unsafe_path__/CODEOWNERS", "plan.json"],
+        )
+        self.assertFalse(any(hasattr(file, "relative_path") for file in files))
+
+    def test_dashboard_upload_request_taints_pathlike_upload_filename_without_metadata(
+        self,
+    ) -> None:
+        request = FakeRequest(
+            [
+                (
+                    "files",
+                    FakeStarletteUpload(
+                        "services/payments/plan.json",
+                        content=b'{"resource_changes": []}',
+                    ),
+                ),
+            ]
+        )
+
+        files = asyncio.run(dashboard_file_uploads_from_request(request))  # type: ignore[arg-type]
+
+        self.assertEqual(
+            [file.name for file in files],
+            ["__unsafe_path__/services/payments/plan.json"],
+        )
+        self.assertFalse(any(hasattr(file, "relative_path") for file in files))
+
+    def test_dashboard_upload_request_does_not_trust_codeowners_basename_metadata(
+        self,
+    ) -> None:
+        request = FakeRequest(
+            [
+                (DASHBOARD_UPLOAD_ARTIFACT_PATH_FIELD, "CODEOWNERS"),
+                (DASHBOARD_UPLOAD_ARTIFACT_PATH_FIELD, "plan.json"),
+                (
+                    "CODEOWNERS",
+                    FakeStarletteUpload(
+                        "CODEOWNERS",
+                        content=b"/services/payments/ @payments-sre",
+                    ),
+                ),
+                (
+                    "plan.json",
+                    FakeStarletteUpload(
+                        "plan.json",
+                        content=b'{"resource_changes": []}',
+                    ),
+                ),
+            ]
+        )
+
+        files = asyncio.run(dashboard_file_uploads_from_request(request))  # type: ignore[arg-type]
+
+        self.assertEqual(
+            [file.name for file in files],
+            ["__unsafe_path__/CODEOWNERS", "plan.json"],
+        )
+        self.assertFalse(any(hasattr(file, "relative_path") for file in files))
+
     def test_dashboard_upload_request_preserves_duplicate_basename_fallback_uploads(
         self,
     ) -> None:
@@ -359,6 +475,37 @@ class UploadPanelTests(unittest.TestCase):
 
         self.assertEqual([file.name for file in files], ["plan.json", "plan.json"])
         self.assertFalse(any(hasattr(file, "relative_path") for file in files))
+
+    def test_dashboard_upload_request_rejects_basename_fallback_with_field_path(
+        self,
+    ) -> None:
+        request = FakeRequest(
+            [
+                (DASHBOARD_UPLOAD_ARTIFACT_PATH_FIELD, "plan.json"),
+                ("services/payments/plan.json", FakeStarletteUpload("plan.json")),
+            ]
+        )
+
+        with self.assertRaisesRegex(ValueError, "directory path metadata"):
+            asyncio.run(  # type: ignore[arg-type]
+                dashboard_file_uploads_from_request(
+                    request,
+                    require_directory_paths=True,
+                )
+            )
+
+    def test_dashboard_upload_request_rejects_conflicting_basename_metadata(
+        self,
+    ) -> None:
+        request = FakeRequest(
+            [
+                (DASHBOARD_UPLOAD_ARTIFACT_PATH_FIELD, "plan.json"),
+                ("services/payments/plan.json", FakeStarletteUpload("plan.json")),
+            ]
+        )
+
+        with self.assertRaisesRegex(ValueError, "metadata must match uploaded files"):
+            asyncio.run(dashboard_file_uploads_from_request(request))  # type: ignore[arg-type]
 
     def test_dashboard_directory_upload_rejects_duplicate_basename_fallbacks(
         self,
@@ -401,7 +548,7 @@ class UploadPanelTests(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "metadata is ambiguous"):
             asyncio.run(dashboard_file_uploads_from_request(request))  # type: ignore[arg-type]
 
-    def test_dashboard_upload_request_rejects_duplicate_field_path_bindings(
+    def test_dashboard_upload_request_rejects_duplicate_field_paths_without_metadata(
         self,
     ) -> None:
         request = FakeRequest(
@@ -411,7 +558,19 @@ class UploadPanelTests(unittest.TestCase):
             ]
         )
 
-        with self.assertRaisesRegex(ValueError, "metadata is ambiguous"):
+        with self.assertRaisesRegex(ValueError, "metadata must match uploaded files"):
+            asyncio.run(dashboard_file_uploads_from_request(request))  # type: ignore[arg-type]
+
+    def test_dashboard_upload_request_rejects_mismatched_field_path_without_metadata(
+        self,
+    ) -> None:
+        request = FakeRequest(
+            [
+                ("services/payments/vars.tfvars", FakeStarletteUpload("plan.json")),
+            ]
+        )
+
+        with self.assertRaisesRegex(ValueError, "metadata must match uploaded files"):
             asyncio.run(dashboard_file_uploads_from_request(request))  # type: ignore[arg-type]
 
     def test_dashboard_upload_request_rejects_mixed_field_path_metadata(
@@ -649,6 +808,82 @@ class UploadPanelTests(unittest.TestCase):
         self.assertEqual(response.status_code, 400)
         self.assertEqual(widget.handled_files, [])
 
+    def test_dashboard_upload_route_taints_codeowners_basename_metadata(self) -> None:
+        widget = FakeDashboardUploadWidget(
+            "client-codeowners-basename",
+            "upload-codeowners-basename",
+        )
+        upload_url = register_dashboard_upload_handler(widget, lambda _text: None)
+        upload_key = upload_url.rsplit("/", maxsplit=1)[-1]
+        route_path = f"{DASHBOARD_UPLOAD_ROUTE_PREFIX}/{{upload_key}}"
+        route = next(
+            route
+            for route in getattr(dashboard_app.router, "routes", [])
+            if getattr(route, "path", None) == route_path
+        )
+
+        response = asyncio.run(
+            route.endpoint(  # type: ignore[attr-defined]
+                upload_key,
+                FakeRequest(
+                    [
+                        (DASHBOARD_UPLOAD_ARTIFACT_PATH_FIELD, "CODEOWNERS"),
+                        (
+                            "CODEOWNERS",
+                            FakeStarletteUpload(
+                                "CODEOWNERS",
+                                content=b"/services/payments/ @payments-sre",
+                            ),
+                        ),
+                    ]
+                ),
+            )
+        )
+
+        self.assertEqual(response, {"upload": "success"})
+        self.assertEqual(
+            [file.name for file in widget.handled_files],
+            ["__unsafe_path__/CODEOWNERS"],
+        )
+        self.assertFalse(
+            any(hasattr(file, "relative_path") for file in widget.handled_files)
+        )
+
+    def test_dashboard_upload_route_rejects_conflicting_basename_metadata(self) -> None:
+        widget = FakeDashboardUploadWidget(
+            "client-conflicting-basename",
+            "upload-conflicting-basename",
+        )
+        upload_url = register_dashboard_upload_handler(widget, lambda _text: None)
+        upload_key = upload_url.rsplit("/", maxsplit=1)[-1]
+        route_path = f"{DASHBOARD_UPLOAD_ROUTE_PREFIX}/{{upload_key}}"
+        route = next(
+            route
+            for route in getattr(dashboard_app.router, "routes", [])
+            if getattr(route, "path", None) == route_path
+        )
+
+        response = asyncio.run(
+            route.endpoint(  # type: ignore[attr-defined]
+                upload_key,
+                FakeRequest(
+                    [
+                        (DASHBOARD_UPLOAD_ARTIFACT_PATH_FIELD, "plan.json"),
+                        (
+                            "services/payments/plan.json",
+                            FakeStarletteUpload(
+                                "plan.json",
+                                content=b'{"resource_changes": []}',
+                            ),
+                        ),
+                    ]
+                ),
+            )
+        )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(widget.handled_files, [])
+
     def test_dashboard_directory_upload_route_rejects_basename_only_metadata(
         self,
     ) -> None:
@@ -675,6 +910,87 @@ class UploadPanelTests(unittest.TestCase):
                         (DASHBOARD_UPLOAD_ARTIFACT_PATH_FIELD, "plan.json"),
                         ("plan.json", FakeStarletteUpload("plan.json")),
                         ("plan.json", FakeStarletteUpload("plan.json")),
+                    ]
+                ),
+            )
+        )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(widget.handled_files, [])
+
+    def test_dashboard_directory_upload_route_rejects_missing_artifact_paths(
+        self,
+    ) -> None:
+        widget = FakeDashboardUploadWidget(
+            "client-dir-no-paths",
+            "upload-dir-no-paths",
+        )
+        upload_url = register_dashboard_upload_handler(
+            widget,
+            lambda _text: None,
+            require_directory_paths=True,
+        )
+        upload_key = upload_url.rsplit("/", maxsplit=1)[-1]
+        route_path = f"{DASHBOARD_UPLOAD_ROUTE_PREFIX}/{{upload_key}}"
+        route = next(
+            route
+            for route in getattr(dashboard_app.router, "routes", [])
+            if getattr(route, "path", None) == route_path
+        )
+
+        response = asyncio.run(
+            route.endpoint(  # type: ignore[attr-defined]
+                upload_key,
+                FakeRequest(
+                    [
+                        (
+                            "files",
+                            FakeStarletteUpload(
+                                "services/unowned/plan.json",
+                                content=b'{"resource_changes": []}',
+                            ),
+                        )
+                    ]
+                ),
+            )
+        )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(widget.handled_files, [])
+
+    def test_dashboard_directory_upload_route_rejects_basename_artifact_paths(
+        self,
+    ) -> None:
+        widget = FakeDashboardUploadWidget(
+            "client-dir-basename-paths",
+            "upload-dir-basename-paths",
+        )
+        upload_url = register_dashboard_upload_handler(
+            widget,
+            lambda _text: None,
+            require_directory_paths=True,
+        )
+        upload_key = upload_url.rsplit("/", maxsplit=1)[-1]
+        route_path = f"{DASHBOARD_UPLOAD_ROUTE_PREFIX}/{{upload_key}}"
+        route = next(
+            route
+            for route in getattr(dashboard_app.router, "routes", [])
+            if getattr(route, "path", None) == route_path
+        )
+
+        response = asyncio.run(
+            route.endpoint(  # type: ignore[attr-defined]
+                upload_key,
+                FakeRequest(
+                    [
+                        (DASHBOARD_UPLOAD_ARTIFACT_PATH_FIELD, "plan.json"),
+                        (
+                            "files",
+                            FakeStarletteUpload(
+                                "plan.json",
+                                content=b'{"resource_changes": []}',
+                            ),
+                        ),
                     ]
                 ),
             )

--- a/tests/test_ui/test_upload_panel.py
+++ b/tests/test_ui/test_upload_panel.py
@@ -2,11 +2,21 @@
 
 from __future__ import annotations
 
+import asyncio
 import unittest
 from unittest.mock import patch
 
 from ui.components.upload_panel import (
+    DASHBOARD_UPLOAD_ACCEPT,
+    DASHBOARD_UPLOAD_ARTIFACT_PATH_FIELD,
+    DASHBOARD_UPLOAD_ROUTE_PREFIX,
+    app as dashboard_app,
+    apply_upload_widget_state,
     build_feedback_rerender_handler,
+    configure_dashboard_upload_widget,
+    dashboard_upload_field_name_prop,
+    dashboard_file_uploads_from_request,
+    dashboard_upload_directory_javascript,
     format_analysis_failure,
     persisted_report_reference,
     format_submission_manifest_fallback_summary,
@@ -14,8 +24,12 @@ from ui.components.upload_panel import (
     format_submission_manifest_summary,
     process_uploaded_files,
     render_report_incident_matches,
+    reset_upload_widgets,
     resolve_initial_project_selection,
+    register_dashboard_upload_handler,
+    unregister_dashboard_upload_handler,
     should_clear_pending_uploads,
+    uploaded_file_artifact_name,
     uploads_allowed,
     run_uploaded_analysis,
 )
@@ -56,6 +70,87 @@ class FakeUi:
         return FakeUiElement()
 
 
+class FakeUploadFile:
+    def __init__(self, name: str, **attrs: str) -> None:
+        self.name = name
+        for key, value in attrs.items():
+            setattr(self, key, value)
+
+
+class FakeUploadWidget:
+    def __init__(self) -> None:
+        self.props_calls: list[str] = []
+        self._props: dict[str, str] = {"url": "/old-upload"}
+        self.enabled = True
+        self.reset_count = 0
+
+    def props(self, value: str) -> "FakeUploadWidget":
+        self.props_calls.append(value)
+        return self
+
+    def enable(self) -> None:
+        self.enabled = True
+
+    def disable(self) -> None:
+        self.enabled = False
+
+    def reset(self) -> None:
+        self.reset_count += 1
+
+
+class FakeDashboardUploadWidget(FakeUploadWidget):
+    def __init__(self, client_id: str, widget_id: str) -> None:
+        super().__init__()
+        self.client = type("Client", (), {"id": client_id})()
+        self.id = widget_id
+        self.handled_files: list[object] = []
+
+    async def handle_uploads(self, files: list[object]) -> None:
+        self.handled_files = files
+        return None
+
+
+class FakeForm:
+    def __init__(self, items: list[tuple[str, object]]) -> None:
+        self._items = items
+
+    async def __aenter__(self) -> "FakeForm":
+        return self
+
+    async def __aexit__(self, exc_type, exc_value, traceback) -> bool:
+        return False
+
+    def multi_items(self) -> list[tuple[str, object]]:
+        return self._items
+
+
+class FakeRequest:
+    def __init__(self, items: list[tuple[str, object]]) -> None:
+        self._items = items
+
+    def form(self) -> FakeForm:
+        return FakeForm(self._items)
+
+
+class FakeStarletteUpload:
+    def __init__(self, filename: str, content: bytes = b"") -> None:
+        self.filename = filename
+        self.content_type = "application/octet-stream"
+        self._content = content
+        self._offset = 0
+        self.closed = False
+
+    async def read(self, size: int = -1) -> bytes:
+        if size is None or size < 0:
+            size = len(self._content) - self._offset
+        start = self._offset
+        self._offset = min(len(self._content), self._offset + size)
+        return self._content[start : self._offset]
+
+    async def close(self) -> None:
+        self.closed = True
+
+
 class UploadPanelTests(unittest.TestCase):
     def test_process_uploaded_files_marks_supported_inputs_ready(self) -> None:
         current_files: list[tuple[str, bytes]] = []
@@ -73,6 +168,559 @@ class UploadPanelTests(unittest.TestCase):
         self.assertEqual(summary.ready_count, 1)
         self.assertEqual(summary.items[0].status, "ready")
         self.assertEqual(current_files[0][0], "etcd-pvc-new.yaml")
+
+    def test_process_uploaded_files_preserves_safe_relative_paths(self) -> None:
+        current_files: list[tuple[str, bytes]] = []
+
+        summary = process_uploaded_files(
+            current_files,
+            [
+                (
+                    "repo/services/payments/plan.json",
+                    b'{"resource_changes": []}',
+                )
+            ],
+        )
+
+        self.assertEqual(summary.ready_count, 1)
+        self.assertEqual(current_files[0][0], "repo/services/payments/plan.json")
+
+    def test_uploaded_file_artifact_name_prefers_relative_path_metadata(self) -> None:
+        upload = FakeUploadFile(
+            "plan.json",
+            webkitRelativePath="repo/services/payments/plan.json",
+        )
+
+        self.assertEqual(
+            uploaded_file_artifact_name(upload),
+            "repo/services/payments/plan.json",
+        )
+        self.assertEqual(
+            uploaded_file_artifact_name(FakeUploadFile("plan.json")),
+            "plan.json",
+        )
+
+    def test_uploaded_file_artifact_name_ignores_untrusted_local_paths(self) -> None:
+        upload = FakeUploadFile(
+            "plan.json",
+            full_path="/Users/alice/private/repo/services/payments/plan.json",
+            path="/private/tmp/nicegui-upload/plan.json",
+        )
+
+        self.assertEqual(uploaded_file_artifact_name(upload), "plan.json")
+
+    def test_uploaded_file_artifact_name_rejects_unsafe_relative_metadata(
+        self,
+    ) -> None:
+        unsafe_uploads = [
+            FakeUploadFile(
+                "CODEOWNERS",
+                relative_path="/Users/alice/repo/.github/CODEOWNERS",
+            ),
+            FakeUploadFile(
+                "CODEOWNERS",
+                webkitRelativePath="C:\\Users\\alice\\repo\\.github\\CODEOWNERS",
+            ),
+            FakeUploadFile(
+                "CODEOWNERS",
+                webkit_relative_path="repo/../.github/CODEOWNERS",
+            ),
+            FakeUploadFile(
+                "CODEOWNERS",
+                relative_path="__unsafe_path__/CODEOWNERS",
+            ),
+            FakeUploadFile(
+                "CODEOWNERS",
+                relative_path="__UNSAFE_PATH__/CODEOWNERS",
+            ),
+        ]
+
+        self.assertEqual(
+            [uploaded_file_artifact_name(upload) for upload in unsafe_uploads],
+            ["CODEOWNERS", "CODEOWNERS", "CODEOWNERS", "CODEOWNERS", "CODEOWNERS"],
+        )
+
+    def test_configure_dashboard_upload_widget_sends_browser_relative_paths(
+        self,
+    ) -> None:
+        widget = FakeUploadWidget()
+
+        configure_dashboard_upload_widget(widget, upload_url="/dashboard-upload")
+
+        self.assertEqual(widget._props["url"], "/dashboard-upload")
+        props = " ".join(widget.props_calls)
+        self.assertNotIn("data-dw-dashboard-directory-upload", props)
+        self.assertIn(":form-fields", props)
+        self.assertIn(":field-name", props)
+        self.assertIn(DASHBOARD_UPLOAD_ARTIFACT_PATH_FIELD, props)
+        self.assertIn("webkitRelativePath", props)
+        self.assertEqual(
+            dashboard_upload_field_name_prop(),
+            ":field-name=\"file => file.webkitRelativePath || file.relativePath || file.name || 'files'\"",
+        )
+        self.assertIn(f"accept={DASHBOARD_UPLOAD_ACCEPT}", props)
+
+        directory_widget = FakeUploadWidget()
+        configure_dashboard_upload_widget(
+            directory_widget,
+            upload_url="/dashboard-directory-upload",
+            enable_directory=True,
+        )
+        directory_props = " ".join(directory_widget.props_calls)
+        self.assertEqual(
+            directory_widget._props["url"],
+            "/dashboard-directory-upload",
+        )
+        self.assertIn('data-dw-dashboard-directory-upload="1"', directory_props)
+        self.assertIn(f"accept={DASHBOARD_UPLOAD_ACCEPT}", directory_props)
+
+        directory_script = dashboard_upload_directory_javascript()
+        self.assertIn("webkitdirectory", directory_script)
+        self.assertIn("directory", directory_script)
+
+    def test_dashboard_upload_request_rejects_reordered_artifact_paths(
+        self,
+    ) -> None:
+        request = FakeRequest(
+            [
+                (
+                    DASHBOARD_UPLOAD_ARTIFACT_PATH_FIELD,
+                    "services/payments/plan.json",
+                ),
+                (DASHBOARD_UPLOAD_ARTIFACT_PATH_FIELD, ".github/CODEOWNERS"),
+                ("files", FakeStarletteUpload("CODEOWNERS")),
+                ("files", FakeStarletteUpload("plan.json")),
+            ]
+        )
+
+        with self.assertRaisesRegex(ValueError, "metadata must match uploaded files"):
+            asyncio.run(dashboard_file_uploads_from_request(request))  # type: ignore[arg-type]
+
+    def test_dashboard_upload_request_preserves_duplicate_artifact_path_filenames(
+        self,
+    ) -> None:
+        request = FakeRequest(
+            [
+                (
+                    DASHBOARD_UPLOAD_ARTIFACT_PATH_FIELD,
+                    "services/payments/plan.json",
+                ),
+                (
+                    DASHBOARD_UPLOAD_ARTIFACT_PATH_FIELD,
+                    "services/billing/plan.json",
+                ),
+                ("services/payments/plan.json", FakeStarletteUpload("plan.json")),
+                ("services/billing/plan.json", FakeStarletteUpload("plan.json")),
+            ]
+        )
+
+        files = asyncio.run(dashboard_file_uploads_from_request(request))  # type: ignore[arg-type]
+
+        self.assertEqual([file.name for file in files], ["plan.json", "plan.json"])
+        self.assertEqual(
+            [getattr(file, "relative_path") for file in files],
+            ["services/payments/plan.json", "services/billing/plan.json"],
+        )
+
+    def test_dashboard_upload_request_rejects_duplicate_basenames_without_path_binding(
+        self,
+    ) -> None:
+        request = FakeRequest(
+            [
+                (
+                    DASHBOARD_UPLOAD_ARTIFACT_PATH_FIELD,
+                    "services/payments/plan.json",
+                ),
+                (
+                    DASHBOARD_UPLOAD_ARTIFACT_PATH_FIELD,
+                    "services/billing/plan.json",
+                ),
+                ("files", FakeStarletteUpload("plan.json")),
+                ("files", FakeStarletteUpload("plan.json")),
+            ]
+        )
+
+        with self.assertRaisesRegex(ValueError, "metadata is ambiguous"):
+            asyncio.run(dashboard_file_uploads_from_request(request))  # type: ignore[arg-type]
+
+    def test_dashboard_upload_request_preserves_duplicate_basename_fallback_uploads(
+        self,
+    ) -> None:
+        request = FakeRequest(
+            [
+                (DASHBOARD_UPLOAD_ARTIFACT_PATH_FIELD, "plan.json"),
+                (DASHBOARD_UPLOAD_ARTIFACT_PATH_FIELD, "plan.json"),
+                ("plan.json", FakeStarletteUpload("plan.json")),
+                ("plan.json", FakeStarletteUpload("plan.json")),
+            ]
+        )
+
+        files = asyncio.run(dashboard_file_uploads_from_request(request))  # type: ignore[arg-type]
+
+        self.assertEqual([file.name for file in files], ["plan.json", "plan.json"])
+        self.assertFalse(any(hasattr(file, "relative_path") for file in files))
+
+    def test_dashboard_directory_upload_rejects_duplicate_basename_fallbacks(
+        self,
+    ) -> None:
+        request = FakeRequest(
+            [
+                (DASHBOARD_UPLOAD_ARTIFACT_PATH_FIELD, "plan.json"),
+                (DASHBOARD_UPLOAD_ARTIFACT_PATH_FIELD, "plan.json"),
+                ("plan.json", FakeStarletteUpload("plan.json")),
+                ("plan.json", FakeStarletteUpload("plan.json")),
+            ]
+        )
+
+        with self.assertRaisesRegex(ValueError, "directory path metadata"):
+            asyncio.run(  # type: ignore[arg-type]
+                dashboard_file_uploads_from_request(
+                    request,
+                    require_directory_paths=True,
+                )
+            )
+
+    def test_dashboard_upload_request_rejects_duplicate_artifact_paths(
+        self,
+    ) -> None:
+        request = FakeRequest(
+            [
+                (
+                    DASHBOARD_UPLOAD_ARTIFACT_PATH_FIELD,
+                    "services/payments/plan.json",
+                ),
+                (
+                    DASHBOARD_UPLOAD_ARTIFACT_PATH_FIELD,
+                    "services/payments/plan.json",
+                ),
+                ("files", FakeStarletteUpload("plan.json")),
+                ("files", FakeStarletteUpload("plan.json")),
+            ]
+        )
+
+        with self.assertRaisesRegex(ValueError, "metadata is ambiguous"):
+            asyncio.run(dashboard_file_uploads_from_request(request))  # type: ignore[arg-type]
+
+    def test_dashboard_upload_request_rejects_duplicate_field_path_bindings(
+        self,
+    ) -> None:
+        request = FakeRequest(
+            [
+                ("services/payments/plan.json", FakeStarletteUpload("plan.json")),
+                ("services/payments/plan.json", FakeStarletteUpload("plan.json")),
+            ]
+        )
+
+        with self.assertRaisesRegex(ValueError, "metadata is ambiguous"):
+            asyncio.run(dashboard_file_uploads_from_request(request))  # type: ignore[arg-type]
+
+    def test_dashboard_upload_request_rejects_mixed_field_path_metadata(
+        self,
+    ) -> None:
+        request = FakeRequest(
+            [
+                ("services/payments/plan.json", FakeStarletteUpload("plan.json")),
+                ("files", FakeStarletteUpload("vars.tfvars")),
+            ]
+        )
+
+        with self.assertRaisesRegex(ValueError, "metadata must match uploaded files"):
+            asyncio.run(dashboard_file_uploads_from_request(request))  # type: ignore[arg-type]
+
+    def test_dashboard_upload_request_rejects_oversized_route_payload(
+        self,
+    ) -> None:
+        request = FakeRequest(
+            [("files", FakeStarletteUpload("plan.json", b"123456789"))]
+        )
+
+        with patch("ui.components.upload_panel.MAX_TOTAL_UPLOAD_BYTES", 8):
+            with self.assertRaisesRegex(ValueError, "upload size exceeds"):
+                asyncio.run(dashboard_file_uploads_from_request(request))  # type: ignore[arg-type]
+
+    def test_dashboard_upload_request_rejects_invalid_artifact_paths(
+        self,
+    ) -> None:
+        invalid_values = (
+            "/Users/alice/repo/services/payments/plan.json",
+            "services/../payments/plan.json",
+            "__unsafe_path__/services/payments/plan.json",
+            "__external_path__/services/payments/plan.json",
+        )
+
+        for artifact_path in invalid_values:
+            with self.subTest(artifact_path=artifact_path):
+                request = FakeRequest(
+                    [
+                        (DASHBOARD_UPLOAD_ARTIFACT_PATH_FIELD, artifact_path),
+                        ("files", FakeStarletteUpload("plan.json")),
+                    ]
+                )
+
+                with self.assertRaisesRegex(
+                    ValueError,
+                    "metadata must match uploaded files",
+                ):
+                    asyncio.run(dashboard_file_uploads_from_request(request))  # type: ignore[arg-type]
+
+    def test_dashboard_upload_handler_registers_single_stable_route(self) -> None:
+        route_path = f"{DASHBOARD_UPLOAD_ROUTE_PREFIX}/{{upload_key}}"
+        before_count = sum(
+            1
+            for route in getattr(dashboard_app.router, "routes", [])
+            if getattr(route, "path", None) == route_path
+        )
+
+        first_url = register_dashboard_upload_handler(
+            FakeDashboardUploadWidget("client-a", "upload-a"),
+            lambda _text: None,
+        )
+        second_url = register_dashboard_upload_handler(
+            FakeDashboardUploadWidget("client-b", "upload-b"),
+            lambda _text: None,
+        )
+
+        after_count = sum(
+            1
+            for route in getattr(dashboard_app.router, "routes", [])
+            if getattr(route, "path", None) == route_path
+        )
+        self.assertEqual(after_count, max(before_count, 1))
+        self.assertTrue(first_url.startswith(f"{DASHBOARD_UPLOAD_ROUTE_PREFIX}/"))
+        self.assertTrue(second_url.startswith(f"{DASHBOARD_UPLOAD_ROUTE_PREFIX}/"))
+        self.assertNotEqual(first_url, second_url)
+
+    def test_dashboard_upload_handler_replaces_stale_widget_keys(self) -> None:
+        widget = FakeDashboardUploadWidget("client-random", "upload-random")
+        first_url = register_dashboard_upload_handler(widget, lambda _text: None)
+        second_url = register_dashboard_upload_handler(widget, lambda _text: None)
+        first_key = first_url.rsplit("/", maxsplit=1)[-1]
+        second_key = second_url.rsplit("/", maxsplit=1)[-1]
+        route_path = f"{DASHBOARD_UPLOAD_ROUTE_PREFIX}/{{upload_key}}"
+        route = next(
+            route
+            for route in getattr(dashboard_app.router, "routes", [])
+            if getattr(route, "path", None) == route_path
+        )
+
+        old_response = asyncio.run(route.endpoint(first_key, FakeRequest([])))  # type: ignore[attr-defined]
+        new_response = asyncio.run(
+            route.endpoint(  # type: ignore[attr-defined]
+                second_key,
+                FakeRequest([("files", FakeStarletteUpload("plan.json", b"{}"))]),
+            )
+        )
+
+        self.assertNotEqual(first_url, second_url)
+        self.assertNotEqual(first_key, "client-random-upload-random")
+        self.assertNotEqual(second_key, "client-random-upload-random")
+        self.assertEqual(old_response.status_code, 404)
+        self.assertEqual(new_response, {"upload": "success"})
+        self.assertEqual([file.name for file in widget.handled_files], ["plan.json"])
+
+    def test_dashboard_upload_handler_replaces_stale_client_widget_set(
+        self,
+    ) -> None:
+        old_file_widget = FakeDashboardUploadWidget("client-rebuild", "upload-old")
+        old_directory_widget = FakeDashboardUploadWidget(
+            "client-rebuild", "directory-old"
+        )
+        old_file_url = register_dashboard_upload_handler(
+            old_file_widget,
+            lambda _text: None,
+        )
+        old_directory_url = register_dashboard_upload_handler(
+            old_directory_widget,
+            lambda _text: None,
+        )
+        new_file_widget = FakeDashboardUploadWidget("client-rebuild", "upload-new")
+        new_directory_widget = FakeDashboardUploadWidget(
+            "client-rebuild", "directory-new"
+        )
+        new_file_url = register_dashboard_upload_handler(
+            new_file_widget,
+            lambda _text: None,
+        )
+        new_directory_url = register_dashboard_upload_handler(
+            new_directory_widget,
+            lambda _text: None,
+        )
+        route_path = f"{DASHBOARD_UPLOAD_ROUTE_PREFIX}/{{upload_key}}"
+        route = next(
+            route
+            for route in getattr(dashboard_app.router, "routes", [])
+            if getattr(route, "path", None) == route_path
+        )
+
+        old_file_response = asyncio.run(
+            route.endpoint(old_file_url.rsplit("/", maxsplit=1)[-1], FakeRequest([]))  # type: ignore[attr-defined]
+        )
+        old_directory_response = asyncio.run(
+            route.endpoint(  # type: ignore[attr-defined]
+                old_directory_url.rsplit("/", maxsplit=1)[-1],
+                FakeRequest([]),
+            )
+        )
+        new_file_response = asyncio.run(
+            route.endpoint(  # type: ignore[attr-defined]
+                new_file_url.rsplit("/", maxsplit=1)[-1],
+                FakeRequest([("files", FakeStarletteUpload("plan.json", b"{}"))]),
+            )
+        )
+        new_directory_response = asyncio.run(
+            route.endpoint(  # type: ignore[attr-defined]
+                new_directory_url.rsplit("/", maxsplit=1)[-1],
+                FakeRequest([("files", FakeStarletteUpload("values.yaml", b"{}"))]),
+            )
+        )
+
+        self.assertEqual(old_file_response.status_code, 404)
+        self.assertEqual(old_directory_response.status_code, 404)
+        self.assertEqual(new_file_response, {"upload": "success"})
+        self.assertEqual(new_directory_response, {"upload": "success"})
+        self.assertEqual(
+            [file.name for file in new_file_widget.handled_files], ["plan.json"]
+        )
+        self.assertEqual(
+            [file.name for file in new_directory_widget.handled_files],
+            ["values.yaml"],
+        )
+
+    def test_dashboard_upload_handler_unregisters_widget_keys(self) -> None:
+        widget = FakeDashboardUploadWidget("client-cleanup", "upload-cleanup")
+        upload_url = register_dashboard_upload_handler(widget, lambda _text: None)
+        upload_key = upload_url.rsplit("/", maxsplit=1)[-1]
+        route_path = f"{DASHBOARD_UPLOAD_ROUTE_PREFIX}/{{upload_key}}"
+        route = next(
+            route
+            for route in getattr(dashboard_app.router, "routes", [])
+            if getattr(route, "path", None) == route_path
+        )
+
+        unregister_dashboard_upload_handler(upload_url)
+
+        response = asyncio.run(route.endpoint(upload_key, FakeRequest([])))  # type: ignore[attr-defined]
+        self.assertEqual(response.status_code, 404)
+
+    def test_dashboard_upload_route_rejects_invalid_artifact_path_metadata(
+        self,
+    ) -> None:
+        widget = FakeDashboardUploadWidget("client-route", "upload-route")
+        upload_url = register_dashboard_upload_handler(widget, lambda _text: None)
+        upload_key = upload_url.rsplit("/", maxsplit=1)[-1]
+        route_path = f"{DASHBOARD_UPLOAD_ROUTE_PREFIX}/{{upload_key}}"
+        route = next(
+            route
+            for route in getattr(dashboard_app.router, "routes", [])
+            if getattr(route, "path", None) == route_path
+        )
+
+        response = asyncio.run(
+            route.endpoint(  # type: ignore[attr-defined]
+                upload_key,
+                FakeRequest(
+                    [
+                        (
+                            DASHBOARD_UPLOAD_ARTIFACT_PATH_FIELD,
+                            "/Users/alice/repo/plan.json",
+                        ),
+                        ("files", FakeStarletteUpload("plan.json")),
+                    ]
+                ),
+            )
+        )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(widget.handled_files, [])
+
+    def test_dashboard_upload_route_rejects_empty_payload(self) -> None:
+        widget = FakeDashboardUploadWidget("client-empty", "upload-empty")
+        upload_url = register_dashboard_upload_handler(widget, lambda _text: None)
+        upload_key = upload_url.rsplit("/", maxsplit=1)[-1]
+        route_path = f"{DASHBOARD_UPLOAD_ROUTE_PREFIX}/{{upload_key}}"
+        route = next(
+            route
+            for route in getattr(dashboard_app.router, "routes", [])
+            if getattr(route, "path", None) == route_path
+        )
+
+        response = asyncio.run(route.endpoint(upload_key, FakeRequest([])))  # type: ignore[attr-defined]
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(widget.handled_files, [])
+
+    def test_dashboard_directory_upload_route_rejects_basename_only_metadata(
+        self,
+    ) -> None:
+        widget = FakeDashboardUploadWidget("client-dir-route", "upload-dir-route")
+        upload_url = register_dashboard_upload_handler(
+            widget,
+            lambda _text: None,
+            require_directory_paths=True,
+        )
+        upload_key = upload_url.rsplit("/", maxsplit=1)[-1]
+        route_path = f"{DASHBOARD_UPLOAD_ROUTE_PREFIX}/{{upload_key}}"
+        route = next(
+            route
+            for route in getattr(dashboard_app.router, "routes", [])
+            if getattr(route, "path", None) == route_path
+        )
+
+        response = asyncio.run(
+            route.endpoint(  # type: ignore[attr-defined]
+                upload_key,
+                FakeRequest(
+                    [
+                        (DASHBOARD_UPLOAD_ARTIFACT_PATH_FIELD, "plan.json"),
+                        (DASHBOARD_UPLOAD_ARTIFACT_PATH_FIELD, "plan.json"),
+                        ("plan.json", FakeStarletteUpload("plan.json")),
+                        ("plan.json", FakeStarletteUpload("plan.json")),
+                    ]
+                ),
+            )
+        )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(widget.handled_files, [])
+
+    def test_dashboard_upload_route_rejects_unknown_upload_key(self) -> None:
+        register_dashboard_upload_handler(
+            FakeDashboardUploadWidget("client-known", "upload-known"),
+            lambda _text: None,
+        )
+        route_path = f"{DASHBOARD_UPLOAD_ROUTE_PREFIX}/{{upload_key}}"
+        route = next(
+            route
+            for route in getattr(dashboard_app.router, "routes", [])
+            if getattr(route, "path", None) == route_path
+        )
+
+        response = asyncio.run(route.endpoint("missing-upload-key", FakeRequest([])))  # type: ignore[attr-defined]
+
+        self.assertEqual(response.status_code, 404)
+
+    def test_apply_upload_widget_state_updates_all_upload_widgets(self) -> None:
+        file_widget = FakeUploadWidget()
+        directory_widget = FakeUploadWidget()
+
+        apply_upload_widget_state((file_widget, directory_widget), enabled=False)
+
+        self.assertFalse(file_widget.enabled)
+        self.assertFalse(directory_widget.enabled)
+
+        apply_upload_widget_state((file_widget, directory_widget), enabled=True)
+
+        self.assertTrue(file_widget.enabled)
+        self.assertTrue(directory_widget.enabled)
+
+    def test_reset_upload_widgets_updates_all_upload_widgets(self) -> None:
+        file_widget = FakeUploadWidget()
+        directory_widget = FakeUploadWidget()
+
+        reset_upload_widgets((file_widget, directory_widget, None))
+
+        self.assertEqual(file_widget.reset_count, 1)
+        self.assertEqual(directory_widget.reset_count, 1)
 
     def test_run_uploaded_analysis_uses_shared_pipeline_with_dashboard_audit_context(
         self,

--- a/ui/components/context_completeness_panel.py
+++ b/ui/components/context_completeness_panel.py
@@ -79,6 +79,24 @@ def _context_todo_items(value: object) -> list[str]:
     return [str(item).strip() for item in value if str(item).strip()]
 
 
+def _context_list_items(value: object) -> list[str]:
+    if not isinstance(value, list | tuple):
+        return []
+    return [str(item).strip() for item in value if str(item).strip()]
+
+
+def _owner_signal_items(value: object) -> list[dict]:
+    if not isinstance(value, list | tuple):
+        return []
+    signals: list[dict] = []
+    for item in value:
+        if isinstance(item, dict):
+            subject = str(item.get("subject") or "").strip()
+            if subject:
+                signals.append(item)
+    return signals
+
+
 def _context_warning_action(context: dict, link_target: str) -> tuple[str, str]:
     todos = " ".join(
         item.lower() for item in _context_todo_items(context.get("context_todos"))
@@ -90,6 +108,8 @@ def _context_warning_action(context: dict, link_target: str) -> tuple[str, str]:
     parser_success_rate = context_number(context.get("parser_success_rate"), 1.0)
     if "parser" in todos or parser_success_rate < 1.0:
         return "Review artifacts", "#context-todos"
+    if "ownership" in todos or "codeowners" in todos:
+        return "Review ownership", "#ownership-context"
     incident_index_size = _context_int(context, "incident_index_size")
     if incident_index_size == 0 or "incident" in todos:
         return "Review incidents", "#context-todos"
@@ -106,6 +126,8 @@ def _todo_guidance(todo: str, link_target: str) -> tuple[str, str]:
         return "Evidence model guide", f"{DOCS_BASE_URL}/docs/evidence-model.md"
     if "parser" in todo_text or "artifact" in todo_text:
         return "Report schema guide", f"{DOCS_BASE_URL}/docs/schemas/report-v2.md"
+    if "ownership" in todo_text or "codeowners" in todo_text:
+        return "Ownership context guide", f"{DOCS_BASE_URL}/docs/schemas/report-v2.md"
     return "Report context guide", f"{DOCS_BASE_URL}/docs/schemas/report-v2.md"
 
 
@@ -124,6 +146,9 @@ def _render_todo_item(todo: str, link_target: str) -> None:
 def _has_context_followups(context: dict) -> bool:
     return (
         bool(_context_todo_items(context.get("context_todos")))
+        or bool(_owner_signal_items(context.get("owner_signals")))
+        or bool(_context_list_items(context.get("escalation_hints")))
+        or bool(_context_list_items(context.get("ownership_unmapped_subjects")))
         or bool(str(context.get("uncertainty") or "").strip())
         or bool(context.get("insufficient_context"))
         or context_score(context) < 0.7
@@ -144,6 +169,9 @@ def render_context_summary_panel(
     if not _has_context_followups(details):
         return
     context_todos = _context_todo_items(details.get("context_todos"))
+    owner_signals = _owner_signal_items(details.get("owner_signals"))
+    escalation_hints = _context_list_items(details.get("escalation_hints"))
+    unmapped_subjects = _context_list_items(details.get("ownership_unmapped_subjects"))
     uncertainty = str(details.get("uncertainty") or "").strip()
     score = context_score(details)
 
@@ -169,7 +197,27 @@ def render_context_summary_panel(
                 with ui.column().classes("w-full gap-2"):
                     for todo in context_todos[:4]:
                         _render_todo_item(todo, link_target)
-            else:
+            has_ownership_summary = bool(
+                owner_signals or escalation_hints or unmapped_subjects
+            )
+            if has_ownership_summary:
+                ui.label("Ownership context").classes("text-sm font-semibold dw-text")
+                with ui.column().classes("w-full gap-2"):
+                    for signal in owner_signals[:3]:
+                        owners = _context_list_items(signal.get("owners"))
+                        owner_text = ", ".join(owners) if owners else "Unowned"
+                        subject = str(signal.get("subject") or "").strip()
+                        if subject:
+                            ui.label(f"Owner: {subject} -> {owner_text}").classes(
+                                "text-xs dw-muted leading-5"
+                            )
+                    for hint in escalation_hints[:3]:
+                        ui.label(hint).classes("text-xs dw-muted leading-5")
+                    for subject in unmapped_subjects[:3]:
+                        ui.label(f"Missing owner: {subject}").classes(
+                            "text-xs dw-muted leading-5"
+                        )
+            if not context_todos and not has_ownership_summary:
                 ui.label("No context TODOs were generated.").classes("text-xs dw-muted")
 
 
@@ -188,6 +236,9 @@ def render_context_completeness_panel(
         else {}
     )
     context_todos = _context_todo_items(details.get("context_todos"))
+    owner_signals = _owner_signal_items(details.get("owner_signals"))
+    escalation_hints = _context_list_items(details.get("escalation_hints"))
+    unmapped_subjects = _context_list_items(details.get("ownership_unmapped_subjects"))
     uncertainty = str(details.get("uncertainty") or "").strip()
     score = context_score(details)
     low_context = bool(details.get("insufficient_context")) or score < 0.7
@@ -291,6 +342,43 @@ def render_context_completeness_panel(
                         ui.label(
                             "No context follow-up actions were generated."
                         ).classes("text-xs dw-muted")
+
+        if owner_signals or escalation_hints or unmapped_subjects:
+            with ui.card().classes("w-full dw-panel-soft shadow-none mt-3"):
+                with ui.column().classes("gap-2 p-3"):
+                    ui.label("Ownership context").props("id=ownership-context").classes(
+                        "text-sm font-semibold dw-text"
+                    )
+                    if owner_signals:
+                        with ui.column().classes("w-full gap-2"):
+                            for signal in owner_signals:
+                                owners = _context_list_items(signal.get("owners"))
+                                owner_text = ", ".join(owners) if owners else "Unowned"
+                                scope = str(signal.get("scope") or "ownership").title()
+                                subject = str(signal.get("subject") or "").strip()
+                                source = str(
+                                    signal.get("source_ref")
+                                    or signal.get("source")
+                                    or ""
+                                ).strip()
+                                detail = f"{scope}: {subject} -> {owner_text}"
+                                if source:
+                                    detail = f"{detail} ({source})"
+                                ui.label(detail).classes("text-xs dw-muted leading-5")
+                    if escalation_hints:
+                        ui.label("Escalation hints").classes(
+                            "text-xs font-semibold dw-text"
+                        )
+                        for hint in escalation_hints:
+                            ui.label(hint).classes("text-xs dw-muted leading-5")
+                    if unmapped_subjects:
+                        ui.label("Missing ownership").classes(
+                            "text-xs font-semibold dw-text"
+                        )
+                        for subject in unmapped_subjects:
+                            ui.label(f"Missing owner: {subject}").classes(
+                                "text-xs dw-muted leading-5"
+                            )
 
         with ui.card().classes("w-full dw-panel-soft shadow-none mt-3"):
             with ui.column().classes("gap-2 p-3"):

--- a/ui/components/upload_panel.py
+++ b/ui/components/upload_panel.py
@@ -2,10 +2,15 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable
+import secrets
+from collections.abc import Callable, Iterable
 from typing import Any
 
-from nicegui import events, run, ui
+from nicegui import app, core, events, run, ui
+from nicegui.elements.upload_files import SmallFileUpload
+from starlette.datastructures import UploadFile as StarletteUploadFile
+from starlette.requests import Request
+from starlette.responses import JSONResponse
 
 from analysis.blast_radius import BlastRadiusResult
 from analysis.incident_matcher import IncidentMatch
@@ -17,6 +22,9 @@ from services.intake_service import (
     build_pending_analysis,
     is_sensitive_file,
     total_upload_bytes,
+    trusted_artifact_path_binding_is_ambiguous,
+    trusted_artifact_path_matches_filename,
+    trusted_relative_artifact_path,
     uniquify_artifact_names,
 )
 from services.project_service import (
@@ -74,6 +82,16 @@ STATUS_STYLES = {
     "unsupported": "color: #d8a432;",
     "sensitive": "color: #cf3f3f;",
 }
+DASHBOARD_UPLOAD_ARTIFACT_PATH_FIELD = "artifact_paths"
+DASHBOARD_UPLOAD_ACCEPT = ".json,.yaml,.yml,.tf,.tfvars,.hcl,Jenkinsfile,CODEOWNERS"
+DASHBOARD_DIRECTORY_UPLOAD_SELECTOR = '[data-dw-dashboard-directory-upload="1"]'
+DASHBOARD_UPLOAD_ROUTE_PREFIX = "/_deploywhisper/dashboard-upload"
+DASHBOARD_UPLOAD_ROUTE_PATH = f"{DASHBOARD_UPLOAD_ROUTE_PREFIX}/{{upload_key}}"
+DASHBOARD_UPLOAD_READ_CHUNK_BYTES = 1_048_576
+_DASHBOARD_UPLOAD_HANDLERS: dict[str, tuple[object, Callable[[str], None], bool]] = {}
+_DASHBOARD_UPLOAD_WIDGET_KEYS: dict[tuple[str, str], str] = {}
+_DASHBOARD_UPLOAD_ROUTE_REGISTERED = False
+_DASHBOARD_UPLOAD_MAX_WIDGETS_PER_CLIENT = 2
 ORANGE = "#ff6900"
 ORANGE_BUTTON_STYLE = (
     f"background:{ORANGE};color:#fff;border-radius:12px;font-weight:700;"
@@ -94,6 +112,378 @@ def process_uploaded_files(
         (name, raw_content) for name, raw_content in normalized_uploads
     )
     return build_pending_analysis(current_files)
+
+
+def reset_upload_widgets(upload_widgets: Iterable[object | None]) -> None:
+    """Reset every available dashboard upload widget."""
+    for upload_widget in upload_widgets:
+        reset = getattr(upload_widget, "reset", None)
+        if callable(reset):
+            reset()
+
+
+def dashboard_upload_artifact_path_form_fields_prop(
+    field_name: str = DASHBOARD_UPLOAD_ARTIFACT_PATH_FIELD,
+) -> str:
+    """Return Quasar uploader prop for browser-provided relative path metadata."""
+    return (
+        ':form-fields="files => files.map(file => ({ '
+        f"name: '{field_name}', "
+        "value: file.webkitRelativePath || file.relativePath || file.name || '' "
+        '}))"'
+    )
+
+
+def dashboard_upload_field_name_prop() -> str:
+    """Return Quasar uploader prop that binds file parts to browser paths."""
+    return (
+        ':field-name="file => '
+        "file.webkitRelativePath || file.relativePath || file.name || 'files'"
+        '"'
+    )
+
+
+def configure_dashboard_upload_widget(
+    upload_widget: object, *, upload_url: str, enable_directory: bool = False
+) -> object:
+    """Configure the dashboard uploader to preserve repo-relative browser paths."""
+    props = getattr(upload_widget, "_props", None)
+    if isinstance(props, dict):
+        props["url"] = upload_url
+    upload_widget.props(f"accept={DASHBOARD_UPLOAD_ACCEPT}")
+    if enable_directory:
+        upload_widget.props('data-dw-dashboard-directory-upload="1"')
+    upload_widget.props(dashboard_upload_field_name_prop())
+    upload_widget.props(dashboard_upload_artifact_path_form_fields_prop())
+    return upload_widget
+
+
+def _dashboard_upload_route_exists() -> bool:
+    return any(
+        getattr(route, "path", None) == DASHBOARD_UPLOAD_ROUTE_PATH
+        and "POST" in getattr(route, "methods", set())
+        for route in getattr(app.router, "routes", [])
+    )
+
+
+def _ensure_dashboard_upload_route_registered() -> None:
+    global _DASHBOARD_UPLOAD_ROUTE_REGISTERED
+    if _DASHBOARD_UPLOAD_ROUTE_REGISTERED or _dashboard_upload_route_exists():
+        _DASHBOARD_UPLOAD_ROUTE_REGISTERED = True
+        return
+
+    @app.post(DASHBOARD_UPLOAD_ROUTE_PATH, response_model=None)
+    async def dashboard_upload_route(
+        upload_key: str, request: Request
+    ) -> dict[str, str] | JSONResponse:
+        handler = _DASHBOARD_UPLOAD_HANDLERS.get(upload_key)
+        if handler is None:
+            return JSONResponse({"upload": "unknown"}, status_code=404)
+        upload_widget, set_upload_error, require_directory_paths = handler
+        try:
+            files = await dashboard_file_uploads_from_request(
+                request,
+                require_directory_paths=require_directory_paths,
+            )
+        except ValueError as exc:
+            if "upload size exceeds" in str(exc):
+                set_upload_error(
+                    "Total upload size exceeds the 50 MB analysis-session limit. Remove some artifacts and try again."
+                )
+                return JSONResponse({"upload": "too_large"}, status_code=413)
+            set_upload_error(
+                "Upload metadata did not match the selected files. Select the artifacts again."
+            )
+            return JSONResponse({"upload": "metadata_error"}, status_code=400)
+        await upload_widget.handle_uploads(files)
+        return {"upload": "success"}
+
+    _DASHBOARD_UPLOAD_ROUTE_REGISTERED = True
+
+
+def register_dashboard_upload_handler(
+    upload_widget: object,
+    set_upload_error: Callable[[str], None],
+    *,
+    require_directory_paths: bool = False,
+) -> str:
+    """Register an upload widget handler behind the stable dashboard upload route."""
+    _ensure_dashboard_upload_route_registered()
+    client_id = str(getattr(getattr(upload_widget, "client", None), "id", "client"))
+    widget_identity = (
+        client_id,
+        str(getattr(upload_widget, "id", "upload")),
+    )
+    _drop_stale_dashboard_upload_client_widgets(
+        client_id, keep_identity=widget_identity
+    )
+    previous_key = _DASHBOARD_UPLOAD_WIDGET_KEYS.pop(widget_identity, None)
+    if previous_key is not None:
+        _DASHBOARD_UPLOAD_HANDLERS.pop(previous_key, None)
+    upload_key = secrets.token_urlsafe(32)
+    while upload_key in _DASHBOARD_UPLOAD_HANDLERS:
+        upload_key = secrets.token_urlsafe(32)
+    _DASHBOARD_UPLOAD_WIDGET_KEYS[widget_identity] = upload_key
+    _DASHBOARD_UPLOAD_HANDLERS[upload_key] = (
+        upload_widget,
+        set_upload_error,
+        require_directory_paths,
+    )
+    return f"{DASHBOARD_UPLOAD_ROUTE_PREFIX}/{upload_key}"
+
+
+def _drop_stale_dashboard_upload_client_widgets(
+    client_id: str,
+    *,
+    keep_identity: tuple[str, str],
+) -> None:
+    active_identities = [
+        identity
+        for identity in _DASHBOARD_UPLOAD_WIDGET_KEYS
+        if identity[0] == client_id and identity != keep_identity
+    ]
+    if len(active_identities) < _DASHBOARD_UPLOAD_MAX_WIDGETS_PER_CLIENT:
+        return
+    for identity in active_identities:
+        stale_key = _DASHBOARD_UPLOAD_WIDGET_KEYS.pop(identity, None)
+        if stale_key is not None:
+            _DASHBOARD_UPLOAD_HANDLERS.pop(stale_key, None)
+
+
+def unregister_dashboard_upload_handler(upload_url_or_key: str) -> None:
+    """Remove a dashboard upload handler registered for a widget."""
+    upload_key = str(upload_url_or_key or "").rsplit("/", maxsplit=1)[-1]
+    handler = _DASHBOARD_UPLOAD_HANDLERS.pop(upload_key, None)
+    if handler is None:
+        return
+    upload_widget, _, _ = handler
+    widget_identity = (
+        str(getattr(getattr(upload_widget, "client", None), "id", "client")),
+        str(getattr(upload_widget, "id", "upload")),
+    )
+    if _DASHBOARD_UPLOAD_WIDGET_KEYS.get(widget_identity) == upload_key:
+        _DASHBOARD_UPLOAD_WIDGET_KEYS.pop(widget_identity, None)
+
+
+def _register_dashboard_upload_disconnect_cleanup(upload_urls: Iterable[str]) -> None:
+    client = getattr(ui.context, "client", None)
+    on_disconnect = getattr(client, "on_disconnect", None)
+    if not callable(on_disconnect):
+        return
+    for upload_url in upload_urls:
+        on_disconnect(lambda url=upload_url: unregister_dashboard_upload_handler(url))
+
+
+def dashboard_upload_directory_javascript(
+    selector: str = DASHBOARD_DIRECTORY_UPLOAD_SELECTOR,
+) -> str:
+    """Return browser script that enables directory selection on Quasar's file input."""
+    return f"""
+(() => {{
+  const applyDirectoryUploadAttrs = () => {{
+    document
+      .querySelectorAll('{selector} input[type="file"]')
+      .forEach((input) => {{
+        input.setAttribute('webkitdirectory', '');
+        input.setAttribute('directory', '');
+      }});
+  }};
+  if (window.__dwDashboardUploadDirectoryObserver) {{
+    window.__dwDashboardUploadDirectoryObserver.disconnect();
+  }}
+  applyDirectoryUploadAttrs();
+  window.__dwDashboardUploadDirectoryObserver = new MutationObserver(
+    applyDirectoryUploadAttrs
+  );
+  window.__dwDashboardUploadDirectoryObserver.observe(document.body, {{
+    childList: true,
+    subtree: true,
+  }});
+}})();
+"""
+
+
+def _dashboard_artifact_paths_are_basename_fallbacks(
+    trusted_paths: Iterable[str],
+    uploads: Iterable[tuple[str, StarletteUploadFile]],
+) -> bool:
+    paths = list(trusted_paths)
+    if not paths or any("/" in path for path in paths):
+        return False
+    upload_names = [
+        str(getattr(upload, "filename", "") or "").replace("\\", "/").rsplit("/", 1)[-1]
+        for _, upload in uploads
+    ]
+    return paths == upload_names
+
+
+async def dashboard_file_uploads_from_request(
+    request: Request,
+    *,
+    require_directory_paths: bool = False,
+) -> list[object]:
+    """Create NiceGUI upload files while preserving submitted artifact path metadata."""
+    uploads: list[tuple[str, StarletteUploadFile]] = []
+    artifact_paths: list[str] = []
+    async with request.form() as form:
+        for field_name, value in form.multi_items():
+            if field_name == DASHBOARD_UPLOAD_ARTIFACT_PATH_FIELD and isinstance(
+                value, str
+            ):
+                artifact_paths.append(str(value))
+            elif not isinstance(value, str):
+                uploads.append((field_name, value))
+        if not uploads:
+            raise ValueError("upload must include files")
+        if artifact_paths and len(artifact_paths) != len(uploads):
+            raise ValueError("artifact path metadata must match uploaded files")
+
+        field_paths: list[str | None] = []
+        binding_names: list[object] = []
+        for field_name, upload in uploads:
+            field_path = trusted_relative_artifact_path(field_name)
+            upload_filename = getattr(upload, "filename", None)
+            if field_path is not None and trusted_artifact_path_matches_filename(
+                field_path,
+                upload_filename,
+            ):
+                field_paths.append(field_path)
+                binding_names.append(field_path)
+            else:
+                field_paths.append(None)
+                binding_names.append(upload_filename)
+        if any(path is None for path in field_paths) and any(
+            path is not None for path in field_paths
+        ):
+            raise ValueError("artifact path metadata must match uploaded files")
+
+        trusted_paths: list[str] = []
+        basename_fallback = False
+        if artifact_paths:
+            artifact_path_set: set[str] = set()
+            for artifact_path in artifact_paths:
+                trusted_path = trusted_relative_artifact_path(artifact_path)
+                if trusted_path is None:
+                    raise ValueError("artifact path metadata must match uploaded files")
+                artifact_path_set.add(trusted_path)
+                trusted_paths.append(trusted_path)
+            bound_field_paths = [path for path in field_paths if path is not None]
+            basename_fallback = _dashboard_artifact_paths_are_basename_fallbacks(
+                trusted_paths,
+                uploads,
+            )
+            if bound_field_paths:
+                if not basename_fallback and (
+                    len(bound_field_paths) != len(uploads)
+                    or artifact_path_set != set(bound_field_paths)
+                    or len(artifact_path_set) != len(bound_field_paths)
+                ):
+                    raise ValueError("artifact path metadata must match uploaded files")
+                if not basename_fallback:
+                    trusted_paths = [path or "" for path in field_paths]
+            else:
+                for index, trusted_path in enumerate(trusted_paths):
+                    _, upload = uploads[index]
+                    if not trusted_artifact_path_matches_filename(
+                        trusted_path,
+                        getattr(upload, "filename", None),
+                    ):
+                        raise ValueError(
+                            "artifact path metadata must match uploaded files"
+                        )
+            if trusted_artifact_path_binding_is_ambiguous(
+                trusted_paths,
+                binding_names,
+            ):
+                if basename_fallback:
+                    if require_directory_paths:
+                        raise ValueError(
+                            "directory path metadata must include relative paths"
+                        )
+                    trusted_paths = []
+                else:
+                    raise ValueError(
+                        "artifact path metadata is ambiguous for duplicate paths"
+                    )
+        elif all(path is not None for path in field_paths):
+            trusted_paths = [path or "" for path in field_paths]
+            if trusted_artifact_path_binding_is_ambiguous(
+                trusted_paths,
+                binding_names,
+            ):
+                raise ValueError(
+                    "artifact path metadata is ambiguous for duplicate paths"
+                )
+
+        files: list[object] = []
+        upload_bytes = 0
+        for index, (_, upload) in enumerate(uploads):
+            file_upload = await dashboard_create_file_upload(
+                upload,
+                max_bytes=MAX_TOTAL_UPLOAD_BYTES - upload_bytes,
+            )
+            upload_bytes += len(getattr(file_upload, "_data", b""))
+            if trusted_paths:
+                setattr(file_upload, "relative_path", trusted_paths[index])
+            files.append(file_upload)
+        return files
+
+
+async def _read_dashboard_upload_data(upload: object, *, max_bytes: int) -> bytes:
+    read = getattr(upload, "read", None)
+    if not callable(read):
+        return b""
+    chunks: list[bytes] = []
+    total_bytes = 0
+    while True:
+        try:
+            chunk = await read(DASHBOARD_UPLOAD_READ_CHUNK_BYTES)
+        except TypeError:
+            chunk = await read()
+            total_bytes += len(chunk)
+            if total_bytes > max_bytes:
+                raise ValueError("upload size exceeds analysis-session limit")
+            return chunk
+        if not chunk:
+            break
+        total_bytes += len(chunk)
+        if total_bytes > max_bytes:
+            raise ValueError("upload size exceeds analysis-session limit")
+        chunks.append(chunk)
+    return b"".join(chunks)
+
+
+async def dashboard_create_file_upload(
+    upload: object,
+    *,
+    max_bytes: int = MAX_TOTAL_UPLOAD_BYTES,
+) -> SmallFileUpload:
+    """Create an in-memory NiceGUI upload object without closing metadata first."""
+    filename = str(getattr(upload, "filename", "") or "artifact.bin")
+    content_type = str(getattr(upload, "content_type", "") or "")
+    close = getattr(upload, "close", None)
+    try:
+        data = await _read_dashboard_upload_data(upload, max_bytes=max_bytes)
+    finally:
+        if callable(close):
+            await close()
+    return SmallFileUpload(
+        filename.rsplit("/", 1)[-1].rsplit("\\", 1)[-1], content_type, data
+    )
+
+
+def uploaded_file_artifact_name(uploaded_file: object) -> str:
+    """Return the richest browser-provided artifact name for ownership matching."""
+    for attr_name in (
+        "relative_path",
+        "webkit_relative_path",
+        "webkitRelativePath",
+    ):
+        value = getattr(uploaded_file, attr_name, None)
+        trusted_path = trusted_relative_artifact_path(value)
+        if trusted_path is not None:
+            return trusted_path
+    return str(getattr(uploaded_file, "name", "") or "artifact.bin")
 
 
 def _accepted_files(files: list[tuple[str, bytes]]) -> list[tuple[str, bytes]]:
@@ -170,6 +560,20 @@ def uploads_allowed(active_project_key: str | None) -> bool:
     return bool(active_project_key)
 
 
+def apply_upload_widget_state(
+    upload_widgets: tuple[object | None, ...],
+    *,
+    enabled: bool,
+) -> None:
+    """Enable or disable every dashboard upload widget in lockstep."""
+    for upload_widget in upload_widgets:
+        if upload_widget is None:
+            continue
+        action = getattr(upload_widget, "enable" if enabled else "disable", None)
+        if callable(action):
+            action()
+
+
 def should_clear_pending_uploads(
     *,
     current_file_count: int,
@@ -241,7 +645,7 @@ def build_upload_panel(
         "is_running": False,
         "progress_value": 0,
         "progress_message": "Waiting to analyze",
-        "result_token": 0,
+        "result_counter": 0,
         "active_result": None,
         "projects": projects,
         "active_project_id": initial_project_id,
@@ -302,12 +706,11 @@ def build_upload_panel(
             )
 
     def sync_upload_widget_state() -> None:
-        if upload_widget is None:
-            return
-        if uploads_allowed(state["active_project_key"]):
-            upload_widget.enable()
-        else:
-            upload_widget.disable()
+        apply_upload_widget_state(
+            (upload_widget, directory_upload_widget),
+            enabled=uploads_allowed(state["active_project_key"])
+            and not state["is_running"],
+        )
 
     def refresh_projects(
         *,
@@ -367,8 +770,7 @@ def build_upload_panel(
                 state["files"] = []
                 state["summary"] = build_pending_analysis([])
                 upload_error.set_text("Re-upload artifacts after switching projects.")
-                if upload_widget is not None:
-                    upload_widget.reset()
+                reset_upload_widgets((upload_widget, directory_upload_widget))
             refresh_projects(selected_project_id=selected_id, notify_parent=True)
             render_summary()
             render_actions()
@@ -403,7 +805,7 @@ def build_upload_panel(
             ui.html("<span>Create project</span>")
 
     def clear_result_if_current(token: int) -> None:
-        if token != state["result_token"]:
+        if token != state["result_counter"]:
             return
         state["active_result"] = None
         result_mount.clear()
@@ -411,8 +813,8 @@ def build_upload_panel(
     def render_result_card(
         report: dict, *, remaining_seconds: int | None = None, parse_batch=None
     ) -> None:
-        token = int(state["result_token"]) + 1
-        state["result_token"] = token
+        token = int(state["result_counter"]) + 1
+        state["result_counter"] = token
         state["active_result"] = report
         result_mount.clear()
         countdown_label = None
@@ -429,7 +831,7 @@ def build_upload_panel(
         }
 
         def update_countdown() -> None:
-            if token != state["result_token"]:
+            if token != state["result_counter"]:
                 return
             if timer_state["remaining"] <= 0:
                 clear_result_if_current(token)
@@ -690,7 +1092,7 @@ def build_upload_panel(
             return
 
         state["is_running"] = True
-        upload_widget.disable()
+        sync_upload_widget_state()
         render_actions()
         update_progress(5, "Preparing analysis")
 
@@ -730,7 +1132,7 @@ def build_upload_panel(
             )
             state["files"] = []
             state["summary"] = build_pending_analysis([])
-            upload_widget.reset()
+            reset_upload_widgets((upload_widget, directory_upload_widget))
             render_summary()
             if parse_batch.has_partial_context:
                 ui.notify(
@@ -842,7 +1244,7 @@ def build_upload_panel(
                     "Total upload size exceeds the 50 MB analysis-session limit. Remove some artifacts and try again."
                 )
                 return
-            uploads.append((uploaded_file.name, content))
+            uploads.append((uploaded_file_artifact_name(uploaded_file), content))
         state["summary"] = process_uploaded_files(state["files"], uploads)
         render_summary()
 
@@ -852,19 +1254,45 @@ def build_upload_panel(
         )
 
     upload_widget = None
+    directory_upload_widget = None
     with upload_card:
-        upload_widget = (
-            ui.upload(
-                on_multi_upload=handle_multi_upload,
-                on_rejected=handle_rejected,
-                auto_upload=True,
-                multiple=True,
-                label="Select deployment artifacts",
-                max_file_size=50_000_000,
-            )
-            .props("accept=.json,.yaml,.yml,.tf,.tfvars,.hcl,Jenkinsfile")
-            .classes("w-full")
-        )
+        upload_widget = ui.upload(
+            on_multi_upload=handle_multi_upload,
+            on_rejected=handle_rejected,
+            auto_upload=True,
+            multiple=True,
+            label="Select deployment artifacts",
+            max_file_size=50_000_000,
+        ).classes("w-full")
+        directory_upload_widget = ui.upload(
+            on_multi_upload=handle_multi_upload,
+            on_rejected=handle_rejected,
+            auto_upload=True,
+            multiple=True,
+            label="Select artifact directory",
+            max_file_size=50_000_000,
+        ).classes("w-full")
+    dashboard_upload_url = register_dashboard_upload_handler(
+        upload_widget,
+        upload_error.set_text,
+    )
+    configure_dashboard_upload_widget(upload_widget, upload_url=dashboard_upload_url)
+
+    dashboard_directory_upload_url = register_dashboard_upload_handler(
+        directory_upload_widget,
+        upload_error.set_text,
+        require_directory_paths=True,
+    )
+    configure_dashboard_upload_widget(
+        directory_upload_widget,
+        upload_url=dashboard_directory_upload_url,
+        enable_directory=True,
+    )
+    _register_dashboard_upload_disconnect_cleanup(
+        (dashboard_upload_url, dashboard_directory_upload_url)
+    )
+    if core.loop is not None:
+        ui.run_javascript(dashboard_upload_directory_javascript())
 
     refresh_projects()
     render_summary()

--- a/ui/components/upload_panel.py
+++ b/ui/components/upload_panel.py
@@ -25,6 +25,7 @@ from services.intake_service import (
     trusted_artifact_path_binding_is_ambiguous,
     trusted_artifact_path_matches_filename,
     trusted_relative_artifact_path,
+    untrusted_upload_filename,
     uniquify_artifact_names,
 )
 from services.project_service import (
@@ -337,6 +338,12 @@ async def dashboard_file_uploads_from_request(
             raise ValueError("upload must include files")
         if artifact_paths and len(artifact_paths) != len(uploads):
             raise ValueError("artifact path metadata must match uploaded files")
+        if require_directory_paths and not artifact_paths:
+            raise ValueError("directory path metadata must include relative paths")
+        if not artifact_paths and any(
+            "/" in str(field_name or "").replace("\\", "/") for field_name, _ in uploads
+        ):
+            raise ValueError("artifact path metadata must match uploaded files")
 
         field_paths: list[str | None] = []
         binding_names: list[object] = []
@@ -365,6 +372,10 @@ async def dashboard_file_uploads_from_request(
                 trusted_path = trusted_relative_artifact_path(artifact_path)
                 if trusted_path is None:
                     raise ValueError("artifact path metadata must match uploaded files")
+                if require_directory_paths and "/" not in trusted_path:
+                    raise ValueError(
+                        "directory path metadata must include relative paths"
+                    )
                 artifact_path_set.add(trusted_path)
                 trusted_paths.append(trusted_path)
             bound_field_paths = [path for path in field_paths if path is not None]
@@ -372,7 +383,24 @@ async def dashboard_file_uploads_from_request(
                 trusted_paths,
                 uploads,
             )
+            if (
+                basename_fallback
+                and bound_field_paths
+                and any(
+                    field_paths[index] is not None
+                    and field_paths[index] != trusted_paths[index]
+                    for index in range(len(uploads))
+                )
+            ):
+                raise ValueError("artifact path metadata must match uploaded files")
+            if basename_fallback and any(
+                path.rsplit("/", maxsplit=1)[-1] == "CODEOWNERS"
+                for path in trusted_paths
+            ):
+                trusted_paths = []
             if bound_field_paths:
+                if basename_fallback and require_directory_paths:
+                    raise ValueError("artifact path metadata must match uploaded files")
                 if not basename_fallback and (
                     len(bound_field_paths) != len(uploads)
                     or artifact_path_set != set(bound_field_paths)
@@ -405,19 +433,9 @@ async def dashboard_file_uploads_from_request(
                     raise ValueError(
                         "artifact path metadata is ambiguous for duplicate paths"
                     )
-        elif all(path is not None for path in field_paths):
-            trusted_paths = [path or "" for path in field_paths]
-            if trusted_artifact_path_binding_is_ambiguous(
-                trusted_paths,
-                binding_names,
-            ):
-                raise ValueError(
-                    "artifact path metadata is ambiguous for duplicate paths"
-                )
-
         files: list[object] = []
         upload_bytes = 0
-        for index, (_, upload) in enumerate(uploads):
+        for index, (field_name, upload) in enumerate(uploads):
             file_upload = await dashboard_create_file_upload(
                 upload,
                 max_bytes=MAX_TOTAL_UPLOAD_BYTES - upload_bytes,
@@ -425,6 +443,22 @@ async def dashboard_file_uploads_from_request(
             upload_bytes += len(getattr(file_upload, "_data", b""))
             if trusted_paths:
                 setattr(file_upload, "relative_path", trusted_paths[index])
+            else:
+                field_name_text = str(field_name or "").replace("\\", "/")
+                upload_filename = getattr(upload, "filename", None)
+                upload_filename_leaf = (
+                    str(upload_filename or "")
+                    .replace("\\", "/")
+                    .rsplit("/", maxsplit=1)[-1]
+                )
+                field_name_leaf = field_name_text.rsplit("/", maxsplit=1)[-1]
+                upload_name = (
+                    field_name
+                    if "/" in field_name_text
+                    and field_name_leaf == upload_filename_leaf
+                    else upload_filename
+                )
+                file_upload.name = untrusted_upload_filename(upload_name)
             files.append(file_upload)
         return files
 
@@ -483,7 +517,7 @@ def uploaded_file_artifact_name(uploaded_file: object) -> str:
         trusted_path = trusted_relative_artifact_path(value)
         if trusted_path is not None:
             return trusted_path
-    return str(getattr(uploaded_file, "name", "") or "artifact.bin")
+    return untrusted_upload_filename(getattr(uploaded_file, "name", None))
 
 
 def _accepted_files(files: list[tuple[str, bytes]]) -> list[tuple[str, bytes]]:


### PR DESCRIPTION
## Summary
- Preserve trusted repo-relative artifact paths only when API/dashboard metadata can be bound to uploaded files
- Keep untrusted CODEOWNERS and path-like upload names out of authoritative ownership discovery
- Preserve reviewer-facing missing ownership TODOs while allowing service ownership to satisfy only the resolved unsafe upload occurrence

## Validation
- ./.venv/bin/python -m unittest tests.test_api.test_analyses tests.test_services.test_intake_service tests.test_services.test_ownership_service tests.test_services.test_analysis_service tests.test_ui.test_upload_panel -q
- ./.venv/bin/ruff check .
- ./.venv/bin/ruff format --check .
- ./.venv/bin/python -m unittest discover -q
- bash scripts/ci-local.sh
- APP_PORT=18118 npm run test:ui-review

## Review
- BMad code review rerun completed for Story 7.4
- Blind Hunter findings triaged as false positives/already covered
- Acceptance Auditor: no actionable findings
- Edge Case Hunter timed out after two waits; no completed output