### PR TITLE
Story 7.5 context graph freshness ledger

### DIFF
--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -1,5 +1,5 @@
 # generated: 2026-05-01
-# last_updated: 2026-06-17
+# last_updated: 2026-06-18
 # project: deploywhisper
 # project_key: NOKEY
 # tracking_system: file-system
@@ -35,7 +35,7 @@
 # - Dev moves story to review, then runs code-review
 
 generated: 2026-05-01
-last_updated: 2026-06-17
+last_updated: 2026-06-18
 project: deploywhisper
 project_key: NOKEY
 tracking_system: file-system
@@ -114,7 +114,7 @@ development_status:
   7-2-terraform-state-connector: done
   7-3-kubernetes-live-state-connector: done
   7-4-codeowners-and-ownership-mapping: done
-  7-5-context-graph-and-freshness-ledger: done
+  7-5-context-graph-and-freshness-ledger: review
   epic-7-retrospective: optional
 
   epic-8: in-progress

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -1,5 +1,5 @@
 # generated: 2026-05-01
-# last_updated: 2026-06-15
+# last_updated: 2026-06-17
 # project: deploywhisper
 # project_key: NOKEY
 # tracking_system: file-system
@@ -35,7 +35,7 @@
 # - Dev moves story to review, then runs code-review
 
 generated: 2026-05-01
-last_updated: 2026-06-15
+last_updated: 2026-06-17
 project: deploywhisper
 project_key: NOKEY
 tracking_system: file-system
@@ -114,7 +114,7 @@ development_status:
   7-2-terraform-state-connector: done
   7-3-kubernetes-live-state-connector: done
   7-4-codeowners-and-ownership-mapping: done
-  7-5-context-graph-and-freshness-ledger: ready-for-dev
+  7-5-context-graph-and-freshness-ledger: done
   epic-7-retrospective: optional
 
   epic-8: in-progress

--- a/api/schemas.py
+++ b/api/schemas.py
@@ -6,7 +6,11 @@ import math
 from typing import Any, Literal
 
 from config import settings
-from evidence.models import FindingEvidenceClassification
+from evidence.models import (
+    ContextSourceFreshness,
+    ContextSourceType,
+    FindingEvidenceClassification,
+)
 from pydantic import (
     BaseModel,
     ConfigDict,
@@ -1176,6 +1180,50 @@ class FindingData(BaseModel):
     )
 
 
+class ContextSourceMetadataData(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    source_id: str = Field(..., min_length=1, description="Stable context source id")
+    source_type: ContextSourceType = Field(..., description="Context source category")
+    source_ref: str | None = Field(
+        default=None, min_length=1, description="Source path, version, or URI"
+    )
+    scope: str = Field(
+        ..., min_length=1, description="Project/workspace scope for this source"
+    )
+    freshness_status: ContextSourceFreshness = Field(
+        default="unknown", description="Freshness state for this source"
+    )
+    last_observed_at: str | None = Field(
+        default=None,
+        min_length=1,
+        description="ISO timestamp when this source was last observed",
+    )
+    age_days: int | None = Field(
+        default=None, ge=0, description="Source age in days when available"
+    )
+    confidence: float = Field(
+        default=0.0,
+        ge=0.0,
+        le=1.0,
+        allow_inf_nan=False,
+        description="Confidence contribution from this source",
+    )
+    conflicts: list[str] = Field(
+        default_factory=list,
+        description="Conflicting sources or signals associated with this source",
+    )
+    limitations: list[str] = Field(
+        default_factory=list,
+        description="Freshness, completeness, or quality limitations",
+    )
+
+    @field_validator("conflicts", "limitations")
+    @classmethod
+    def _validate_context_source_strings(cls, value: list[str]) -> list[str]:
+        return _validate_non_empty_strings(value)
+
+
 class EvidenceItemData(BaseModel):
     evidence_id: str = Field(..., description="Stable evidence identifier")
     analysis_id: int = Field(..., description="Analysis identifier")
@@ -1216,6 +1264,10 @@ class EvidenceItemData(BaseModel):
     confidence: float = Field(..., description="Confidence score between 0 and 1")
     related_change_ids: list[str] = Field(
         default_factory=list, description="Traceable normalized change identifiers"
+    )
+    context_source: ContextSourceMetadataData | None = Field(
+        default=None,
+        description="Context source metadata that supplied or qualified this evidence",
     )
 
 
@@ -1345,6 +1397,10 @@ class ContextCompletenessData(BaseModel):
     ownership_unmapped_subjects: list[str] = Field(
         default_factory=list,
         description="Analyzed files, resources, or services missing ownership data",
+    )
+    context_sources: list[ContextSourceMetadataData] = Field(
+        default_factory=list,
+        description="Per-source freshness, confidence, scope, and conflict ledger",
     )
 
     @field_validator("escalation_hints", "ownership_unmapped_subjects")

--- a/docs/schemas/report-v2.md
+++ b/docs/schemas/report-v2.md
@@ -264,7 +264,33 @@ without storing raw plan internals in a separate contract.
       "Escalate file review for services/payments/plan.json to @payments-sre.",
       "Escalate service review for Payments API to @payments-runtime."
     ],
-    "ownership_unmapped_subjects": []
+    "ownership_unmapped_subjects": [],
+    "context_sources": [
+      {
+        "source_id": "artifact:plan.json",
+        "source_type": "artifact",
+        "source_ref": "plan.json",
+        "scope": "project:payments/workspace:prod",
+        "freshness_status": "current",
+        "last_observed_at": null,
+        "age_days": null,
+        "confidence": 1.0,
+        "conflicts": [],
+        "limitations": []
+      },
+      {
+        "source_id": "incident:index:incidents:empty",
+        "source_type": "incident",
+        "source_ref": "incidents:empty",
+        "scope": "project:payments",
+        "freshness_status": "empty",
+        "last_observed_at": null,
+        "age_days": null,
+        "confidence": 0.0,
+        "conflicts": ["missing_incident_history"],
+        "limitations": ["empty_incident_index"]
+      }
+    ]
   },
   "blast_radius": {
     "affected": [
@@ -411,8 +437,49 @@ without storing raw plan internals in a separate contract.
       "actor": "api-reviewer@example.com"
     }
   ],
-  "findings": [],
-  "evidence_items": [],
+  "findings": [
+    {
+      "finding_id": "finding-public-ingress",
+      "analysis_id": 42,
+      "title": "Public ingress exposure",
+      "description": "Terraform opened SSH ingress from 0.0.0.0/0 on port 22.",
+      "explanation": "Administrative ingress from the public internet has caused common deployment incidents.",
+      "guidance": [
+        "Confirm whether the public CIDR is intentional and time-bound.",
+        "Restrict administrative ingress to trusted networks or a managed access path."
+      ],
+      "severity": "high",
+      "category": "network_exposure",
+      "deterministic": true,
+      "confidence": 1.0,
+      "uncertainty_note": null,
+      "evidence_classification": "deterministic",
+      "evidence_refs": ["ev-plan-json-1"],
+      "skill_id": "terraform"
+    }
+  ],
+  "evidence_items": [
+    {
+      "evidence_id": "ev-plan-json-1",
+      "finding_id": "finding-public-ingress",
+      "source_type": "artifact",
+      "source_ref": "plan.json",
+      "artifact": "plan.json",
+      "summary": "Terraform opened SSH ingress from 0.0.0.0/0 on port 22.",
+      "deterministic": true,
+      "confidence": 1.0,
+      "context_source": {
+        "source_id": "artifact:plan.json",
+        "source_type": "artifact",
+        "source_ref": "plan.json",
+        "scope": "project:payments/workspace:prod",
+        "freshness_status": "current",
+        "confidence": 1.0,
+        "conflicts": [],
+        "limitations": []
+      }
+    }
+  ],
   "incident_matches": [
     {
       "incident_id": 0,
@@ -464,6 +531,28 @@ without storing raw plan internals in a separate contract.
   }
 }
 ```
+
+### Context source freshness ledger
+
+`context_completeness.context_sources` is the per-report freshness ledger for
+the context inputs used during analysis. Each row exposes `source_id`,
+`source_type`, optional `source_ref`, `scope`, `freshness_status`,
+`confidence`, `conflicts`, and `limitations` so API, CLI, and UI consumers can
+show whether topology, incident history, artifact, parser, evidence, ownership,
+or external context was current enough to trust.
+
+`freshness_status` uses the same values as the report context state:
+`current`, `stale`, `missing`, `incomplete`, `conflicting`, `unknown`, `empty`,
+or `not_applicable`. Non-current populated incident ledgers should surface
+remediation from `context_todos`; for example stale indexes ask reviewers to
+refresh incident history, while conflicting or incomplete indexes ask reviewers
+to resolve the specific incident freshness state.
+
+Evidence rows may include `context_source` when DeployWhisper can tie that
+evidence item to one ledger source. Consumers should render the relationship as
+provenance, not as a separate finding. Legacy persisted reports can contain
+malformed context-source rows; readers may drop invalid source rows while
+preserving the rest of the context completeness payload.
 
 ### Blast-radius topology context
 

--- a/evidence/models.py
+++ b/evidence/models.py
@@ -11,6 +11,26 @@ RiskSeverity = Literal["low", "medium", "high", "critical"]
 DeployRecommendation = Literal["go", "caution", "no-go"]
 ContextConfidenceLevel = Literal["high", "medium", "low"]
 OwnerSignalScope = Literal["file", "service"]
+ContextSourceFreshness = Literal[
+    "current",
+    "stale",
+    "missing",
+    "incomplete",
+    "conflicting",
+    "unknown",
+    "empty",
+    "not_applicable",
+]
+ContextSourceType = Literal[
+    "artifact",
+    "topology",
+    "incident",
+    "parser",
+    "evidence",
+    "ownership",
+    "external_scanner",
+    "user_context",
+]
 EvidenceSourceType = Literal[
     "artifact",
     "topology",
@@ -67,6 +87,33 @@ def _parse_source_ref(source_ref: str) -> dict[str, str]:
     }
 
 
+class ContextSourceMetadata(BaseModel):
+    """Freshness and confidence metadata for one report context source."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    source_id: str = Field(..., min_length=1)
+    source_type: ContextSourceType
+    source_ref: str | None = Field(default=None, min_length=1)
+    scope: str = Field(..., min_length=1)
+    freshness_status: ContextSourceFreshness = Field(default="unknown")
+    last_observed_at: str | None = Field(default=None, min_length=1)
+    age_days: int | None = Field(default=None, ge=0)
+    confidence: float = Field(default=0.0, ge=0.0, le=1.0)
+    conflicts: list[str] = Field(default_factory=list)
+    limitations: list[str] = Field(default_factory=list)
+
+    @field_validator("conflicts")
+    @classmethod
+    def _validate_conflicts(cls, value: list[str]) -> list[str]:
+        return _validate_string_list(value)
+
+    @field_validator("limitations")
+    @classmethod
+    def _validate_limitations(cls, value: list[str]) -> list[str]:
+        return _validate_string_list(value)
+
+
 class ContextCompleteness(BaseModel):
     """Frozen context quality inputs captured for one analysis."""
 
@@ -90,6 +137,7 @@ class ContextCompleteness(BaseModel):
     owner_signals: list["OwnerSignal"] = Field(default_factory=list)
     escalation_hints: list[str] = Field(default_factory=list)
     ownership_unmapped_subjects: list[str] = Field(default_factory=list)
+    context_sources: list[ContextSourceMetadata] = Field(default_factory=list)
 
     @field_validator("parser_success_by_tool")
     @classmethod
@@ -187,6 +235,7 @@ class EvidenceItem(BaseModel):
     deterministic: bool
     confidence: float = Field(..., ge=0.0, le=1.0)
     related_change_ids: list[str] = Field(default_factory=list)
+    context_source: ContextSourceMetadata | None = Field(default=None)
 
     @field_validator("related_change_ids")
     @classmethod

--- a/frontend/e2e/dashboard.spec.ts
+++ b/frontend/e2e/dashboard.spec.ts
@@ -54,7 +54,11 @@ test.describe("React dashboard", () => {
   test("renders scoped KPIs and supports accessible keyboard navigation", async ({ page }) => {
     await selectProject(page);
 
-    await expect(page.getByRole("heading", { name: /Good afternoon/i })).toBeVisible();
+    await expect(
+      page.getByRole("heading", {
+        name: /(Good morning|Good afternoon|Good evening|Working late), DW/i,
+      }),
+    ).toBeVisible();
     await expect(page.getByText("Evidence Law enforced").first()).toBeVisible();
     await expect(page.getByText("Total analyses")).toBeVisible();
     await expect(page.getByText("0").first()).toBeVisible();

--- a/frontend/e2e/history.spec.ts
+++ b/frontend/e2e/history.spec.ts
@@ -142,8 +142,10 @@ test.describe("React history screen", () => {
       await page.getByLabel(`Select report ${reportId}`).check();
     }
     await expect(page.getByText(`${seededReports.length} selected`)).toBeVisible();
-    page.once("dialog", (dialog) => dialog.accept());
     await page.getByRole("button", { name: /Delete selected/i }).click();
-    await expect(page.getByText(`Deleted ${seededReports.length} analysis report(s).`)).toBeVisible();
+    const deleteDialog = page.getByRole("dialog", { name: /Delete selected reports/i });
+    await expect(deleteDialog).toBeVisible();
+    await deleteDialog.getByRole("button", { name: /Delete reports/i }).click();
+    await expect(page.getByText(`Deleted ${seededReports.length} analysis report(s).`)).toBeVisible({ timeout: 60_000 });
   });
 });

--- a/frontend/e2e/phase6.spec.ts
+++ b/frontend/e2e/phase6.spec.ts
@@ -118,7 +118,7 @@ test.describe("Phase 6 settings, incidents, and skills", () => {
     await page.goto("/incidents", { waitUntil: "networkidle" });
     await selectProject(page);
     await expect(page.getByRole("heading", { name: "Incidents" })).toBeVisible();
-    await expect(page.getByRole("button", { name: /Checkout rollout incident/ })).toBeVisible();
+    await expect(page.getByRole("button", { name: /Checkout rollout incident/ })).toBeVisible({ timeout: 60_000 });
     await page.getByRole("button", { name: /Checkout rollout incident/ }).click();
     await expect(page.getByText("checkout-incident.json").first()).toBeVisible();
     await expectNoSeriousA11y(page);

--- a/frontend/e2e/report.spec.ts
+++ b/frontend/e2e/report.spec.ts
@@ -13,9 +13,23 @@ const shareToken = process.env.DEPLOYWHISPER_SHARE_TOKEN ?? "DEPLOYWHISPER_API_T
 type ApiEnvelope<T> = { data: T };
 type Project = { id: number; project_key: string; name: string; env_label: string };
 type AnalysisRun = { persisted_report: { id: number } };
+type ContextSource = {
+  source_id: string;
+  source_type: string;
+  source_ref?: string | null;
+  scope: string;
+  freshness_status: string;
+  last_observed_at?: string | null;
+  age_days?: number | null;
+  confidence: number;
+  conflicts?: string[];
+  limitations?: string[];
+};
 type ReportDetail = {
   id: number;
   findings: { finding_id: string; title: string }[];
+  context_completeness?: { context_sources?: ContextSource[] };
+  evidence_items?: { context_source?: ContextSource | null }[];
   feedback_state: { finding_feedback: Record<string, { outcome_label: string }> };
 };
 
@@ -45,22 +59,68 @@ async function ensureProject(request: APIRequestContext): Promise<Project> {
   return created.data;
 }
 
+function multipartBody(parts: { name: string; value: string }[], files: { name: string; filename: string; mimeType: string; buffer: Buffer }[]) {
+  const boundary = `----deploywhisper-${runId}`;
+  const chunks: Buffer[] = [];
+  const pushText = (value: string) => chunks.push(Buffer.from(value, "utf-8"));
+
+  for (const part of parts) {
+    pushText(`--${boundary}\r\n`);
+    pushText(`Content-Disposition: form-data; name="${part.name}"\r\n\r\n`);
+    pushText(`${part.value}\r\n`);
+  }
+  for (const file of files) {
+    pushText(`--${boundary}\r\n`);
+    pushText(
+      `Content-Disposition: form-data; name="${file.name}"; filename="${file.filename}"\r\n`,
+    );
+    pushText(`Content-Type: ${file.mimeType}\r\n\r\n`);
+    chunks.push(file.buffer);
+    pushText("\r\n");
+  }
+  pushText(`--${boundary}--\r\n`);
+  return { boundary, body: Buffer.concat(chunks) };
+}
+
 async function seedReport(request: APIRequestContext, project: Project): Promise<ReportDetail> {
+  const uploadBuffer = fs.readFileSync(uploadArtifact);
+  const shadowUploadBuffer = Buffer.from(
+    uploadBuffer
+      .toString("utf-8")
+      .replaceAll("checkout-api", "checkout-api-shadow")
+      .replaceAll("checkout-web", "checkout-web-shadow")
+      .replaceAll("payments-worker", "payments-worker-shadow"),
+    "utf-8",
+  );
+  const { boundary, body } = multipartBody(
+    [
+      { name: "project_id", value: String(project.id) },
+      { name: "artifact_paths", value: "checkout-platform.yaml" },
+      { name: "artifact_paths", value: "checkout-platform-shadow.yaml" },
+    ],
+    [
+      {
+        name: "files",
+        filename: "checkout-platform.yaml",
+        mimeType: "application/x-yaml",
+        buffer: uploadBuffer,
+      },
+      {
+        name: "files",
+        filename: "checkout-platform-shadow.yaml",
+        mimeType: "application/x-yaml",
+        buffer: shadowUploadBuffer,
+      },
+    ],
+  );
   const run = await apiJson<ApiEnvelope<AnalysisRun>>(
     request.post("/api/v1/analyses", {
       headers: {
         "X-DeployWhisper-Actor": "react_report_e2e",
         "X-DeployWhisper-Trigger-Type": "playwright_seed",
+        "Content-Type": `multipart/form-data; boundary=${boundary}`,
       },
-      multipart: {
-        project_id: String(project.id),
-        artifact_paths: "checkout-platform.yaml",
-        files: {
-          name: "checkout-platform.yaml",
-          mimeType: "application/x-yaml",
-          buffer: fs.readFileSync(uploadArtifact),
-        },
-      },
+      data: body,
     }),
   );
 
@@ -99,6 +159,67 @@ async function clickTab(page: Page, name: string) {
   await expect(page.getByRole("tabpanel")).toBeVisible();
 }
 
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function contextSourceRow(page: Page, source: ContextSource) {
+  const identity = contextSourceIdentity(source);
+  return page
+    .locator(`[data-testid="context-source-row"][data-context-source-identity="${identity}"]`);
+}
+
+function contextSourceIdentity(source: ContextSource) {
+  const notes = [
+    ...new Set([...(source.conflicts ?? []), ...(source.limitations ?? [])]),
+  ].sort();
+  return encodeURIComponent(JSON.stringify([
+    source.source_id,
+    source.source_type,
+    source.source_ref ?? "",
+    source.scope,
+    source.freshness_status,
+    source.confidence ?? "",
+    source.last_observed_at ?? "",
+    source.age_days ?? "",
+    notes,
+  ]));
+}
+
+function distinctContextSources(sources: ContextSource[]) {
+  const seen = new Set<string>();
+  return sources.filter((source) => {
+    const identity = contextSourceIdentity(source);
+    if (seen.has(identity)) {
+      return false;
+    }
+    seen.add(identity);
+    return true;
+  });
+}
+
+async function expectContextSourceRow(page: Page, source: ContextSource) {
+  const row = contextSourceRow(page, source);
+  await expect(row).toHaveCount(1);
+  await expect(row.getByText(source.source_type, { exact: true })).toBeVisible();
+  await expect(row.getByText(source.source_id, { exact: true })).toBeVisible();
+  await expect(
+    row.getByText(source.source_ref || "source reference unavailable", {
+      exact: true,
+    }),
+  ).toBeVisible();
+  await expect(row.getByText(source.scope)).toBeVisible();
+  await expect(
+    row.getByText(
+      new RegExp(
+        `${escapeRegExp(source.freshness_status)}\\s*-\\s*${Math.round(
+          (source.confidence ?? 0) * 100,
+        )}%\\s*-\\s*${escapeRegExp(source.scope)}`,
+      ),
+    ),
+  ).toBeVisible();
+}
+
 async function maybeCapture(page: Page, name: string, width: number) {
   if (process.env.CAPTURE_REPORT_SCREENSHOTS !== "1") {
     return;
@@ -126,6 +247,53 @@ test.describe("React report screen", () => {
     for (const tabName of ["Findings", "Confidence", "Context", "Rollback", "Audit"]) {
       await clickTab(page, tabName);
       await maybeCapture(page, tabName.toLowerCase(), 1440);
+    }
+
+    const contextSources = report.context_completeness?.context_sources ?? [];
+    const distinctSources = distinctContextSources(contextSources);
+    expect(distinctSources.length).toBeGreaterThan(1);
+    const contextSource = distinctSources[0];
+    const secondContextSource = distinctSources[1];
+
+    await clickTab(page, "Context");
+    await expect(page.getByText("CONTEXT SOURCES")).toBeVisible();
+    await expectContextSourceRow(page, contextSource);
+    await expectContextSourceRow(page, secondContextSource);
+    const notedContextSource = contextSources.find(
+      (source) =>
+        (source.conflicts?.length ?? 0) > 0 ||
+        (source.limitations?.length ?? 0) > 0,
+    );
+    const contextNote = notedContextSource
+      ? [...(notedContextSource.conflicts ?? []), ...(notedContextSource.limitations ?? [])][0]
+      : null;
+    if (notedContextSource && contextNote) {
+      const notedRow = contextSourceRow(page, notedContextSource);
+      await expect(notedRow).toHaveCount(1);
+      await expect(notedRow.getByText(notedContextSource.source_id)).toBeVisible();
+      await expect(notedRow.getByText(contextNote, { exact: true })).toBeVisible();
+    }
+
+    await clickTab(page, "Confidence");
+    const evidenceContextSources =
+      report.evidence_items
+        ?.map((item) => item.context_source)
+        .filter((source): source is ContextSource => Boolean(source)) ?? [];
+    const distinctEvidenceContextSources = distinctContextSources(evidenceContextSources);
+    expect(distinctEvidenceContextSources.length).toBeGreaterThan(1);
+    for (const source of distinctEvidenceContextSources.slice(0, 2)) {
+      expect(source.scope).toBeTruthy();
+      expect(source.confidence).toBeGreaterThanOrEqual(0);
+      expect(source.confidence).toBeLessThanOrEqual(1);
+      await expect(
+        page.getByText(
+          new RegExp(
+            `${escapeRegExp(source.source_id)}\\s*\\(${escapeRegExp(
+              source.freshness_status,
+            )}\\)`,
+          ),
+        ).first(),
+      ).toBeVisible();
     }
 
     await clickTab(page, "Findings");

--- a/frontend/e2e/report.spec.ts
+++ b/frontend/e2e/report.spec.ts
@@ -90,7 +90,7 @@ async function openReport(page: Page, reportId: number) {
   await page.goto(`/reports/${reportId}?private=1`, { waitUntil: "networkidle" });
   await expect(page.getByRole("heading").first()).toBeVisible();
   await expect(page.getByRole("navigation", { name: "Primary" })).toBeVisible();
-  await expect(page.getByText("DeployWhisper")).toBeVisible();
+  await expect(page.getByRole("img", { name: "DeployWhisper" })).toBeVisible();
   await expect(page.getByLabel("Global search")).toBeVisible();
 }
 

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -1290,6 +1290,35 @@ export interface components {
              */
             uncertainty_drivers?: string[];
         };
+        /** ContextSourceMetadataData */
+        ContextSourceMetadataData: {
+            /** Source Id */
+            source_id: string;
+            /** Source Type */
+            source_type: "artifact" | "topology" | "incident" | "parser" | "evidence" | "ownership" | "external_scanner" | "user_context";
+            /** Source Ref */
+            source_ref?: string | null;
+            /** Scope */
+            scope: string;
+            /**
+             * Freshness Status
+             * @default unknown
+             */
+            freshness_status: "current" | "stale" | "missing" | "incomplete" | "conflicting" | "unknown" | "empty" | "not_applicable";
+            /** Last Observed At */
+            last_observed_at?: string | null;
+            /** Age Days */
+            age_days?: number | null;
+            /**
+             * Confidence
+             * @default 0
+             */
+            confidence: number;
+            /** Conflicts */
+            conflicts?: string[];
+            /** Limitations */
+            limitations?: string[];
+        };
         /** ContextCompletenessData */
         ContextCompletenessData: {
             /**
@@ -1392,6 +1421,11 @@ export interface components {
              * @description Analyzed files, resources, or services missing ownership data
              */
             ownership_unmapped_subjects?: string[];
+            /**
+             * Context Sources
+             * @description Per-source freshness, confidence, scope, and conflict ledger
+             */
+            context_sources?: components["schemas"]["ContextSourceMetadataData"][];
         };
         /** CountMetaPayload */
         CountMetaPayload: {
@@ -1767,6 +1801,11 @@ export interface components {
              * @description Traceable normalized change identifiers
              */
             related_change_ids?: string[];
+            /**
+             * Context Source
+             * @description Context source metadata that supplied or qualified this evidence
+             */
+            context_source?: components["schemas"]["ContextSourceMetadataData"] | null;
         };
         /** FeedbackCurrentStateData */
         FeedbackCurrentStateData: {

--- a/frontend/src/screens/Report.test.tsx
+++ b/frontend/src/screens/Report.test.tsx
@@ -165,7 +165,7 @@ const report = {
         age_days: null,
         confidence: 0,
         conflicts: ["missing_incident_history"],
-        limitations: ["empty_incident_index", "incident_pack_missing", "incident_dates_unknown", "incident_scope_unverified"],
+        limitations: ["missing_incident_history", "empty_incident_index", "incident_pack_missing", "incident_dates_unknown", "incident_scope_unverified"],
       },
     ],
     context_todos: [],
@@ -285,6 +285,7 @@ describe("ReportScreen", () => {
     expect(markup).toContain("current-context");
     expect(markup).toContain("90%");
     expect(markup).toContain("missing_incident_history");
+    expect(markup.match(/>missing_incident_history</g)?.length).toBe(1);
     expect(markup).toContain("incident_pack_missing");
     expect(markup).toContain("incident_dates_unknown");
     expect(markup).toContain("incident_scope_unverified");
@@ -293,6 +294,88 @@ describe("ReportScreen", () => {
     expect(markup).toContain("checkout");
     expect(markup).toContain("Direct");
     expect(markup).toContain("Transitive");
+  });
+
+  it("renders context sources with duplicate source ids as separate rows", () => {
+    const duplicateSourceReport = {
+      ...report,
+      context_completeness: {
+        ...report.context_completeness,
+        context_sources: [
+          ...report.context_completeness.context_sources,
+          {
+            ...report.context_completeness.context_sources[0],
+            source_ref: "current-context-shadow",
+            scope: "project:checkout/workspace:shadow",
+            freshness_status: "stale",
+            confidence: 0.4,
+          },
+        ],
+      },
+    } satisfies ReportDetail;
+
+    const markup = renderReport(
+      "/reports/77?private=1&tab=context",
+      duplicateSourceReport,
+    );
+
+    expect(markup.match(/data-testid="context-source-row"/g)?.length).toBe(3);
+    expect(markup).toContain("current-context");
+    expect(markup).toContain("current-context-shadow");
+    expect(markup).toContain("project:checkout/workspace:shadow");
+    expect(markup).toContain("stale - 40%");
+  });
+
+  it("renders note-only duplicate context sources with distinct row identities", () => {
+    const noteOnlyDuplicateReport = {
+      ...report,
+      context_completeness: {
+        ...report.context_completeness,
+        context_sources: [
+          ...report.context_completeness.context_sources,
+          {
+            ...report.context_completeness.context_sources[0],
+            limitations: ["note_only_shadow"],
+          },
+        ],
+      },
+    } satisfies ReportDetail;
+
+    const markup = renderReport(
+      "/reports/77?private=1&tab=context",
+      noteOnlyDuplicateReport,
+    );
+
+    expect(markup.match(/data-testid="context-source-row"/g)?.length).toBe(3);
+    expect(markup).toContain("note_only_shadow");
+    expect(markup).toContain("data-context-source-identity");
+  });
+
+  it("encodes selector-sensitive context source row identities", () => {
+    const encodedIdentityReport = {
+      ...report,
+      context_completeness: {
+        ...report.context_completeness,
+        context_sources: [
+          {
+            ...report.context_completeness.context_sources[0],
+            source_ref: "current|context\"]",
+            scope: "project:checkout|workspace:prod]",
+            limitations: ["note|with]delimiter"],
+          },
+        ],
+      },
+    } satisfies ReportDetail;
+
+    const markup = renderReport(
+      "/reports/77?private=1&tab=context",
+      encodedIdentityReport,
+    );
+
+    expect(markup).toContain("current|context&quot;]");
+    expect(markup).toContain("note|with]delimiter");
+    expect(markup).toContain("current%7Ccontext%5C%22%5D");
+    expect(markup).toContain("note%7Cwith%5Ddelimiter");
   });
 
   it("renders evidence context source references on the confidence tab", () => {

--- a/frontend/src/screens/Report.test.tsx
+++ b/frontend/src/screens/Report.test.tsx
@@ -95,6 +95,18 @@ const report = {
       severity_hint: "high",
       deterministic: true,
       confidence: 0.9,
+      context_source: {
+        source_id: "topology:kubernetes:current-context",
+        source_type: "topology",
+        source_ref: "current-context",
+        scope: "project:checkout",
+        freshness_status: "current",
+        last_observed_at: "2026-06-14T00:00:00Z",
+        age_days: 2,
+        confidence: 0.9,
+        conflicts: [],
+        limitations: [],
+      },
       related_change_ids: [],
     },
   ],
@@ -130,6 +142,32 @@ const report = {
     incident_index_version: null,
     incident_index_freshness_status: null,
     evidence_success_rate: 1,
+    context_sources: [
+      {
+        source_id: "topology:kubernetes:current-context",
+        source_type: "topology",
+        source_ref: "current-context",
+        scope: "project:checkout",
+        freshness_status: "current",
+        last_observed_at: "2026-06-14T00:00:00Z",
+        age_days: 2,
+        confidence: 0.9,
+        conflicts: [],
+        limitations: [],
+      },
+      {
+        source_id: "incident:index:checkout",
+        source_type: "incident",
+        source_ref: "incidents:empty",
+        scope: "project:checkout",
+        freshness_status: "empty",
+        last_observed_at: null,
+        age_days: null,
+        confidence: 0,
+        conflicts: ["missing_incident_history"],
+        limitations: ["empty_incident_index", "incident_pack_missing", "incident_dates_unknown", "incident_scope_unverified"],
+      },
+    ],
     context_todos: [],
     partial_context: false,
   },
@@ -242,10 +280,26 @@ describe("ReportScreen", () => {
     const markup = renderReport("/reports/77?private=1&tab=context");
 
     expect(markup).toContain("BLAST RADIUS");
+    expect(markup).toContain("CONTEXT SOURCES");
+    expect(markup).toContain("topology:kubernetes:current-context");
+    expect(markup).toContain("current-context");
+    expect(markup).toContain("90%");
+    expect(markup).toContain("missing_incident_history");
+    expect(markup).toContain("incident_pack_missing");
+    expect(markup).toContain("incident_dates_unknown");
+    expect(markup).toContain("incident_scope_unverified");
+    expect(markup).not.toContain("+2 more");
     expect(markup).toContain("Contained radius");
     expect(markup).toContain("checkout");
     expect(markup).toContain("Direct");
     expect(markup).toContain("Transitive");
+  });
+
+  it("renders evidence context source references on the confidence tab", () => {
+    const markup = renderReport("/reports/77?private=1&tab=confidence");
+
+    expect(markup).toContain("EVIDENCE REGISTER");
+    expect(markup).toContain("topology:kubernetes:current-context (current)");
   });
 
   it("renders a green safe state when the blast radius is zero", () => {

--- a/frontend/src/screens/Report.tsx
+++ b/frontend/src/screens/Report.tsx
@@ -53,6 +53,7 @@ type EvidenceItem = NonNullable<ReportDetail["evidence_items"]>[number];
 type RollbackPlan = NonNullable<ReportDetail["rollback_plan"]>;
 type BlastRadius = NonNullable<ReportDetail["blast_radius"]>;
 type ContextCompleteness = NonNullable<ReportDetail["context_completeness"]>;
+type ContextSourceMetadata = NonNullable<ContextCompleteness["context_sources"]>[number];
 type ConfidenceLedger = NonNullable<ReportDetail["confidence_ledger"]>;
 type FeedbackState = NonNullable<ReportDetail["feedback_state"]>;
 
@@ -710,6 +711,26 @@ function BlastRadiusCard({ blastRadius }: { blastRadius: BlastRadius }) {
 
 function ContextSourcesCard({ context }: { context: ContextCompleteness }) {
   const sources = context.context_sources ?? [];
+  const sourceNotes = (source: ContextSourceMetadata) =>
+    Array.from(new Set([...(source.conflicts ?? []), ...(source.limitations ?? [])])).sort();
+  const rowIdentityPayload = (source: ContextSourceMetadata) => [
+    source.source_id,
+    source.source_type,
+    source.source_ref ?? "",
+    source.scope,
+    source.freshness_status,
+    source.confidence ?? "",
+    source.last_observed_at ?? "",
+    source.age_days ?? "",
+    sourceNotes(source),
+  ];
+  const rowIdentity = (source: ContextSourceMetadata) =>
+    encodeURIComponent(JSON.stringify(rowIdentityPayload(source)));
+  const rowKey = (source: ContextSourceMetadata, index: number) =>
+    [
+      rowIdentity(source),
+      index,
+    ].join("|");
 
   return (
     <Card eyebrow="CONTEXT SOURCES" title={`${sources.length} source${sources.length === 1 ? "" : "s"} in freshness ledger`}>
@@ -717,17 +738,21 @@ function ContextSourcesCard({ context }: { context: ContextCompleteness }) {
         <div className="dw-report-empty">No context source metadata was persisted for this report.</div>
       ) : (
         <div className="dw-evidence-register">
-          {sources.map((source) => {
-            const sourceNotes = [...(source.conflicts ?? []), ...(source.limitations ?? [])];
+          {sources.map((source, index) => {
+            const notes = sourceNotes(source);
             return (
-              <div key={source.source_id}>
+              <div
+                data-context-source-identity={rowIdentity(source)}
+                data-testid="context-source-row"
+                key={rowKey(source, index)}
+              >
                 <span>{source.source_type}</span>
                 <MonoRef>{source.source_id}</MonoRef>
                 <p>{source.source_ref || "source reference unavailable"}</p>
                 <em>
                   {source.freshness_status} - {Math.round((source.confidence ?? 0) * 100)}% - {source.scope}
                 </em>
-                {sourceNotes.map((item) => (
+                {notes.map((item) => (
                   <EvidenceTag key={`${source.source_id}-${item}`}>{item}</EvidenceTag>
                 ))}
               </div>

--- a/frontend/src/screens/Report.tsx
+++ b/frontend/src/screens/Report.tsx
@@ -112,6 +112,7 @@ function getContextCompleteness(report: ReportDetail): ContextCompleteness {
       incident_index_freshness_status: null,
       evidence_success_rate: 0,
       context_todos: ["Context completeness was not persisted for this report."],
+      context_sources: [],
       partial_context: true,
     }
   );
@@ -580,7 +581,10 @@ function ConfidenceTab({ report }: { report: ReportDetail }) {
               <span>{item.evidence_id || `EV-${String(index + 1).padStart(2, "0")}`}</span>
               <MonoRef>{evidenceReference(item)}</MonoRef>
               <p>{item.summary}</p>
-              <em>{item.source_type}</em>
+              <em>
+                {item.source_type}
+                {item.context_source ? ` - ${item.context_source.source_id} (${item.context_source.freshness_status})` : ""}
+              </em>
             </div>
           ))}
         </div>
@@ -704,6 +708,37 @@ function BlastRadiusCard({ blastRadius }: { blastRadius: BlastRadius }) {
   );
 }
 
+function ContextSourcesCard({ context }: { context: ContextCompleteness }) {
+  const sources = context.context_sources ?? [];
+
+  return (
+    <Card eyebrow="CONTEXT SOURCES" title={`${sources.length} source${sources.length === 1 ? "" : "s"} in freshness ledger`}>
+      {sources.length === 0 ? (
+        <div className="dw-report-empty">No context source metadata was persisted for this report.</div>
+      ) : (
+        <div className="dw-evidence-register">
+          {sources.map((source) => {
+            const sourceNotes = [...(source.conflicts ?? []), ...(source.limitations ?? [])];
+            return (
+              <div key={source.source_id}>
+                <span>{source.source_type}</span>
+                <MonoRef>{source.source_id}</MonoRef>
+                <p>{source.source_ref || "source reference unavailable"}</p>
+                <em>
+                  {source.freshness_status} - {Math.round((source.confidence ?? 0) * 100)}% - {source.scope}
+                </em>
+                {sourceNotes.map((item) => (
+                  <EvidenceTag key={`${source.source_id}-${item}`}>{item}</EvidenceTag>
+                ))}
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </Card>
+  );
+}
+
 function ContextTab({ report }: { report: ReportDetail }) {
   const context = getContextCompleteness(report);
   const blastRadius = getBlastRadius(report);
@@ -732,6 +767,7 @@ function ContextTab({ report }: { report: ReportDetail }) {
         </div>
         <Button variant="ghost">+ Resolve open context TODO</Button>
       </Card>
+      <ContextSourcesCard context={context} />
       <BlastRadiusCard blastRadius={blastRadius} />
     </div>
   );

--- a/migrations/versions/026_add_evidence_context_source.py
+++ b/migrations/versions/026_add_evidence_context_source.py
@@ -1,0 +1,35 @@
+"""Persist evidence context source metadata.
+
+Revision ID: 026_add_evidence_context_source
+Revises: 025_add_event_analysis_indexes
+Create Date: 2026-06-17
+"""
+
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "026_add_evidence_context_source"
+down_revision = "025_add_event_analysis_indexes"
+branch_labels = None
+depends_on = None
+
+
+def _columns(table_name: str) -> set[str]:
+    inspector = sa.inspect(op.get_bind())
+    return {column["name"] for column in inspector.get_columns(table_name)}
+
+
+def upgrade() -> None:
+    if "context_source_json" not in _columns("evidence_items"):
+        op.add_column(
+            "evidence_items",
+            sa.Column("context_source_json", sa.Text(), nullable=True),
+        )
+
+
+def downgrade() -> None:
+    if "context_source_json" in _columns("evidence_items"):
+        op.drop_column("evidence_items", "context_source_json")

--- a/models/repositories/analysis_reports.py
+++ b/models/repositories/analysis_reports.py
@@ -752,6 +752,11 @@ def create_analysis_report(
                     related_change_ids_json=json.dumps(
                         evidence.get("related_change_ids", [])
                     ),
+                    context_source_json=(
+                        json.dumps(evidence["context_source"])
+                        if evidence.get("context_source") is not None
+                        else None
+                    ),
                 )
             )
 

--- a/models/tables.py
+++ b/models/tables.py
@@ -437,6 +437,7 @@ if "EvidenceItem" not in globals():
         deterministic: Mapped[bool] = mapped_column(Boolean, default=True)
         confidence: Mapped[float] = mapped_column(Float, default=1.0)
         related_change_ids_json: Mapped[str] = mapped_column(Text, default="[]")
+        context_source_json: Mapped[str | None] = mapped_column(Text, nullable=True)
         created_at: Mapped[datetime] = mapped_column(
             DateTime(timezone=True), default=lambda: datetime.now(UTC)
         )

--- a/services/analysis_service.py
+++ b/services/analysis_service.py
@@ -23,7 +23,13 @@ from analysis.risk_scorer import (
 from analysis.rollback_planner import RollbackPlan, generate_rollback_plan
 from evidence.extractor import extract_batch_evidence
 from evidence.mappers import build_findings
-from evidence.models import ContextCompleteness, EvidenceItem, Finding
+from evidence.models import (
+    ContextCompleteness,
+    ContextSourceMetadata,
+    EvidenceItem,
+    Finding,
+    OwnerSignal,
+)
 from llm.narrator import NarrativeResult, generate_narrative
 from llm.providers import generate_completion_with_settings
 from parsers.base import ParseBatchResult, UnifiedChange, is_non_mutating_action
@@ -370,6 +376,357 @@ def _context_confidence_level(context_score: float) -> str:
     return "low"
 
 
+def _scope_label(
+    *,
+    project_id: int | None = None,
+    project_key: str | None = None,
+    workspace_id: int | None = None,
+    workspace_key: str | None = None,
+) -> str:
+    project = f"project:{project_key or project_id or 'unscoped'}"
+    if workspace_key is not None or workspace_id is not None:
+        return f"{project}/workspace:{workspace_key or workspace_id}"
+    return project
+
+
+def _source_id(source_type: str, source_ref: str | None) -> str:
+    cleaned_ref = str(source_ref or "unknown").strip() or "unknown"
+    return f"{source_type}:{cleaned_ref}"
+
+
+def _warning_conflicts(warnings: list[str] | None) -> list[str]:
+    conflicts: list[str] = []
+    for warning in warnings or []:
+        warning_text = str(warning or "").strip()
+        if not warning_text:
+            continue
+        lower_warning = warning_text.lower()
+        if "conflict" in lower_warning or "drift" in lower_warning:
+            conflicts.append(warning_text)
+    return _unique_texts(conflicts)
+
+
+def _topology_context_source(
+    *,
+    topology_status: Any | None,
+    topology_freshness_days: int | None,
+    topology_warnings: list[str],
+    topology_score: float,
+    scope: str,
+) -> ContextSourceMetadata:
+    topology_payload = getattr(topology_status, "payload", None)
+    import_metadata = {}
+    if isinstance(topology_payload, dict):
+        metadata = topology_payload.get("metadata")
+        if isinstance(metadata, dict) and isinstance(metadata.get("import"), dict):
+            import_metadata = metadata["import"]
+    source_kind = str(import_metadata.get("source_type") or "topology").strip()
+    source_ref = str(
+        import_metadata.get("source_ref")
+        or getattr(topology_status, "path", None)
+        or "topology:missing"
+    ).strip()
+    if topology_freshness_days is None:
+        freshness_status = "missing"
+    elif _warning_conflicts(topology_warnings):
+        freshness_status = "conflicting"
+    elif _has_kubernetes_live_state_degradation(topology_warnings):
+        freshness_status = "incomplete"
+    elif topology_freshness_days > STALE_AFTER_DAYS:
+        freshness_status = "stale"
+    else:
+        freshness_status = "current"
+    limitations = _unique_texts(
+        [
+            *(["missing_topology"] if topology_freshness_days is None else []),
+            *(
+                ["stale_topology"]
+                if topology_freshness_days
+                and topology_freshness_days > STALE_AFTER_DAYS
+                else []
+            ),
+            *topology_warnings,
+        ]
+    )
+    return ContextSourceMetadata(
+        source_id=_source_id(f"topology:{source_kind}", source_ref),
+        source_type="topology",
+        source_ref=source_ref,
+        scope=scope,
+        freshness_status=freshness_status,
+        last_observed_at=getattr(topology_status, "updated_at", None),
+        age_days=topology_freshness_days,
+        confidence=round(topology_score, 2),
+        conflicts=_warning_conflicts(topology_warnings),
+        limitations=limitations,
+    )
+
+
+def _incident_context_source(
+    *,
+    incident_index_snapshot: dict[str, Any],
+    incident_index_size: int,
+    scope: str,
+) -> ContextSourceMetadata:
+    version = str(
+        incident_index_snapshot.get("incident_index_version") or "incidents:unknown"
+    )
+    last_indexed_at = incident_index_snapshot.get("incident_index_last_indexed_at")
+    freshness_status = str(
+        incident_index_snapshot.get("incident_index_freshness_status")
+        or ("current" if incident_index_size else "empty")
+    )
+    limitations = [] if incident_index_size else ["empty_incident_index"]
+    conflicts = [] if incident_index_size else ["missing_incident_history"]
+    if incident_index_size and freshness_status != "current":
+        limitations.append("stale_incident_index")
+    return ContextSourceMetadata(
+        source_id=_source_id("incident:index", version),
+        source_type="incident",
+        source_ref=version,
+        scope=scope,
+        freshness_status=freshness_status,
+        last_observed_at=last_indexed_at,
+        age_days=_topology_freshness_days(last_indexed_at),
+        confidence=round(
+            _incident_context_confidence(incident_index_size, freshness_status), 2
+        ),
+        conflicts=conflicts,
+        limitations=limitations,
+    )
+
+
+def _incident_context_confidence(
+    incident_index_size: int,
+    incident_freshness_status: str,
+) -> float:
+    score = _incident_score(incident_index_size)
+    if incident_index_size and incident_freshness_status != "current":
+        return min(score, 0.5)
+    return score
+
+
+def _ownership_context_sources(
+    *,
+    owner_signals: list[OwnerSignal],
+    ownership_unmapped_subjects: list[str],
+    scope: str,
+) -> list[ContextSourceMetadata]:
+    sources: list[ContextSourceMetadata] = []
+    grouped_signals: dict[tuple[str, str], list[OwnerSignal]] = {}
+    for signal in owner_signals:
+        source_kind = str(signal.source or "ownership").strip() or "ownership"
+        source_ref = str(signal.source_ref or source_kind).strip() or source_kind
+        grouped_signals.setdefault((source_kind, source_ref), []).append(signal)
+    for (source_kind, source_ref), signals in grouped_signals.items():
+        subjects = _unique_texts([signal.subject for signal in signals])
+        owners = _unique_texts(
+            owner for signal in signals for owner in list(signal.owners)
+        )
+        sources.append(
+            ContextSourceMetadata(
+                source_id=_source_id(f"ownership:{source_kind}", source_ref),
+                source_type="ownership",
+                source_ref=source_ref,
+                scope=scope,
+                freshness_status="current",
+                confidence=1.0 if owners else 0.5,
+                limitations=[]
+                if owners
+                else [f"ownership_source_has_no_owners:{source_ref}"],
+                conflicts=[],
+            )
+        )
+        if not subjects:
+            sources[-1].limitations.append("ownership_source_has_no_subjects")
+    if ownership_unmapped_subjects:
+        sources.append(
+            ContextSourceMetadata(
+                source_id="ownership:unmapped",
+                source_type="ownership",
+                source_ref="unmapped-subjects",
+                scope=scope,
+                freshness_status="incomplete",
+                confidence=0.5 if sources else 0.0,
+                limitations=list(ownership_unmapped_subjects),
+            )
+        )
+    if not sources:
+        sources.append(
+            ContextSourceMetadata(
+                source_id="ownership:none",
+                source_type="ownership",
+                source_ref="ownership-signals",
+                scope=scope,
+                freshness_status="not_applicable",
+                confidence=0.0,
+                limitations=["no_ownership_signals"],
+            )
+        )
+    return sources
+
+
+def _build_context_sources(
+    *,
+    parse_batch: ParseBatchResult,
+    scope: str,
+    topology_status: Any | None,
+    topology_freshness_days: int | None,
+    topology_warnings: list[str],
+    topology_score: float | None,
+    include_topology_context: bool,
+    incident_index_snapshot: dict[str, Any],
+    incident_index_size: int,
+    include_incident_context: bool,
+    raw_parser_success_rate: float,
+    evidence_success_rate: float,
+    owner_signals: list[OwnerSignal],
+    ownership_unmapped_subjects: list[str],
+) -> list[ContextSourceMetadata]:
+    sources: list[ContextSourceMetadata] = []
+    for file_result in parse_batch.files:
+        status = "current" if file_result.status == "parsed" else "incomplete"
+        limitations: list[str] = []
+        if file_result.status != "parsed":
+            limitations.append(f"{file_result.status}_artifact")
+        if file_result.issue is not None:
+            limitations.append(file_result.issue.message)
+        sources.append(
+            ContextSourceMetadata(
+                source_id=_source_id("artifact", file_result.file_name),
+                source_type="artifact",
+                source_ref=file_result.file_name,
+                scope=scope,
+                freshness_status=status,
+                confidence=1.0 if file_result.status == "parsed" else 0.0,
+                limitations=_unique_texts(limitations),
+            )
+        )
+    if include_topology_context:
+        sources.append(
+            _topology_context_source(
+                topology_status=topology_status,
+                topology_freshness_days=topology_freshness_days,
+                topology_warnings=topology_warnings,
+                topology_score=topology_score if topology_score is not None else 0.0,
+                scope=scope,
+            )
+        )
+    if include_incident_context:
+        sources.append(
+            _incident_context_source(
+                incident_index_snapshot=incident_index_snapshot,
+                incident_index_size=incident_index_size,
+                scope=scope,
+            )
+        )
+    parser_success_by_tool = _parser_success_by_tool(parse_batch)
+    for tool_name, score in parser_success_by_tool.items():
+        sources.append(
+            ContextSourceMetadata(
+                source_id=_source_id("parser", tool_name),
+                source_type="parser",
+                source_ref=tool_name,
+                scope=scope,
+                freshness_status="not_applicable",
+                confidence=round(score, 2),
+                limitations=[] if score >= 1.0 else ["partial_parser_coverage"],
+            )
+        )
+    if not parser_success_by_tool:
+        sources.append(
+            ContextSourceMetadata(
+                source_id="parser:none",
+                source_type="parser",
+                source_ref="submitted-artifacts",
+                scope=scope,
+                freshness_status="incomplete",
+                confidence=round(raw_parser_success_rate, 2),
+                limitations=["no_parser_results"],
+            )
+        )
+    sources.append(
+        ContextSourceMetadata(
+            source_id="evidence:extractor",
+            source_type="evidence",
+            source_ref="analysis-evidence",
+            scope=scope,
+            freshness_status="not_applicable",
+            confidence=round(evidence_success_rate, 2),
+            limitations=[]
+            if evidence_success_rate >= 1.0
+            else ["partial_evidence_coverage"],
+        )
+    )
+    sources.extend(
+        _ownership_context_sources(
+            owner_signals=owner_signals,
+            ownership_unmapped_subjects=ownership_unmapped_subjects,
+            scope=scope,
+        )
+    )
+    return sources
+
+
+def _context_source_for_evidence(
+    evidence_item: EvidenceItem,
+    context_sources: list[ContextSourceMetadata],
+) -> ContextSourceMetadata | None:
+    if evidence_item.context_source is not None:
+        return evidence_item.context_source
+    if evidence_item.source_type == "artifact":
+        artifact = evidence_item.artifact.strip()
+        source_ref = evidence_item.source_ref.strip()
+        for source in context_sources:
+            if source.source_type != "artifact":
+                continue
+            if artifact and source.source_ref == artifact:
+                return source
+            if source.source_ref and _source_ref_matches(
+                source_ref, f"artifact://{source.source_ref}"
+            ):
+                return source
+    type_matches = [
+        source
+        for source in context_sources
+        if source.source_type == evidence_item.source_type
+    ]
+    if evidence_item.source_ref:
+        for source in type_matches:
+            if source.source_ref and _source_ref_matches(
+                evidence_item.source_ref, source.source_ref
+            ):
+                return source
+    return None
+
+
+def _source_ref_matches(candidate_ref: str, source_ref: str) -> bool:
+    if candidate_ref == source_ref:
+        return True
+    if not candidate_ref.startswith(source_ref):
+        return False
+    suffix = candidate_ref[len(source_ref) :]
+    return suffix == "" or suffix[0] in {"#", "?"}
+
+
+def _evidence_items_with_context_sources(
+    evidence_items: list[EvidenceItem],
+    context_sources: list[ContextSourceMetadata],
+) -> list[EvidenceItem]:
+    if not context_sources:
+        return evidence_items
+    enriched: list[EvidenceItem] = []
+    for evidence_item in evidence_items:
+        matched = _context_source_for_evidence(evidence_item, context_sources)
+        if matched is None:
+            enriched.append(evidence_item)
+        else:
+            enriched.append(
+                evidence_item.model_copy(update={"context_source": matched})
+            )
+    return enriched
+
+
 def _context_todos(
     *,
     evidence_success_rate: float,
@@ -377,6 +734,7 @@ def _context_todos(
     topology_warnings: list[str] | None = None,
     incident_index_size: int,
     parser_success_rate: float,
+    incident_freshness_status: str = "unknown",
     include_topology_context: bool = True,
     include_incident_context: bool = True,
 ) -> list[str]:
@@ -394,6 +752,8 @@ def _context_todos(
             )
     if include_incident_context and incident_index_size == 0:
         todos.append("Import relevant incident history for this project/workspace.")
+    elif include_incident_context and incident_freshness_status != "current":
+        todos.append("Refresh stale incident history for this project/workspace.")
     if parser_success_rate < 1.0:
         todos.append("Review parser errors and resubmit supported artifacts.")
     if evidence_success_rate < 1.0:
@@ -409,6 +769,7 @@ def _context_uncertainty(
     topology_warnings: list[str] | None = None,
     incident_index_size: int,
     parser_success_rate: float,
+    incident_freshness_status: str = "unknown",
     ownership_unmapped_subjects: list[str] | tuple[str, ...] = (),
     include_topology_context: bool = True,
     include_incident_context: bool = True,
@@ -425,6 +786,8 @@ def _context_uncertainty(
             weak_signals.append("Kubernetes live-state context is degraded")
     if include_incident_context and incident_index_size == 0:
         weak_signals.append("incident history is unavailable")
+    elif include_incident_context and incident_freshness_status != "current":
+        weak_signals.append("incident history is stale")
     if parser_success_rate < 1.0:
         weak_signals.append("parser coverage is partial")
     if evidence_success_rate < 1.0:
@@ -557,6 +920,8 @@ def _build_context_completeness(
     topology_warnings: list[str] = []
     topology_payload_is_usable = False
     topology_payload_is_kubernetes = False
+    topology_status = None
+    topology_score: float | None = None
     if include_topology_context:
         topology_status = get_topology_status(
             project_id=project_id,
@@ -607,6 +972,10 @@ def _build_context_completeness(
         incident_index_size = int(
             incident_index_snapshot.get("incident_index_size") or 0
         )
+    incident_freshness_status = str(
+        incident_index_snapshot.get("incident_index_freshness_status")
+        or ("current" if incident_index_size else "empty")
+    )
     raw_parser_success_rate = parse_batch.parsed_count / max(len(parse_batch.files), 1)
     parser_success_rate = round(raw_parser_success_rate, 2)
     evidence_success_rate = _evidence_success_rate(
@@ -626,7 +995,14 @@ def _build_context_completeness(
             )
         weighted_scores.append((topology_score, 0.25))
     if include_incident_context:
-        weighted_scores.append((_incident_score(incident_index_size), 0.20))
+        weighted_scores.append(
+            (
+                _incident_context_confidence(
+                    incident_index_size, incident_freshness_status
+                ),
+                0.20,
+            )
+        )
     total_weight = sum(weight for _, weight in weighted_scores) or 1.0
     raw_context_score = min(
         1.0,
@@ -644,11 +1020,34 @@ def _build_context_completeness(
         topology_freshness_days=topology_freshness_days,
         topology_warnings=topology_warnings,
         incident_index_size=incident_index_size,
+        incident_freshness_status=incident_freshness_status,
         parser_success_rate=raw_parser_success_rate,
         include_topology_context=include_topology_context,
         include_incident_context=include_incident_context,
     )
     context_todos = _unique_texts(context_todos + list(ownership_context.context_todos))
+    scope = _scope_label(
+        project_id=project_id,
+        project_key=project_key,
+        workspace_id=workspace_id,
+        workspace_key=workspace_key,
+    )
+    context_sources = _build_context_sources(
+        parse_batch=parse_batch,
+        scope=scope,
+        topology_status=topology_status,
+        topology_freshness_days=topology_freshness_days,
+        topology_warnings=topology_warnings,
+        topology_score=topology_score,
+        include_topology_context=include_topology_context,
+        incident_index_snapshot=incident_index_snapshot,
+        incident_index_size=incident_index_size,
+        include_incident_context=include_incident_context,
+        raw_parser_success_rate=raw_parser_success_rate,
+        evidence_success_rate=evidence_success_rate,
+        owner_signals=list(ownership_context.owner_signals),
+        ownership_unmapped_subjects=list(ownership_context.unmapped_subjects),
+    )
     return ContextCompleteness(
         topology_freshness_days=topology_freshness_days,
         topology_last_imported_at=topology_last_imported_at,
@@ -659,9 +1058,7 @@ def _build_context_completeness(
         incident_index_last_indexed_at=incident_index_snapshot.get(
             "incident_index_last_indexed_at"
         ),
-        incident_index_freshness_status=str(
-            incident_index_snapshot.get("incident_index_freshness_status") or "empty"
-        ),
+        incident_index_freshness_status=incident_freshness_status,
         parser_success_rate=parser_success_rate,
         evidence_success_rate=round(evidence_success_rate, 2),
         parser_success_by_tool=_parser_success_by_tool(parse_batch),
@@ -673,6 +1070,7 @@ def _build_context_completeness(
             topology_freshness_days=topology_freshness_days,
             topology_warnings=topology_warnings,
             incident_index_size=incident_index_size,
+            incident_freshness_status=incident_freshness_status,
             parser_success_rate=raw_parser_success_rate,
             ownership_unmapped_subjects=ownership_context.unmapped_subjects,
             include_topology_context=include_topology_context,
@@ -683,6 +1081,7 @@ def _build_context_completeness(
         owner_signals=list(ownership_context.owner_signals),
         escalation_hints=list(ownership_context.escalation_hints),
         ownership_unmapped_subjects=list(ownership_context.unmapped_subjects),
+        context_sources=context_sources,
     )
 
 
@@ -1335,7 +1734,7 @@ def build_analysis_artifacts(
         completion_client=completion_client,
         allow_llm_assistance=allow_llm_assistance,
     )
-    assessment.context_completeness = _build_context_completeness(
+    context_completeness = _build_context_completeness(
         parse_batch,
         evidence_items=evidence_items,
         project_id=project_id,
@@ -1347,6 +1746,10 @@ def build_analysis_artifacts(
         topology=topology,
         codeowners_sources=codeowners_sources,
     )
+    evidence_items = _evidence_items_with_context_sources(
+        evidence_items, list(context_completeness.context_sources)
+    )
+    assessment.context_completeness = context_completeness
     assessment = apply_context_uncertainty(assessment)
     findings = build_findings(
         assessment=assessment,

--- a/services/analysis_service.py
+++ b/services/analysis_service.py
@@ -401,9 +401,40 @@ def _warning_conflicts(warnings: list[str] | None) -> list[str]:
         if not warning_text:
             continue
         lower_warning = warning_text.lower()
-        if "conflict" in lower_warning or "drift" in lower_warning:
-            conflicts.append(warning_text)
+        if "conflict" in lower_warning:
+            conflicts.append("topology_conflict")
+        elif "drift" in lower_warning:
+            conflicts.append("topology_drift")
     return _unique_texts(conflicts)
+
+
+def _topology_warning_limitations(warnings: list[str] | None) -> list[str]:
+    limitations: list[str] = []
+    for warning in warnings or []:
+        warning_text = str(warning or "").strip().lower()
+        if not warning_text:
+            continue
+        if "kubernetes live-state context todo" in warning_text:
+            limitations.append("kubernetes_live_state_context_todo")
+        elif "kubernetes live-state import partially parsed" in warning_text:
+            limitations.append("partial_kubernetes_live_state")
+        elif (
+            "kubernetes live-state import did not produce any supported resources"
+            in warning_text
+        ):
+            limitations.append("empty_kubernetes_live_state")
+        elif (
+            "kubernetes live-state import did not produce any non-namespace resources"
+            in warning_text
+        ):
+            limitations.append("namespace_only_kubernetes_live_state")
+        elif "conflict" in warning_text:
+            limitations.append("topology_conflict")
+        elif "drift" in warning_text:
+            limitations.append("topology_drift")
+        else:
+            limitations.append("topology_warning")
+    return _unique_texts(limitations)
 
 
 def _topology_context_source(
@@ -445,7 +476,7 @@ def _topology_context_source(
                 and topology_freshness_days > STALE_AFTER_DAYS
                 else []
             ),
-            *topology_warnings,
+            *_topology_warning_limitations(topology_warnings),
         ]
     )
     return ContextSourceMetadata(
@@ -478,8 +509,15 @@ def _incident_context_source(
     )
     limitations = [] if incident_index_size else ["empty_incident_index"]
     conflicts = [] if incident_index_size else ["missing_incident_history"]
-    if incident_index_size and freshness_status != "current":
+    if incident_index_size and freshness_status == "stale":
         limitations.append("stale_incident_index")
+    elif incident_index_size and freshness_status == "conflicting":
+        limitations.append("incident_index_conflicting")
+        conflicts.append("incident_index_conflicting")
+    elif incident_index_size and freshness_status == "incomplete":
+        limitations.append("incident_index_incomplete")
+    elif incident_index_size and freshness_status not in {"current", "empty"}:
+        limitations.append(f"incident_index_{freshness_status}")
     return ContextSourceMetadata(
         source_id=_source_id("incident:index", version),
         source_type="incident",
@@ -511,6 +549,8 @@ def _ownership_context_sources(
     owner_signals: list[OwnerSignal],
     ownership_unmapped_subjects: list[str],
     scope: str,
+    topology_freshness_status: str = "not_applicable",
+    topology_confidence: float = 0.0,
 ) -> list[ContextSourceMetadata]:
     sources: list[ContextSourceMetadata] = []
     grouped_signals: dict[tuple[str, str], list[OwnerSignal]] = {}
@@ -523,17 +563,31 @@ def _ownership_context_sources(
         owners = _unique_texts(
             owner for signal in signals for owner in list(signal.owners)
         )
+        source_is_topology = source_kind == "topology"
+        base_confidence = 1.0 if owners else 0.5
+        freshness_status = (
+            topology_freshness_status if source_is_topology else "current"
+        )
+        confidence = (
+            min(base_confidence, topology_confidence)
+            if source_is_topology
+            else base_confidence
+        )
+        limitations = [] if owners else [f"ownership_source_has_no_owners:{source_ref}"]
+        if source_is_topology and freshness_status not in {
+            "current",
+            "not_applicable",
+        }:
+            limitations.append(f"topology_ownership_source_{freshness_status}")
         sources.append(
             ContextSourceMetadata(
                 source_id=_source_id(f"ownership:{source_kind}", source_ref),
                 source_type="ownership",
                 source_ref=source_ref,
                 scope=scope,
-                freshness_status="current",
-                confidence=1.0 if owners else 0.5,
-                limitations=[]
-                if owners
-                else [f"ownership_source_has_no_owners:{source_ref}"],
+                freshness_status=freshness_status,
+                confidence=confidence,
+                limitations=limitations,
                 conflicts=[],
             )
         )
@@ -566,6 +620,12 @@ def _ownership_context_sources(
     return sources
 
 
+def _artifact_context_source_ref(file_name: str) -> tuple[str, list[str]]:
+    source_ref = str(file_name or "").strip() or "unknown-file"
+    limitations = [] if str(file_name or "").strip() else ["missing_artifact_name"]
+    return source_ref, limitations
+
+
 def _build_context_sources(
     *,
     parse_batch: ParseBatchResult,
@@ -585,17 +645,20 @@ def _build_context_sources(
 ) -> list[ContextSourceMetadata]:
     sources: list[ContextSourceMetadata] = []
     for file_result in parse_batch.files:
+        artifact_source_ref, artifact_limitations = _artifact_context_source_ref(
+            file_result.file_name
+        )
         status = "current" if file_result.status == "parsed" else "incomplete"
-        limitations: list[str] = []
+        limitations: list[str] = list(artifact_limitations)
         if file_result.status != "parsed":
             limitations.append(f"{file_result.status}_artifact")
         if file_result.issue is not None:
-            limitations.append(file_result.issue.message)
+            limitations.append("parser_issue")
         sources.append(
             ContextSourceMetadata(
-                source_id=_source_id("artifact", file_result.file_name),
+                source_id=_source_id("artifact", artifact_source_ref),
                 source_type="artifact",
-                source_ref=file_result.file_name,
+                source_ref=artifact_source_ref,
                 scope=scope,
                 freshness_status=status,
                 confidence=1.0 if file_result.status == "parsed" else 0.0,
@@ -603,15 +666,16 @@ def _build_context_sources(
             )
         )
     if include_topology_context:
-        sources.append(
-            _topology_context_source(
-                topology_status=topology_status,
-                topology_freshness_days=topology_freshness_days,
-                topology_warnings=topology_warnings,
-                topology_score=topology_score if topology_score is not None else 0.0,
-                scope=scope,
-            )
+        topology_context_source = _topology_context_source(
+            topology_status=topology_status,
+            topology_freshness_days=topology_freshness_days,
+            topology_warnings=topology_warnings,
+            topology_score=topology_score if topology_score is not None else 0.0,
+            scope=scope,
         )
+        sources.append(topology_context_source)
+    else:
+        topology_context_source = None
     if include_incident_context:
         sources.append(
             _incident_context_source(
@@ -665,6 +729,16 @@ def _build_context_sources(
             owner_signals=owner_signals,
             ownership_unmapped_subjects=ownership_unmapped_subjects,
             scope=scope,
+            topology_freshness_status=(
+                topology_context_source.freshness_status
+                if topology_context_source is not None
+                else "not_applicable"
+            ),
+            topology_confidence=(
+                topology_context_source.confidence
+                if topology_context_source is not None
+                else 0.0
+            ),
         )
     )
     return sources

--- a/services/analysis_service.py
+++ b/services/analysis_service.py
@@ -628,7 +628,7 @@ def _build_context_sources(
                 source_type="parser",
                 source_ref=tool_name,
                 scope=scope,
-                freshness_status="not_applicable",
+                freshness_status="not_applicable" if score >= 1.0 else "incomplete",
                 confidence=round(score, 2),
                 limitations=[] if score >= 1.0 else ["partial_parser_coverage"],
             )
@@ -651,7 +651,9 @@ def _build_context_sources(
             source_type="evidence",
             source_ref="analysis-evidence",
             scope=scope,
-            freshness_status="not_applicable",
+            freshness_status="not_applicable"
+            if evidence_success_rate >= 1.0
+            else "incomplete",
             confidence=round(evidence_success_rate, 2),
             limitations=[]
             if evidence_success_rate >= 1.0
@@ -752,8 +754,12 @@ def _context_todos(
             )
     if include_incident_context and incident_index_size == 0:
         todos.append("Import relevant incident history for this project/workspace.")
-    elif include_incident_context and incident_freshness_status != "current":
+    elif include_incident_context and incident_freshness_status == "stale":
         todos.append("Refresh stale incident history for this project/workspace.")
+    elif include_incident_context and incident_freshness_status != "current":
+        todos.append(
+            f"Resolve incident history freshness: {incident_freshness_status}."
+        )
     if parser_success_rate < 1.0:
         todos.append("Review parser errors and resubmit supported artifacts.")
     if evidence_success_rate < 1.0:
@@ -786,8 +792,12 @@ def _context_uncertainty(
             weak_signals.append("Kubernetes live-state context is degraded")
     if include_incident_context and incident_index_size == 0:
         weak_signals.append("incident history is unavailable")
-    elif include_incident_context and incident_freshness_status != "current":
+    elif include_incident_context and incident_freshness_status == "stale":
         weak_signals.append("incident history is stale")
+    elif include_incident_context and incident_freshness_status != "current":
+        weak_signals.append(
+            f"incident history freshness is {incident_freshness_status}"
+        )
     if parser_success_rate < 1.0:
         weak_signals.append("parser coverage is partial")
     if evidence_success_rate < 1.0:

--- a/services/report_service.py
+++ b/services/report_service.py
@@ -30,7 +30,12 @@ from analysis.risk_scorer import (
 )
 from api.schemas import IntakeItem, PendingAnalysis
 from evidence.mappers import classify_finding_evidence
-from evidence.models import ContextCompleteness, EvidenceItem, Finding
+from evidence.models import (
+    ContextCompleteness,
+    ContextSourceMetadata,
+    EvidenceItem,
+    Finding,
+)
 from llm.narrator import NarrativeResult
 
 from models.database import SessionLocal
@@ -3290,6 +3295,23 @@ def _context_confidence_level_from_score(context_score: float) -> str:
     return "low"
 
 
+def _topology_freshness_score(topology_freshness_days: int | None) -> float:
+    if topology_freshness_days is None:
+        return 0.0
+    if topology_freshness_days <= STALE_AFTER_DAYS:
+        return 1.0
+    return max(0.0, 1.0 - ((topology_freshness_days - STALE_AFTER_DAYS) / 60))
+
+
+def _incident_context_score(
+    incident_index_size: int,
+    *,
+    stale: bool = False,
+) -> float:
+    score = min(max(incident_index_size, 0) / 10, 1.0)
+    return min(score, 0.5) if stale and incident_index_size else score
+
+
 def _context_float_value(
     decoded: dict,
     key: str,
@@ -3314,6 +3336,33 @@ def _context_int_value(decoded: dict, key: str) -> int:
     except (TypeError, ValueError):
         return 0
     return max(value, 0)
+
+
+def _context_sources(value: object) -> list[dict[str, Any]]:
+    if not isinstance(value, list):
+        return []
+    return [source for source in value if isinstance(source, dict)]
+
+
+def _has_context_source(context_completeness: dict, source_type: str) -> bool:
+    return any(
+        source.get("source_type") == source_type
+        for source in _context_sources(context_completeness.get("context_sources"))
+    )
+
+
+def _context_source_confidence(
+    context_completeness: dict,
+    source_type: str,
+) -> float | None:
+    confidences = [
+        _context_float_value(source, "confidence", missing_default=0.0)
+        for source in _context_sources(context_completeness.get("context_sources"))
+        if source.get("source_type") == source_type
+    ]
+    if not confidences:
+        return None
+    return max(confidences)
 
 
 def _context_todo_items(value: object) -> list[str]:
@@ -3503,6 +3552,56 @@ def _clamp_confidence_to_context(
     return round(min(confidence, max(0.0, min(context_score, 1.0))), 2)
 
 
+def _recomputed_stale_incident_context_score(context_completeness: dict) -> float:
+    weighted_scores = [
+        (
+            _context_float_value(
+                context_completeness, "parser_success_rate", missing_default=1.0
+            ),
+            0.35,
+        ),
+        (
+            _context_float_value(
+                context_completeness, "evidence_success_rate", missing_default=1.0
+            ),
+            0.20,
+        ),
+    ]
+    topology_score = _context_source_confidence(context_completeness, "topology")
+    topology_freshness_days = context_completeness.get("topology_freshness_days")
+    if topology_freshness_days is not None:
+        try:
+            topology_freshness_days = int(topology_freshness_days)
+        except (TypeError, ValueError):
+            topology_freshness_days = None
+    if topology_score is None:
+        topology_score = _topology_freshness_score(topology_freshness_days)
+    if topology_score is not None and (
+        topology_freshness_days is not None
+        or _has_context_source(context_completeness, "topology")
+    ):
+        weighted_scores.append((topology_score, 0.25))
+    incident_index_size = _context_int_value(
+        context_completeness, "incident_index_size"
+    )
+    if context_completeness.get("incident_index_version") not in {
+        None,
+        "",
+        "incidents:unknown",
+        "incidents:unscoped",
+    }:
+        weighted_scores.append(
+            (_incident_context_score(incident_index_size, stale=True), 0.20)
+        )
+    total_weight = sum(weight for _, weight in weighted_scores) or 1.0
+    return round(
+        min(
+            1.0, sum(score * weight for score, weight in weighted_scores) / total_weight
+        ),
+        2,
+    )
+
+
 def _context_with_incident_index_freshness(report, context_completeness: dict) -> dict:
     stored_version = str(context_completeness.get("incident_index_version") or "")
     if not stored_version or stored_version in {
@@ -3531,12 +3630,11 @@ def _mark_incident_context_stale(context_completeness: dict) -> dict:
     updated = dict(context_completeness)
     updated["incident_index_freshness_status"] = "stale"
     context_score = _context_float_value(updated, "context_score", missing_default=0.0)
-    if context_score > 0.8:
-        context_score = 0.8
-        updated["context_score"] = context_score
-        updated["confidence_level"] = _context_confidence_level_from_score(
-            context_score
-        )
+    recomputed_score = _recomputed_stale_incident_context_score(updated)
+    context_score = min(context_score, recomputed_score)
+    updated["context_score"] = context_score
+    updated["confidence_level"] = _context_confidence_level_from_score(context_score)
+    updated["insufficient_context"] = context_score < 0.7
     todos = _context_todo_items(updated.get("context_todos"))
     if not any(
         "incident" in item.lower() and "stale" in item.lower() for item in todos
@@ -3608,6 +3706,10 @@ def _load_evidence_context_source(
     except (TypeError, ValueError, json.JSONDecodeError):
         return None
     if not isinstance(decoded, dict):
+        return None
+    try:
+        decoded = ContextSourceMetadata.model_validate(decoded).model_dump(mode="json")
+    except ValidationError:
         return None
     if (
         decoded.get("source_type") == "incident"

--- a/services/report_service.py
+++ b/services/report_service.py
@@ -468,6 +468,70 @@ def _redact_text_value(value: Any, pairs: list[tuple[str, str]]) -> Any:
     return redacted
 
 
+def _redact_text_list(
+    values: object,
+    pairs: list[tuple[str, str]],
+) -> list[str]:
+    if not isinstance(values, list | tuple):
+        return []
+    return [
+        str(_redact_text_value(item, pairs)) for item in values if str(item).strip()
+    ]
+
+
+def _redact_context_source_metadata(
+    source: object,
+    pairs: list[tuple[str, str]],
+) -> object:
+    if not isinstance(source, dict):
+        return source
+    redacted = dict(source)
+    for key in ("source_id", "source_ref", "scope", "last_observed_at"):
+        redacted[key] = _redact_text_value(redacted.get(key), pairs)
+    redacted["conflicts"] = _redact_text_list(redacted.get("conflicts"), pairs)
+    redacted["limitations"] = _redact_text_list(redacted.get("limitations"), pairs)
+    return redacted
+
+
+def _redact_context_completeness(
+    context: object,
+    pairs: list[tuple[str, str]],
+) -> object:
+    if not isinstance(context, dict):
+        return context
+    redacted = dict(context)
+    redacted["uncertainty"] = _redact_text_value(redacted.get("uncertainty"), pairs)
+    redacted["context_todos"] = _redact_text_list(redacted.get("context_todos"), pairs)
+    redacted["escalation_hints"] = _redact_text_list(
+        redacted.get("escalation_hints"), pairs
+    )
+    redacted["ownership_unmapped_subjects"] = _redact_text_list(
+        redacted.get("ownership_unmapped_subjects"), pairs
+    )
+    redacted["context_sources"] = [
+        _redact_context_source_metadata(source, pairs)
+        for source in redacted.get("context_sources") or []
+    ]
+    owner_signals: list[object] = []
+    for signal in redacted.get("owner_signals") or []:
+        if not isinstance(signal, dict):
+            owner_signals.append(signal)
+            continue
+        signal_payload = dict(signal)
+        for key in (
+            "subject",
+            "source_ref",
+            "matched_pattern",
+            "resource_id",
+            "service_id",
+            "escalation_hint",
+        ):
+            signal_payload[key] = _redact_text_value(signal_payload.get(key), pairs)
+        owner_signals.append(signal_payload)
+    redacted["owner_signals"] = owner_signals
+    return redacted
+
+
 def _redact_report_file_names(report: dict[str, Any]) -> dict[str, Any]:
     audit_names = list(report.get("audit", {}).get("files_analyzed") or [])
     original_names = list(audit_names)
@@ -502,6 +566,10 @@ def _redact_report_file_names(report: dict[str, Any]) -> dict[str, Any]:
             **dict(report.get("audit") or {}),
             "files_analyzed": [redaction_map[name] for name in audit_names],
         },
+        "context_completeness": _redact_context_completeness(
+            report.get("context_completeness") or {},
+            pairs,
+        ),
         "submission_manifest": _redact_submission_manifest_file_names(
             dict(report.get("submission_manifest") or {}),
             redaction_map,
@@ -553,6 +621,10 @@ def _redact_report_file_names(report: dict[str, Any]) -> dict[str, Any]:
                     evidence_item.get("location", ""), pairs
                 ),
                 "summary": _redact_text_value(evidence_item.get("summary"), pairs),
+                "context_source": _redact_context_source_metadata(
+                    evidence_item.get("context_source"),
+                    pairs,
+                ),
                 "redaction_status": (
                     "sensitive_blocked"
                     if evidence_item.get("redaction_status") == "sensitive_blocked"
@@ -3619,11 +3691,22 @@ def _context_with_incident_index_freshness(report, context_completeness: dict) -
             workspace_id=report.workspace_id,
         )
     except Exception:
+        if _incident_context_is_empty(context_completeness):
+            return context_completeness
         return _mark_incident_context_stale(context_completeness)
     current_version = str(current.get("incident_index_version") or "")
     if current_version and current_version != stored_version:
         return _mark_incident_context_stale(context_completeness)
     return context_completeness
+
+
+def _incident_context_is_empty(context_completeness: dict) -> bool:
+    return (
+        str(context_completeness.get("incident_index_version") or "")
+        in {"incidents:empty", "incidents:0:empty"}
+        or str(context_completeness.get("incident_index_freshness_status") or "")
+        == "empty"
+    )
 
 
 def _mark_incident_context_stale(context_completeness: dict) -> dict:
@@ -3650,6 +3733,10 @@ def _mark_incident_context_stale(context_completeness: dict) -> dict:
             else f"Uncertainty: {stale_message}."
         )
     context_sources = updated.get("context_sources")
+    stale_source_confidence = _incident_context_score(
+        _context_int_value(updated, "incident_index_size"),
+        stale=True,
+    )
     if isinstance(context_sources, list):
         updated_sources: list[object] = []
         stored_version = str(updated.get("incident_index_version") or "")
@@ -3671,6 +3758,12 @@ def _mark_incident_context_stale(context_completeness: dict) -> dict:
                 continue
             stale_source = dict(source)
             stale_source["freshness_status"] = "stale"
+            stale_source["confidence"] = min(
+                _context_float_value(
+                    stale_source, "confidence", missing_default=stale_source_confidence
+                ),
+                stale_source_confidence,
+            )
             limitations = _context_todo_items(stale_source.get("limitations"))
             if "stale_incident_index" not in limitations:
                 limitations.append("stale_incident_index")
@@ -3724,6 +3817,13 @@ def _load_evidence_context_source(
     ):
         decoded = dict(decoded)
         decoded["freshness_status"] = "stale"
+        decoded["confidence"] = min(
+            _context_float_value(decoded, "confidence", missing_default=0.0),
+            _incident_context_score(
+                _context_int_value(context_completeness, "incident_index_size"),
+                stale=True,
+            ),
+        )
         limitations = _context_todo_items(decoded.get("limitations"))
         if "stale_incident_index" not in limitations:
             limitations.append("stale_incident_index")

--- a/services/report_service.py
+++ b/services/report_service.py
@@ -16,7 +16,7 @@ from collections import Counter, defaultdict
 from datetime import UTC, datetime
 from functools import lru_cache
 from urllib.parse import urlsplit
-from typing import Any
+from typing import Any, get_args
 
 from pydantic import ValidationError
 
@@ -32,6 +32,7 @@ from api.schemas import IntakeItem, PendingAnalysis
 from evidence.mappers import classify_finding_evidence
 from evidence.models import (
     ContextCompleteness,
+    ContextSourceFreshness,
     ContextSourceMetadata,
     EvidenceItem,
     Finding,
@@ -141,6 +142,20 @@ _CONTEXT_UNAVAILABLE_UNCERTAINTY = (
 _AUDIT_ACTOR_MAX_LENGTH = 120
 _CONTEXT_UNAVAILABLE_TODO = (
     "Re-run analysis to regenerate context completeness metadata."
+)
+_CONTEXT_SOURCES_DROPPED_TODO = (
+    "Review dropped context source metadata for this report."
+)
+_CONTEXT_INCIDENT_IMPORT_TODO = (
+    "Import relevant incident history for this project/workspace."
+)
+_CONTEXT_INCIDENT_FRESHNESS_CONFLICT_TODO = (
+    "Resolve incident history freshness: empty state conflicts with populated index."
+)
+_CONTEXT_SOURCE_METADATA_FIELDS = frozenset(ContextSourceMetadata.model_fields)
+_CONTEXT_FRESHNESS_STATUSES = frozenset(get_args(ContextSourceFreshness))
+_EXPLICIT_EMPTY_INCIDENT_INDEX_VERSIONS = frozenset(
+    {"incidents:empty", "incidents:0:empty", "incidents:unscoped"}
 )
 _LEGACY_CONTEXT_CORE_FIELDS = {
     "topology_freshness_days",
@@ -3416,6 +3431,30 @@ def _context_sources(value: object) -> list[dict[str, Any]]:
     return [source for source in value if isinstance(source, dict)]
 
 
+def _validated_context_sources(value: object) -> tuple[list[dict[str, Any]], int]:
+    if not isinstance(value, list):
+        return [], 1 if value is not None else 0
+    sources: list[dict[str, Any]] = []
+    dropped_count = 0
+    for source in value:
+        if not isinstance(source, dict):
+            dropped_count += 1
+            continue
+        candidate = {
+            key: field_value
+            for key, field_value in source.items()
+            if key in _CONTEXT_SOURCE_METADATA_FIELDS
+        }
+        try:
+            sources.append(
+                ContextSourceMetadata.model_validate(candidate).model_dump(mode="json")
+            )
+        except (TypeError, ValueError, ValidationError):
+            dropped_count += 1
+            continue
+    return sources, dropped_count
+
+
 def _has_context_source(context_completeness: dict, source_type: str) -> bool:
     return any(
         source.get("source_type") == source_type
@@ -3461,6 +3500,34 @@ def _persisted_bool_value(value: object, *, default: bool = False) -> bool:
     return default
 
 
+def _incident_index_freshness_status(
+    value: object,
+    *,
+    incident_index_size: int,
+    incident_index_version: object,
+) -> str:
+    normalized_version = str(incident_index_version or "").strip().lower()
+    explicit_empty_version = (
+        normalized_version in _EXPLICIT_EMPTY_INCIDENT_INDEX_VERSIONS
+    )
+    if incident_index_size > 0 and explicit_empty_version:
+        return "conflicting"
+    if value is None or str(value).strip() == "":
+        if explicit_empty_version:
+            return "empty"
+        return "empty" if incident_index_size == 0 else "unknown"
+    normalized = str(value).strip().lower()
+    if incident_index_size == 0:
+        if explicit_empty_version or normalized == "empty":
+            return "empty"
+        if normalized == "stale" and normalized_version == "incidents:unknown":
+            return "stale"
+        return "unknown"
+    if normalized in _CONTEXT_FRESHNESS_STATUSES:
+        return normalized
+    return "unknown"
+
+
 def _require_mapping(value: object, *, field_name: str) -> dict:
     if not isinstance(value, dict):
         raise ValueError(f"{field_name} must be an object")
@@ -3490,22 +3557,35 @@ def _normalize_context_completeness_payload(decoded: dict) -> dict:
             topology_gap = "missing"
 
     normalized = dict(decoded)
+    dropped_context_source_count = 0
+    if "context_sources" in normalized:
+        context_sources, dropped_context_source_count = _validated_context_sources(
+            normalized.get("context_sources")
+        )
+        normalized["context_sources"] = context_sources
     normalized["context_score"] = context_score
     normalized["parser_success_rate"] = parser_success_rate
     normalized["evidence_success_rate"] = evidence_success_rate
     normalized["incident_index_size"] = incident_index_size
-    normalized["incident_index_version"] = str(
+    incident_index_version = str(
         decoded.get("incident_index_version") or "incidents:unknown"
+    )
+    normalized["incident_index_version"] = incident_index_version
+    incident_version_conflicts_with_size = (
+        incident_index_size > 0
+        and incident_index_version.strip().lower()
+        in _EXPLICIT_EMPTY_INCIDENT_INDEX_VERSIONS
     )
     normalized["incident_index_last_indexed_at"] = (
         str(decoded["incident_index_last_indexed_at"])
         if decoded.get("incident_index_last_indexed_at")
         else None
     )
-    incident_freshness_status = decoded.get("incident_index_freshness_status")
-    if not incident_freshness_status:
-        incident_freshness_status = "unknown" if incident_index_size > 0 else "empty"
-    normalized["incident_index_freshness_status"] = str(incident_freshness_status)
+    normalized["incident_index_freshness_status"] = _incident_index_freshness_status(
+        decoded.get("incident_index_freshness_status"),
+        incident_index_size=incident_index_size,
+        incident_index_version=incident_index_version,
+    )
     normalized["topology_freshness_days"] = topology_freshness_days
 
     insufficient_context = context_score < 0.7
@@ -3525,18 +3605,37 @@ def _normalize_context_completeness_payload(decoded: dict) -> dict:
         "topology" in item.lower() for item in todos
     ):
         todos.append("Refresh stale topology context for this project/workspace.")
-    if incident_index_size == 0 and not any(
-        "incident" in item.lower() for item in todos
-    ):
-        todos.append("Import relevant incident history for this project/workspace.")
+    incident_freshness_status = normalized["incident_index_freshness_status"]
     if (
-        normalized["incident_index_freshness_status"] == "stale"
-        and incident_index_size > 0
-        and not any(
-            "incident" in item.lower() and "stale" in item.lower() for item in todos
-        )
+        incident_index_size == 0
+        and incident_freshness_status == "empty"
+        and _CONTEXT_INCIDENT_IMPORT_TODO not in todos
+    ):
+        todos.append(_CONTEXT_INCIDENT_IMPORT_TODO)
+    if incident_freshness_status == "stale" and not any(
+        "incident" in item.lower() and "stale" in item.lower() for item in todos
     ):
         todos.append("Refresh stale incident history for this project/workspace.")
+    if (
+        incident_freshness_status not in {"current", "empty", "stale"}
+        and not incident_version_conflicts_with_size
+        and not any(
+            "incident" in item.lower()
+            and "freshness" in item.lower()
+            and str(incident_freshness_status).lower() in item.lower()
+            for item in todos
+        )
+    ):
+        todos.append(
+            f"Resolve incident history freshness: {incident_freshness_status}."
+        )
+    if (
+        (incident_index_size > 0 and incident_freshness_status == "empty")
+        or incident_version_conflicts_with_size
+    ) and _CONTEXT_INCIDENT_FRESHNESS_CONFLICT_TODO not in todos:
+        todos.append(_CONTEXT_INCIDENT_FRESHNESS_CONFLICT_TODO)
+    if dropped_context_source_count > 0 and _CONTEXT_SOURCES_DROPPED_TODO not in todos:
+        todos.append(_CONTEXT_SOURCES_DROPPED_TODO)
     if parser_success_rate < 1.0 and not any(
         "parser" in item.lower() for item in todos
     ):
@@ -3800,8 +3899,15 @@ def _load_evidence_context_source(
         return None
     if not isinstance(decoded, dict):
         return None
+    candidate = {
+        key: field_value
+        for key, field_value in decoded.items()
+        if key in _CONTEXT_SOURCE_METADATA_FIELDS
+    }
     try:
-        decoded = ContextSourceMetadata.model_validate(decoded).model_dump(mode="json")
+        decoded = ContextSourceMetadata.model_validate(candidate).model_dump(
+            mode="json"
+        )
     except ValidationError:
         return None
     if (

--- a/services/report_service.py
+++ b/services/report_service.py
@@ -3408,6 +3408,14 @@ def _normalize_context_completeness_payload(decoded: dict) -> dict:
         "incident" in item.lower() for item in todos
     ):
         todos.append("Import relevant incident history for this project/workspace.")
+    if (
+        normalized["incident_index_freshness_status"] == "stale"
+        and incident_index_size > 0
+        and not any(
+            "incident" in item.lower() and "stale" in item.lower() for item in todos
+        )
+    ):
+        todos.append("Refresh stale incident history for this project/workspace.")
     if parser_success_rate < 1.0 and not any(
         "parser" in item.lower() for item in todos
     ):
@@ -3512,15 +3520,113 @@ def _context_with_incident_index_freshness(report, context_completeness: dict) -
             workspace_id=report.workspace_id,
         )
     except Exception:
-        updated = dict(context_completeness)
-        updated["incident_index_freshness_status"] = "stale"
-        return updated
+        return _mark_incident_context_stale(context_completeness)
     current_version = str(current.get("incident_index_version") or "")
     if current_version and current_version != stored_version:
-        updated = dict(context_completeness)
-        updated["incident_index_freshness_status"] = "stale"
-        return updated
+        return _mark_incident_context_stale(context_completeness)
     return context_completeness
+
+
+def _mark_incident_context_stale(context_completeness: dict) -> dict:
+    updated = dict(context_completeness)
+    updated["incident_index_freshness_status"] = "stale"
+    context_score = _context_float_value(updated, "context_score", missing_default=0.0)
+    if context_score > 0.8:
+        context_score = 0.8
+        updated["context_score"] = context_score
+        updated["confidence_level"] = _context_confidence_level_from_score(
+            context_score
+        )
+    todos = _context_todo_items(updated.get("context_todos"))
+    if not any(
+        "incident" in item.lower() and "stale" in item.lower() for item in todos
+    ):
+        todos.append("Refresh stale incident history for this project/workspace.")
+    updated["context_todos"] = todos
+    uncertainty = str(updated.get("uncertainty") or "").strip()
+    stale_message = "incident history is stale"
+    if stale_message not in uncertainty.lower():
+        updated["uncertainty"] = (
+            f"{uncertainty} {stale_message}.".strip()
+            if uncertainty
+            else f"Uncertainty: {stale_message}."
+        )
+    context_sources = updated.get("context_sources")
+    if isinstance(context_sources, list):
+        updated_sources: list[object] = []
+        stored_version = str(updated.get("incident_index_version") or "")
+        incident_sources = [
+            source
+            for source in context_sources
+            if isinstance(source, dict) and source.get("source_type") == "incident"
+        ]
+        for source in context_sources:
+            if not isinstance(source, dict):
+                updated_sources.append(source)
+                continue
+            if not _incident_context_source_matches_stale_version(
+                source,
+                stored_version=stored_version,
+                incident_source_count=len(incident_sources),
+            ):
+                updated_sources.append(source)
+                continue
+            stale_source = dict(source)
+            stale_source["freshness_status"] = "stale"
+            limitations = _context_todo_items(stale_source.get("limitations"))
+            if "stale_incident_index" not in limitations:
+                limitations.append("stale_incident_index")
+            stale_source["limitations"] = limitations
+            updated_sources.append(stale_source)
+        updated["context_sources"] = updated_sources
+    return updated
+
+
+def _incident_context_source_matches_stale_version(
+    source: dict,
+    *,
+    stored_version: str,
+    incident_source_count: int,
+) -> bool:
+    if source.get("source_type") != "incident":
+        return False
+    source_ref = str(source.get("source_ref") or "")
+    if stored_version:
+        return source_ref == stored_version
+    return incident_source_count == 1
+
+
+def _load_evidence_context_source(
+    raw_value: str | None,
+    *,
+    context_completeness: dict,
+) -> dict[str, Any] | None:
+    if not raw_value:
+        return None
+    try:
+        decoded = json.loads(raw_value)
+    except (TypeError, ValueError, json.JSONDecodeError):
+        return None
+    if not isinstance(decoded, dict):
+        return None
+    if (
+        decoded.get("source_type") == "incident"
+        and context_completeness.get("incident_index_freshness_status") == "stale"
+        and _incident_context_source_matches_stale_version(
+            decoded,
+            stored_version=str(
+                context_completeness.get("incident_index_version") or ""
+            ),
+            incident_source_count=1,
+        )
+    ):
+        decoded = dict(decoded)
+        decoded["freshness_status"] = "stale"
+        limitations = _context_todo_items(decoded.get("limitations"))
+        if "stale_incident_index" not in limitations:
+            limitations.append("stale_incident_index")
+        decoded["limitations"] = limitations
+    return decoded
 
 
 def _context_with_partial_context_signal(
@@ -3817,6 +3923,10 @@ def _serialize_report(report, *, include_evidence: bool = True) -> dict:
                     "confidence": evidence_item.confidence,
                     "related_change_ids": json.loads(
                         evidence_item.related_change_ids_json or "[]"
+                    ),
+                    "context_source": _load_evidence_context_source(
+                        getattr(evidence_item, "context_source_json", None),
+                        context_completeness=context_completeness,
                     ),
                 }
             )

--- a/services/report_service.py
+++ b/services/report_service.py
@@ -14,9 +14,10 @@ import secrets
 import unicodedata
 from collections import Counter, defaultdict
 from datetime import UTC, datetime
+from decimal import Decimal, ROUND_HALF_UP
 from functools import lru_cache
-from urllib.parse import urlsplit
 from typing import Any, get_args
+from urllib.parse import urlsplit
 
 from pydantic import ValidationError
 
@@ -3576,6 +3577,7 @@ def _normalize_context_completeness_payload(decoded: dict) -> dict:
         and incident_index_version.strip().lower()
         in _EXPLICIT_EMPTY_INCIDENT_INDEX_VERSIONS
     )
+    incident_freshness_was_persisted = "incident_index_freshness_status" in decoded
     normalized["incident_index_last_indexed_at"] = (
         str(decoded["incident_index_last_indexed_at"])
         if decoded.get("incident_index_last_indexed_at")
@@ -3618,6 +3620,7 @@ def _normalize_context_completeness_payload(decoded: dict) -> dict:
         todos.append("Refresh stale incident history for this project/workspace.")
     if (
         incident_freshness_status not in {"current", "empty", "stale"}
+        and incident_freshness_was_persisted
         and not incident_version_conflicts_with_size
         and not any(
             "incident" in item.lower()
@@ -3764,13 +3767,14 @@ def _recomputed_stale_incident_context_score(context_completeness: dict) -> floa
         weighted_scores.append(
             (_incident_context_score(incident_index_size, stale=True), 0.20)
         )
-    total_weight = sum(weight for _, weight in weighted_scores) or 1.0
-    return round(
-        min(
-            1.0, sum(score * weight for score, weight in weighted_scores) / total_weight
-        ),
-        2,
+    total_weight = sum(Decimal(str(weight)) for _, weight in weighted_scores)
+    if total_weight == 0:
+        total_weight = Decimal("1.0")
+    weighted_total = sum(
+        Decimal(str(score)) * Decimal(str(weight)) for score, weight in weighted_scores
     )
+    normalized_score = min(Decimal("1.0"), weighted_total / total_weight)
+    return float(normalized_score.quantize(Decimal("0.01"), rounding=ROUND_HALF_UP))
 
 
 def _context_with_incident_index_freshness(report, context_completeness: dict) -> dict:

--- a/tests/test_api/test_analyses.py
+++ b/tests/test_api/test_analyses.py
@@ -19,7 +19,12 @@ import services.deployment_outcome_service as deployment_outcome_service_module
 import services.project_service as project_service_module
 import services.report_service as report_service_module
 from analysis.blast_radius import BlastRadiusResult, ImpactNode
-from api.schemas import BlastRadiusData, ContextCompletenessData, PersistedReportData
+from api.schemas import (
+    BlastRadiusData,
+    ContextCompletenessData,
+    EvidenceItemData,
+    PersistedReportData,
+)
 from services.analysis_service import AnalysisPersistenceError
 from services.analysis_service import AnalysisRunResult
 from analysis.rollback_planner import RollbackPlan
@@ -148,6 +153,71 @@ class AnalysesApiTests(unittest.TestCase):
         os.environ.pop("APP_BASE_URL", None)
         os.environ.pop("DEPLOYWHISPER_SHARE_TOKEN", None)
         self.tempdir.cleanup()
+
+    def test_context_completeness_api_schema_exposes_source_freshness_ledger(
+        self,
+    ) -> None:
+        context = ContextCompletenessData.model_validate(
+            {
+                "context_score": 0.68,
+                "confidence_level": "low",
+                "context_sources": [
+                    {
+                        "source_id": "topology:terraform-state:state://prod",
+                        "source_type": "topology",
+                        "source_ref": "state://prod",
+                        "scope": "project:payments/workspace:prod",
+                        "freshness_status": "stale",
+                        "last_observed_at": "2026-05-01T00:00:00Z",
+                        "age_days": 47,
+                        "confidence": 0.42,
+                        "conflicts": ["kubernetes-live-state"],
+                        "limitations": ["stale_topology"],
+                    }
+                ],
+            }
+        )
+
+        source = context.context_sources[0]
+        self.assertEqual(source.source_type, "topology")
+        self.assertEqual(source.freshness_status, "stale")
+        self.assertEqual(source.scope, "project:payments/workspace:prod")
+        self.assertEqual(source.confidence, 0.42)
+        self.assertEqual(source.conflicts, ["kubernetes-live-state"])
+
+    def test_evidence_item_api_schema_can_reference_context_source_metadata(
+        self,
+    ) -> None:
+        evidence = EvidenceItemData.model_validate(
+            {
+                "evidence_id": "ev-topology-1",
+                "analysis_id": 1,
+                "finding_id": "finding-1",
+                "source_type": "topology",
+                "source_ref": "state://prod#aws_instance.web",
+                "summary": "Terraform state mapped aws_instance.web to checkout.",
+                "severity_hint": "medium",
+                "deterministic": True,
+                "confidence": 0.81,
+                "context_source": {
+                    "source_id": "topology:terraform-state:state://prod",
+                    "source_type": "topology",
+                    "source_ref": "state://prod",
+                    "scope": "project:payments/workspace:prod",
+                    "freshness_status": "current",
+                    "last_observed_at": "2026-06-16T00:00:00Z",
+                    "age_days": 1,
+                    "confidence": 0.81,
+                    "conflicts": [],
+                    "limitations": [],
+                },
+            }
+        )
+
+        self.assertEqual(
+            evidence.context_source.source_id, "topology:terraform-state:state://prod"
+        )
+        self.assertEqual(evidence.context_source.freshness_status, "current")
 
     def _analysis_result_with_persisted_report(
         self,

--- a/tests/test_cli/test_analyze.py
+++ b/tests/test_cli/test_analyze.py
@@ -1162,6 +1162,18 @@ class AnalyzeCliTests(unittest.TestCase):
             ),
             encoding="utf-8",
         )
+        admin_artifact_path = Path(self.tempdir.name) / "admin-plan.json"
+        admin_artifact_path.write_text(
+            (
+                '{"planned_values": {}, "resource_changes": [{"address": "module.network.aws_security_group.admin", '
+                '"module_address": "module.network", "type": "aws_security_group", '
+                '"name": "admin", "provider_name": "registry.terraform.io/hashicorp/aws", '
+                '"change": {"actions": ["update"], "after_unknown": {"arn": true}, '
+                '"after_sensitive": {"ingress": [{"description": true}]}, '
+                '"replace_paths": [["ingress", 0, "cidr_blocks"]]}}]}'
+            ),
+            encoding="utf-8",
+        )
         narrative = NarrativeResult(
             opening_sentence="CAUTION: review the security group update.",
             explanation="The deployment widens database access and should be reviewed.",
@@ -1205,6 +1217,7 @@ class AnalyzeCliTests(unittest.TestCase):
                     "--project",
                     "payments",
                     str(artifact_path),
+                    str(admin_artifact_path),
                 ],
             ),
             redirect_stdout(output),
@@ -1217,30 +1230,75 @@ class AnalyzeCliTests(unittest.TestCase):
         self.assertEqual(payload["meta"]["interface"], "cli")
         self.assertEqual(payload["meta"]["report_schema_version"], "v2")
         self.assertTrue(payload["meta"]["advisory_only"])
-        self.assertEqual(payload["meta"]["accepted_artifact_count"], 1)
+        self.assertEqual(payload["meta"]["accepted_artifact_count"], 2)
         self.assertIn(payload["data"]["assessment"]["severity"], {"high", "critical"})
         self.assertIn("context_completeness", payload["data"]["assessment"])
         context_sources = payload["data"]["assessment"]["context_completeness"][
             "context_sources"
         ]
         self.assertTrue(context_sources)
+
+        def context_source_identity(source: dict) -> tuple[object, ...]:
+            notes = tuple(
+                sorted(
+                    {
+                        *(source.get("conflicts") or []),
+                        *(source.get("limitations") or []),
+                    }
+                )
+            )
+            return (
+                source.get("source_id"),
+                source.get("source_type"),
+                source.get("source_ref") or "",
+                source.get("scope"),
+                source.get("freshness_status"),
+                source.get("confidence"),
+                notes,
+            )
+
+        def distinct_context_sources(sources: list[dict]) -> list[dict]:
+            seen: set[tuple[object, ...]] = set()
+            distinct_sources: list[dict] = []
+            for source in sources:
+                identity = context_source_identity(source)
+                if identity in seen:
+                    continue
+                seen.add(identity)
+                distinct_sources.append(source)
+            return distinct_sources
+
+        def assert_context_source_fields(source: dict) -> None:
+            self.assertIn(
+                source["freshness_status"],
+                {
+                    "current",
+                    "stale",
+                    "missing",
+                    "incomplete",
+                    "conflicting",
+                    "unknown",
+                    "empty",
+                    "not_applicable",
+                },
+            )
+            self.assertIn("confidence", source)
+            self.assertGreaterEqual(source["confidence"], 0.0)
+            self.assertLessEqual(source["confidence"], 1.0)
+            self.assertIn("scope", source)
+            self.assertTrue(source["scope"])
+            self.assertIn("conflicts", source)
+            self.assertIsInstance(source["conflicts"], list)
+
+        distinct_sources = distinct_context_sources(context_sources)
+        self.assertGreater(len(distinct_sources), 1)
+        for source in distinct_sources[:2]:
+            assert_context_source_fields(source)
         topology_sources = [
             source for source in context_sources if source["source_type"] == "topology"
         ]
         self.assertTrue(topology_sources)
-        self.assertIn(
-            topology_sources[0]["freshness_status"],
-            {
-                "current",
-                "stale",
-                "missing",
-                "incomplete",
-                "conflicting",
-                "unknown",
-                "empty",
-                "not_applicable",
-            },
-        )
+        assert_context_source_fields(topology_sources[0])
         self.assertEqual(
             payload["data"]["incident_matches"][0]["public_pattern_id"],
             "public-ingress-wide-open",
@@ -1289,10 +1347,45 @@ class AnalyzeCliTests(unittest.TestCase):
             "context_sources",
             payload["data"]["persisted_report"]["context_completeness"],
         )
+        self.assertGreater(
+            len(
+                payload["data"]["persisted_report"]["context_completeness"][
+                    "context_sources"
+                ]
+            ),
+            1,
+        )
+        persisted_context_sources = payload["data"]["persisted_report"][
+            "context_completeness"
+        ]["context_sources"]
+        persisted_distinct_sources = distinct_context_sources(persisted_context_sources)
+        self.assertGreater(len(persisted_distinct_sources), 1)
+        for source in persisted_distinct_sources[:2]:
+            assert_context_source_fields(source)
         self.assertIn(
             "context_source",
             payload["data"]["persisted_report"]["evidence_items"][0],
         )
+        evidence_context_sources = [
+            item["context_source"]
+            for item in payload["data"]["persisted_report"]["evidence_items"]
+            if item.get("context_source") is not None
+        ]
+        distinct_evidence_context_sources = distinct_context_sources(
+            evidence_context_sources
+        )
+        self.assertGreater(len(distinct_evidence_context_sources), 1)
+        for evidence_context_source in distinct_evidence_context_sources[:2]:
+            self.assertIn("source_id", evidence_context_source)
+            self.assertIn("freshness_status", evidence_context_source)
+            self.assertIn("confidence", evidence_context_source)
+            self.assertGreaterEqual(evidence_context_source["confidence"], 0.0)
+            self.assertLessEqual(evidence_context_source["confidence"], 1.0)
+            self.assertIn("scope", evidence_context_source)
+            self.assertTrue(evidence_context_source["scope"])
+            self.assertIn("source_ref", evidence_context_source)
+            self.assertIn("conflicts", evidence_context_source)
+            self.assertIsInstance(evidence_context_source["conflicts"], list)
         self.assertEqual(
             payload["data"]["persisted_report"]["report_schema_version"], "v2"
         )

--- a/tests/test_cli/test_analyze.py
+++ b/tests/test_cli/test_analyze.py
@@ -1220,6 +1220,27 @@ class AnalyzeCliTests(unittest.TestCase):
         self.assertEqual(payload["meta"]["accepted_artifact_count"], 1)
         self.assertIn(payload["data"]["assessment"]["severity"], {"high", "critical"})
         self.assertIn("context_completeness", payload["data"]["assessment"])
+        context_sources = payload["data"]["assessment"]["context_completeness"][
+            "context_sources"
+        ]
+        self.assertTrue(context_sources)
+        topology_sources = [
+            source for source in context_sources if source["source_type"] == "topology"
+        ]
+        self.assertTrue(topology_sources)
+        self.assertIn(
+            topology_sources[0]["freshness_status"],
+            {
+                "current",
+                "stale",
+                "missing",
+                "incomplete",
+                "conflicting",
+                "unknown",
+                "empty",
+                "not_applicable",
+            },
+        )
         self.assertEqual(
             payload["data"]["incident_matches"][0]["public_pattern_id"],
             "public-ingress-wide-open",
@@ -1264,6 +1285,14 @@ class AnalyzeCliTests(unittest.TestCase):
             expected_report_link,
         )
         self.assertTrue(payload["data"]["persisted_report"]["findings"])
+        self.assertIn(
+            "context_sources",
+            payload["data"]["persisted_report"]["context_completeness"],
+        )
+        self.assertIn(
+            "context_source",
+            payload["data"]["persisted_report"]["evidence_items"][0],
+        )
         self.assertEqual(
             payload["data"]["persisted_report"]["report_schema_version"], "v2"
         )

--- a/tests/test_infra/test_container_contract.py
+++ b/tests/test_infra/test_container_contract.py
@@ -39,6 +39,7 @@ class ContainerContractTests(unittest.TestCase):
                 "023_add_incident_ingestion_sources.py",
                 "024_add_analysis_duration_seconds.py",
                 "025_add_event_analysis_indexes.py",
+                "026_add_evidence_context_source.py",
             ],
         )
         baseline_content = migrations[0].read_text(encoding="utf-8")
@@ -63,6 +64,7 @@ class ContainerContractTests(unittest.TestCase):
         incident_ingestion_sources_content = migrations[19].read_text(encoding="utf-8")
         analysis_duration_content = migrations[20].read_text(encoding="utf-8")
         event_indexes_content = migrations[21].read_text(encoding="utf-8")
+        evidence_context_source_content = migrations[22].read_text(encoding="utf-8")
         self.assertIn("down_revision = None", baseline_content)
         self.assertIn('"app_settings"', baseline_content)
         self.assertIn(
@@ -178,6 +180,11 @@ class ContainerContractTests(unittest.TestCase):
             event_indexes_content,
         )
         self.assertIn("ix_feedback_events_analysis_created", event_indexes_content)
+        self.assertIn(
+            'down_revision = "025_add_event_analysis_indexes"',
+            evidence_context_source_content,
+        )
+        self.assertIn('"context_source_json"', evidence_context_source_content)
 
     def test_dockerfile_exists(self) -> None:
         self.assertTrue(Path("Dockerfile").exists())

--- a/tests/test_infra/test_migrations.py
+++ b/tests/test_infra/test_migrations.py
@@ -251,6 +251,7 @@ class MigrationTests(unittest.TestCase):
         self.assertIn("source_kind", self._table_columns("evidence_items"))
         self.assertIn("determinism_level", self._table_columns("evidence_items"))
         self.assertIn("redaction_status", self._table_columns("evidence_items"))
+        self.assertIn("context_source_json", self._table_columns("evidence_items"))
         self.assertIn("analysis_id", self._table_columns("findings"))
         self.assertIn("explanation", self._table_columns("findings"))
         self.assertIn("guidance_json", self._table_columns("findings"))
@@ -1101,7 +1102,7 @@ class MigrationTests(unittest.TestCase):
         self.assertIn("topology_versions", tables)
         self.assertIn("incident_ingestion_sources", tables)
         self._assert_incident_ingestion_source_schema()
-        self.assertEqual(revision, "025_add_event_analysis_indexes")
+        self.assertEqual(revision, "026_add_evidence_context_source")
 
     def test_init_db_repairs_partial_evidence_schema_without_alembic_version(
         self,
@@ -1152,7 +1153,7 @@ class MigrationTests(unittest.TestCase):
         self.assertIn("projects", tables)
         self.assertIn("incident_ingestion_sources", tables)
         self._assert_incident_ingestion_source_schema()
-        self.assertEqual(revision, "025_add_event_analysis_indexes")
+        self.assertEqual(revision, "026_add_evidence_context_source")
 
     def test_init_db_repairs_current_schema_without_alembic_version(self) -> None:
         command.upgrade(self._config(), "head")
@@ -1178,7 +1179,7 @@ class MigrationTests(unittest.TestCase):
         finally:
             sqlite_conn.close()
 
-        self.assertEqual(revision, "025_add_event_analysis_indexes")
+        self.assertEqual(revision, "026_add_evidence_context_source")
         self.assertIn("report_schema_version", columns)
         self.assertIn("blast_radius_json", columns)
         self.assertIn("project_id", columns)
@@ -1210,7 +1211,7 @@ class MigrationTests(unittest.TestCase):
         finally:
             sqlite_conn.close()
 
-        self.assertEqual(revision, "025_add_event_analysis_indexes")
+        self.assertEqual(revision, "026_add_evidence_context_source")
         self.assertEqual(
             self._index_columns("ix_deployment_outcomes_analysis_deployed_outcome"),
             ("analysis_id", "deployed_at", "outcome_label"),
@@ -1236,7 +1237,7 @@ class MigrationTests(unittest.TestCase):
         finally:
             sqlite_conn.close()
 
-        self.assertEqual(revision, "025_add_event_analysis_indexes")
+        self.assertEqual(revision, "026_add_evidence_context_source")
         self._assert_incident_ingestion_source_schema()
 
     def test_init_db_rejects_partial_report_workspace_scope_schema(self) -> None:
@@ -1668,7 +1669,7 @@ class MigrationTests(unittest.TestCase):
         finally:
             sqlite_conn.close()
 
-        self.assertEqual(revision, "025_add_event_analysis_indexes")
+        self.assertEqual(revision, "026_add_evidence_context_source")
         self._assert_incident_ingestion_source_schema()
 
 

--- a/tests/test_models/test_evidence_models.py
+++ b/tests/test_models/test_evidence_models.py
@@ -52,6 +52,7 @@ class EvidenceModelTests(unittest.TestCase):
                 "owner_signals": [],
                 "escalation_hints": [],
                 "ownership_unmapped_subjects": [],
+                "context_sources": [],
             },
         )
 

--- a/tests/test_services/test_analysis_service.py
+++ b/tests/test_services/test_analysis_service.py
@@ -1901,6 +1901,138 @@ class AnalysisServiceTests(unittest.TestCase):
         self.assertLess(context.context_score, 1.0)
         self.assertIn("incident history is stale", context.uncertainty or "")
 
+    def test_partial_parser_and_evidence_sources_are_incomplete(self) -> None:
+        covered_change = UnifiedChange(
+            change_id="change-covered",
+            source_file="plan-a.json",
+            tool="terraform",
+            resource_id="aws_instance.web",
+            action="modify",
+            summary="Terraform changed a web instance.",
+        )
+        uncovered_change = UnifiedChange(
+            change_id="change-uncovered",
+            source_file="plan-b.json",
+            tool="terraform",
+            resource_id="aws_instance.api",
+            action="modify",
+            summary="Terraform changed an API instance.",
+        )
+        batch = ParseBatchResult(
+            files=[
+                ParsedFileResult(
+                    file_name="plan-a.json",
+                    tool="terraform",
+                    status="parsed",
+                    changes=[covered_change],
+                ),
+                ParsedFileResult(
+                    file_name="plan-b.json",
+                    tool="terraform",
+                    status="failed",
+                    issue=ParseIssue(
+                        file_name="plan-b.json",
+                        tool="terraform",
+                        message="invalid plan JSON",
+                    ),
+                ),
+                ParsedFileResult(
+                    file_name="plan-c.json",
+                    tool="terraform",
+                    status="parsed",
+                    changes=[uncovered_change],
+                ),
+            ]
+        )
+        evidence = EvidenceItem(
+            evidence_id="ev-plan-a",
+            analysis_id=0,
+            finding_id="finding-1",
+            source_type="artifact",
+            source_ref="artifact://plan-a.json#aws_instance.web?action=modify",
+            artifact="plan-a.json",
+            location="plan-a.json#aws_instance.web",
+            resource="aws_instance.web",
+            operation="modify",
+            summary="Web instance changed.",
+            severity_hint="medium",
+            deterministic=True,
+            confidence=1.0,
+            related_change_ids=["change-covered"],
+        )
+
+        with (
+            patch(
+                "services.analysis_service.get_topology_status",
+                return_value=SimpleNamespace(updated_at="2026-05-10T00:00:00Z"),
+            ),
+            patch(
+                "services.analysis_service.get_incident_index_snapshot",
+                return_value=_incident_snapshot(1),
+            ),
+        ):
+            context = build_analysis_artifacts.__globals__[
+                "_build_context_completeness"
+            ](batch, evidence_items=[evidence], project_id=123)
+
+        sources_by_type = {
+            source.source_type: source for source in context.context_sources
+        }
+        self.assertEqual(sources_by_type["parser"].freshness_status, "incomplete")
+        self.assertIn("partial_parser_coverage", sources_by_type["parser"].limitations)
+        self.assertEqual(sources_by_type["evidence"].freshness_status, "incomplete")
+        self.assertIn(
+            "partial_evidence_coverage", sources_by_type["evidence"].limitations
+        )
+
+    def test_non_stale_incident_freshness_uses_specific_guidance(self) -> None:
+        batch = ParseBatchResult(
+            files=[
+                ParsedFileResult(
+                    file_name="plan.json",
+                    tool="terraform",
+                    status="parsed",
+                    changes=[
+                        UnifiedChange(
+                            change_id="change-plan",
+                            source_file="plan.json",
+                            tool="terraform",
+                            resource_id="aws_instance.web",
+                            action="modify",
+                            summary="Terraform changed a web instance.",
+                        )
+                    ],
+                )
+            ]
+        )
+
+        with (
+            patch(
+                "services.analysis_service.get_topology_status",
+                return_value=SimpleNamespace(updated_at="2026-05-10T00:00:00Z"),
+            ),
+            patch(
+                "services.analysis_service.get_incident_index_snapshot",
+                return_value={
+                    **_incident_snapshot(2),
+                    "incident_index_freshness_status": "conflicting",
+                },
+            ),
+        ):
+            context = build_analysis_artifacts.__globals__[
+                "_build_context_completeness"
+            ](batch, evidence_items=[], project_id=123)
+
+        self.assertIn(
+            "Resolve incident history freshness: conflicting.",
+            context.context_todos,
+        )
+        self.assertNotIn(
+            "Refresh stale incident history for this project/workspace.",
+            context.context_todos,
+        )
+        self.assertIn("incident history freshness is conflicting", context.uncertainty)
+
     def test_build_context_completeness_uses_raw_parser_rate_for_tiny_gap(
         self,
     ) -> None:

--- a/tests/test_services/test_analysis_service.py
+++ b/tests/test_services/test_analysis_service.py
@@ -15,9 +15,9 @@ from analysis.risk_scorer import RiskAssessment, RiskContributor
 from analysis.blast_radius import BlastRadiusResult
 from analysis.rollback_planner import RollbackPlan
 from evidence.extractor import extract_batch_evidence
-from evidence.models import EvidenceItem
+from evidence.models import ContextSourceMetadata, EvidenceItem
 from llm.narrator import NarrativeResult
-from parsers.base import ParseBatchResult, ParsedFileResult, UnifiedChange
+from parsers.base import ParseBatchResult, ParseIssue, ParsedFileResult, UnifiedChange
 from services.analysis_service import (
     AnalysisArtifacts,
     analyze_uploaded_files,
@@ -1588,6 +1588,318 @@ class AnalysisServiceTests(unittest.TestCase):
             context.context_todos,
         )
         self.assertIn("incident history", context.uncertainty)
+
+    def test_context_sources_are_artifact_specific_and_match_evidence(self) -> None:
+        change = UnifiedChange(
+            change_id="change-plan-a",
+            source_file="plan-a.json",
+            tool="terraform",
+            resource_id="aws_security_group.main",
+            action="modify",
+            summary="Terraform changed a security group.",
+        )
+        batch = ParseBatchResult(
+            files=[
+                ParsedFileResult(
+                    file_name="plan-a.json",
+                    tool="terraform",
+                    status="parsed",
+                    changes=[change],
+                ),
+                ParsedFileResult(
+                    file_name="plan-b.json",
+                    tool="terraform",
+                    status="failed",
+                    issue=ParseIssue(
+                        file_name="plan-b.json",
+                        tool="terraform",
+                        message="invalid plan JSON",
+                    ),
+                ),
+            ]
+        )
+        evidence = EvidenceItem(
+            evidence_id="ev-plan-a",
+            analysis_id=0,
+            finding_id="finding-1",
+            source_type="artifact",
+            source_ref="artifact://plan-a.json#aws_security_group.main?action=modify",
+            artifact="plan-a.json",
+            location="plan-a.json#aws_security_group.main",
+            resource="aws_security_group.main",
+            operation="modify",
+            summary="Security group changed.",
+            severity_hint="medium",
+            deterministic=True,
+            confidence=1.0,
+            related_change_ids=["change-plan-a"],
+        )
+
+        with (
+            patch(
+                "services.analysis_service.get_topology_status",
+                return_value=SimpleNamespace(updated_at="2026-05-10T00:00:00Z"),
+            ),
+            patch(
+                "services.analysis_service.get_incident_index_snapshot",
+                return_value=_incident_snapshot(1),
+            ),
+        ):
+            context = build_analysis_artifacts.__globals__[
+                "_build_context_completeness"
+            ](
+                batch,
+                evidence_items=[evidence],
+                project_id=123,
+                codeowners_sources=(
+                    CodeownersSource(
+                        source_ref="CODEOWNERS",
+                        content="plan-a.json @platform\nplan-b.json @platform\n",
+                    ),
+                ),
+            )
+
+        sources_by_id = {source.source_id: source for source in context.context_sources}
+        self.assertIn("artifact:plan-a.json", sources_by_id)
+        self.assertIn("artifact:plan-b.json", sources_by_id)
+        self.assertEqual(
+            sources_by_id["artifact:plan-b.json"].freshness_status, "incomplete"
+        )
+        self.assertIn("parser:terraform", sources_by_id)
+        self.assertEqual(
+            sources_by_id["ownership:CODEOWNERS:CODEOWNERS"].freshness_status,
+            "current",
+        )
+
+        enriched = build_analysis_artifacts.__globals__[
+            "_evidence_items_with_context_sources"
+        ]([evidence], list(context.context_sources))
+        self.assertIsNotNone(enriched[0].context_source)
+        self.assertEqual(enriched[0].context_source.source_type, "artifact")
+        self.assertEqual(enriched[0].context_source.source_ref, "plan-a.json")
+
+    def test_context_sources_split_ownership_by_actual_signal_source(self) -> None:
+        batch = ParseBatchResult(
+            files=[
+                ParsedFileResult(
+                    file_name="plan-a.json",
+                    tool="terraform",
+                    status="parsed",
+                    changes=[
+                        UnifiedChange(
+                            change_id="change-plan-a",
+                            source_file="plan-a.json",
+                            tool="terraform",
+                            resource_id="aws_instance.web",
+                            action="modify",
+                            summary="Terraform changed a web instance.",
+                        )
+                    ],
+                ),
+                ParsedFileResult(
+                    file_name="plan-b.json",
+                    tool="terraform",
+                    status="parsed",
+                    changes=[
+                        UnifiedChange(
+                            change_id="change-plan-b",
+                            source_file="plan-b.json",
+                            tool="terraform",
+                            resource_id="aws_instance.api",
+                            action="modify",
+                            summary="Terraform changed an API instance.",
+                        )
+                    ],
+                ),
+            ]
+        )
+
+        with (
+            patch(
+                "services.analysis_service.get_topology_status",
+                return_value=SimpleNamespace(updated_at="2026-05-10T00:00:00Z"),
+            ),
+            patch(
+                "services.analysis_service.get_incident_index_snapshot",
+                return_value=_incident_snapshot(1),
+            ),
+        ):
+            context = build_analysis_artifacts.__globals__[
+                "_build_context_completeness"
+            ](
+                batch,
+                project_id=123,
+                topology={
+                    "metadata": {"import": {"source_ref": "topology://cluster-a"}},
+                    "services": [
+                        {
+                            "id": "checkout",
+                            "label": "checkout",
+                            "owners": ["@runtime"],
+                            "resource_keys": ["aws_instance.api"],
+                        }
+                    ],
+                },
+                codeowners_sources=(
+                    CodeownersSource(
+                        source_ref="CODEOWNERS",
+                        content="plan-a.json @platform\n",
+                    ),
+                ),
+            )
+
+        ownership_sources = {
+            source.source_id: source
+            for source in context.context_sources
+            if source.source_type == "ownership"
+        }
+        self.assertIn("ownership:CODEOWNERS:CODEOWNERS", ownership_sources)
+        self.assertIn("ownership:topology:topology://cluster-a", ownership_sources)
+        self.assertNotIn("ownership:mapping", ownership_sources)
+
+    def test_evidence_context_source_matching_rejects_prefix_collisions(
+        self,
+    ) -> None:
+        evidence = EvidenceItem(
+            evidence_id="ev-prod-2",
+            analysis_id=0,
+            finding_id="finding-1",
+            source_type="topology",
+            source_ref="state://prod-2#aws_instance.web",
+            artifact="topology.json",
+            location="state://prod-2#aws_instance.web",
+            resource="aws_instance.web",
+            operation="modify",
+            summary="Topology evidence came from prod-2.",
+            severity_hint="medium",
+            deterministic=True,
+            confidence=1.0,
+        )
+        sources = [
+            ContextSourceMetadata(
+                source_id="topology:terraform-state:state://prod",
+                source_type="topology",
+                source_ref="state://prod",
+                scope="project:payments",
+                freshness_status="current",
+                confidence=1.0,
+            ),
+            ContextSourceMetadata(
+                source_id="topology:terraform-state:state://prod-2",
+                source_type="topology",
+                source_ref="state://prod-2",
+                scope="project:payments",
+                freshness_status="current",
+                confidence=1.0,
+            ),
+        ]
+
+        enriched = build_analysis_artifacts.__globals__[
+            "_evidence_items_with_context_sources"
+        ]([evidence], sources)
+
+        self.assertIsNotNone(enriched[0].context_source)
+        self.assertEqual(enriched[0].context_source.source_ref, "state://prod-2")
+
+    def test_evidence_context_source_matching_does_not_use_type_only_fallback(
+        self,
+    ) -> None:
+        evidence = EvidenceItem(
+            evidence_id="ev-unmatched-topology",
+            analysis_id=0,
+            finding_id="finding-1",
+            source_type="topology",
+            source_ref="state://unseen#aws_instance.web",
+            artifact="topology.json",
+            location="state://unseen#aws_instance.web",
+            resource="aws_instance.web",
+            operation="modify",
+            summary="Topology evidence came from an unseen source.",
+            severity_hint="medium",
+            deterministic=True,
+            confidence=1.0,
+        )
+        sources = [
+            ContextSourceMetadata(
+                source_id="topology:terraform-state:state://prod",
+                source_type="topology",
+                source_ref="state://prod",
+                scope="project:payments",
+                freshness_status="current",
+                confidence=1.0,
+            )
+        ]
+
+        enriched = build_analysis_artifacts.__globals__[
+            "_evidence_items_with_context_sources"
+        ]([evidence], sources)
+
+        self.assertIsNone(enriched[0].context_source)
+
+    def test_stale_incident_index_downgrades_context_source_and_score(self) -> None:
+        batch = ParseBatchResult(
+            files=[
+                ParsedFileResult(
+                    file_name="plan.json",
+                    tool="terraform",
+                    status="parsed",
+                    changes=[
+                        UnifiedChange(
+                            change_id="change-plan",
+                            source_file="plan.json",
+                            tool="terraform",
+                            resource_id="aws_instance.web",
+                            action="modify",
+                            summary="Terraform changed a web instance.",
+                        )
+                    ],
+                )
+            ]
+        )
+        evidence = EvidenceItem(
+            evidence_id="ev-plan",
+            analysis_id=0,
+            finding_id="finding-1",
+            source_type="artifact",
+            source_ref="artifact://plan.json#aws_instance.web?action=modify",
+            artifact="plan.json",
+            location="plan.json#aws_instance.web",
+            resource="aws_instance.web",
+            operation="modify",
+            summary="Web instance changed.",
+            severity_hint="medium",
+            deterministic=True,
+            confidence=1.0,
+            related_change_ids=["change-plan"],
+        )
+
+        with (
+            patch(
+                "services.analysis_service.get_topology_status",
+                return_value=SimpleNamespace(updated_at="2026-05-10T00:00:00Z"),
+            ),
+            patch(
+                "services.analysis_service.get_incident_index_snapshot",
+                return_value={
+                    **_incident_snapshot(4),
+                    "incident_index_freshness_status": "stale",
+                },
+            ),
+        ):
+            context = build_analysis_artifacts.__globals__[
+                "_build_context_completeness"
+            ](batch, evidence_items=[evidence], project_id=123)
+
+        incident_source = next(
+            source
+            for source in context.context_sources
+            if source.source_type == "incident"
+        )
+        self.assertEqual(incident_source.freshness_status, "stale")
+        self.assertLessEqual(incident_source.confidence, 0.5)
+        self.assertIn("stale_incident_index", incident_source.limitations)
+        self.assertLess(context.context_score, 1.0)
+        self.assertIn("incident history is stale", context.uncertainty or "")
 
     def test_build_context_completeness_uses_raw_parser_rate_for_tiny_gap(
         self,

--- a/tests/test_services/test_analysis_service.py
+++ b/tests/test_services/test_analysis_service.py
@@ -1757,6 +1757,108 @@ class AnalysisServiceTests(unittest.TestCase):
         self.assertIn("ownership:topology:topology://cluster-a", ownership_sources)
         self.assertNotIn("ownership:mapping", ownership_sources)
 
+    def test_topology_ownership_source_inherits_topology_freshness(self) -> None:
+        batch = ParseBatchResult(
+            files=[
+                ParsedFileResult(
+                    file_name="plan.json",
+                    tool="terraform",
+                    status="parsed",
+                    changes=[
+                        UnifiedChange(
+                            change_id="change-plan",
+                            source_file="plan.json",
+                            tool="terraform",
+                            resource_id="aws_instance.api",
+                            action="modify",
+                            summary="Terraform changed an API instance.",
+                        )
+                    ],
+                )
+            ]
+        )
+
+        with (
+            patch(
+                "services.analysis_service.get_topology_status",
+                return_value=SimpleNamespace(
+                    updated_at="2026-03-01T00:00:00Z",
+                    payload={
+                        "metadata": {"import": {"source_ref": "topology://cluster-a"}}
+                    },
+                    warnings=[],
+                ),
+            ),
+            patch(
+                "services.analysis_service.get_incident_index_snapshot",
+                return_value=_incident_snapshot(1),
+            ),
+        ):
+            context = build_analysis_artifacts.__globals__[
+                "_build_context_completeness"
+            ](
+                batch,
+                project_id=123,
+                topology={
+                    "metadata": {"import": {"source_ref": "topology://cluster-a"}},
+                    "services": [
+                        {
+                            "id": "checkout",
+                            "label": "checkout",
+                            "owners": ["@runtime"],
+                            "resource_keys": ["aws_instance.api"],
+                        }
+                    ],
+                },
+            )
+
+        ownership_source = next(
+            source
+            for source in context.context_sources
+            if source.source_id == "ownership:topology:topology://cluster-a"
+        )
+        self.assertEqual(ownership_source.freshness_status, "stale")
+        self.assertLess(ownership_source.confidence, 1.0)
+        self.assertIn(
+            "topology_ownership_source_stale",
+            ownership_source.limitations,
+        )
+
+    def test_blank_artifact_name_degrades_context_source_to_unknown_file(self) -> None:
+        batch = ParseBatchResult(
+            files=[
+                ParsedFileResult(
+                    file_name="",
+                    tool="terraform",
+                    status="failed",
+                    issue=ParseIssue(
+                        file_name="",
+                        tool="terraform",
+                        message="raw parser error for /private/tmp/secret.tf",
+                    ),
+                )
+            ]
+        )
+
+        context = build_analysis_artifacts.__globals__["_build_context_completeness"](
+            batch,
+            include_topology_context=False,
+            include_incident_context=False,
+        )
+
+        artifact_source = next(
+            source
+            for source in context.context_sources
+            if source.source_type == "artifact"
+        )
+        self.assertEqual(artifact_source.source_ref, "unknown-file")
+        self.assertIn("missing_artifact_name", artifact_source.limitations)
+        self.assertIn("parser_issue", artifact_source.limitations)
+        self.assertNotIn(
+            "/private/tmp/secret.tf",
+            " ".join(artifact_source.limitations),
+        )
+
     def test_evidence_context_source_matching_rejects_prefix_collisions(
         self,
     ) -> None:
@@ -2032,6 +2134,15 @@ class AnalysisServiceTests(unittest.TestCase):
             context.context_todos,
         )
         self.assertIn("incident history freshness is conflicting", context.uncertainty)
+        incident_source = next(
+            source
+            for source in context.context_sources
+            if source.source_type == "incident"
+        )
+        self.assertEqual(incident_source.freshness_status, "conflicting")
+        self.assertIn("incident_index_conflicting", incident_source.limitations)
+        self.assertIn("incident_index_conflicting", incident_source.conflicts)
+        self.assertNotIn("stale_incident_index", incident_source.limitations)
 
     def test_build_context_completeness_uses_raw_parser_rate_for_tiny_gap(
         self,

--- a/tests/test_services/test_report_service.py
+++ b/tests/test_services/test_report_service.py
@@ -4339,6 +4339,8 @@ class ReportServiceTests(unittest.TestCase):
         }
         self.assertEqual(sources["incidents:1:old"]["freshness_status"], "stale")
         self.assertEqual(sources["incidents:2:other"]["freshness_status"], "current")
+        self.assertEqual(sources["incidents:1:old"]["confidence"], 0.1)
+        self.assertEqual(sources["incidents:2:other"]["confidence"], 0.8)
         self.assertEqual(context["context_score"], 0.76)
         self.assertEqual(context["confidence_level"], "medium")
 
@@ -4379,6 +4381,12 @@ class ReportServiceTests(unittest.TestCase):
         self.assertEqual(context["context_score"], 0.67)
         self.assertEqual(context["confidence_level"], "low")
         self.assertTrue(context["insufficient_context"])
+        incident_source = next(
+            source
+            for source in context["context_sources"]
+            if source["source_type"] == "incident"
+        )
+        self.assertEqual(incident_source["confidence"], 0.5)
 
     def test_load_evidence_context_source_marks_incident_source_stale(self) -> None:
         context_source = report_service_module._load_evidence_context_source(
@@ -4397,11 +4405,13 @@ class ReportServiceTests(unittest.TestCase):
             context_completeness={
                 "incident_index_freshness_status": "stale",
                 "incident_index_version": "incidents:1:old",
+                "incident_index_size": 1,
             },
         )
 
         self.assertIsNotNone(context_source)
         self.assertEqual(context_source["freshness_status"], "stale")
+        self.assertEqual(context_source["confidence"], 0.1)
         self.assertIn("stale_incident_index", context_source["limitations"])
 
     def test_load_evidence_context_source_rejects_invalid_payload(self) -> None:
@@ -4420,6 +4430,93 @@ class ReportServiceTests(unittest.TestCase):
         )
 
         self.assertIsNone(context_source)
+
+    def test_fetch_analysis_report_preserves_empty_incident_snapshot_on_lookup_failure(
+        self,
+    ) -> None:
+        project = project_service_module.create_project(
+            project_key="payments",
+            display_name="Payments",
+        )
+        parse_batch = ParseBatchResult(
+            files=[
+                ParsedFileResult(
+                    file_name="plan.json",
+                    tool="terraform",
+                    status="parsed",
+                    changes=[
+                        UnifiedChange(
+                            source_file="plan.json",
+                            tool="terraform",
+                            resource_id="aws_security_group.main",
+                            action="modify",
+                            summary="Terraform changed a security group.",
+                        )
+                    ],
+                )
+            ]
+        )
+        assessment = RiskAssessment(
+            score=42,
+            severity="medium",
+            recommendation="caution",
+            top_risk="Security group review.",
+            contributors=[],
+            interaction_risks=[],
+            context_completeness=ContextCompleteness(
+                context_score=0.76,
+                confidence_level="medium",
+                incident_index_size=0,
+                incident_index_version="incidents:empty",
+                incident_index_freshness_status="empty",
+                context_sources=[
+                    ContextSourceMetadata(
+                        source_id="incident:index:empty",
+                        source_type="incident",
+                        source_ref="incidents:empty",
+                        scope="project:payments",
+                        freshness_status="empty",
+                        confidence=0.0,
+                        limitations=["empty_incident_index"],
+                    )
+                ],
+            ),
+            partial_context=False,
+            warnings=[],
+        )
+        narrative = NarrativeResult(
+            opening_sentence="CAUTION: review the security group update.",
+            explanation="Review the ingress change.",
+            guidance=[],
+            degraded=False,
+            warnings=[],
+        )
+        persisted = report_service_module.persist_analysis_report(
+            parse_batch,
+            assessment,
+            narrative,
+            project_id=project.id,
+            audit_context={"source_interface": "api"},
+        )
+
+        with patch(
+            "services.incident_service.get_incident_index_snapshot",
+            side_effect=RuntimeError("snapshot unavailable"),
+        ):
+            fetched = report_service_module.fetch_analysis_report(persisted["id"])
+
+        self.assertIsNotNone(fetched)
+        assert fetched is not None
+        context = fetched["context_completeness"]
+        self.assertEqual(context["incident_index_freshness_status"], "empty")
+        self.assertEqual(context["incident_index_version"], "incidents:empty")
+        self.assertNotIn(
+            "Refresh stale incident history for this project/workspace.",
+            context["context_todos"],
+        )
+        incident_source = context["context_sources"][0]
+        self.assertEqual(incident_source["freshness_status"], "empty")
+        self.assertEqual(incident_source["confidence"], 0.0)
 
     def test_persist_analysis_report_cleans_up_committed_row_after_artifact_failure(
         self,
@@ -4985,6 +5082,60 @@ class ReportServiceTests(unittest.TestCase):
             "prod/network/plan.json",
             shared_report["evidence_items"][0]["source_ref"],
         )
+
+    def test_shared_report_redaction_rewrites_context_source_metadata(self) -> None:
+        report = self._persist_shareable_report()
+        context_source = ContextSourceMetadata(
+            source_id="artifact:prod/network/plan.json",
+            source_type="artifact",
+            source_ref="prod/network/plan.json",
+            scope="project:prod/network/plan.json",
+            freshness_status="incomplete",
+            confidence=0.5,
+            conflicts=["conflict in prod/network/plan.json"],
+            limitations=["parser_issue: prod/network/plan.json"],
+        ).model_dump(mode="json")
+        context = ContextCompleteness(
+            context_score=0.8,
+            confidence_level="medium",
+            incident_index_size=0,
+            parser_success_rate=1.0,
+            evidence_success_rate=1.0,
+            context_sources=[ContextSourceMetadata.model_validate(context_source)],
+            owner_signals=[],
+            escalation_hints=["Escalate prod/network/plan.json."],
+            ownership_unmapped_subjects=["prod/network/plan.json"],
+        ).model_dump(mode="json")
+        with sqlite3.connect(self.db_path) as connection:
+            connection.execute(
+                "UPDATE risk_assessments SET context_completeness_json = ? "
+                "WHERE analysis_id = ?",
+                (json.dumps(context), report["id"]),
+            )
+            connection.execute(
+                "UPDATE evidence_items SET context_source_json = ? "
+                "WHERE analysis_id = ?",
+                (json.dumps(context_source), report["id"]),
+            )
+        report_service_module.configure_report_share(
+            report["id"],
+            password="s3cret-pass",
+            redact_filenames=True,
+        )
+
+        shared_report = report_service_module.fetch_shared_analysis_report(
+            report["id"],
+            password="s3cret-pass",
+        )
+
+        self.assertIsNotNone(shared_report)
+        assert shared_report is not None
+        serialized_context = json.dumps(shared_report["context_completeness"])
+        serialized_evidence = json.dumps(shared_report["evidence_items"])
+        self.assertNotIn("prod/network/plan.json", serialized_context)
+        self.assertNotIn("prod/network/plan.json", serialized_evidence)
+        self.assertIn("Artifact 1", serialized_context)
+        self.assertIn("Artifact 1", serialized_evidence)
 
     def test_fetch_analysis_report_builds_confidence_ledger_from_legacy_contributors(
         self,

--- a/tests/test_services/test_report_service.py
+++ b/tests/test_services/test_report_service.py
@@ -26,7 +26,12 @@ from analysis.blast_radius import BlastRadiusResult, ImpactNode
 from analysis.incident_matcher import IncidentMatch
 from analysis.rollback_planner import RollbackPlan, RollbackStep
 from analysis.risk_scorer import RiskAssessment, RiskContributor
-from evidence.models import ContextCompleteness, EvidenceItem, Finding
+from evidence.models import (
+    ContextCompleteness,
+    ContextSourceMetadata,
+    EvidenceItem,
+    Finding,
+)
 from llm.narrator import NarrativeResult
 from parsers.base import ParseBatchResult, ParseIssue, ParsedFileResult, UnifiedChange
 from parsers.terraform_parser import parse_terraform
@@ -4154,6 +4159,16 @@ class ReportServiceTests(unittest.TestCase):
                 incident_index_freshness_status=str(
                     snapshot["incident_index_freshness_status"]
                 ),
+                context_sources=[
+                    ContextSourceMetadata(
+                        source_id="incident:index:test",
+                        source_type="incident",
+                        source_ref=str(snapshot["incident_index_version"]),
+                        scope="project:payments",
+                        freshness_status="current",
+                        confidence=0.8,
+                    )
+                ],
             ),
             partial_context=False,
             warnings=[],
@@ -4189,6 +4204,19 @@ class ReportServiceTests(unittest.TestCase):
             fetched["context_completeness"]["incident_index_version"],
             snapshot["incident_index_version"],
         )
+        self.assertEqual(fetched["context_completeness"]["context_score"], 0.8)
+        self.assertEqual(fetched["context_completeness"]["confidence_level"], "medium")
+        self.assertIn(
+            "Refresh stale incident history for this project/workspace.",
+            fetched["context_completeness"]["context_todos"],
+        )
+        incident_sources = [
+            source
+            for source in fetched["context_completeness"]["context_sources"]
+            if source["source_type"] == "incident"
+        ]
+        self.assertEqual(incident_sources[0]["freshness_status"], "stale")
+        self.assertIn("stale_incident_index", incident_sources[0]["limitations"])
 
     def test_fetch_analysis_report_marks_incident_index_stale_when_lookup_fails(
         self,
@@ -4228,6 +4256,16 @@ class ReportServiceTests(unittest.TestCase):
                 incident_index_version="incidents:1:old",
                 incident_index_last_indexed_at="2026-05-20T00:00:00Z",
                 incident_index_freshness_status="current",
+                context_sources=[
+                    ContextSourceMetadata(
+                        source_id="incident:index:old",
+                        source_type="incident",
+                        source_ref="incidents:1:old",
+                        scope="project:payments",
+                        freshness_status="current",
+                        confidence=0.8,
+                    )
+                ],
             ),
             partial_context=False,
             warnings=[],
@@ -4258,6 +4296,74 @@ class ReportServiceTests(unittest.TestCase):
             fetched["context_completeness"]["incident_index_freshness_status"],
             "stale",
         )
+        self.assertEqual(fetched["context_completeness"]["context_score"], 0.8)
+        self.assertEqual(fetched["context_completeness"]["confidence_level"], "medium")
+        incident_source = fetched["context_completeness"]["context_sources"][0]
+        self.assertEqual(incident_source["freshness_status"], "stale")
+        self.assertIn("stale_incident_index", incident_source["limitations"])
+
+    def test_mark_incident_context_stale_targets_matching_source_version(self) -> None:
+        context = report_service_module._mark_incident_context_stale(
+            {
+                "context_score": 0.9,
+                "confidence_level": "high",
+                "incident_index_version": "incidents:1:old",
+                "incident_index_freshness_status": "current",
+                "context_todos": [],
+                "context_sources": [
+                    {
+                        "source_id": "incident:index:old",
+                        "source_type": "incident",
+                        "source_ref": "incidents:1:old",
+                        "scope": "project:payments",
+                        "freshness_status": "current",
+                        "confidence": 0.8,
+                        "limitations": [],
+                    },
+                    {
+                        "source_id": "incident:index:other",
+                        "source_type": "incident",
+                        "source_ref": "incidents:2:other",
+                        "scope": "project:payments",
+                        "freshness_status": "current",
+                        "confidence": 0.8,
+                        "limitations": [],
+                    },
+                ],
+            }
+        )
+
+        sources = {
+            source["source_ref"]: source for source in context["context_sources"]
+        }
+        self.assertEqual(sources["incidents:1:old"]["freshness_status"], "stale")
+        self.assertEqual(sources["incidents:2:other"]["freshness_status"], "current")
+        self.assertEqual(context["context_score"], 0.8)
+        self.assertEqual(context["confidence_level"], "medium")
+
+    def test_load_evidence_context_source_marks_incident_source_stale(self) -> None:
+        context_source = report_service_module._load_evidence_context_source(
+            json.dumps(
+                {
+                    "source_id": "incident:index:old",
+                    "source_type": "incident",
+                    "source_ref": "incidents:1:old",
+                    "scope": "project:payments",
+                    "freshness_status": "current",
+                    "confidence": 0.8,
+                    "conflicts": [],
+                    "limitations": [],
+                }
+            ),
+            context_completeness={
+                "incident_index_freshness_status": "stale",
+                "incident_index_version": "incidents:1:old",
+            },
+        )
+
+        self.assertIsNotNone(context_source)
+        self.assertEqual(context_source["freshness_status"], "stale")
+        self.assertIn("stale_incident_index", context_source["limitations"])
 
     def test_persist_analysis_report_cleans_up_committed_row_after_artifact_failure(
         self,

--- a/tests/test_services/test_report_service.py
+++ b/tests/test_services/test_report_service.py
@@ -4431,6 +4431,469 @@ class ReportServiceTests(unittest.TestCase):
 
         self.assertIsNone(context_source)
 
+    def test_load_evidence_context_source_preserves_forward_compatible_payload(
+        self,
+    ) -> None:
+        context_source = report_service_module._load_evidence_context_source(
+            json.dumps(
+                {
+                    "source_id": "topology:kubernetes:current-context",
+                    "source_type": "topology",
+                    "source_ref": "current-context",
+                    "scope": "project:checkout",
+                    "freshness_status": "current",
+                    "confidence": 0.9,
+                    "conflicts": [],
+                    "limitations": [],
+                    "future_writer_field": {"producer": "newer-deploywhisper"},
+                }
+            ),
+            context_completeness={
+                "incident_index_freshness_status": "current",
+                "incident_index_version": "incidents:1:current",
+            },
+        )
+
+        self.assertIsNotNone(context_source)
+        self.assertEqual(
+            context_source["source_id"],
+            "topology:kubernetes:current-context",
+        )
+        self.assertEqual(context_source["freshness_status"], "current")
+        self.assertNotIn("future_writer_field", context_source)
+
+    def test_load_context_completeness_adds_non_stale_incident_guidance(
+        self,
+    ) -> None:
+        context, warning = report_service_module._load_context_completeness_payload(
+            json.dumps(
+                ContextCompleteness(
+                    context_score=0.88,
+                    parser_success_rate=1.0,
+                    evidence_success_rate=1.0,
+                    incident_index_size=2,
+                    incident_index_version="incidents:2:conflict",
+                    incident_index_freshness_status="conflicting",
+                    context_todos=[],
+                ).model_dump(mode="json")
+            )
+        )
+
+        self.assertIsNone(warning)
+        self.assertEqual(context["context_score"], 0.88)
+        self.assertIn(
+            "Resolve incident history freshness: conflicting.",
+            context["context_todos"],
+        )
+        self.assertNotIn(
+            "Refresh stale incident history for this project/workspace.",
+            context["context_todos"],
+        )
+
+    def test_load_context_completeness_drops_only_malformed_context_sources(
+        self,
+    ) -> None:
+        payload = ContextCompleteness(
+            context_score=0.76,
+            parser_success_rate=1.0,
+            evidence_success_rate=1.0,
+            incident_index_size=0,
+            incident_index_freshness_status="empty",
+            context_sources=[
+                ContextSourceMetadata(
+                    source_id="topology:kubernetes:current-context",
+                    source_type="topology",
+                    source_ref="current-context",
+                    scope="project:checkout",
+                    freshness_status="current",
+                    confidence=0.9,
+                )
+            ],
+        ).model_dump(mode="json")
+        payload["context_sources"].append(
+            {
+                "source_id": "",
+                "source_type": "topology",
+                "source_ref": "bad-context.json",
+                "scope": "project:checkout",
+                "freshness_status": "current",
+                "confidence": 0.5,
+            }
+        )
+
+        context, warning = report_service_module._load_context_completeness_payload(
+            json.dumps(payload)
+        )
+
+        self.assertIsNone(warning)
+        self.assertEqual(context["context_score"], 0.76)
+        self.assertEqual(len(context["context_sources"]), 1)
+        self.assertEqual(
+            context["context_sources"][0]["source_id"],
+            "topology:kubernetes:current-context",
+        )
+        self.assertIn(
+            "Review dropped context source metadata for this report.",
+            context["context_todos"],
+        )
+
+    def test_load_context_completeness_flags_all_malformed_context_sources(
+        self,
+    ) -> None:
+        payload = ContextCompleteness(
+            context_score=0.92,
+            parser_success_rate=1.0,
+            evidence_success_rate=1.0,
+            incident_index_size=0,
+            incident_index_freshness_status="empty",
+        ).model_dump(mode="json")
+        payload["context_sources"] = [
+            {
+                "source_id": "",
+                "source_type": "topology",
+                "source_ref": "bad-context.json",
+                "scope": "project:checkout",
+                "freshness_status": "current",
+                "confidence": 0.5,
+            },
+            "not-a-source-row",
+        ]
+
+        context, warning = report_service_module._load_context_completeness_payload(
+            json.dumps(payload)
+        )
+
+        self.assertIsNone(warning)
+        self.assertEqual(context["context_score"], 0.92)
+        self.assertEqual(context["context_sources"], [])
+        self.assertIn(
+            "Review dropped context source metadata for this report.",
+            context["context_todos"],
+        )
+
+    def test_load_context_completeness_flags_malformed_context_source_shape(
+        self,
+    ) -> None:
+        payload = ContextCompleteness(
+            context_score=0.92,
+            parser_success_rate=1.0,
+            evidence_success_rate=1.0,
+            incident_index_size=0,
+            incident_index_freshness_status="empty",
+        ).model_dump(mode="json")
+        payload["context_sources"] = {"source_id": "not-a-list"}
+
+        context, warning = report_service_module._load_context_completeness_payload(
+            json.dumps(payload)
+        )
+
+        self.assertIsNone(warning)
+        self.assertEqual(context["context_score"], 0.92)
+        self.assertEqual(context["context_sources"], [])
+        self.assertIn(
+            "Review dropped context source metadata for this report.",
+            context["context_todos"],
+        )
+
+    def test_load_context_completeness_preserves_forward_compatible_context_source(
+        self,
+    ) -> None:
+        payload = ContextCompleteness(
+            context_score=0.92,
+            parser_success_rate=1.0,
+            evidence_success_rate=1.0,
+            incident_index_size=0,
+            incident_index_freshness_status="empty",
+            context_sources=[
+                ContextSourceMetadata(
+                    source_id="topology:kubernetes:current-context",
+                    source_type="topology",
+                    source_ref="current-context",
+                    scope="project:checkout",
+                    freshness_status="current",
+                    confidence=0.9,
+                )
+            ],
+        ).model_dump(mode="json")
+        payload["context_sources"][0]["future_writer_field"] = {
+            "producer": "newer-deploywhisper"
+        }
+
+        context, warning = report_service_module._load_context_completeness_payload(
+            json.dumps(payload)
+        )
+
+        self.assertIsNone(warning)
+        self.assertEqual(context["context_score"], 0.92)
+        self.assertEqual(len(context["context_sources"]), 1)
+        self.assertEqual(
+            context["context_sources"][0]["source_id"],
+            "topology:kubernetes:current-context",
+        )
+        self.assertNotIn(
+            "future_writer_field",
+            context["context_sources"][0],
+        )
+        self.assertNotIn(
+            "Review dropped context source metadata for this report.",
+            context["context_todos"],
+        )
+
+    def test_load_context_completeness_coerces_unknown_incident_freshness(
+        self,
+    ) -> None:
+        context, warning = report_service_module._load_context_completeness_payload(
+            json.dumps(
+                ContextCompleteness(
+                    context_score=0.88,
+                    parser_success_rate=1.0,
+                    evidence_success_rate=1.0,
+                    incident_index_size=2,
+                    incident_index_version="incidents:2:conflict",
+                    incident_index_freshness_status="currnet",
+                    context_todos=[],
+                ).model_dump(mode="json")
+            )
+        )
+
+        self.assertIsNone(warning)
+        self.assertEqual(context["incident_index_freshness_status"], "unknown")
+        self.assertIn(
+            "Resolve incident history freshness: unknown.",
+            context["context_todos"],
+        )
+
+    def test_load_context_completeness_coerces_invalid_zero_incident_freshness_to_unknown(
+        self,
+    ) -> None:
+        context, warning = report_service_module._load_context_completeness_payload(
+            json.dumps(
+                ContextCompleteness(
+                    context_score=0.88,
+                    parser_success_rate=1.0,
+                    evidence_success_rate=1.0,
+                    incident_index_size=0,
+                    incident_index_version="incidents:unknown",
+                    incident_index_freshness_status="currnet",
+                    context_todos=[],
+                ).model_dump(mode="json")
+            )
+        )
+
+        self.assertIsNone(warning)
+        self.assertEqual(context["incident_index_freshness_status"], "unknown")
+        self.assertIn(
+            "Resolve incident history freshness: unknown.",
+            context["context_todos"],
+        )
+        self.assertNotIn(
+            "Import relevant incident history for this project/workspace.",
+            context["context_todos"],
+        )
+
+    def test_load_context_completeness_coerces_supported_zero_incident_freshness_to_unknown(
+        self,
+    ) -> None:
+        for freshness_status in ("current", "stale", "conflicting", "incomplete"):
+            with self.subTest(freshness_status=freshness_status):
+                context, warning = (
+                    report_service_module._load_context_completeness_payload(
+                        json.dumps(
+                            ContextCompleteness(
+                                context_score=0.88,
+                                parser_success_rate=1.0,
+                                evidence_success_rate=1.0,
+                                incident_index_size=0,
+                                incident_index_version=f"incidents:0:{freshness_status}",
+                                incident_index_freshness_status=freshness_status,
+                                context_todos=[],
+                            ).model_dump(mode="json")
+                        )
+                    )
+                )
+
+                self.assertIsNone(warning)
+                self.assertEqual(
+                    context["incident_index_freshness_status"],
+                    "unknown",
+                )
+                self.assertIn(
+                    "Resolve incident history freshness: unknown.",
+                    context["context_todos"],
+                )
+                self.assertNotIn(
+                    "Import relevant incident history for this project/workspace.",
+                    context["context_todos"],
+                )
+
+    def test_load_context_completeness_flags_populated_empty_incident_freshness(
+        self,
+    ) -> None:
+        context, warning = report_service_module._load_context_completeness_payload(
+            json.dumps(
+                ContextCompleteness(
+                    context_score=0.88,
+                    parser_success_rate=1.0,
+                    evidence_success_rate=1.0,
+                    incident_index_size=2,
+                    incident_index_version="incidents:2:conflict",
+                    incident_index_freshness_status="empty",
+                    context_todos=[],
+                ).model_dump(mode="json")
+            )
+        )
+
+        self.assertIsNone(warning)
+        self.assertIn(
+            "Resolve incident history freshness: empty state conflicts with populated index.",
+            context["context_todos"],
+        )
+
+    def test_load_context_completeness_adds_empty_incident_import_guidance_with_other_incident_todos(
+        self,
+    ) -> None:
+        context, warning = report_service_module._load_context_completeness_payload(
+            json.dumps(
+                ContextCompleteness(
+                    context_score=0.88,
+                    parser_success_rate=1.0,
+                    evidence_success_rate=1.0,
+                    incident_index_size=0,
+                    incident_index_version="incidents:empty",
+                    incident_index_freshness_status="empty",
+                    context_todos=[
+                        "Resolve incident history freshness: unknown.",
+                    ],
+                ).model_dump(mode="json")
+            )
+        )
+
+        self.assertIsNone(warning)
+        self.assertIn(
+            "Resolve incident history freshness: unknown.",
+            context["context_todos"],
+        )
+        self.assertIn(
+            "Import relevant incident history for this project/workspace.",
+            context["context_todos"],
+        )
+
+    def test_load_context_completeness_flags_blank_explicit_empty_incident_freshness(
+        self,
+    ) -> None:
+        payload = ContextCompleteness(
+            context_score=0.88,
+            parser_success_rate=1.0,
+            evidence_success_rate=1.0,
+            incident_index_size=2,
+            incident_index_version="incidents:empty",
+            incident_index_freshness_status="empty",
+            context_todos=[],
+        ).model_dump(mode="json")
+        payload["incident_index_freshness_status"] = ""
+
+        context, warning = report_service_module._load_context_completeness_payload(
+            json.dumps(payload)
+        )
+
+        self.assertIsNone(warning)
+        self.assertEqual(context["incident_index_freshness_status"], "conflicting")
+        self.assertIn(
+            "Resolve incident history freshness: empty state conflicts with populated index.",
+            context["context_todos"],
+        )
+
+    def test_load_context_completeness_flags_populated_explicit_empty_incident_freshness(
+        self,
+    ) -> None:
+        for freshness_status in ("current", "empty", "stale", "unknown"):
+            with self.subTest(freshness_status=freshness_status):
+                context, warning = (
+                    report_service_module._load_context_completeness_payload(
+                        json.dumps(
+                            ContextCompleteness(
+                                context_score=0.88,
+                                parser_success_rate=1.0,
+                                evidence_success_rate=1.0,
+                                incident_index_size=2,
+                                incident_index_version="incidents:empty",
+                                incident_index_freshness_status=freshness_status,
+                                context_todos=[],
+                            ).model_dump(mode="json")
+                        )
+                    )
+                )
+
+                self.assertIsNone(warning)
+                self.assertEqual(
+                    context["incident_index_freshness_status"],
+                    "conflicting",
+                )
+                self.assertIn(
+                    "Resolve incident history freshness: empty state conflicts with populated index.",
+                    context["context_todos"],
+                )
+                self.assertNotIn(
+                    "Resolve incident history freshness: conflicting.",
+                    context["context_todos"],
+                )
+
+    def test_load_context_completeness_coerces_zero_incident_freshness_to_empty(
+        self,
+    ) -> None:
+        for freshness_status in ("current", "stale", "conflicting", "unknown"):
+            with self.subTest(freshness_status=freshness_status):
+                context, warning = (
+                    report_service_module._load_context_completeness_payload(
+                        json.dumps(
+                            ContextCompleteness(
+                                context_score=0.88,
+                                parser_success_rate=1.0,
+                                evidence_success_rate=1.0,
+                                incident_index_size=0,
+                                incident_index_version="incidents:empty",
+                                incident_index_freshness_status=freshness_status,
+                                context_todos=[],
+                            ).model_dump(mode="json")
+                        )
+                    )
+                )
+
+                self.assertIsNone(warning)
+                self.assertEqual(context["incident_index_freshness_status"], "empty")
+                self.assertNotIn(
+                    "Resolve incident history freshness:",
+                    "\n".join(context["context_todos"]),
+                )
+
+    def test_load_context_completeness_preserves_incident_lookup_failure_freshness(
+        self,
+    ) -> None:
+        context, warning = report_service_module._load_context_completeness_payload(
+            json.dumps(
+                ContextCompleteness(
+                    context_score=0.88,
+                    parser_success_rate=1.0,
+                    evidence_success_rate=1.0,
+                    incident_index_size=0,
+                    incident_index_version="incidents:unknown",
+                    incident_index_freshness_status="stale",
+                    context_todos=[],
+                ).model_dump(mode="json")
+            )
+        )
+
+        self.assertIsNone(warning)
+        self.assertEqual(context["incident_index_freshness_status"], "stale")
+        self.assertIn(
+            "Refresh stale incident history for this project/workspace.",
+            context["context_todos"],
+        )
+        self.assertNotIn(
+            "Import relevant incident history for this project/workspace.",
+            context["context_todos"],
+        )
+
     def test_fetch_analysis_report_preserves_empty_incident_snapshot_on_lookup_failure(
         self,
     ) -> None:

--- a/tests/test_services/test_report_service.py
+++ b/tests/test_services/test_report_service.py
@@ -4204,7 +4204,7 @@ class ReportServiceTests(unittest.TestCase):
             fetched["context_completeness"]["incident_index_version"],
             snapshot["incident_index_version"],
         )
-        self.assertEqual(fetched["context_completeness"]["context_score"], 0.8)
+        self.assertEqual(fetched["context_completeness"]["context_score"], 0.76)
         self.assertEqual(fetched["context_completeness"]["confidence_level"], "medium")
         self.assertIn(
             "Refresh stale incident history for this project/workspace.",
@@ -4296,7 +4296,7 @@ class ReportServiceTests(unittest.TestCase):
             fetched["context_completeness"]["incident_index_freshness_status"],
             "stale",
         )
-        self.assertEqual(fetched["context_completeness"]["context_score"], 0.8)
+        self.assertEqual(fetched["context_completeness"]["context_score"], 0.76)
         self.assertEqual(fetched["context_completeness"]["confidence_level"], "medium")
         incident_source = fetched["context_completeness"]["context_sources"][0]
         self.assertEqual(incident_source["freshness_status"], "stale")
@@ -4307,6 +4307,7 @@ class ReportServiceTests(unittest.TestCase):
             {
                 "context_score": 0.9,
                 "confidence_level": "high",
+                "incident_index_size": 1,
                 "incident_index_version": "incidents:1:old",
                 "incident_index_freshness_status": "current",
                 "context_todos": [],
@@ -4338,8 +4339,46 @@ class ReportServiceTests(unittest.TestCase):
         }
         self.assertEqual(sources["incidents:1:old"]["freshness_status"], "stale")
         self.assertEqual(sources["incidents:2:other"]["freshness_status"], "current")
-        self.assertEqual(context["context_score"], 0.8)
+        self.assertEqual(context["context_score"], 0.76)
         self.assertEqual(context["confidence_level"], "medium")
+
+    def test_mark_incident_context_stale_recomputes_score_below_cap(self) -> None:
+        context = report_service_module._mark_incident_context_stale(
+            {
+                "context_score": 0.73,
+                "confidence_level": "medium",
+                "parser_success_rate": 0.8,
+                "evidence_success_rate": 0.8,
+                "incident_index_size": 8,
+                "incident_index_version": "incidents:8:old",
+                "incident_index_freshness_status": "current",
+                "context_todos": [],
+                "context_sources": [
+                    {
+                        "source_id": "topology:kubernetes:current-context",
+                        "source_type": "topology",
+                        "source_ref": "current-context",
+                        "scope": "project:payments",
+                        "freshness_status": "current",
+                        "confidence": 0.5,
+                        "limitations": [],
+                    },
+                    {
+                        "source_id": "incident:index:old",
+                        "source_type": "incident",
+                        "source_ref": "incidents:8:old",
+                        "scope": "project:payments",
+                        "freshness_status": "current",
+                        "confidence": 0.8,
+                        "limitations": [],
+                    },
+                ],
+            }
+        )
+
+        self.assertEqual(context["context_score"], 0.67)
+        self.assertEqual(context["confidence_level"], "low")
+        self.assertTrue(context["insufficient_context"])
 
     def test_load_evidence_context_source_marks_incident_source_stale(self) -> None:
         context_source = report_service_module._load_evidence_context_source(
@@ -4364,6 +4403,23 @@ class ReportServiceTests(unittest.TestCase):
         self.assertIsNotNone(context_source)
         self.assertEqual(context_source["freshness_status"], "stale")
         self.assertIn("stale_incident_index", context_source["limitations"])
+
+    def test_load_evidence_context_source_rejects_invalid_payload(self) -> None:
+        context_source = report_service_module._load_evidence_context_source(
+            json.dumps(
+                {
+                    "source_id": "incident:index:old",
+                    "source_type": "incident",
+                    "freshness_status": "current",
+                }
+            ),
+            context_completeness={
+                "incident_index_freshness_status": "current",
+                "incident_index_version": "incidents:1:old",
+            },
+        )
+
+        self.assertIsNone(context_source)
 
     def test_persist_analysis_report_cleans_up_committed_row_after_artifact_failure(
         self,


### PR DESCRIPTION
## Summary
- Add context source freshness metadata across evidence models, API schemas, persistence, report loading, CLI/UI output, and frontend API types.
- Persist evidence context-source metadata and add the Alembic migration for evidence_items.context_source_json.
- Fix BMad rerun findings: strict source-ref matching, per-signal ownership ledger rows, stale incident confidence/score downgrade, targeted stale incident source marking, and visible context-source conflict/limitation details.

## Validation
- ./.venv/bin/ruff format --check .
- ./.venv/bin/ruff check .
- ./.venv/bin/python -m unittest discover -q (316 tests, 1 skipped)
- npm run test -- Report.test.tsx --run (5 tests)
- npm run build
- ./.venv/bin/bandit -r api/ analysis/ services/ parsers/ llm/ models/ cli/ evidence/ --severity-level high --confidence-level high -x tests/
- git diff --check

## Notes
- Earlier composed-app Playwright validation passed before the final ownership-source patch; not rerun after that backend-only ownership ledger adjustment.