### PR TITLE
Story 8.3 external evidence report context

### DIFF
--- a/_bmad-output/implementation-artifacts/8-3-external-evidence-report-context.md
+++ b/_bmad-output/implementation-artifacts/8-3-external-evidence-report-context.md
@@ -1,0 +1,338 @@
+# Story 8.3: External Evidence Report Context
+
+Status: done
+
+<!-- Generated from updated PRD/architecture/epics plus implementation-readiness-report-2026-05-01.md. -->
+
+## Story
+
+As a reviewer,
+I want scanner context visible but clearly labeled,
+So that I know what came from DeployWhisper versus another tool.
+
+## Acceptance Criteria
+
+1. Given external scanner findings are linked to a report, When the report, PR comment, or API output renders, Then scanner findings are labeled as external evidence. And they do not automatically become high/critical DeployWhisper findings.
+
+### Requirement Traceability
+
+- Primary PRD requirements: Epic 8 coverage: EXT-01..08, ADM-10, EVD-04, REV-02, WRK-04, DOC-25.
+- Supporting PRD / NFR / differentiation requirements: See `_bmad-output/planning-artifacts/prd.md`, `_bmad-output/planning-artifacts/architecture.md`, and `_bmad-output/planning-artifacts/implementation-readiness-report-2026-05-01.md`.
+- Coverage intent: Baseline + Delta.
+- Story alignment note: This story was created from the updated Epic 8 plan after the 2026-05-01 readiness rerun. The readiness report verified 187/187 PRD functional requirement IDs in the epics artifact, 38 NFR IDs present, and no critical or major readiness defects.
+
+## Tasks / Subtasks
+
+- [x] Implement and verify acceptance criterion 1. (AC: 1)
+- [x] Reuse existing services, repositories, schemas, and UI/CLI/API helpers before adding new abstractions. (AC: all)
+- [x] Add or update deterministic regression coverage for the changed behavior. (AC: all)
+- [x] Update relevant docs or examples if the story changes user-visible, operator, API, CLI, integration, or contribution behavior. (AC: all)
+- [x] Run required validation and record commands/results in the Dev Agent Record. (AC: all)
+
+### Review Findings
+
+- [x] [Review][Patch] Report finding rows need explicit external-evidence labels [frontend/src/screens/Report.tsx:429]
+- [x] [Review][Patch] Share-summary findings need per-finding external-evidence labels in JSON, markdown, and plain text [services/analysis_service.py:1624]
+- [x] [Review][Patch] Evidence register title must not call external scanner context deterministic evidence [frontend/src/screens/Report.tsx:586]
+- [x] [Review][Patch] Repository boundary needs a regression test for scanner-only severe evidence rejection [models/repositories/analysis_reports.py:425]
+- [x] [Review][Patch] Report-detail API should emit server-derived external evidence labels instead of making the UI re-derive scanner provenance [services/report_service.py:4216]
+- [x] [Review][Patch] Mixed DeployWhisper plus scanner findings should use precise `Includes external context` wording instead of labeling the entire finding `External evidence` [services/analysis_service.py:1515]
+- [x] [Review][Patch] External scanner checks should inspect both `source_kind` and `source_type` instead of letting a stale `source_kind` hide scanner context [services/analysis_service.py:1508]
+- [x] [Review][Patch] Report header still labels external scanner context as deterministic evidence [frontend/src/screens/Report.tsx:331]
+- [x] [Review][Patch] Report-detail finding labels ignore external evidence linked only through `evidence_refs` [services/report_service.py:4394]
+- [x] [Review][Patch] Share-summary finding evidence counts ignore ref-linked evidence when owned evidence exists [services/analysis_service.py:1484]
+- [x] [Review][Patch] Legacy UI fallback does not preserve mixed-vs-external evidence labeling [frontend/src/screens/Report.tsx:200]
+- [x] [Review][Patch] Header and evidence-register summary can render impossible external-evidence counts [frontend/src/screens/Report.tsx:218]
+- [x] [Review][Patch] External-context labels treat every non-scanner source as DeployWhisper support [services/analysis_service.py:1525]
+- [x] [Review][Patch] Share-summary output can omit external scanner findings outside the top-three slice [services/analysis_service.py:1678]
+- [x] [Review][Patch] Share-summary external-context finding selection needs a hard bound and compact-mode duplicate-title handling [services/analysis_service.py:1688]
+- [x] [Review][Patch] UI external-context evidence totals can undercount actual evidence rows when payload counts lag rendered rows [frontend/src/screens/Report.tsx:236]
+- [x] [Review][Patch] Report schema example contradicts scanner-only evidence downgrade semantics [docs/schemas/report-v2.md:153]
+- [x] [Review][Patch] UI external-context count should not undercount rendered scanner evidence rows when payload external count lags [frontend/src/screens/Report.tsx:236]
+- [x] [Review][Patch] Share-summary extra external-context slots should prioritize pure scanner-only findings before mixed-context findings [services/analysis_service.py:1697]
+- [x] [Review][Patch] Repository Evidence Law gate should not treat user-provided context as DeployWhisper deterministic support [models/repositories/analysis_reports.py:523]
+- [x] [Review][Patch] UI external-context count should not exceed total evidence when payload external counts are stale-high [frontend/src/screens/Report.tsx:236]
+- [x] [Review][Patch] Positive DeployWhisper source detection should not hard-code only known internal source names [models/repositories/analysis_reports.py:523]
+- [x] [Review][Patch] Compact PR/share summary must preserve top-risk findings before adding lower-severity scanner context [services/analysis_service.py:1853]
+- [x] [Review][Patch] Internal-only redacted reports should not undercount evidence totals [frontend/src/screens/Report.tsx:236]
+- [x] [Review][Patch] Share-summary totals should not label all evidence deterministic when no external rows are visible [frontend/src/screens/Report.tsx:331]
+- [x] [Review][Patch] Report-detail schema examples should show additive `evidence_label` fields [docs/schemas/report-v2.md:153]
+- [x] [Review][Patch] Share-summary markdown should not duplicate severity prefixes [services/analysis_service.py:1742]
+- [x] [Review][Patch] UI external-context count should trust rendered scanner rows when rendered rows already match payload total [frontend/src/screens/Report.tsx:236]
+- [x] [Review][Patch] Story file list should include the report schema documentation regression test [tests/test_docs/test_report_schema_documentation.py:34]
+- [x] [Review][Patch] Partially redacted reports should not count visible internal evidence rows as stale external context [frontend/src/screens/Report.tsx:233]
+- [x] [Review][Patch] Cross-layer Story 8.3 completion should record `bash scripts/ci-local.sh` validation before remaining `done` [_bmad-output/implementation-artifacts/8-3-external-evidence-report-context.md:117]
+- [x] [Review][Patch] Share-summary redaction should preserve external-context labels and counts when evidence rows are omitted [services/analysis_service.py:1773]
+- [x] [Review][Patch] Story closure should happen on a short-lived Git Flow branch rather than `develop` [_bmad-output/project-context.md:76]
+- [x] [Review][Patch] Redacted share summaries should preserve prior total evidence count alongside prior external count [services/analysis_service.py:1797]
+- [x] [Review][Patch] Partially redacted share summaries should clamp stored external counts by visible internal evidence rows [services/analysis_service.py:1727]
+- [x] [Review][Patch] Redacted evidence registers should render an explicit omitted-detail state instead of an empty body [frontend/src/screens/Report.tsx:662]
+
+## Dev Notes
+
+### Epic Context
+
+- Epic: 8. Existing Security Tool Integration
+- Epic goal: Make DeployWhisper complementary to scanners rather than a replacement or severity passthrough.
+- Epic coverage: EXT-01..08, ADM-10, EVD-04, REV-02, WRK-04, DOC-25
+
+### Architecture and Product Guardrails
+
+- Preserve DeployWhisper's local-first raw artifact boundary: raw IaC, scanner artifacts, incident exports, and sensitive context stay in the user's infrastructure by default.
+- Preserve the advisory-first core. Optional adapters may interpret report outputs, but canonical report semantics remain advisory unless explicit story scope says otherwise.
+- Reuse the shared analysis core and service layer before adapting UI, API, CLI, GitHub, or future workflow surfaces.
+- Keep Evidence Law behavior intact: no high or critical finding without deterministic evidence.
+- Keep project/workspace scope explicit for reports, incidents, topology, outcomes, feedback, scanner imports, and connector-related data.
+- Do not introduce new dependencies unless the active story explicitly requires and justifies them.
+
+### Source Tree Guidance
+
+- API routes belong under `api/routes/` and should use existing `ApiRoute` / `ApiError` envelope patterns.
+- Shared orchestration belongs in `services/`; parsers normalize input, analysis modules score/derive risk, and surfaces adapt outputs.
+- UI work belongs under `frontend/src/screens/` and `frontend/src/components/`, following the existing retired Python UI composition style.
+- CLI behavior belongs under `cli/` and must call the same service-layer paths as UI/API flows.
+- Persistence work belongs under `models/` with Alembic migrations when schema changes are required.
+- Documentation required by a story should be updated in the same workstream.
+
+### Testing Requirements
+
+- Use standard-library `unittest` in the existing `tests/test_*` layout.
+- Add focused regression tests for the layer changed by the story before broad refactors.
+- For Python changes, run `./.venv/bin/ruff check .`, `./.venv/bin/ruff format --check .`, and `./.venv/bin/python -m unittest discover -q` before closing implementation.
+- Use `bash scripts/ci-local.sh` for broader or cross-layer changes.
+
+### Project Structure Notes
+
+- Follow the current repository shape documented in `_bmad-output/project-context.md` and `AGENTS.md`.
+- If implementation reveals a conflict between this story and the current code baseline, keep the smallest compatible change and update the story notes rather than silently drifting from the PRD.
+
+### References
+
+- `_bmad-output/planning-artifacts/epics.md` - source Epic 8 / Story 8.3 definition.
+- `_bmad-output/planning-artifacts/prd.md` - functional and non-functional requirements.
+- `_bmad-output/planning-artifacts/architecture.md` - target architecture, boundaries, and guardrails.
+- `_bmad-output/planning-artifacts/ux-design-specification.md` - UX expectations for user-facing stories.
+- `_bmad-output/planning-artifacts/implementation-readiness-report-2026-05-01.md` - readiness verdict and residual story-format concern.
+- `_bmad-output/project-context.md` - repository-specific implementation rules.
+
+## Dev Agent Record
+
+### Agent Model Used
+
+GPT-5.4 Codex
+
+### Debug Log References
+
+- 2026-06-24: Red tests added for scanner-only severe downgrade, share-summary external scanner context labeling, and report UI external evidence labeling.
+- 2026-06-24: `./.venv/bin/python -m unittest tests.test_services.test_report_service.ReportServiceTests.test_persist_analysis_report_downgrades_external_scanner_only_severe_finding tests.test_services.test_adapter_output_contract.AdapterOutputContractTests.test_share_summary_labels_external_scanner_context_for_comments` failed before implementation, then passed after implementation.
+- 2026-06-24: `npm run ui:test -- Report.test.tsx` passed after adding the report UI regression.
+- 2026-06-24: `./.venv/bin/python -m unittest tests.test_services.test_report_service tests.test_services.test_adapter_output_contract` passed.
+- 2026-06-24: `./.venv/bin/ruff check .` passed.
+- 2026-06-24: `./.venv/bin/ruff format --check .` initially reported formatting drift in `models/repositories/analysis_reports.py` and `services/analysis_service.py`; `./.venv/bin/ruff format models/repositories/analysis_reports.py services/analysis_service.py` reformatted both files.
+- 2026-06-24: `./.venv/bin/ruff check .` passed after formatting.
+- 2026-06-24: `./.venv/bin/ruff format --check .` passed after formatting.
+- 2026-06-24: `./.venv/bin/python -m pip check` passed.
+- 2026-06-24: `./.venv/bin/bandit -r api/ analysis/ services/ parsers/ llm/ models/ cli/ evidence/ --severity-level high --confidence-level high -x tests/` passed with no high-severity issues.
+- 2026-06-24: `./.venv/bin/python -m unittest discover -q` passed after formatting: 345 tests, 1 skipped.
+- 2026-06-24: `npm run ui:typecheck` passed.
+- 2026-06-24: `docker compose up -d --build` completed and started the composed app.
+- 2026-06-24: `curl -fsSL http://127.0.0.1:8080/api/v1/health` returned status `ok`.
+- 2026-06-24: `BASE_URL=http://127.0.0.1:8080 npm run test:ui-review` passed: 8 Playwright tests.
+- 2026-06-24: `docker compose down` stopped and removed the validation stack.
+- 2026-06-24: Code review findings fixed: per-finding external evidence labels added to report rows and share-summary findings; evidence register title now distinguishes scanner context from deterministic items; repository regression added for scanner-only severe direct persistence rejection.
+- 2026-06-24: `./.venv/bin/python -m unittest tests.test_services.test_report_service tests.test_services.test_adapter_output_contract` passed after review fixes: 182 tests.
+- 2026-06-24: `npm run ui:test -- Report.test.tsx` passed after review fixes: 9 tests.
+- 2026-06-24: `npm run ui:typecheck` passed after review fixes.
+- 2026-06-24: `./.venv/bin/ruff check .` passed after review fixes.
+- 2026-06-24: `./.venv/bin/ruff format --check .` passed after review fixes: 255 files already formatted.
+- 2026-06-24: `./.venv/bin/python -m unittest discover -q` passed after review fixes: 345 tests, 1 skipped.
+- 2026-06-24: `docker compose up -d --build` completed after review fixes and rebuilt the production frontend bundle.
+- 2026-06-24: `curl -fsSL http://127.0.0.1:8080/api/v1/health` returned status `ok` after review fixes.
+- 2026-06-24: `BASE_URL=http://127.0.0.1:8080 npm run test:ui-review` passed after review fixes: 8 Playwright tests.
+- 2026-06-24: `docker compose down` stopped and removed the validation stack after review fixes.
+- 2026-06-25: Second-pass review findings fixed: report-detail API now emits server-derived finding/evidence labels, mixed DeployWhisper plus scanner findings use `Includes external context`, and scanner checks inspect both `source_kind` and `source_type`.
+- 2026-06-25: `./.venv/bin/python -m unittest tests.test_services.test_report_service tests.test_services.test_adapter_output_contract` initially failed on a stale test expectation for normalized `source_kind`, then passed after correction: 182 tests.
+- 2026-06-25: `npm run ui:test -- Report.test.tsx` passed after second-pass review fixes: 10 tests.
+- 2026-06-25: `./.venv/bin/ruff check .` passed after second-pass review fixes.
+- 2026-06-25: `./.venv/bin/ruff format --check .` passed after second-pass review fixes: 255 files already formatted.
+- 2026-06-25: `npm run ui:typecheck` passed after second-pass review fixes.
+- 2026-06-25: `./.venv/bin/python -m unittest discover -q` passed after second-pass review fixes: 345 tests, 1 skipped.
+- 2026-06-25: `docker compose up -d --build` completed after second-pass review fixes and rebuilt the production frontend bundle.
+- 2026-06-25: `curl -fsSL http://127.0.0.1:8080/api/v1/health` returned status `ok` after second-pass review fixes.
+- 2026-06-25: `BASE_URL=http://127.0.0.1:8080 npm run test:ui-review` passed after second-pass review fixes: 8 Playwright tests.
+- 2026-06-25: `docker compose down` stopped and removed the validation stack after second-pass review fixes.
+- 2026-06-25: Third-pass review findings fixed: report overview/register summary copy now distinguishes external context, report-detail labels merge ORM-owned evidence with `evidence_refs`, and share-summary per-finding evidence counts use ref-linked evidence.
+- 2026-06-25: `npm run ui:test -- Report.test.tsx` passed after third-pass review fixes: 10 tests.
+- 2026-06-25: `./.venv/bin/python -m unittest tests.test_services.test_report_service tests.test_services.test_adapter_output_contract` passed after third-pass review fixes: 183 tests.
+- 2026-06-25: `./.venv/bin/ruff check .` passed after third-pass review fixes.
+- 2026-06-25: `./.venv/bin/ruff format --check .` passed after third-pass review fixes: 255 files already formatted.
+- 2026-06-25: `npm run ui:typecheck` passed after third-pass review fixes.
+- 2026-06-25: `./.venv/bin/python -m unittest discover -q` passed after third-pass review fixes: 345 tests, 1 skipped.
+- 2026-06-25: `./.venv/bin/bandit -r api/ analysis/ services/ parsers/ llm/ models/ cli/ evidence/ --severity-level high --confidence-level high -x tests/` passed after third-pass review fixes with no high-severity issues.
+- 2026-06-25: `docker compose up -d --build` completed after third-pass review fixes and rebuilt the production frontend bundle.
+- 2026-06-25: `curl -fsSL http://127.0.0.1:8080/api/v1/health` returned status `ok` after third-pass review fixes.
+- 2026-06-25: `BASE_URL=http://127.0.0.1:8080 npm run test:ui-review` passed after third-pass review fixes: 8 Playwright tests.
+- 2026-06-25: `docker compose down` stopped and removed the validation stack after third-pass review fixes.
+- 2026-06-25: Fourth-pass review regressions added for share-summary external findings past top-three, scanner plus user-context labeling, legacy UI fallback mixed labels, and single-source evidence count rendering; focused red tests failed before implementation and passed after fixes.
+- 2026-06-25: `./.venv/bin/python -m unittest tests.test_services.test_adapter_output_contract.AdapterOutputContractTests.test_share_summary_keeps_external_scanner_findings_after_top_three tests.test_services.test_adapter_output_contract.AdapterOutputContractTests.test_share_summary_does_not_treat_user_context_as_deploywhisper_support tests.test_services.test_report_service.ReportServiceTests.test_persist_analysis_report_does_not_label_user_context_as_deploywhisper_support` passed after fourth-pass fixes: 3 tests.
+- 2026-06-25: `npm run ui:test -- Report.test.tsx` passed after fourth-pass fixes: 12 tests.
+- 2026-06-25: `./.venv/bin/python -m unittest tests.test_services.test_report_service tests.test_services.test_adapter_output_contract` passed after fourth-pass fixes: 186 tests.
+- 2026-06-25: `npm run ui:typecheck` passed after fourth-pass fixes.
+- 2026-06-25: `./.venv/bin/ruff format services/analysis_service.py services/report_service.py tests/test_services/test_adapter_output_contract.py tests/test_services/test_report_service.py` completed after fourth-pass fixes: 4 files left unchanged.
+- 2026-06-25: `./.venv/bin/ruff check .` passed after fourth-pass fixes.
+- 2026-06-25: `./.venv/bin/ruff format --check .` passed after fourth-pass fixes: 255 files already formatted.
+- 2026-06-25: `git diff --check` passed after fourth-pass fixes.
+- 2026-06-25: `./.venv/bin/python -m unittest discover -q` passed after fourth-pass fixes: 345 tests, 1 skipped.
+- 2026-06-25: `./.venv/bin/bandit -r api/ analysis/ services/ parsers/ llm/ models/ cli/ evidence/ --severity-level high --confidence-level high -x tests/` passed after fourth-pass fixes with no high-severity issues.
+- 2026-06-25: `docker compose up -d --build` completed after fourth-pass fixes and rebuilt the production frontend bundle.
+- 2026-06-25: `curl -fsSL http://127.0.0.1:8080/api/v1/health` returned status `ok` after fourth-pass fixes.
+- 2026-06-25: `BASE_URL=http://127.0.0.1:8080 npm run test:ui-review` passed after fourth-pass fixes: 8 Playwright tests.
+- 2026-06-25: `docker compose down` stopped and removed the validation stack after fourth-pass fixes.
+- 2026-06-26: Fifth-pass review findings fixed: share-summary external-context expansion is bounded, compact markdown preserves duplicate-titled external labels, report UI totals include actual rendered evidence rows, and report schema docs now show mixed external context for high findings.
+- 2026-06-26: `./.venv/bin/python -m unittest tests.test_services.test_adapter_output_contract.AdapterOutputContractTests.test_share_summary_caps_external_scanner_findings_after_top_three tests.test_services.test_adapter_output_contract.AdapterOutputContractTests.test_share_summary_compact_markdown_keeps_duplicate_title_external_label tests.test_services.test_adapter_output_contract.AdapterOutputContractTests.test_share_summary_keeps_external_scanner_findings_after_top_three` passed after fifth-pass fixes: 3 tests.
+- 2026-06-26: `npm run ui:test -- Report.test.tsx` passed after fifth-pass fixes: 13 tests.
+- 2026-06-26: `npm run ui:typecheck` passed after fifth-pass fixes.
+- 2026-06-26: `./.venv/bin/ruff format services/analysis_service.py tests/test_services/test_adapter_output_contract.py` completed after fifth-pass fixes: 2 files left unchanged.
+- 2026-06-26: `./.venv/bin/python -m unittest tests.test_services.test_report_service tests.test_services.test_adapter_output_contract` passed after fifth-pass fixes: 188 tests.
+- 2026-06-26: `./.venv/bin/ruff check .` passed after fifth-pass fixes.
+- 2026-06-26: `./.venv/bin/ruff format --check .` passed after fifth-pass fixes: 255 files already formatted.
+- 2026-06-26: `git diff --check` passed after fifth-pass fixes.
+- 2026-06-26: `./.venv/bin/python -m unittest discover -q` passed after fifth-pass fixes: 345 tests, 1 skipped.
+- 2026-06-26: `./.venv/bin/bandit -r api/ analysis/ services/ parsers/ llm/ models/ cli/ evidence/ --severity-level high --confidence-level high -x tests/` passed after fifth-pass fixes with no high-severity issues.
+- 2026-06-26: `docker compose up -d --build` completed after fifth-pass fixes and rebuilt the production frontend bundle.
+- 2026-06-26: `curl -fsSL http://127.0.0.1:8080/api/v1/health` returned status `ok` after fifth-pass fixes.
+- 2026-06-26: `BASE_URL=http://127.0.0.1:8080 npm run test:ui-review` passed after fifth-pass fixes: 8 Playwright tests.
+- 2026-06-26: `docker compose down` stopped and removed the validation stack after fifth-pass fixes.
+- 2026-06-26: Sixth-pass review findings fixed: UI external-context counts now prefer rendered scanner rows when payload external counts lag, and share-summary extra external-context slots prioritize scanner-only findings before mixed-context findings.
+- 2026-06-26: `./.venv/bin/python -m unittest tests.test_services.test_adapter_output_contract.AdapterOutputContractTests.test_share_summary_caps_external_scanner_findings_after_top_three` passed after sixth-pass fixes: 1 test.
+- 2026-06-26: `npm run ui:test -- Report.test.tsx` passed after sixth-pass fixes: 13 tests.
+- 2026-06-26: `./.venv/bin/ruff format services/analysis_service.py tests/test_services/test_adapter_output_contract.py` completed after sixth-pass fixes: 1 file reformatted, 1 file left unchanged.
+- 2026-06-26: `npm run ui:typecheck` passed after sixth-pass fixes.
+- 2026-06-26: `./.venv/bin/python -m unittest tests.test_services.test_report_service tests.test_services.test_adapter_output_contract` passed after sixth-pass fixes: 188 tests.
+- 2026-06-26: `./.venv/bin/ruff check .` passed after sixth-pass fixes.
+- 2026-06-26: `./.venv/bin/ruff format --check .` passed after sixth-pass fixes: 255 files already formatted.
+- 2026-06-26: `git diff --check` passed after sixth-pass fixes.
+- 2026-06-26: `./.venv/bin/python -m unittest discover -q` passed after sixth-pass fixes: 345 tests, 1 skipped.
+- 2026-06-26: `./.venv/bin/bandit -r api/ analysis/ services/ parsers/ llm/ models/ cli/ evidence/ --severity-level high --confidence-level high -x tests/` passed after sixth-pass fixes with no high-severity issues.
+- 2026-06-26: `docker compose up -d --build` completed after sixth-pass fixes and rebuilt the production frontend bundle.
+- 2026-06-26: `curl -fsSL http://127.0.0.1:8080/api/v1/health` returned status `ok` after sixth-pass fixes.
+- 2026-06-26: `BASE_URL=http://127.0.0.1:8080 npm run test:ui-review` passed after sixth-pass fixes: 8 Playwright tests.
+- 2026-06-26: `docker compose down` stopped and removed the validation stack after sixth-pass fixes.
+- 2026-06-26: Seventh-pass BMad code review found repository/user-context Evidence Law drift and stale-high UI external-count handling; acceptance auditor reported no findings.
+- 2026-06-26: `./.venv/bin/python -m unittest tests.test_services.test_report_service.ReportServiceTests.test_create_analysis_report_validates_finding_context_payloads` passed after seventh-pass fixes: 1 test.
+- 2026-06-26: `npm run ui:test -- Report.test.tsx` passed after seventh-pass fixes: 14 tests.
+- 2026-06-26: `./.venv/bin/ruff format models/repositories/analysis_reports.py tests/test_services/test_report_service.py` completed after seventh-pass fixes: 1 file reformatted, 1 file left unchanged.
+- 2026-06-26: `npm run ui:typecheck` passed after seventh-pass fixes.
+- 2026-06-26: `./.venv/bin/python -m unittest tests.test_services.test_report_service tests.test_services.test_adapter_output_contract` passed after seventh-pass fixes: 188 tests.
+- 2026-06-26: `./.venv/bin/ruff check .` passed after seventh-pass fixes.
+- 2026-06-26: `./.venv/bin/ruff format --check .` passed after seventh-pass fixes: 255 files already formatted.
+- 2026-06-26: `git diff --check` passed after seventh-pass fixes.
+- 2026-06-26: `./.venv/bin/python -m unittest discover -q` passed after seventh-pass fixes: 345 tests, 1 skipped.
+- 2026-06-26: Eighth-pass BMad code review found hard-coded internal-source allowlisting, compact share-summary top-risk truncation, internal-only redacted report undercounting, deterministic wording drift, and missing `evidence_label` schema examples; all were fixed.
+- 2026-06-26: Ninth-pass BMad code review found duplicated severity prefixes in share-summary markdown and stale-high UI external-context counts when rendered rows already match payload totals; both were fixed.
+- 2026-06-26: Final BMad rerun Blind Hunter reported no findings; Acceptance Auditor found only the story file-list omission for `tests/test_docs/test_report_schema_documentation.py`, which was fixed.
+- 2026-06-26: `npm run ui:test -- Report.test.tsx` passed after final review fixes: 16 tests.
+- 2026-06-26: `npm run ui:typecheck` passed after final review fixes.
+- 2026-06-26: `./.venv/bin/python -m unittest tests.test_services.test_report_service tests.test_services.test_adapter_output_contract tests.test_docs.test_report_schema_documentation` passed after final review fixes: 191 tests.
+- 2026-06-26: `./.venv/bin/ruff check .` passed after final review fixes.
+- 2026-06-26: `./.venv/bin/ruff format --check .` passed after final review fixes: 255 files already formatted.
+- 2026-06-26: `git diff --check` passed after final review fixes.
+- 2026-06-26: Final Edge Case Hunter found a partially redacted stale-high external-count boundary; final Acceptance Auditor required `bash scripts/ci-local.sh` validation to be recorded for the cross-layer diff; both were fixed.
+- 2026-06-26: `npm run ui:test -- Report.test.tsx` passed after the final partial-redaction count fix: 17 tests.
+- 2026-06-26: `npm run ui:typecheck` passed after the final partial-redaction count fix.
+- 2026-06-26: Final BMad clean-confirmation rerun reported no code findings from Blind Hunter and no edge-case findings from Edge Case Hunter.
+- 2026-06-26: `docker compose up -d --build` completed after the final UI count fix and rebuilt the production frontend bundle.
+- 2026-06-26: `curl -fsSL http://127.0.0.1:8080/api/v1/health` returned status `ok` after the final UI count fix.
+- 2026-06-26: `BASE_URL=http://127.0.0.1:8080 npm run test:ui-review` passed after the final UI count fix: 8 Playwright tests.
+- 2026-06-26: `./.venv/bin/python -m unittest discover -q` passed after the final UI count fix: 345 tests, 1 skipped.
+- 2026-06-26: `bash scripts/ci-local.sh` passed after final review fixes: Ruff, format check, pip check, Bandit high-confidence gate, compileall, `cli.py skill test`, and 345 unittest tests with 1 skipped.
+- 2026-06-26: BMad rerun found share-summary redaction drift and non-compliant closure on `develop`; fixes moved the worktree to `feature/8-3-external-evidence-report-context` and made redacted share summaries reuse stored external-context labels/counts.
+- 2026-06-26: `./.venv/bin/python -m unittest tests.test_services.test_adapter_output_contract.AdapterOutputContractTests.test_share_summary_preserves_external_context_when_evidence_rows_omitted tests.test_services.test_adapter_output_contract.AdapterOutputContractTests.test_share_summary_labels_external_scanner_context_for_comments` passed after BMad rerun fixes: 2 tests.
+- 2026-06-26: `./.venv/bin/ruff format services/analysis_service.py tests/test_services/test_adapter_output_contract.py` completed after BMad rerun fixes: 1 file reformatted, 1 file left unchanged.
+- 2026-06-26: `./.venv/bin/python -m unittest tests.test_services.test_adapter_output_contract tests.test_services.test_report_service tests.test_docs.test_report_schema_documentation` passed after BMad rerun fixes: 192 tests.
+- 2026-06-26: `./.venv/bin/ruff check .` passed after BMad rerun fixes.
+- 2026-06-26: `./.venv/bin/ruff format --check .` passed after BMad rerun fixes: 255 files already formatted.
+- 2026-06-26: `git diff --check` passed after BMad rerun fixes.
+- 2026-06-26: Clean-confirmation rerun found redacted share-summary total/external-count drift; fixes preserve prior total evidence count and clamp stored external counts by visible internal rows.
+- 2026-06-26: `./.venv/bin/python -m unittest tests.test_services.test_adapter_output_contract.AdapterOutputContractTests.test_share_summary_preserves_external_context_when_evidence_rows_omitted tests.test_services.test_adapter_output_contract.AdapterOutputContractTests.test_share_summary_caps_external_context_when_rows_are_partially_redacted` passed after redacted count fixes: 2 tests.
+- 2026-06-26: `./.venv/bin/ruff format services/analysis_service.py tests/test_services/test_adapter_output_contract.py` completed after redacted count fixes: 2 files left unchanged.
+- 2026-06-26: Clean-confirmation Edge Case Hunter found the redacted Confidence evidence register rendered a populated title with an empty body; the register now shows an omitted/redacted evidence-detail empty state.
+- 2026-06-26: `npm run ui:test -- Report.test.tsx` passed after the redacted evidence-register empty-state fix: 17 tests.
+- 2026-06-26: `npm run ui:typecheck` passed after the redacted evidence-register empty-state fix.
+- 2026-06-26: `./.venv/bin/python -m unittest tests.test_services.test_adapter_output_contract tests.test_services.test_report_service tests.test_docs.test_report_schema_documentation` passed after the redacted evidence-register empty-state fix: 193 tests.
+- 2026-06-26: `./.venv/bin/ruff check .` passed after the redacted evidence-register empty-state fix.
+- 2026-06-26: `./.venv/bin/ruff format --check .` passed after the redacted evidence-register empty-state fix: 255 files already formatted.
+- 2026-06-26: `git diff --check` passed after the redacted evidence-register empty-state fix.
+- 2026-06-26: `bash scripts/ci-local.sh` passed after the redacted evidence-register empty-state fix: Ruff, format check, pip check, Bandit high-confidence gate, compileall, `cli.py skill test`, and 345 unittest tests with 1 skipped.
+
+### Completion Notes List
+
+- External scanner evidence now remains classified as external context and is not counted as DeployWhisper deterministic proof for high/critical Evidence Law support.
+- Scanner-only high/critical report findings are downgraded/reconciled by the report service, and direct repository persistence no longer treats scanner evidence as sufficient severe support.
+- Share-summary JSON, markdown, and plain text now include external scanner context counts/summaries for PR-comment and API consumers.
+- Share-summary JSON, markdown, and plain text now label affected top findings as `External evidence`, not only the aggregate scanner context.
+- Report overview, findings tab, and evidence register render `external_scanner` evidence as `External evidence` for reviewers.
+- The evidence register title no longer calls scanner context deterministic evidence when external scanner items are present.
+- Report-detail API output now carries server-derived `evidence_label` values on findings and evidence items; the UI only falls back to derivation for older payloads.
+- Mixed DeployWhisper plus scanner findings now render `Includes external context` rather than labeling the entire finding `External evidence`.
+- External scanner checks now inspect both `source_kind` and `source_type` so stale source-kind values cannot hide scanner context.
+- The repository Evidence Law gate now uses the same positive DeployWhisper evidence-source rule as report/share-summary labeling, so `user_context` cannot support severe DeployWhisper findings.
+- UI evidence summary counts now cap external-context counts at the total evidence count when payload counts are stale-high.
+- Report overview and evidence register count labels now say when evidence includes external context instead of calling mixed scanner context deterministic evidence.
+- Report-detail API finding labels now include external evidence linked by `evidence_refs`, even when a finding also owns DeployWhisper evidence.
+- Share-summary top-finding `evidence_count` now counts the same linked evidence set used for external-context labels.
+- Legacy UI fallback labeling now mirrors server-side linked-evidence semantics before consulting `evidence_classification`.
+- Report header and evidence register use one evidence-count source, avoiding contradictory external-context totals when evidence rows are partial or redacted.
+- External-context labels now use a positive DeployWhisper evidence-source predicate, so `user_context` does not make scanner evidence look first-party.
+- Share-summary output now preserves external-labeled scanner findings beyond the ordinary top-three finding slice.
+- Share-summary external-context expansion is now bounded and compact markdown keeps duplicate-titled external labels.
+- Report header and evidence register totals now prefer the largest available evidence count across rendered rows and share-summary payload counts.
+- Report header and evidence register external-context counts now prefer rendered scanner rows when payload external counts lag.
+- Share-summary extra external-context slots now prioritize pure scanner-only findings before mixed-context findings.
+- Report schema docs, evidence model docs, and the checked-in TypeScript API schema mirror were updated for the additive share-summary fields and per-finding label.
+- Positive DeployWhisper evidence classification now excludes known non-DeployWhisper sources without rejecting future internal parser/source names.
+- Compact share-summary markdown keeps the top three ranked findings before bounded external-context expansion.
+- Internal-only redacted reports now preserve evidence totals without inventing deterministic wording.
+- Share-summary markdown de-duplicates severity prefixes for findings whose titles already carry severity.
+- Report-detail schema examples and documentation regression tests now cover additive `evidence_label` fields.
+- Partially redacted report summaries cap external-context counts by visible non-external evidence rows, so stale payload totals cannot classify visible internal evidence as external context.
+- Redacted share-summary generation preserves stored external-context finding labels and external evidence counts when detailed evidence rows are omitted.
+- Redacted share-summary generation also preserves stored total evidence counts, preventing contradictory `0 evidence items` with external-context summaries.
+- Partially redacted share summaries clamp stored external counts by the number of visible non-external rows.
+- Redacted evidence registers now show an explicit omitted/redacted detail state when aggregate counts exist but row-level evidence has been suppressed.
+- Story closure work now lives on `feature/8-3-external-evidence-report-context` instead of `develop`.
+
+### File List
+
+- `_bmad-output/implementation-artifacts/8-3-external-evidence-report-context.md`
+- `_bmad-output/implementation-artifacts/sprint-status.yaml`
+- `api/schemas.py`
+- `docs/evidence-model.md`
+- `docs/schemas/report-v2.md`
+- `frontend/src/api/schema.d.ts`
+- `frontend/src/screens/Report.test.tsx`
+- `frontend/src/screens/Report.tsx`
+- `frontend/src/screens/report.css`
+- `models/repositories/analysis_reports.py`
+- `services/analysis_service.py`
+- `services/report_service.py`
+- `tests/test_services/test_adapter_output_contract.py`
+- `tests/test_docs/test_report_schema_documentation.py`
+- `tests/test_services/test_report_service.py`
+
+## Change Log
+
+- 2026-05-01: Story created/aligned from updated PRD, architecture, epics, sprint status, and readiness report.
+- 2026-06-24: Implemented external scanner report context labeling and prevented scanner-only evidence from satisfying high/critical DeployWhisper severity proof.
+- 2026-06-24: Fixed code review findings for per-finding external labels across report, PR-comment/API summaries, evidence register copy, and repository boundary coverage.
+- 2026-06-25: Fixed second-pass code review findings for server-derived report-detail labels, mixed external-context wording, and stale `source_kind` scanner detection.
+- 2026-06-25: Fixed third-pass code review findings for external-context header copy, ref-linked report-detail labels, and ref-linked share-summary evidence counts.
+- 2026-06-25: Fixed fourth-pass code review findings for legacy UI fallback labels, evidence-count source consistency, positive DeployWhisper evidence-source detection, and external scanner findings outside top-three share-summary output.
+- 2026-06-26: Fixed fifth-pass code review findings for bounded share-summary external-context expansion, stale UI count fallback, and scanner evidence schema example semantics.
+- 2026-06-26: Fixed sixth-pass code review findings for stale UI external-count fallback and scanner-only priority in share-summary extra slots.
+- 2026-06-26: Fixed seventh-pass code review findings for repository user-context Evidence Law support and stale-high UI external evidence counts.
+- 2026-06-26: Fixed final-pass review findings for source-classification breadth, compact summary ordering, redacted report counts, neutral evidence wording, schema examples, severity-prefix de-duplication, and story file-list completeness.
+- 2026-06-26: Fixed clean-confirmation findings for partially redacted stale-high external-context counts and recorded required local CI validation.
+- 2026-06-26: Fixed BMad rerun findings for redacted share-summary external-context preservation and Git Flow branch compliance.
+- 2026-06-26: Fixed clean-confirmation findings for redacted share-summary total/external count consistency.
+- 2026-06-26: Fixed clean-confirmation finding for the redacted evidence-register empty state.

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -1,5 +1,5 @@
 # generated: 2026-05-01
-# last_updated: 2026-06-18
+# last_updated: 2026-06-26
 # project: deploywhisper
 # project_key: NOKEY
 # tracking_system: file-system
@@ -35,7 +35,7 @@
 # - Dev moves story to review, then runs code-review
 
 generated: 2026-05-01
-last_updated: 2026-06-23
+last_updated: 2026-06-26
 project: deploywhisper
 project_key: NOKEY
 tracking_system: file-system
@@ -120,7 +120,7 @@ development_status:
   epic-8: in-progress
   8-1-sarif-ingestion: review
   8-2-scanner-json-adapter-v1: done
-  8-3-external-evidence-report-context: ready-for-dev
+  8-3-external-evidence-report-context: done
   8-4-scanner-conflict-handling: ready-for-dev
   8-5-existing-security-tools-comparison-guide: ready-for-dev
   epic-8-retrospective: optional

--- a/api/schemas.py
+++ b/api/schemas.py
@@ -1174,6 +1174,10 @@ class FindingData(BaseModel):
     evidence_refs: list[str] = Field(
         default_factory=list, description="Evidence IDs linked to the finding"
     )
+    evidence_label: str | None = Field(
+        default=None,
+        description="Reviewer-facing label for external or mixed evidence context",
+    )
     skill_id: str | None = Field(
         default=None,
         description="Skill identifier when a skill contributed the finding",
@@ -1262,6 +1266,10 @@ class EvidenceItemData(BaseModel):
         ..., description="Whether the evidence came from deterministic logic"
     )
     confidence: float = Field(..., description="Confidence score between 0 and 1")
+    evidence_label: str | None = Field(
+        default=None,
+        description="Reviewer-facing label for external evidence context",
+    )
     related_change_ids: list[str] = Field(
         default_factory=list, description="Traceable normalized change identifiers"
     )
@@ -1778,6 +1786,10 @@ class ShareSummaryFindingData(BaseModel):
     severity: RiskSeverity = Field(..., description="Finding severity")
     evidence_count: int = Field(..., description="Evidence count for the finding")
     confidence: float = Field(..., description="Finding confidence score")
+    evidence_label: str | None = Field(
+        default=None,
+        description="Reviewer-facing label for external or non-DeployWhisper evidence",
+    )
 
 
 class ShareSummaryContextData(BaseModel):
@@ -1809,6 +1821,14 @@ class ShareSummaryJsonPayloadData(BaseModel):
         default_factory=list, description="Top findings to surface"
     )
     evidence_count: int = Field(..., description="Total evidence-item count")
+    external_evidence_count: int = Field(
+        default=0,
+        description="External scanner evidence items included as review context",
+    )
+    external_evidence_summary: str | None = Field(
+        default=None,
+        description="How external scanner context should be interpreted",
+    )
     blast_radius_summary: str = Field(..., description="Concise blast-radius summary")
     rollback_summary: str = Field(..., description="Concise rollback summary")
     context_completeness: ShareSummaryContextData = Field(

--- a/docs/evidence-model.md
+++ b/docs/evidence-model.md
@@ -41,6 +41,10 @@ Story 2.4 extends findings with explicit support context:
 Story 2.5 enforces Evidence Law at report persistence time:
 
 - high and critical findings must link to at least one deterministic evidence item
+- external scanner evidence is labeled `external` and may appear in reports, API
+  output, and PR-comment summaries as review context, but scanner severity alone
+  does not satisfy the deterministic-evidence requirement for high/critical
+  DeployWhisper findings
 - the shared report service downgrades unsupported high/critical findings to medium, caps their confidence at `0.85`, reconciles unsupported report-level severe verdicts to caution, and records an Evidence Law warning
 - the report repository rejects direct persistence payloads that try to save high/critical findings or report-level high/critical verdicts without linked deterministic severe evidence
 

--- a/docs/schemas/report-v2.md
+++ b/docs/schemas/report-v2.md
@@ -123,6 +123,10 @@ Evidence Law status values are `Satisfied`, `Needs review`, `Reconciled`, and
 `Detail omitted`. CLI/API analysis responses include evidence detail and should
 not emit `Detail omitted`; compact report-list style views may use it when
 evidence rows were intentionally excluded.
+When scanner evidence is present, share-summary JSON and PR-comment markdown
+label it as external scanner context. External scanner severity is not
+DeployWhisper severity proof on its own; high/critical DeployWhisper findings
+still require linked DeployWhisper deterministic evidence.
 
 ```json
 {
@@ -155,10 +159,13 @@ evidence rows were intentionally excluded.
           "title": "HIGH: public ingress exposure",
           "severity": "high",
           "evidence_count": 2,
-          "confidence": 1.0
+          "confidence": 1.0,
+          "evidence_label": "Includes external context"
         }
       ],
       "evidence_count": 4,
+      "external_evidence_count": 1,
+      "external_evidence_summary": "1 external scanner evidence item is included as context, not DeployWhisper severity proof.",
       "context_completeness": {
         "score": 0.22,
         "label": "LIMITED CONTEXT",
@@ -454,6 +461,7 @@ without storing raw plan internals in a separate contract.
       "confidence": 1.0,
       "uncertainty_note": null,
       "evidence_classification": "deterministic",
+      "evidence_label": null,
       "evidence_refs": ["ev-plan-json-1"],
       "skill_id": "terraform"
     }
@@ -467,6 +475,7 @@ without storing raw plan internals in a separate contract.
       "artifact": "plan.json",
       "summary": "Terraform opened SSH ingress from 0.0.0.0/0 on port 22.",
       "deterministic": true,
+      "evidence_label": null,
       "confidence": 1.0,
       "context_source": {
         "source_id": "artifact:plan.json",

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -1865,6 +1865,11 @@ export interface components {
              */
             confidence: number;
             /**
+             * Evidence Label
+             * @description Reviewer-facing label for external evidence context
+             */
+            evidence_label?: string | null;
+            /**
              * Related Change Ids
              * @description Traceable normalized change identifiers
              */
@@ -2150,6 +2155,11 @@ export interface components {
              * @description Evidence IDs linked to the finding
              */
             evidence_refs?: string[];
+            /**
+             * Evidence Label
+             * @description Reviewer-facing label for external or mixed evidence context
+             */
+            evidence_label?: string | null;
             /**
              * Skill Id
              * @description Skill identifier when a skill contributed the finding
@@ -3531,6 +3541,11 @@ export interface components {
              * @description Finding confidence score
              */
             confidence: number;
+            /**
+             * Evidence Label
+             * @description Reviewer-facing label for external or non-DeployWhisper evidence
+             */
+            evidence_label?: string | null;
         };
         /** ShareSummaryJsonPayloadData */
         ShareSummaryJsonPayloadData: {
@@ -3590,6 +3605,16 @@ export interface components {
              * @description Total evidence-item count
              */
             evidence_count: number;
+            /**
+             * External Evidence Count
+             * @description External scanner evidence items included as review context
+             */
+            external_evidence_count?: number;
+            /**
+             * External Evidence Summary
+             * @description How external scanner context should be interpreted
+             */
+            external_evidence_summary?: string | null;
             /**
              * Blast Radius Summary
              * @description Concise blast-radius summary

--- a/frontend/src/screens/Report.test.tsx
+++ b/frontend/src/screens/Report.test.tsx
@@ -326,6 +326,299 @@ describe("ReportScreen", () => {
     expect(markup).toContain("stale - 40%");
   });
 
+  it("labels scanner findings as external evidence across report surfaces", () => {
+    const scannerReport = {
+      ...report,
+      findings: [
+        {
+          ...report.findings[0],
+          evidence_classification: "external",
+          evidence_label: "External evidence",
+          evidence_refs: ["ev-scanner"],
+        },
+      ],
+      evidence_items: [
+        {
+          ...report.evidence_items[0],
+          evidence_id: "ev-scanner",
+          source_type: "external_scanner",
+          source_kind: "artifact",
+          source_ref: "semgrep://finding/abc123",
+          summary: "Semgrep flagged a scanner finding.",
+          evidence_label: "External evidence",
+        },
+      ],
+      share_summary: {
+        ...report.share_summary,
+        json_payload: {
+          ...report.share_summary.json_payload,
+          external_evidence_count: 0,
+          external_evidence_summary: "1 external scanner evidence item is included as context, not DeployWhisper severity proof.",
+        },
+      },
+    } satisfies ReportDetail;
+
+    const overviewMarkup = renderReport("/reports/77?private=1", scannerReport);
+    const findingsMarkup = renderReport("/reports/77?private=1&tab=findings", scannerReport);
+    const confidenceMarkup = renderReport("/reports/77?private=1&tab=confidence", scannerReport);
+
+    expect(overviewMarkup).toContain("External evidence");
+    expect(overviewMarkup).toContain("1 evidence item - includes 1 external context item");
+    expect(overviewMarkup).not.toContain("1 deterministic items");
+    expect(findingsMarkup).toContain("External evidence");
+    expect(confidenceMarkup).toContain("1 evidence item - includes 1 external context item");
+    expect(confidenceMarkup).toContain("External evidence");
+    expect(confidenceMarkup).toContain("Semgrep flagged a scanner finding.");
+    expect(`${overviewMarkup}${findingsMarkup}${confidenceMarkup}`).not.toContain(">external_scanner<");
+  });
+
+  it("labels mixed scanner findings as including external context", () => {
+    const mixedReport = {
+      ...report,
+      findings: [
+        {
+          ...report.findings[0],
+          evidence_label: "Includes external context",
+          evidence_refs: ["ev-ingress", "ev-scanner"],
+        },
+      ],
+      evidence_items: [
+        ...report.evidence_items,
+        {
+          ...report.evidence_items[0],
+          evidence_id: "ev-scanner",
+          source_type: "external_scanner",
+          source_kind: "external_scanner",
+          source_ref: "semgrep://finding/abc123",
+          summary: "Semgrep flagged supporting scanner context.",
+          evidence_label: "External evidence",
+        },
+      ],
+      share_summary: {
+        ...report.share_summary,
+        json_payload: {
+          ...report.share_summary.json_payload,
+          external_evidence_count: 1,
+          external_evidence_summary: "1 external scanner evidence item is included as context, not DeployWhisper severity proof.",
+        },
+      },
+    } satisfies ReportDetail;
+
+    const markup = renderReport("/reports/77?private=1&tab=findings", mixedReport);
+
+    expect(markup).toContain("Includes external context");
+    expect(markup).toContain("Includes external context</span><span class=\"dw-cross-tool");
+    expect(markup).not.toContain("External evidence</span><span class=\"dw-cross-tool");
+  });
+
+  it("keeps legacy fallback labels aligned with linked evidence provenance", () => {
+    const legacyReport = {
+      ...report,
+      findings: [
+        {
+          ...report.findings[0],
+          evidence_classification: "external",
+          evidence_label: null,
+          evidence_refs: ["ev-ingress", "ev-scanner"],
+        },
+      ],
+      evidence_items: [
+        ...report.evidence_items,
+        {
+          ...report.evidence_items[0],
+          evidence_id: "ev-scanner",
+          source_type: "external_scanner",
+          source_kind: "external_scanner",
+          source_ref: "semgrep://finding/abc123",
+          summary: "Semgrep flagged supporting scanner context.",
+          evidence_label: null,
+        },
+      ],
+      share_summary: {
+        ...report.share_summary,
+        json_payload: {
+          ...report.share_summary.json_payload,
+          external_evidence_count: 1,
+        },
+      },
+    } satisfies ReportDetail;
+
+    const markup = renderReport("/reports/77?private=1&tab=findings", legacyReport);
+
+    expect(markup).toContain("Includes external context");
+    expect(markup).not.toContain("External evidence</span><span class=\"dw-cross-tool");
+  });
+
+  it("uses one evidence-count source for external context summaries", () => {
+    const redactedEvidenceReport = {
+      ...report,
+      findings: [],
+      evidence_items: [],
+      share_summary: {
+        ...report.share_summary,
+        json_payload: {
+          ...report.share_summary.json_payload,
+          evidence_count: 4,
+          external_evidence_count: 2,
+        },
+      },
+    } satisfies ReportDetail;
+
+    const markup = renderReport("/reports/77?private=1", redactedEvidenceReport);
+    const confidenceMarkup = renderReport("/reports/77?private=1&tab=confidence", redactedEvidenceReport);
+
+    expect(markup).toContain("4 evidence items - includes 2 external context items");
+    expect(markup).not.toContain("0 evidence items - includes 2 external context items");
+    expect(confidenceMarkup).toContain("4 evidence items - includes 2 external context items");
+    expect(confidenceMarkup).toContain("Evidence detail was omitted or redacted for this view.");
+  });
+
+  it("uses payload totals for redacted internal-only evidence summaries", () => {
+    const redactedInternalReport = {
+      ...report,
+      findings: [],
+      evidence_items: [],
+      share_summary: {
+        ...report.share_summary,
+        json_payload: {
+          ...report.share_summary.json_payload,
+          evidence_count: 4,
+          external_evidence_count: 0,
+        },
+      },
+    } satisfies ReportDetail;
+
+    const markup = renderReport("/reports/77?private=1", redactedInternalReport);
+
+    expect(markup).toContain("4 evidence items");
+    expect(markup).not.toContain("4 deterministic items");
+    expect(markup).not.toContain("0 evidence items");
+  });
+
+  it("does not undercount rendered evidence rows when summary counts lag", () => {
+    const stalePayloadReport = {
+      ...report,
+      evidence_items: [
+        ...report.evidence_items,
+        ...Array.from({ length: 4 }, (_, index) => ({
+          ...report.evidence_items[0],
+          evidence_id: `ev-extra-${index}`,
+          source_type: index < 3 ? "external_scanner" : "artifact",
+          source_kind: index < 3 ? "external_scanner" : "artifact",
+          source_ref: `scanner://finding/${index}`,
+          summary: `Additional evidence row ${index}.`,
+        })),
+      ],
+      share_summary: {
+        ...report.share_summary,
+        json_payload: {
+          ...report.share_summary.json_payload,
+          evidence_count: 4,
+          external_evidence_count: 1,
+        },
+      },
+    } satisfies ReportDetail;
+
+    const markup = renderReport("/reports/77?private=1", stalePayloadReport);
+
+    expect(markup).toContain("5 evidence items - includes 3 external context items");
+    expect(markup).not.toContain("5 evidence items - includes 1 external context item");
+  });
+
+  it("does not let stale external evidence counts exceed total evidence", () => {
+    const staleHighExternalReport = {
+      ...report,
+      evidence_items: [],
+      share_summary: {
+        ...report.share_summary,
+        json_payload: {
+          ...report.share_summary.json_payload,
+          evidence_count: 4,
+          external_evidence_count: 9,
+        },
+      },
+    } satisfies ReportDetail;
+
+    const markup = renderReport("/reports/77?private=1", staleHighExternalReport);
+
+    expect(markup).toContain("4 evidence items - includes 4 external context items");
+    expect(markup).not.toContain("4 evidence items - includes 9 external context items");
+  });
+
+  it("does not count visible internal evidence rows as stale external context", () => {
+    const partiallyRedactedReport = {
+      ...report,
+      evidence_items: [
+        {
+          ...report.evidence_items[0],
+          evidence_id: "ev-visible-internal-1",
+          source_type: "artifact",
+          source_kind: "artifact",
+          source_ref: "terraform://plan.json#internal-1",
+          summary: "Visible DeployWhisper evidence.",
+        },
+        {
+          ...report.evidence_items[0],
+          evidence_id: "ev-visible-internal-2",
+          source_type: "parser",
+          source_kind: "parser",
+          source_ref: "parser://plan.json#internal-2",
+          summary: "Visible parser evidence.",
+        },
+      ],
+      share_summary: {
+        ...report.share_summary,
+        json_payload: {
+          ...report.share_summary.json_payload,
+          evidence_count: 4,
+          external_evidence_count: 9,
+        },
+      },
+    } satisfies ReportDetail;
+
+    const markup = renderReport("/reports/77?private=1", partiallyRedactedReport);
+
+    expect(markup).toContain("4 evidence items - includes 2 external context items");
+    expect(markup).not.toContain("4 evidence items - includes 4 external context items");
+  });
+
+  it("does not overcount external context when rendered evidence already matches payload total", () => {
+    const staleHighRenderedReport = {
+      ...report,
+      evidence_items: [
+        {
+          ...report.evidence_items[0],
+          evidence_id: "ev-internal",
+          source_type: "artifact",
+          source_kind: "artifact",
+          source_ref: "terraform://plan.json#internal",
+          summary: "Internal DeployWhisper evidence.",
+        },
+        {
+          ...report.evidence_items[0],
+          evidence_id: "ev-scanner",
+          source_type: "external_scanner",
+          source_kind: "external_scanner",
+          source_ref: "scanner://finding/1",
+          summary: "External scanner context.",
+        },
+      ],
+      share_summary: {
+        ...report.share_summary,
+        json_payload: {
+          ...report.share_summary.json_payload,
+          evidence_count: 2,
+          external_evidence_count: 4,
+        },
+      },
+    } satisfies ReportDetail;
+
+    const markup = renderReport("/reports/77?private=1", staleHighRenderedReport);
+
+    expect(markup).toContain("2 evidence items - includes 1 external context item");
+    expect(markup).not.toContain("2 evidence items - includes 2 external context items");
+  });
+
   it("renders note-only duplicate context sources with distinct row identities", () => {
     const noteOnlyDuplicateReport = {
       ...report,

--- a/frontend/src/screens/Report.tsx
+++ b/frontend/src/screens/Report.tsx
@@ -183,6 +183,80 @@ function evidenceReference(item: EvidenceItem) {
   return item.location || item.source_ref || item.resource || item.evidence_id;
 }
 
+function evidenceSourceLabel(item: EvidenceItem) {
+  if (item.evidence_label) {
+    return item.evidence_label;
+  }
+  if (isExternalScannerEvidence(item)) {
+    return "External evidence";
+  }
+  return item.source_type;
+}
+
+function isExternalScannerEvidence(item: EvidenceItem) {
+  return [item.source_kind, item.source_type].some((source) => source === "external_scanner");
+}
+
+const nonDeployWhisperEvidenceSources = new Set(["external_scanner", "user_context"]);
+
+function isDeployWhisperEvidence(item: EvidenceItem) {
+  if (isExternalScannerEvidence(item)) {
+    return false;
+  }
+  const sources = [item.source_kind, item.source_type].filter(Boolean);
+  return !sources.some((source) => nonDeployWhisperEvidenceSources.has(source ?? ""));
+}
+
+function fallbackFindingEvidenceLabel(finding: Finding, items: EvidenceItem[]) {
+  const hasExternalScanner = items.some(isExternalScannerEvidence);
+  const hasDeployWhisperEvidence = items.some(isDeployWhisperEvidence);
+  if (hasExternalScanner && hasDeployWhisperEvidence) {
+    return "Includes external context";
+  }
+  if (hasExternalScanner) {
+    return "External evidence";
+  }
+  if (finding.evidence_classification === "external") {
+    return "External evidence";
+  }
+  return null;
+}
+
+function findingEvidenceLabel(finding: Finding, items: EvidenceItem[]) {
+  return finding.evidence_label || fallbackFindingEvidenceLabel(finding, items);
+}
+
+function evidenceItemCountLabel(count: number) {
+  return `${count} evidence ${count === 1 ? "item" : "items"}`;
+}
+
+function evidenceSummaryCounts(report: ReportDetail, items: EvidenceItem[]) {
+  const payloadTotal = report.share_summary.json_payload.evidence_count ?? 0;
+  const payloadCount = report.share_summary.json_payload.external_evidence_count ?? 0;
+  const itemCount = items.filter(isExternalScannerEvidence).length;
+  const visibleDeployWhisperCount = items.filter((item) => !isExternalScannerEvidence(item)).length;
+  const totalCount = Math.max(items.length, payloadTotal);
+  const maxExternalCount = Math.max(itemCount, totalCount - visibleDeployWhisperCount);
+  const externalCount = Math.min(maxExternalCount, Math.max(itemCount, payloadCount));
+  if (externalCount > 0) {
+    return {
+      total: totalCount,
+      external: externalCount,
+    };
+  }
+  return {
+    total: totalCount,
+    external: itemCount,
+  };
+}
+
+function evidenceSummaryLabel(totalCount: number, externalCount: number) {
+  if (externalCount > 0) {
+    return `${evidenceItemCountLabel(totalCount)} - includes ${externalCount} external context ${externalCount === 1 ? "item" : "items"}`;
+  }
+  return evidenceItemCountLabel(totalCount);
+}
+
 function findingCounts(report: ReportDetail) {
   const findings = getFindings(report);
   const high = findings.filter((finding) => ["high", "critical"].includes(finding.severity)).length;
@@ -273,6 +347,8 @@ function ReportHeader({
   const navigate = useNavigate();
   const findings = getFindings(report);
   const evidenceItems = getEvidenceItems(report);
+  const evidenceCounts = evidenceSummaryCounts(report, evidenceItems);
+  const evidenceSummary = evidenceSummaryLabel(evidenceCounts.total, evidenceCounts.external);
   const findingsTab = tabs.map((tab) => (tab.id === "findings" ? { ...tab, count: findings.length } : tab));
   const compareHref = publicView
     ? `/reports/${report.id}?compare=previous#report-comparison`
@@ -296,7 +372,7 @@ function ReportHeader({
               <VerdictChip verdict={normalizeVerdict(report.verdict)} />
               <SeverityBadge level={normalizeSeverity(report.severity)} />
               <ConfidenceBadge level={confidenceLevel(report.confidence)} />
-              <EvidenceTag>{evidenceItems.length} deterministic items</EvidenceTag>
+              <EvidenceTag>{evidenceSummary}</EvidenceTag>
             </div>
             <h1>{reportTitle(report)}</h1>
             <div className="dw-report-meta">
@@ -429,11 +505,15 @@ function OverviewTab({ report, goFindings }: { report: ReportDetail; goFindings:
             <ul className="dw-top-findings">
               {findings.slice(0, 5).map((finding) => {
                 const evidence = evidenceForFinding(report, finding);
+                const evidenceLabel = findingEvidenceLabel(finding, evidence);
                 return (
                   <li key={finding.finding_id}>
                     <SeverityBadge level={normalizeSeverity(finding.severity)} />
                     <span>{finding.title}</span>
-                    <EvidenceTag>{firstEvidenceTag(evidence)}</EvidenceTag>
+                    <span className="dw-finding-tag-group">
+                      {evidenceLabel && <EvidenceTag>{evidenceLabel}</EvidenceTag>}
+                      <EvidenceTag>{firstEvidenceTag(evidence)}</EvidenceTag>
+                    </span>
                   </li>
                 );
               })}
@@ -505,6 +585,7 @@ function FindingsTab({
       {findings.map((finding) => {
         const open = openId === finding.finding_id;
         const evidence = evidenceForFinding(report, finding);
+        const evidenceLabel = findingEvidenceLabel(finding, evidence);
         const selected = getFeedbackState(report).finding_feedback?.[finding.finding_id]?.outcome_label;
         return (
           <article className={`dw-finding-card${open ? " dw-finding-open" : ""}`} key={finding.finding_id}>
@@ -514,6 +595,7 @@ function FindingsTab({
                 <span className="dw-finding-title-row">
                   <strong>{finding.title}</strong>
                   <SeverityBadge level={normalizeSeverity(finding.severity)} />
+                  {evidenceLabel && <EvidenceTag>{evidenceLabel}</EvidenceTag>}
                   {finding.skill_id && <span className="dw-cross-tool"><Layers size={10} /> Cross-tool</span>}
                 </span>
                 <span className="dw-finding-description">{finding.description || finding.explanation}</span>
@@ -556,6 +638,8 @@ function FindingsTab({
 function ConfidenceTab({ report }: { report: ReportDetail }) {
   const ledger = getConfidenceLedger(report);
   const evidenceItems = getEvidenceItems(report);
+  const evidenceCounts = evidenceSummaryCounts(report, evidenceItems);
+  const evidenceRegisterTitle = evidenceSummaryLabel(evidenceCounts.total, evidenceCounts.external);
   const ledgerCard = (title: string, items: string[], hot = false) => (
     <Card eyebrow="CONFIDENCE LEDGER" title={title}>
       <ol className="dw-ledger-list">
@@ -575,15 +659,17 @@ function ConfidenceTab({ report }: { report: ReportDetail }) {
         {ledgerCard("Why not lower", ledger.why_not_lower ?? [], true)}
         {ledgerCard("Why not higher", ledger.why_not_higher ?? [])}
       </div>
-      <Card eyebrow="EVIDENCE REGISTER" title={`${evidenceItems.length} deterministic items`}>
+      <Card eyebrow="EVIDENCE REGISTER" title={evidenceRegisterTitle}>
         <div className="dw-evidence-register">
-          {evidenceItems.map((item, index) => (
+          {evidenceItems.length === 0 && evidenceCounts.total > 0 ? (
+            <p className="dw-report-empty">Evidence detail was omitted or redacted for this view.</p>
+          ) : evidenceItems.map((item, index) => (
             <div key={item.evidence_id}>
               <span>{item.evidence_id || `EV-${String(index + 1).padStart(2, "0")}`}</span>
               <MonoRef>{evidenceReference(item)}</MonoRef>
               <p>{item.summary}</p>
               <em>
-                {item.source_type}
+                {evidenceSourceLabel(item)}
                 {item.context_source ? ` - ${item.context_source.source_id} (${item.context_source.freshness_status})` : ""}
               </em>
             </div>

--- a/frontend/src/screens/report.css
+++ b/frontend/src/screens/report.css
@@ -263,6 +263,13 @@
   white-space: nowrap;
 }
 
+.dw-finding-tag-group {
+  display: inline-flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 5px;
+}
+
 .dw-decision-list li {
   display: grid;
   grid-template-columns: auto minmax(0, 1fr);

--- a/models/repositories/analysis_reports.py
+++ b/models/repositories/analysis_reports.py
@@ -427,7 +427,9 @@ def _validate_finding_evidence_refs(
                 _evidence_classification(evidence_by_id[evidence_id])
                 for evidence_id in evidence_refs
                 if evidence_id in evidence_by_id
-                and _is_deterministic_evidence(evidence_by_id[evidence_id])
+                and _is_deploywhisper_deterministic_evidence(
+                    evidence_by_id[evidence_id]
+                )
             }
             if not linked_deterministic_classifications:
                 raise ValueError(
@@ -471,7 +473,7 @@ def _validate_finding_evidence_refs(
             for persisted_finding, evidence_refs in finding_rows
             if persisted_finding.severity in {"high", "critical"}
             and any(
-                _is_deterministic_evidence(evidence_by_id[evidence_id])
+                _is_deploywhisper_deterministic_evidence(evidence_by_id[evidence_id])
                 for evidence_id in evidence_refs
                 if evidence_id in evidence_by_id
             )
@@ -518,10 +520,35 @@ def _is_deterministic_evidence(evidence: dict[str, Any]) -> bool:
     )
 
 
+def _is_deploywhisper_deterministic_evidence(evidence: dict[str, Any]) -> bool:
+    return _is_deploywhisper_evidence(evidence) and _is_deterministic_evidence(evidence)
+
+
+def _is_external_scanner_evidence(evidence: dict[str, Any]) -> bool:
+    return any(
+        str(evidence.get(key) or "") == "external_scanner"
+        for key in ("source_kind", "source_type")
+    )
+
+
+_NON_DEPLOYWHISPER_EVIDENCE_SOURCES = frozenset({"external_scanner", "user_context"})
+
+
+def _is_deploywhisper_evidence(evidence: dict[str, Any]) -> bool:
+    if _is_external_scanner_evidence(evidence):
+        return False
+    sources = {
+        str(evidence.get(key) or "")
+        for key in ("source_kind", "source_type")
+        if str(evidence.get(key) or "")
+    }
+    return not (sources & _NON_DEPLOYWHISPER_EVIDENCE_SOURCES)
+
+
 def _evidence_classification(evidence: dict[str, Any]) -> str:
-    source_kind = str(evidence.get("source_kind") or evidence.get("source_type") or "")
-    if source_kind == "external_scanner":
+    if _is_external_scanner_evidence(evidence):
         return "external"
+    source_kind = str(evidence.get("source_kind") or evidence.get("source_type") or "")
     if source_kind == "user_context":
         return "user_provided"
     determinism_level = str(evidence.get("determinism_level") or "deterministic")

--- a/services/analysis_service.py
+++ b/services/analysis_service.py
@@ -264,6 +264,10 @@ class ShareSummaryFinding(BaseModel):
     severity: str = Field(..., description="Finding severity")
     evidence_count: int = Field(..., description="Evidence items linked to the finding")
     confidence: float = Field(..., description="Finding confidence score")
+    evidence_label: str | None = Field(
+        default=None,
+        description="Reviewer-facing label for external or non-DeployWhisper evidence",
+    )
 
 
 class ShareSummaryContext(BaseModel):
@@ -295,12 +299,24 @@ class ShareSummaryJsonPayload(BaseModel):
         default_factory=list, description="Top findings to surface"
     )
     evidence_count: int = Field(..., description="Total evidence-item count")
+    external_evidence_count: int = Field(
+        default=0,
+        description="External scanner evidence items included as review context",
+    )
+    external_evidence_summary: str | None = Field(
+        default=None,
+        description="How external scanner context should be interpreted",
+    )
     blast_radius_summary: str = Field(..., description="Concise blast-radius summary")
     rollback_summary: str = Field(..., description="Concise rollback summary")
     context_completeness: ShareSummaryContext = Field(
         ..., description="Context completeness summary"
     )
     advisory_summary: str = Field(..., description="Advisory-only review summary")
+
+
+_SHARE_SUMMARY_BASE_FINDING_LIMIT = 3
+_SHARE_SUMMARY_EXTERNAL_CONTEXT_EXTRA_LIMIT = 2
 
 
 def _collect_changes(parse_batch: ParseBatchResult) -> list[UnifiedChange]:
@@ -1473,11 +1489,70 @@ def _finding_severity_rank(severity: str) -> int:
 def _finding_evidence_count(
     finding: dict, evidence_items: list[dict[str, object]]
 ) -> int:
-    finding_id = finding.get("finding_id")
-    count = sum(1 for item in evidence_items if item.get("finding_id") == finding_id)
+    count = len(_finding_evidence_items(finding, evidence_items))
     if count:
         return count
     return len(finding.get("evidence_refs") or [])
+
+
+def _finding_evidence_items(
+    finding: dict, evidence_items: list[dict[str, object]]
+) -> list[dict[str, object]]:
+    finding_id = finding.get("finding_id")
+    matched = [item for item in evidence_items if item.get("finding_id") == finding_id]
+    refs = {str(ref) for ref in finding.get("evidence_refs") or []}
+    ref_items = [
+        item for item in evidence_items if str(item.get("evidence_id") or "") in refs
+    ]
+    merged = {
+        str(item.get("evidence_id") or ""): item
+        for item in [*matched, *ref_items]
+        if str(item.get("evidence_id") or "")
+    }
+    return list(merged.values())
+
+
+def _is_external_scanner_evidence(item: dict[str, object]) -> bool:
+    return any(
+        str(item.get(key) or "") == "external_scanner"
+        for key in ("source_kind", "source_type")
+    )
+
+
+_NON_DEPLOYWHISPER_EVIDENCE_SOURCES = frozenset({"external_scanner", "user_context"})
+
+
+def _is_deploywhisper_evidence(item: dict[str, object]) -> bool:
+    if _is_external_scanner_evidence(item):
+        return False
+    sources = {
+        str(item.get(key) or "")
+        for key in ("source_kind", "source_type")
+        if str(item.get(key) or "")
+    }
+    return not (sources & _NON_DEPLOYWHISPER_EVIDENCE_SOURCES)
+
+
+def _finding_evidence_label(
+    finding: dict, evidence_items: list[dict[str, object]]
+) -> str | None:
+    linked_evidence_items = _finding_evidence_items(finding, evidence_items)
+    has_external_scanner = any(
+        _is_external_scanner_evidence(item) for item in linked_evidence_items
+    )
+    has_deploywhisper_evidence = any(
+        _is_deploywhisper_evidence(item) for item in linked_evidence_items
+    )
+    if has_external_scanner and has_deploywhisper_evidence:
+        return "Includes external context"
+    if has_external_scanner:
+        return "External evidence"
+    persisted_label = str(finding.get("evidence_label") or "").strip()
+    if persisted_label in {"External evidence", "Includes external context"}:
+        return persisted_label
+    if str(finding.get("evidence_classification") or "") == "external":
+        return "External evidence"
+    return None
 
 
 def _mapping_items(value: object) -> list[dict]:
@@ -1613,15 +1688,109 @@ def _share_findings(report: dict) -> list[ShareSummaryFinding]:
             str(item.get("title", "")),
         ),
     )
+    selected_findings = list(sorted_findings[:_SHARE_SUMMARY_BASE_FINDING_LIMIT])
+    selected_ids = {
+        str(finding.get("finding_id") or id(finding)) for finding in selected_findings
+    }
+    external_context_extra_count = 0
+    extra_candidates = sorted_findings[_SHARE_SUMMARY_BASE_FINDING_LIMIT:]
+    for preferred_label in ("External evidence", None):
+        for finding in extra_candidates:
+            if (
+                external_context_extra_count
+                >= _SHARE_SUMMARY_EXTERNAL_CONTEXT_EXTRA_LIMIT
+            ):
+                break
+            finding_id = str(finding.get("finding_id") or id(finding))
+            if finding_id in selected_ids:
+                continue
+            evidence_label = _finding_evidence_label(finding, evidence_items)
+            if not evidence_label:
+                continue
+            if preferred_label is not None and evidence_label != preferred_label:
+                continue
+            selected_findings.append(finding)
+            selected_ids.add(finding_id)
+            external_context_extra_count += 1
     return [
         ShareSummaryFinding(
             title=_shorten(str(finding.get("title", "")), 72),
             severity=str(finding.get("severity", "medium")),
             evidence_count=_finding_evidence_count(finding, evidence_items),
             confidence=round(_share_finding_confidence(finding.get("confidence")), 2),
+            evidence_label=_finding_evidence_label(finding, evidence_items),
         )
-        for finding in sorted_findings[:3]
+        for finding in selected_findings
     ]
+
+
+def _external_scanner_evidence_count(report: dict) -> int:
+    evidence_items = _mapping_items(report.get("evidence_items"))
+    row_count = sum(1 for item in evidence_items if _is_external_scanner_evidence(item))
+    visible_deploywhisper_count = len(evidence_items) - row_count
+    total_count = _share_summary_evidence_count(report)
+    existing_count = _existing_share_summary_int(report, "external_evidence_count")
+    candidate_count = max(row_count, existing_count or 0)
+    max_external_count = max(row_count, total_count - visible_deploywhisper_count)
+    return min(candidate_count, max_external_count)
+
+
+def _share_summary_evidence_count(report: dict) -> int:
+    row_count = len(_mapping_items(report.get("evidence_items")))
+    existing_count = _existing_share_summary_int(report, "evidence_count")
+    return max(row_count, existing_count or 0)
+
+
+def _existing_share_summary_int(report: dict, key: str) -> int | None:
+    json_payload = _existing_share_summary_json_payload(report)
+    if json_payload is None:
+        return None
+    value = json_payload.get(key)
+    try:
+        count = int(value)
+    except (TypeError, ValueError):
+        return None
+    return max(0, count)
+
+
+def _existing_share_summary_json_payload(report: dict) -> dict | None:
+    share_summary = report.get("share_summary")
+    if isinstance(share_summary, BaseModel):
+        share_summary = share_summary.model_dump()
+    if not isinstance(share_summary, dict):
+        return None
+    json_payload = share_summary.get("json_payload")
+    if isinstance(json_payload, BaseModel):
+        json_payload = json_payload.model_dump()
+    if not isinstance(json_payload, dict):
+        return None
+    return json_payload
+
+
+def _external_scanner_evidence_summary(count: int) -> str | None:
+    if count <= 0:
+        return None
+    noun = "item is" if count == 1 else "items are"
+    return (
+        f"{count} external scanner evidence {noun} included as context, "
+        "not DeployWhisper severity proof."
+    )
+
+
+def _share_finding_line(finding: ShareSummaryFinding) -> str:
+    label = f"[{finding.evidence_label}] " if finding.evidence_label else ""
+    return (
+        f"  - {_share_finding_plain_title(finding)} "
+        f"{label}({finding.evidence_count} evidence)"
+    )
+
+
+def _share_finding_plain_title(finding: ShareSummaryFinding) -> str:
+    title = finding.title.strip()
+    severity_prefix = f"{finding.severity.upper()}:"
+    if title.upper().startswith(severity_prefix):
+        return title
+    return f"{finding.severity.upper()}: {title}"
 
 
 def build_share_summary(
@@ -1638,7 +1807,11 @@ def build_share_summary(
     )
     verdict_banner = f"DeployWhisper {severity.upper()} · {recommendation.upper()}"
     top_findings = _share_findings(report)
-    evidence_count = len(_mapping_items(report.get("evidence_items")))
+    evidence_count = _share_summary_evidence_count(report)
+    external_evidence_count = _external_scanner_evidence_count(report)
+    external_evidence_summary = _external_scanner_evidence_summary(
+        external_evidence_count
+    )
     evidence_status, evidence_detail = evidence_law_status(
         report, evidence_detail_available=evidence_detail_available
     )
@@ -1687,6 +1860,8 @@ def build_share_summary(
         headline=headline,
         top_findings=top_findings,
         evidence_count=evidence_count,
+        external_evidence_count=external_evidence_count,
+        external_evidence_summary=external_evidence_summary,
         blast_radius_summary=blast_radius_summary,
         rollback_summary=rollback_summary,
         context_completeness=context_summary,
@@ -1698,9 +1873,12 @@ def build_share_summary(
         f"**Summary:** {headline}",
         f"- Findings: {len(top_findings)} shown / {len(report.get('findings') or [])} total · {evidence_count} evidence items",
     ]
+    if external_evidence_summary is not None:
+        markdown_lines.append(
+            f"- External scanner context: {external_evidence_summary}"
+        )
     markdown_lines.extend(
-        f"  - {finding.severity.upper()}: {finding.title} ({finding.evidence_count} evidence)"
-        for finding in json_payload.top_findings
+        _share_finding_line(finding) for finding in json_payload.top_findings
     )
     markdown_lines.extend(
         [
@@ -1717,15 +1895,23 @@ def build_share_summary(
     )
     markdown = "\n".join(markdown_lines)
     if len(markdown) > 1500:
-        finding_lines = [
-            f"  - {finding.severity.upper()}: {finding.title} ({finding.evidence_count} evidence)"
-            for finding in json_payload.top_findings[:2]
-        ]
+        compact_findings = list(json_payload.top_findings[:3])
+        for finding in json_payload.top_findings[3:]:
+            if finding.evidence_label:
+                compact_findings.append(finding)
+        finding_lines = [_share_finding_line(finding) for finding in compact_findings]
         markdown = "\n".join(
             [
                 f"### {verdict_banner}",
                 f"**Summary:** {_shorten(headline, 120)}",
                 f"- Findings: {len(report.get('findings') or [])} total · {evidence_count} evidence items",
+                *(
+                    [
+                        f"- External scanner context: {_shorten(external_evidence_summary, 120)}"
+                    ]
+                    if external_evidence_summary is not None
+                    else []
+                ),
                 *finding_lines,
                 f"- Blast radius: {_shorten(blast_radius_summary, 120)}",
                 (
@@ -1743,6 +1929,16 @@ def build_share_summary(
             verdict_banner + ".",
             f"Summary: {headline}",
             f"Findings: {len(top_findings)} shown / {len(report.get('findings') or [])} total and {evidence_count} evidence items.",
+            " ".join(
+                f"{_share_finding_plain_title(finding)}: {finding.evidence_label}."
+                for finding in top_findings
+                if finding.evidence_label
+            ),
+            (
+                f"External scanner context: {external_evidence_summary}"
+                if external_evidence_summary is not None
+                else ""
+            ),
             f"Blast radius: {blast_radius_summary}.",
             f"Rollback: {rollback_summary}.",
             f"Evidence Law: {evidence_status} - {evidence_detail}.",

--- a/services/report_service.py
+++ b/services/report_service.py
@@ -2478,10 +2478,82 @@ def _has_linked_deterministic_evidence(
 ) -> bool:
     return any(
         (evidence_item := evidence_by_id.get(evidence_ref)) is not None
-        and evidence_item.deterministic
-        and evidence_item.determinism_level == "deterministic"
+        and _is_deploywhisper_deterministic_evidence(evidence_item)
         for evidence_ref in finding.evidence_refs
     )
+
+
+def _is_deploywhisper_deterministic_evidence(evidence_item: EvidenceItem) -> bool:
+    return (
+        _is_deploywhisper_evidence_item(evidence_item)
+        and evidence_item.deterministic
+        and evidence_item.determinism_level == "deterministic"
+    )
+
+
+def _is_external_scanner_evidence_item(evidence_item: EvidenceItem) -> bool:
+    return any(
+        source == "external_scanner"
+        for source in (evidence_item.source_kind, evidence_item.source_type)
+    )
+
+
+_NON_DEPLOYWHISPER_EVIDENCE_SOURCES = frozenset({"external_scanner", "user_context"})
+
+
+def _is_deploywhisper_evidence_item(evidence_item: EvidenceItem) -> bool:
+    if _is_external_scanner_evidence_item(evidence_item):
+        return False
+    sources = {
+        source
+        for source in (evidence_item.source_kind, evidence_item.source_type)
+        if source
+    }
+    return not (sources & _NON_DEPLOYWHISPER_EVIDENCE_SOURCES)
+
+
+def _evidence_item_label(evidence_item: EvidenceItem) -> str | None:
+    if _is_external_scanner_evidence_item(evidence_item):
+        return "External evidence"
+    return None
+
+
+def _finding_evidence_label(finding, evidence_items: list[EvidenceItem]) -> str | None:
+    has_external_scanner = any(
+        _is_external_scanner_evidence_item(item) for item in evidence_items
+    )
+    has_deploywhisper_evidence = any(
+        _is_deploywhisper_evidence_item(item) for item in evidence_items
+    )
+    if has_external_scanner and has_deploywhisper_evidence:
+        return "Includes external context"
+    if has_external_scanner:
+        return "External evidence"
+    if finding.evidence_classification == "external":
+        return "External evidence"
+    return None
+
+
+def _finding_linked_evidence_items(
+    finding,
+    evidence_items_by_finding_id: dict[str, list[EvidenceItem]],
+    evidence_items_by_id: dict[str, EvidenceItem],
+) -> list[EvidenceItem]:
+    refs = set(json.loads(finding.evidence_refs_json or "[]"))
+    linked_items = [
+        *evidence_items_by_finding_id.get(finding.finding_id, []),
+        *(
+            evidence_items_by_id[evidence_ref]
+            for evidence_ref in refs
+            if evidence_ref in evidence_items_by_id
+        ),
+    ]
+    merged = {
+        evidence_item.evidence_id: evidence_item
+        for evidence_item in linked_items
+        if evidence_item.evidence_id
+    }
+    return list(merged.values())
 
 
 def _linked_deterministic_evidence_refs(
@@ -2492,8 +2564,7 @@ def _linked_deterministic_evidence_refs(
         evidence_ref
         for evidence_ref in finding.evidence_refs
         if (evidence_item := evidence_by_id.get(evidence_ref)) is not None
-        and evidence_item.deterministic
-        and evidence_item.determinism_level == "deterministic"
+        and _is_deploywhisper_deterministic_evidence(evidence_item)
     ]
 
 
@@ -4206,8 +4277,13 @@ def _serialize_report(report, *, include_evidence: bool = True) -> dict:
     confidence = _clamp_confidence_to_context(confidence, context_completeness)
     full_evidence_items: list[dict[str, Any]] = []
     seen_evidence_ids: set[str] = set()
+    evidence_items_by_finding_id: dict[str, list[EvidenceItem]] = {}
+    evidence_items_by_id: dict[str, EvidenceItem] = {}
     for finding in report.findings:
-        for evidence_item in finding.evidence_items:
+        finding_evidence_items = list(finding.evidence_items)
+        evidence_items_by_finding_id[finding.finding_id] = finding_evidence_items
+        for evidence_item in finding_evidence_items:
+            evidence_items_by_id[evidence_item.evidence_id] = evidence_item
             if evidence_item.evidence_id in seen_evidence_ids:
                 continue
             seen_evidence_ids.add(evidence_item.evidence_id)
@@ -4233,6 +4309,7 @@ def _serialize_report(report, *, include_evidence: bool = True) -> dict:
                     "severity_hint": evidence_item.severity_hint,
                     "deterministic": evidence_item.deterministic,
                     "confidence": evidence_item.confidence,
+                    "evidence_label": _evidence_item_label(evidence_item),
                     "related_change_ids": json.loads(
                         evidence_item.related_change_ids_json or "[]"
                     ),
@@ -4360,6 +4437,14 @@ def _serialize_report(report, *, include_evidence: bool = True) -> dict:
                 "uncertainty_note": finding.uncertainty_note,
                 "evidence_classification": finding.evidence_classification,
                 "evidence_refs": json.loads(finding.evidence_refs_json or "[]"),
+                "evidence_label": _finding_evidence_label(
+                    finding,
+                    _finding_linked_evidence_items(
+                        finding,
+                        evidence_items_by_finding_id,
+                        evidence_items_by_id,
+                    ),
+                ),
                 "skill_id": finding.skill_id,
             }
             for finding in report.findings

--- a/tests/test_docs/test_report_schema_documentation.py
+++ b/tests/test_docs/test_report_schema_documentation.py
@@ -34,6 +34,7 @@ class ReportSchemaDocumentationTests(unittest.TestCase):
             '"report_schema_version"',
             '"findings"',
             '"evidence_items"',
+            '"evidence_label"',
             '"report_schema_versions"',
             '"context_completeness"',
             '"owner_signals"',

--- a/tests/test_services/test_adapter_output_contract.py
+++ b/tests/test_services/test_adapter_output_contract.py
@@ -281,6 +281,369 @@ class AdapterOutputContractTests(unittest.TestCase):
         with self.assertRaises(ValidationError):
             contract.canonical_summary.json_payload.evidence_law_status = "Needs review"
 
+    def test_share_summary_labels_external_scanner_context_for_comments(self) -> None:
+        payload = _report_payload()
+        payload["findings"][0]["evidence_refs"].append("ev-scanner")
+        payload["evidence_items"].append(
+            {
+                "evidence_id": "ev-scanner",
+                "finding_id": "finding-scanner-context",
+                "source_type": "external_scanner",
+                "source_kind": "external_scanner",
+                "deterministic": True,
+                "determinism_level": "deterministic",
+            }
+        )
+
+        summary = build_share_summary(payload)
+
+        self.assertEqual(summary.json_payload.external_evidence_count, 1)
+        self.assertEqual(
+            summary.json_payload.external_evidence_summary,
+            "1 external scanner evidence item is included as context, not DeployWhisper severity proof.",
+        )
+        self.assertEqual(
+            summary.json_payload.top_findings[0].evidence_label,
+            "Includes external context",
+        )
+        self.assertEqual(summary.json_payload.top_findings[0].evidence_count, 2)
+        self.assertIn("[Includes external context]", summary.markdown)
+        self.assertIn("External scanner context", summary.markdown)
+        self.assertIn(
+            "HIGH: aws_security_group.db: Includes external context.",
+            summary.plain_text,
+        )
+        self.assertIn("external scanner evidence item", summary.plain_text)
+
+    def test_share_summary_preserves_external_context_when_evidence_rows_omitted(
+        self,
+    ) -> None:
+        payload = _report_payload()
+        payload["findings"][0]["evidence_refs"].append("ev-scanner")
+        payload["findings"][0]["evidence_label"] = "Includes external context"
+        payload["evidence_items"] = []
+        payload["share_summary"] = {
+            "json_payload": {
+                "evidence_count": 2,
+                "external_evidence_count": 1,
+            },
+        }
+
+        summary = build_share_summary(payload, evidence_detail_available=False)
+
+        self.assertEqual(summary.json_payload.evidence_count, 2)
+        self.assertEqual(summary.json_payload.external_evidence_count, 1)
+        self.assertEqual(
+            summary.json_payload.external_evidence_summary,
+            "1 external scanner evidence item is included as context, not DeployWhisper severity proof.",
+        )
+        self.assertEqual(
+            summary.json_payload.top_findings[0].evidence_label,
+            "Includes external context",
+        )
+        self.assertEqual(summary.json_payload.top_findings[0].evidence_count, 2)
+        self.assertIn("[Includes external context]", summary.markdown)
+        self.assertIn("External scanner context", summary.markdown)
+        self.assertIn("- Evidence Law: Detail omitted", summary.markdown)
+
+    def test_share_summary_caps_external_context_when_rows_are_partially_redacted(
+        self,
+    ) -> None:
+        payload = _report_payload()
+        payload["findings"][0]["evidence_refs"].append("ev-scanner")
+        payload["findings"][0]["evidence_label"] = "Includes external context"
+        payload["evidence_items"] = [
+            {
+                "evidence_id": "ev-001",
+                "finding_id": "finding-001",
+                "source_type": "artifact",
+                "source_kind": "artifact",
+                "deterministic": True,
+                "determinism_level": "deterministic",
+            },
+        ]
+        payload["share_summary"] = {
+            "json_payload": {
+                "evidence_count": 2,
+                "external_evidence_count": 9,
+            },
+        }
+
+        summary = build_share_summary(payload, evidence_detail_available=False)
+
+        self.assertEqual(summary.json_payload.evidence_count, 2)
+        self.assertEqual(summary.json_payload.external_evidence_count, 1)
+        self.assertIn("2 evidence items", summary.markdown)
+        self.assertIn("1 external scanner evidence item", summary.markdown)
+        self.assertNotIn("9 external scanner evidence", summary.markdown)
+
+    def test_share_summary_keeps_external_scanner_findings_after_top_three(
+        self,
+    ) -> None:
+        payload = _report_payload()
+        payload["findings"] = [
+            {
+                "finding_id": f"finding-high-{index}",
+                "title": f"HIGH: internal finding {index}",
+                "severity": "high",
+                "confidence": 0.99 - (index / 100),
+                "evidence_refs": [f"ev-high-{index}"],
+            }
+            for index in range(3)
+        ] + [
+            {
+                "finding_id": "finding-scanner-context",
+                "title": "LOW: semgrep scanner context",
+                "severity": "low",
+                "confidence": 0.1,
+                "evidence_refs": ["ev-scanner"],
+            }
+        ]
+        payload["evidence_items"] = [
+            {
+                "evidence_id": f"ev-high-{index}",
+                "finding_id": f"finding-high-{index}",
+                "source_type": "artifact",
+                "source_kind": "artifact",
+                "deterministic": True,
+                "determinism_level": "deterministic",
+            }
+            for index in range(3)
+        ] + [
+            {
+                "evidence_id": "ev-scanner",
+                "finding_id": "finding-scanner-context",
+                "source_type": "external_scanner",
+                "source_kind": "external_scanner",
+                "deterministic": True,
+                "determinism_level": "deterministic",
+            }
+        ]
+
+        summary = build_share_summary(payload)
+        titles = [finding.title for finding in summary.json_payload.top_findings]
+
+        self.assertIn("LOW: semgrep scanner context", titles)
+        self.assertGreater(len(summary.json_payload.top_findings), 3)
+        self.assertIn(
+            "LOW: semgrep scanner context [External evidence]",
+            summary.markdown,
+        )
+        self.assertNotIn("LOW: LOW: semgrep scanner context", summary.markdown)
+        self.assertIn(
+            "LOW: semgrep scanner context: External evidence.",
+            summary.plain_text,
+        )
+
+    def test_share_summary_caps_external_scanner_findings_after_top_three(
+        self,
+    ) -> None:
+        payload = _report_payload()
+        payload["findings"] = (
+            [
+                {
+                    "finding_id": f"finding-high-{index}",
+                    "title": f"HIGH: internal finding {index}",
+                    "severity": "high",
+                    "confidence": 0.99 - (index / 100),
+                    "evidence_refs": [f"ev-high-{index}"],
+                }
+                for index in range(3)
+            ]
+            + [
+                {
+                    "finding_id": f"finding-mixed-{index}",
+                    "title": f"LOW: mixed scanner context {index}",
+                    "severity": "low",
+                    "confidence": 0.95 - (index / 100),
+                    "evidence_refs": [f"ev-mixed-{index}", f"ev-scanner-mixed-{index}"],
+                }
+                for index in range(2)
+            ]
+            + [
+                {
+                    "finding_id": f"finding-scanner-{index}",
+                    "title": f"LOW: scanner-only context {index}",
+                    "severity": "low",
+                    "confidence": 0.1 - (index / 100),
+                    "evidence_refs": [f"ev-scanner-only-{index}"],
+                }
+                for index in range(3)
+            ]
+        )
+        payload["evidence_items"] = (
+            [
+                {
+                    "evidence_id": f"ev-high-{index}",
+                    "finding_id": f"finding-high-{index}",
+                    "source_type": "artifact",
+                    "source_kind": "artifact",
+                    "deterministic": True,
+                    "determinism_level": "deterministic",
+                }
+                for index in range(3)
+            ]
+            + [
+                {
+                    "evidence_id": f"ev-mixed-{index}",
+                    "finding_id": f"finding-mixed-{index}",
+                    "source_type": "artifact",
+                    "source_kind": "artifact",
+                    "deterministic": True,
+                    "determinism_level": "deterministic",
+                }
+                for index in range(2)
+            ]
+            + [
+                {
+                    "evidence_id": f"ev-scanner-mixed-{index}",
+                    "finding_id": f"finding-mixed-{index}",
+                    "source_type": "external_scanner",
+                    "source_kind": "external_scanner",
+                    "deterministic": True,
+                    "determinism_level": "deterministic",
+                }
+                for index in range(2)
+            ]
+            + [
+                {
+                    "evidence_id": f"ev-scanner-only-{index}",
+                    "finding_id": f"finding-scanner-{index}",
+                    "source_type": "external_scanner",
+                    "source_kind": "external_scanner",
+                    "deterministic": True,
+                    "determinism_level": "deterministic",
+                }
+                for index in range(3)
+            ]
+        )
+
+        summary = build_share_summary(payload)
+        titles = [finding.title for finding in summary.json_payload.top_findings]
+
+        self.assertEqual(len(summary.json_payload.top_findings), 5)
+        self.assertEqual(
+            sum(
+                1
+                for finding in summary.json_payload.top_findings
+                if finding.evidence_label == "External evidence"
+            ),
+            2,
+        )
+        self.assertIn("LOW: scanner-only context 0", titles)
+        self.assertIn("LOW: scanner-only context 1", titles)
+        self.assertNotIn("LOW: scanner-only context 2", titles)
+        self.assertNotIn("LOW: mixed scanner context 0", titles)
+
+    def test_share_summary_compact_markdown_keeps_duplicate_title_external_label(
+        self,
+    ) -> None:
+        payload = _report_payload()
+        payload["findings"] = [
+            {
+                "finding_id": "finding-internal-duplicate",
+                "title": "DUPLICATE: shared title",
+                "severity": "high",
+                "confidence": 0.99,
+                "evidence_refs": ["ev-internal-duplicate"],
+            },
+            {
+                "finding_id": "finding-internal-other",
+                "title": "HIGH: another internal finding",
+                "severity": "high",
+                "confidence": 0.98,
+                "evidence_refs": ["ev-internal-other"],
+            },
+            {
+                "finding_id": "finding-internal-third",
+                "title": "HIGH: third internal finding",
+                "severity": "high",
+                "confidence": 0.97,
+                "evidence_refs": ["ev-internal-third"],
+            },
+            {
+                "finding_id": "finding-external-duplicate",
+                "title": "DUPLICATE: shared title",
+                "severity": "low",
+                "confidence": 0.1,
+                "evidence_refs": ["ev-scanner-duplicate"],
+            },
+        ]
+        payload["evidence_items"] = [
+            {
+                "evidence_id": evidence_id,
+                "finding_id": finding_id,
+                "source_type": "artifact",
+                "source_kind": "artifact",
+                "deterministic": True,
+                "determinism_level": "deterministic",
+            }
+            for evidence_id, finding_id in (
+                ("ev-internal-duplicate", "finding-internal-duplicate"),
+                ("ev-internal-other", "finding-internal-other"),
+                ("ev-internal-third", "finding-internal-third"),
+            )
+        ] + [
+            {
+                "evidence_id": "ev-scanner-duplicate",
+                "finding_id": "finding-external-duplicate",
+                "source_type": "external_scanner",
+                "source_kind": "external_scanner",
+                "deterministic": True,
+                "determinism_level": "deterministic",
+            }
+        ]
+        payload["context_completeness"] = {
+            "context_score": 0.9,
+            "uncertainty": "Reviewer context remains intentionally verbose. " * 80,
+        }
+
+        summary = build_share_summary(payload)
+
+        self.assertLessEqual(len(summary.markdown), 1500)
+        self.assertIn("HIGH: third internal finding", summary.markdown)
+        self.assertIn(
+            "LOW: DUPLICATE: shared title [External evidence]",
+            summary.markdown,
+        )
+        self.assertNotIn("LOW: LOW: DUPLICATE", summary.markdown)
+        self.assertIn(
+            "LOW: DUPLICATE: shared title: External evidence.",
+            summary.plain_text,
+        )
+
+    def test_share_summary_does_not_treat_user_context_as_deploywhisper_support(
+        self,
+    ) -> None:
+        payload = _report_payload()
+        payload["findings"][0]["evidence_refs"] = ["ev-scanner", "ev-user"]
+        payload["evidence_items"] = [
+            {
+                "evidence_id": "ev-scanner",
+                "finding_id": "finding-001",
+                "source_type": "external_scanner",
+                "source_kind": "external_scanner",
+                "deterministic": True,
+                "determinism_level": "deterministic",
+            },
+            {
+                "evidence_id": "ev-user",
+                "finding_id": "finding-001",
+                "source_type": "user_context",
+                "source_kind": "user_context",
+                "deterministic": True,
+                "determinism_level": "deterministic",
+            },
+        ]
+
+        summary = build_share_summary(payload)
+
+        self.assertEqual(
+            summary.json_payload.top_findings[0].evidence_label,
+            "External evidence",
+        )
+        self.assertNotIn("Includes external context", summary.markdown)
+
     def test_adapter_owned_maps_are_immutable_after_validation(self) -> None:
         contract = build_adapter_output_contract(
             build_share_summary(_report_payload()),

--- a/tests/test_services/test_report_service.py
+++ b/tests/test_services/test_report_service.py
@@ -217,6 +217,42 @@ class ReportServiceTests(unittest.TestCase):
                     ],
                     evidence_payload=[string_false_evidence],
                 )
+        user_context_evidence = {
+            **heuristic_evidence,
+            "evidence_id": "ev-user-context",
+            "source_type": "user_context",
+            "source_ref": "user://review-note/1",
+            "deterministic": True,
+            "determinism_level": "deterministic",
+        }
+        with database_module.SessionLocal() as session:
+            with self.assertRaisesRegex(
+                ValueError,
+                "without linked deterministic evidence",
+            ):
+                analysis_reports_repository_module.create_analysis_report(
+                    session,
+                    **report_kwargs,
+                    findings_payload=[
+                        {
+                            **finding,
+                            "finding_id": "finding-user-context",
+                            "severity": "high",
+                            "evidence_refs": ["ev-user-context"],
+                        }
+                    ],
+                    evidence_payload=[user_context_evidence],
+                )
+        self.assertTrue(
+            analysis_reports_repository_module._is_deploywhisper_evidence(
+                {"source_type": "parser"}
+            )
+        )
+        self.assertFalse(
+            analysis_reports_repository_module._is_deploywhisper_evidence(
+                {"source_type": "user_context"}
+            )
+        )
         string_true_evidence = {
             **heuristic_evidence,
             "evidence_id": "ev-string-true",
@@ -781,6 +817,7 @@ class ReportServiceTests(unittest.TestCase):
             "analysis_id": 0,
             "finding_id": "finding-external-high",
             "source_type": "external_scanner",
+            "source_kind": "artifact",
             "source_ref": "scanner://sast.json#rule.high?action=flag",
             "summary": "External scanner flagged a high risk.",
             "severity_hint": "high",
@@ -789,24 +826,60 @@ class ReportServiceTests(unittest.TestCase):
             "related_change_ids": ["chg-001"],
         }
         with database_module.SessionLocal() as session:
+            with self.assertRaisesRegex(
+                ValueError,
+                "without linked deterministic evidence",
+            ):
+                analysis_reports_repository_module.create_analysis_report(
+                    session,
+                    **{
+                        **report_kwargs,
+                        "risk_score": 72,
+                        "severity": "high",
+                        "recommendation": "no-go",
+                        "top_risk": "HIGH: External scanner high risk.",
+                        "narrative_opening": "NO-GO: External scanner high risk.",
+                        "narrative_explanation": (
+                            "External scanner evidence is reviewer context."
+                        ),
+                        "top_risk_contributors_json": '["ev-external-high"]',
+                    },
+                    findings_payload=[
+                        {
+                            **finding,
+                            "finding_id": "finding-external-high",
+                            "title": "HIGH: External scanner high risk.",
+                            "severity": "high",
+                            "deterministic": True,
+                            "evidence_classification": "external",
+                            "evidence_refs": ["ev-external-high"],
+                        }
+                    ],
+                    evidence_payload=[external_evidence],
+                )
+        with database_module.SessionLocal() as session:
             report = analysis_reports_repository_module.create_analysis_report(
                 session,
                 **{
                     **report_kwargs,
-                    "risk_score": 72,
-                    "severity": "high",
-                    "recommendation": "no-go",
-                    "top_risk": "HIGH: External scanner high risk.",
-                    "narrative_opening": "NO-GO: External scanner high risk.",
-                    "narrative_explanation": "External scanner evidence is deterministic.",
+                    "risk_score": 55,
+                    "severity": "medium",
+                    "recommendation": "caution",
+                    "top_risk": "MEDIUM: External scanner context needs review.",
+                    "narrative_opening": (
+                        "CAUTION: External scanner context needs review."
+                    ),
+                    "narrative_explanation": (
+                        "External scanner evidence is reviewer context."
+                    ),
                     "top_risk_contributors_json": '["ev-external-high"]',
                 },
                 findings_payload=[
                     {
                         **finding,
                         "finding_id": "finding-external-high",
-                        "title": "HIGH: External scanner high risk.",
-                        "severity": "high",
+                        "title": "MEDIUM: External scanner context needs review.",
+                        "severity": "medium",
                         "deterministic": True,
                         "evidence_classification": "external",
                         "evidence_refs": ["ev-external-high"],
@@ -1093,6 +1166,189 @@ class ReportServiceTests(unittest.TestCase):
         self.assertEqual(
             report["evidence_items"][0]["finding_id"],
             report["findings"][0]["finding_id"],
+        )
+
+    def test_persist_analysis_report_labels_ref_linked_external_scanner_context(
+        self,
+    ) -> None:
+        parse_batch = ParseBatchResult(
+            files=[
+                ParsedFileResult(
+                    file_name="scanner.json",
+                    tool="terraform",
+                    status="parsed",
+                    changes=[],
+                )
+            ]
+        )
+        assessment = RiskAssessment(
+            score=55,
+            severity="medium",
+            recommendation="caution",
+            top_risk="External scanner context supports manual review.",
+            contributors=[],
+            interaction_risks=[],
+            partial_context=False,
+            warnings=[],
+        )
+        narrative = NarrativeResult(
+            opening_sentence="CAUTION: scanner context supports manual review.",
+            explanation="Scanner context is present alongside DeployWhisper evidence.",
+            guidance=[],
+            degraded=False,
+            warnings=[],
+        )
+
+        report = report_service_module.persist_analysis_report(
+            parse_batch,
+            assessment,
+            narrative,
+            findings=[
+                Finding(
+                    finding_id="finding-scanner",
+                    analysis_id=0,
+                    title="MEDIUM: scanner context",
+                    description="External scanner context needs review.",
+                    severity="medium",
+                    category="external/scanner",
+                    deterministic=False,
+                    confidence=0.8,
+                    uncertainty_note=None,
+                    evidence_classification="external",
+                    evidence_refs=["ev-scanner"],
+                    skill_id=None,
+                ),
+                Finding(
+                    finding_id="finding-mixed",
+                    analysis_id=0,
+                    title="MEDIUM: mixed context",
+                    description="DeployWhisper evidence has supporting scanner context.",
+                    severity="medium",
+                    category="networking/ingress",
+                    deterministic=True,
+                    confidence=0.85,
+                    uncertainty_note=None,
+                    evidence_refs=["ev-internal", "ev-scanner"],
+                    skill_id=None,
+                ),
+            ],
+            evidence_items=[
+                EvidenceItem(
+                    evidence_id="ev-scanner",
+                    analysis_id=0,
+                    finding_id="finding-scanner",
+                    source_type="external_scanner",
+                    source_ref="scanner://semgrep.json#rule.one?action=flag",
+                    summary="External scanner flagged related context.",
+                    severity_hint="medium",
+                    deterministic=True,
+                    confidence=1.0,
+                ),
+                EvidenceItem(
+                    evidence_id="ev-internal",
+                    analysis_id=0,
+                    finding_id="finding-mixed",
+                    source_type="artifact",
+                    source_ref="terraform://plan.json#aws_security_group.db?action=modify",
+                    summary="DeployWhisper found ingress evidence.",
+                    severity_hint="medium",
+                    deterministic=True,
+                    confidence=1.0,
+                ),
+            ],
+        )
+
+        labels_by_title = {
+            finding["title"]: finding["evidence_label"]
+            for finding in report["findings"]
+        }
+        self.assertEqual(
+            labels_by_title["MEDIUM: scanner context"], "External evidence"
+        )
+        self.assertEqual(
+            labels_by_title["MEDIUM: mixed context"],
+            "Includes external context",
+        )
+
+    def test_persist_analysis_report_does_not_label_user_context_as_deploywhisper_support(
+        self,
+    ) -> None:
+        parse_batch = ParseBatchResult(
+            files=[
+                ParsedFileResult(
+                    file_name="scanner.json",
+                    tool="terraform",
+                    status="parsed",
+                    changes=[],
+                )
+            ]
+        )
+        assessment = RiskAssessment(
+            score=50,
+            severity="medium",
+            recommendation="caution",
+            top_risk="Scanner finding has user-supplied context.",
+            contributors=[],
+            interaction_risks=[],
+            partial_context=False,
+            warnings=[],
+        )
+        narrative = NarrativeResult(
+            opening_sentence="CAUTION: scanner finding has user context.",
+            explanation="External context is present without DeployWhisper evidence.",
+            guidance=[],
+            degraded=False,
+            warnings=[],
+        )
+
+        report = report_service_module.persist_analysis_report(
+            parse_batch,
+            assessment,
+            narrative,
+            findings=[
+                Finding(
+                    finding_id="finding-scanner-user-context",
+                    analysis_id=0,
+                    title="MEDIUM: scanner plus user context",
+                    description="Scanner evidence has user-supplied context only.",
+                    severity="medium",
+                    category="external/scanner",
+                    deterministic=False,
+                    confidence=0.75,
+                    uncertainty_note=None,
+                    evidence_refs=["ev-scanner", "ev-user-context"],
+                    skill_id=None,
+                ),
+            ],
+            evidence_items=[
+                EvidenceItem(
+                    evidence_id="ev-scanner",
+                    analysis_id=0,
+                    finding_id="finding-scanner-user-context",
+                    source_type="external_scanner",
+                    source_ref="scanner://semgrep.json#rule.one?action=flag",
+                    summary="External scanner flagged related context.",
+                    severity_hint="medium",
+                    deterministic=True,
+                    confidence=1.0,
+                ),
+                EvidenceItem(
+                    evidence_id="ev-user-context",
+                    analysis_id=0,
+                    finding_id="finding-scanner-user-context",
+                    source_type="user_context",
+                    source_ref="user://review-note/1",
+                    summary="Reviewer supplied additional context.",
+                    severity_hint="medium",
+                    deterministic=True,
+                    confidence=1.0,
+                ),
+            ],
+        )
+
+        self.assertEqual(
+            report["findings"][0]["evidence_label"],
+            "External evidence",
         )
 
     def test_persist_analysis_report_prefers_severe_owner_for_generated_shared_evidence(
@@ -2963,7 +3219,7 @@ class ReportServiceTests(unittest.TestCase):
         )
         self.assertNotIn("Evidence Law downgraded", " ".join(report["warnings"]))
 
-    def test_persist_analysis_report_preserves_external_deterministic_severe_finding(
+    def test_persist_analysis_report_downgrades_external_scanner_only_severe_finding(
         self,
     ) -> None:
         parse_batch = ParseBatchResult(
@@ -3020,6 +3276,7 @@ class ReportServiceTests(unittest.TestCase):
                     analysis_id=0,
                     finding_id="pending:scanner-1",
                     source_type="external_scanner",
+                    source_kind="artifact",
                     source_ref="scanner://sast.json#rule.high?action=flag",
                     summary="External scanner flagged a high risk.",
                     severity_hint="high",
@@ -3030,10 +3287,18 @@ class ReportServiceTests(unittest.TestCase):
             ],
         )
 
-        self.assertEqual(report["severity"], "high")
-        self.assertEqual(report["findings"][0]["severity"], "high")
-        self.assertTrue(report["findings"][0]["deterministic"])
+        self.assertEqual(report["severity"], "medium")
+        self.assertEqual(report["recommendation"], "caution")
+        self.assertEqual(report["findings"][0]["severity"], "medium")
+        self.assertFalse(report["findings"][0]["deterministic"])
         self.assertEqual(report["findings"][0]["evidence_classification"], "external")
+        self.assertEqual(report["findings"][0]["evidence_label"], "External evidence")
+        self.assertIn("Evidence Law downgraded", " ".join(report["warnings"]))
+        self.assertEqual(report["evidence_items"][0]["source_type"], "external_scanner")
+        self.assertEqual(report["evidence_items"][0]["source_kind"], "external_scanner")
+        self.assertEqual(
+            report["evidence_items"][0]["evidence_label"], "External evidence"
+        )
 
     def test_persist_analysis_report_rejects_unmatched_single_finding_evidence(
         self,


### PR DESCRIPTION
## Summary
- Label external scanner context across report API, share-summary, and React report surfaces without treating it as DeployWhisper severity proof.
- Harden Evidence Law support checks so scanner/user context cannot justify severe first-party findings.
- Preserve and cap redacted evidence totals/external-context counts across report and share-summary paths.
- Update Story 8.3 artifact, sprint status, report schema docs, TypeScript schema mirror, and regression tests.

## Validation
- npm run ui:test -- Report.test.tsx
- npm run ui:typecheck
- ./.venv/bin/python -m unittest tests.test_services.test_adapter_output_contract tests.test_services.test_report_service tests.test_docs.test_report_schema_documentation
- ./.venv/bin/ruff check .
- ./.venv/bin/ruff format --check .
- git diff --check
- bash scripts/ci-local.sh

## BMad Review
- Blind Hunter: no findings
- Edge Case Hunter: no findings
- Acceptance Auditor: no findings