### PR TITLE
Preserve scanner conflict evidence in analysis reports

### DIFF
--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -121,7 +121,7 @@ development_status:
   8-1-sarif-ingestion: review
   8-2-scanner-json-adapter-v1: done
   8-3-external-evidence-report-context: done
-  8-4-scanner-conflict-handling: ready-for-dev
+  8-4-scanner-conflict-handling: review
   8-5-existing-security-tools-comparison-guide: ready-for-dev
   epic-8-retrospective: optional
 

--- a/api/routes/analyses.py
+++ b/api/routes/analyses.py
@@ -122,6 +122,22 @@ def _detail_payload(report: dict, *, comparison: dict | None = None) -> dict:
     }
 
 
+def _shared_report_comparison_or_none(
+    report_id: int,
+    *,
+    bypass_password: bool,
+    previous_bypass_password: bool,
+) -> dict | None:
+    try:
+        return fetch_shared_report_comparison(
+            report_id,
+            bypass_password=bypass_password,
+            previous_bypass_password=previous_bypass_password,
+        )
+    except (KeyError, TypeError, ValueError):
+        return None
+
+
 def _list_report_schema_meta(reports: list[dict]) -> dict[str, object]:
     def schema_major(schema_version: str) -> int:
         return int(schema_version[1:]) if schema_version.startswith("v") else 0
@@ -1004,7 +1020,7 @@ def get_shared_analysis(
             message="Analysis report not found.",
         )
     comparison = (
-        fetch_shared_report_comparison(
+        _shared_report_comparison_or_none(
             report_id,
             bypass_password=password_required,
             previous_bypass_password=True,
@@ -1037,6 +1053,7 @@ def unlock_shared_analysis(
     report_id: int,
     payload: SharedReportUnlockRequest,
     response: Response,
+    compare: str | None = Query(default=None),
 ) -> SharedReportAccessResponse:
     shared_report = fetch_shared_analysis_report(report_id, password=payload.password)
     if shared_report is None:
@@ -1060,8 +1077,17 @@ def unlock_shared_analysis(
         secure=_share_cookie_secure(shared_report),
         samesite="lax",
     )
+    comparison = (
+        _shared_report_comparison_or_none(
+            report_id,
+            bypass_password=True,
+            previous_bypass_password=True,
+        )
+        if compare == "previous"
+        else None
+    )
     return SharedReportAccessResponse(
-        data=_detail_payload(shared_report),
+        data=_detail_payload(shared_report, comparison=comparison),
         meta=build_report_meta(
             id=report_id,
             report_schema_version=normalize_report_schema_version(

--- a/api/schemas.py
+++ b/api/schemas.py
@@ -1798,6 +1798,26 @@ class ShareSummaryContextData(BaseModel):
     summary: str = Field(..., description="Short context completeness summary")
 
 
+class ShareSummaryScannerConflictData(BaseModel):
+    finding_id: str = Field(..., description="Finding with conflicting scanner context")
+    finding_title: str = Field(..., description="Reviewer-facing finding title")
+    scanner_source: str = Field(..., description="Scanner evidence source reference")
+    scanner_freshness: str = Field(..., description="Scanner source freshness status")
+    deterministic_source: str = Field(
+        ..., description="DeployWhisper deterministic evidence source"
+    )
+    deterministic_freshness: str = Field(
+        ..., description="DeployWhisper deterministic source freshness status"
+    )
+    conflict_summary: str = Field(..., description="Short conflict explanation")
+    confidence_impact: str = Field(
+        ..., description="How the conflict affects confidence interpretation"
+    )
+    recommended_verification: str = Field(
+        ..., description="Reviewer action for resolving the conflict"
+    )
+
+
 class ShareSummaryJsonPayloadData(BaseModel):
     version: str = Field(..., description="Share-summary payload version")
     report_schema_version: str = Field(
@@ -1828,6 +1848,10 @@ class ShareSummaryJsonPayloadData(BaseModel):
     external_evidence_summary: str | None = Field(
         default=None,
         description="How external scanner context should be interpreted",
+    )
+    scanner_conflicts: list[ShareSummaryScannerConflictData] = Field(
+        default_factory=list,
+        description="Scanner-vs-deterministic/context conflicts requiring review",
     )
     blast_radius_summary: str = Field(..., description="Concise blast-radius summary")
     rollback_summary: str = Field(..., description="Concise rollback summary")

--- a/docs/ci-advisory-consumption.md
+++ b/docs/ci-advisory-consumption.md
@@ -6,7 +6,8 @@ DeployWhisper remains advisory in automation contexts.
 - `data.advisory.requires_attention` tells the pipeline or PR bot whether humans should take a closer look
 - `data.share_summary` provides a ready-to-render PR / approval-thread summary in both `markdown` and `plain_text`
 - `data.share_summary.markdown` is capped at 1,500 characters for GitHub PR comment fit
-- `data.share_summary.json_payload` provides the machine-friendly summary variant, including `report_schema_version`, Evidence Law status, top findings, evidence count, context completeness, and report / rollback links
+- `data.share_summary.json_payload` provides the machine-friendly summary variant, including `report_schema_version`, Evidence Law status, top findings, evidence count, scanner conflict details, context completeness, and report / rollback links
+- `data.share_summary.json_payload.scanner_conflicts` lists scanner-vs-deterministic/context conflicts with scanner source, deterministic source, both freshness values, confidence impact, and recommended verification; CI and PR-comment consumers should preserve or render these entries instead of silently choosing one side
 - Evidence Law status values are `Satisfied`, `Needs review`, `Reconciled`, and `Detail omitted`; CLI/API analysis responses include evidence detail and should not emit `Detail omitted`
 - Share-summary report links always resolve to an absolute `/reports/{id}` URL; set `APP_BASE_URL` when you need those links to point at a public/reverse-proxied DeployWhisper instance instead of the local app host/port
 - Sensitive shared reports can opt into password protection and file-name redaction through `POST /api/v1/analyses/{id}/share`
@@ -41,6 +42,8 @@ summary = payload["data"]["share_summary"]
 print(summary["markdown"])
 print(summary["json_payload"]["report_schema_version"])
 print(summary["json_payload"]["evidence_law_status"])
+for conflict in summary["json_payload"].get("scanner_conflicts", []):
+    print("Scanner conflict:", conflict["recommended_verification"])
 print(summary["json_payload"]["rollback_link"])
 print("DeployWhisper blocking decision:", advisory["should_block"])
 PY

--- a/docs/github-action.md
+++ b/docs/github-action.md
@@ -99,8 +99,9 @@ still require the configured share password before the public payload loads, and
 
 The machine payload in `share_summary.json_payload` includes
 `report_schema_version`, Evidence Law status, top findings, evidence count,
-context completeness, and report/rollback links. Consumers that need to branch
-on persisted report shape should use `report_schema_version` and the
+context completeness, scanner conflict details, and report/rollback links.
+Consumers that need to branch on persisted report shape should use
+`report_schema_version` and the
 `docs/schemas/report-v2.md` contract rather than parsing PR comment text.
 
 ## Action-Owned GitHub Metadata Outputs

--- a/docs/scanner-imports.md
+++ b/docs/scanner-imports.md
@@ -61,6 +61,17 @@ tool names, and normalized evidence rows. Each evidence row includes:
 - `source_ref`
 - `project_id` and `project_key`
 
+## Conflict Handling
+
+Scanner findings remain external evidence even when they mention a higher or
+lower severity than DeployWhisper's deterministic score. When report synthesis
+finds scanner-linked evidence that conflicts with DeployWhisper deterministic
+evidence or context freshness, the report share summary includes
+`share_summary.json_payload.scanner_conflicts`. Each conflict names the scanner
+source, deterministic evidence source, source freshness, confidence impact, and
+recommended verification step. UI, API, CLI, and PR-comment consumers should
+render that payload instead of choosing one side silently.
+
 ## Semgrep JSON Endpoint
 
 ```http

--- a/docs/schemas/report-v2.md
+++ b/docs/schemas/report-v2.md
@@ -127,6 +127,9 @@ When scanner evidence is present, share-summary JSON and PR-comment markdown
 label it as external scanner context. External scanner severity is not
 DeployWhisper severity proof on its own; high/critical DeployWhisper findings
 still require linked DeployWhisper deterministic evidence.
+When scanner output conflicts with deterministic evidence or context,
+`share_summary.json_payload.scanner_conflicts` lists both source references,
+freshness states, the confidence impact, and the recommended verification step.
 
 ```json
 {
@@ -166,6 +169,19 @@ still require linked DeployWhisper deterministic evidence.
       "evidence_count": 4,
       "external_evidence_count": 1,
       "external_evidence_summary": "1 external scanner evidence item is included as context, not DeployWhisper severity proof.",
+      "scanner_conflicts": [
+        {
+          "finding_id": "finding-public-ingress",
+          "finding_title": "HIGH: public ingress exposure",
+          "scanner_source": "semgrep://results/sg-1",
+          "scanner_freshness": "current",
+          "deterministic_source": "ev-public-ingress",
+          "deterministic_freshness": "current",
+          "conflict_summary": "Scanner severity critical differs from DeployWhisper severity high.",
+          "confidence_impact": "Scanner confidence impact: scanner signal is critical; DeployWhisper confidence remains 1.00 and severity remains high under Evidence Law.",
+          "recommended_verification": "Review scanner evidence against deterministic evidence before acting."
+        }
+      ],
       "context_completeness": {
         "score": 0.22,
         "label": "LIMITED CONTEXT",

--- a/frontend/e2e/report.spec.ts
+++ b/frontend/e2e/report.spec.ts
@@ -1,5 +1,6 @@
 import { test, expect, type APIRequestContext, type Page } from "@playwright/test";
 import AxeBuilder from "@axe-core/playwright";
+import { execFileSync } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
 
@@ -31,6 +32,21 @@ type ReportDetail = {
   context_completeness?: { context_sources?: ContextSource[] };
   evidence_items?: { context_source?: ContextSource | null }[];
   feedback_state: { finding_feedback: Record<string, { outcome_label: string }> };
+  share_summary: {
+    json_payload: {
+      scanner_conflicts?: {
+        finding_id: string;
+        finding_title: string;
+        scanner_source: string;
+        scanner_freshness: string;
+        deterministic_source: string;
+        deterministic_freshness: string;
+        conflict_summary: string;
+        confidence_impact: string;
+        recommended_verification: string;
+      }[];
+    };
+  };
 };
 
 async function apiJson<T>(responsePromise: Promise<import("@playwright/test").APIResponse>): Promise<T> {
@@ -127,6 +143,115 @@ async function seedReport(request: APIRequestContext, project: Project): Promise
   const report = await apiJson<ApiEnvelope<ReportDetail>>(request.get(`/api/v1/analyses/${run.data.persisted_report.id}`));
   expect(report.data.findings.length).toBeGreaterThan(0);
   return report.data;
+}
+
+function injectScannerConflict(reportId: number) {
+  const scannerEvidenceId = `ev-playwright-scanner-${runId}`;
+  const script = `
+import json
+import sqlite3
+import sys
+from datetime import UTC, datetime
+
+report_id = int(sys.argv[1])
+scanner_evidence_id = sys.argv[2]
+conn = sqlite3.connect("/app/data/deploywhisper.db")
+conn.row_factory = sqlite3.Row
+try:
+    report = conn.execute(
+        "SELECT project_id, workspace_id FROM analysis_reports WHERE id = ?",
+        (report_id,),
+    ).fetchone()
+    finding = conn.execute(
+        """
+        SELECT finding_id, evidence_refs_json
+        FROM findings
+        WHERE analysis_id = ?
+        ORDER BY created_at, finding_id
+        LIMIT 1
+        """,
+        (report_id,),
+    ).fetchone()
+    if report is None or finding is None:
+        raise SystemExit("Seed report or finding was not found.")
+    refs = json.loads(finding["evidence_refs_json"] or "[]")
+    if scanner_evidence_id not in refs:
+        refs.append(scanner_evidence_id)
+        conn.execute(
+            "UPDATE findings SET evidence_refs_json = ? WHERE analysis_id = ? AND finding_id = ?",
+            (json.dumps(refs), report_id, finding["finding_id"]),
+        )
+    cursor = conn.execute(
+        """
+        INSERT INTO evidence_items (
+            evidence_id,
+            analysis_id,
+            finding_id,
+            source_type,
+            source_ref,
+            created_at,
+            artifact,
+            location,
+            resource,
+            operation,
+            project_id,
+            workspace_id,
+            source_kind,
+            determinism_level,
+            redaction_status,
+            summary,
+            severity_hint,
+            deterministic,
+            confidence,
+            related_change_ids_json,
+            context_source_json
+        )
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        (
+            scanner_evidence_id,
+            report_id,
+            finding["finding_id"],
+            "external_scanner",
+            "semgrep://playwright/scanner-conflict",
+            datetime.now(UTC).isoformat(),
+            "semgrep-playwright.sarif",
+            "checkout-platform.yaml:1",
+            "checkout-api",
+            "flag",
+            report["project_id"],
+            report["workspace_id"],
+            "external_scanner",
+            "external_context",
+            "none",
+            "Playwright scanner evidence conflicts with deterministic evidence.",
+            "critical",
+            0,
+            0.86,
+            "[]",
+            json.dumps({
+                "source_id": "scanner:playwright",
+                "source_type": "external_scanner",
+                "source_ref": "semgrep-playwright.sarif",
+                "scope": "project",
+                "freshness_status": "current",
+                "confidence": 0.86,
+                "conflicts": ["scanner scope differs from deterministic evidence"],
+                "limitations": [],
+            }),
+        ),
+    )
+    if cursor.rowcount != 1:
+        raise SystemExit("Scanner evidence seed insert did not create a row.")
+    conn.commit()
+finally:
+    conn.close()
+`;
+  execFileSync(
+    "docker",
+    ["compose", "exec", "-T", "deploywhisper", "python", "-c", script, String(reportId), scannerEvidenceId],
+    { cwd: path.resolve(process.cwd()), stdio: "pipe" },
+  );
 }
 
 async function configureProtectedShare(request: APIRequestContext, reportId: number) {
@@ -237,6 +362,12 @@ test.describe("React report screen", () => {
   test.beforeAll(async ({ request }) => {
     const project = await ensureProject(request);
     report = await seedReport(request, project);
+    injectScannerConflict(report.id);
+    const seededReport = await apiJson<ApiEnvelope<ReportDetail>>(
+      request.get(`/api/v1/analyses/${report.id}`),
+    );
+    expect(seededReport.data.share_summary.json_payload.scanner_conflicts?.length ?? 0).toBeGreaterThan(0);
+    report = seededReport.data;
     await configureProtectedShare(request, report.id);
   });
 
@@ -343,5 +474,30 @@ test.describe("React report screen", () => {
     await expect(page.getByRole("heading").first()).toBeVisible();
     await expect(page.getByRole("button", { name: /Copy briefing/i })).toHaveCount(0);
     await expect(page.getByRole("link", { name: /Compare/i })).toBeVisible();
+  });
+
+  test("renders scanner conflicts only when the backend report provides them", async ({ page, request }) => {
+    const detail = await apiJson<ApiEnvelope<ReportDetail>>(
+      request.get(`/api/v1/analyses/${report.id}`),
+    );
+    const conflicts = detail.data.share_summary.json_payload.scanner_conflicts ?? [];
+
+    await openReport(page, report.id);
+    await clickTab(page, "Confidence");
+    expect(conflicts.length).toBeGreaterThan(0);
+
+    const conflict = conflicts[0];
+    await expect(page.getByText("SCANNER CONFLICTS")).toBeVisible();
+    await expect(page.getByText(conflict.scanner_source).first()).toBeVisible();
+    await expect(page.getByText(conflict.deterministic_source).first()).toBeVisible();
+    await expect(
+      page.getByText(
+        `scanner ${conflict.scanner_freshness} - deterministic ${conflict.deterministic_freshness}`,
+      ).first(),
+    ).toBeVisible();
+    await expect(page.getByText(conflict.confidence_impact).first()).toBeVisible();
+    await expect(
+      page.getByText(conflict.recommended_verification).first(),
+    ).toBeVisible();
   });
 });

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -5,6 +5,7 @@ const baseURL = process.env.BASE_URL ?? "http://127.0.0.1:8080";
 export default defineConfig({
   testDir: "./e2e",
   timeout: 5 * 60 * 1000,
+  workers: 1,
   expect: {
     timeout: 15_000,
   },

--- a/frontend/src/api/report.ts
+++ b/frontend/src/api/report.ts
@@ -24,8 +24,11 @@ export function getReportDetail(reportId: number, scope: ReportScope = {}): Prom
   return requestData<ReportDetail>(reportPath(reportId, scope));
 }
 
-export function unlockSharedReport(reportId: number, password: string): Promise<ReportDetail> {
-  return requestData<ReportDetail>(`/api/v1/analyses/${reportId}/shared/unlock`, {
+export function unlockSharedReport(reportId: number, password: string, scope: ReportScope = {}): Promise<ReportDetail> {
+  const path = scope.comparePrevious
+    ? `/api/v1/analyses/${reportId}/shared/unlock?compare=previous`
+    : `/api/v1/analyses/${reportId}/shared/unlock`;
+  return requestData<ReportDetail>(path, {
     method: "POST",
     body: JSON.stringify({ password }),
     headers: {

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -3547,6 +3547,54 @@ export interface components {
              */
             evidence_label?: string | null;
         };
+        /** ShareSummaryScannerConflictData */
+        ShareSummaryScannerConflictData: {
+            /**
+             * Finding Id
+             * @description Finding with conflicting scanner context
+             */
+            finding_id: string;
+            /**
+             * Finding Title
+             * @description Reviewer-facing finding title
+             */
+            finding_title: string;
+            /**
+             * Scanner Source
+             * @description Scanner evidence source reference
+             */
+            scanner_source: string;
+            /**
+             * Scanner Freshness
+             * @description Scanner source freshness status
+             */
+            scanner_freshness: string;
+            /**
+             * Deterministic Source
+             * @description DeployWhisper deterministic evidence source
+             */
+            deterministic_source: string;
+            /**
+             * Deterministic Freshness
+             * @description DeployWhisper deterministic source freshness status
+             */
+            deterministic_freshness: string;
+            /**
+             * Conflict Summary
+             * @description Short conflict explanation
+             */
+            conflict_summary: string;
+            /**
+             * Confidence Impact
+             * @description How the conflict affects confidence interpretation
+             */
+            confidence_impact: string;
+            /**
+             * Recommended Verification
+             * @description Reviewer action for resolving the conflict
+             */
+            recommended_verification: string;
+        };
         /** ShareSummaryJsonPayloadData */
         ShareSummaryJsonPayloadData: {
             /**
@@ -3615,6 +3663,11 @@ export interface components {
              * @description How external scanner context should be interpreted
              */
             external_evidence_summary?: string | null;
+            /**
+             * Scanner Conflicts
+             * @description Scanner-vs-deterministic/context conflicts requiring review
+             */
+            scanner_conflicts?: components["schemas"]["ShareSummaryScannerConflictData"][];
             /**
              * Blast Radius Summary
              * @description Concise blast-radius summary
@@ -5147,7 +5200,9 @@ export interface operations {
     };
     unlock_shared_analysis_api_v1_analyses__report_id__shared_unlock_post: {
         parameters: {
-            query?: never;
+            query?: {
+                compare?: string | null;
+            };
             header?: never;
             path: {
                 report_id: number;

--- a/frontend/src/screens/Report.test.tsx
+++ b/frontend/src/screens/Report.test.tsx
@@ -411,6 +411,54 @@ describe("ReportScreen", () => {
     expect(markup).not.toContain("External evidence</span><span class=\"dw-cross-tool");
   });
 
+  it("renders scanner conflicts with both sources and verification guidance", () => {
+    const conflictReport = {
+      ...report,
+      share_summary: {
+        ...report.share_summary,
+        json_payload: {
+          ...report.share_summary.json_payload,
+          scanner_conflicts: [
+            {
+              finding_id: "finding-ingress",
+              finding_title: "Ingress exposes checkout service",
+              scanner_source: "semgrep://results/sg-1",
+              scanner_freshness: "current",
+              deterministic_source: "ev-ingress",
+              deterministic_freshness: "current",
+              conflict_summary: "Scanner severity high differs from DeployWhisper severity medium.",
+              confidence_impact: "Scanner confidence high; DeployWhisper confidence remains medium.",
+              recommended_verification: "Review scanner evidence against deterministic evidence before acting.",
+            },
+            {
+              finding_id: "finding-ingress",
+              finding_title: "Ingress exposes checkout service",
+              scanner_source: "semgrep://results/sg-1",
+              scanner_freshness: "current",
+              deterministic_source: "ev-topology",
+              deterministic_freshness: "stale",
+              conflict_summary: "Scanner freshness is current while deterministic evidence freshness is stale.",
+              confidence_impact: "Scanner confidence high; DeployWhisper confidence remains medium.",
+              recommended_verification: "Review scanner evidence against deterministic evidence before acting.",
+            },
+          ],
+        },
+      },
+    } satisfies ReportDetail;
+
+    const markup = renderReport("/reports/77?private=1&tab=confidence", conflictReport);
+
+    expect(markup).toContain("SCANNER CONFLICTS");
+    expect(markup).toContain("Ingress exposes checkout service");
+    expect(markup).toContain("semgrep://results/sg-1");
+    expect(markup).toContain("ev-ingress");
+    expect(markup).toContain("ev-topology");
+    expect(markup).toContain("scanner current - deterministic current");
+    expect(markup).toContain("scanner current - deterministic stale");
+    expect(markup).toContain("Scanner confidence high; DeployWhisper confidence remains medium.");
+    expect(markup).toContain("Review scanner evidence against deterministic evidence before acting.");
+  });
+
   it("keeps legacy fallback labels aligned with linked evidence provenance", () => {
     const legacyReport = {
       ...report,

--- a/frontend/src/screens/Report.tsx
+++ b/frontend/src/screens/Report.tsx
@@ -257,6 +257,10 @@ function evidenceSummaryLabel(totalCount: number, externalCount: number) {
   return evidenceItemCountLabel(totalCount);
 }
 
+function scannerConflicts(report: ReportDetail) {
+  return report.share_summary.json_payload.scanner_conflicts ?? [];
+}
+
 function findingCounts(report: ReportDetail) {
   const findings = getFindings(report);
   const high = findings.filter((finding) => ["high", "critical"].includes(finding.severity)).length;
@@ -286,18 +290,20 @@ function Toast({ message }: { message: string | null }) {
 
 function PasswordGate({
   reportId,
+  comparePrevious,
   onUnlocked,
 }: {
   reportId: number;
-  onUnlocked: () => void;
+  comparePrevious: boolean;
+  onUnlocked: (report: ReportDetail) => void;
 }) {
   const [password, setPassword] = useState("");
   const [error, setError] = useState<string | null>(null);
   const mutation = useMutation({
-    mutationFn: () => unlockSharedReport(reportId, password),
-    onSuccess: () => {
+    mutationFn: () => unlockSharedReport(reportId, password, { comparePrevious }),
+    onSuccess: (report) => {
       setError(null);
-      onUnlocked();
+      onUnlocked(report);
     },
     onError: () => setError("Incorrect password. Try again."),
   });
@@ -640,6 +646,7 @@ function ConfidenceTab({ report }: { report: ReportDetail }) {
   const evidenceItems = getEvidenceItems(report);
   const evidenceCounts = evidenceSummaryCounts(report, evidenceItems);
   const evidenceRegisterTitle = evidenceSummaryLabel(evidenceCounts.total, evidenceCounts.external);
+  const conflicts = scannerConflicts(report);
   const ledgerCard = (title: string, items: string[], hot = false) => (
     <Card eyebrow="CONFIDENCE LEDGER" title={title}>
       <ol className="dw-ledger-list">
@@ -659,6 +666,25 @@ function ConfidenceTab({ report }: { report: ReportDetail }) {
         {ledgerCard("Why not lower", ledger.why_not_lower ?? [], true)}
         {ledgerCard("Why not higher", ledger.why_not_higher ?? [])}
       </div>
+      {conflicts.length > 0 && (
+        <Card eyebrow="SCANNER CONFLICTS" title={`${conflicts.length} source ${conflicts.length === 1 ? "conflict" : "conflicts"}`}>
+          <div className="dw-evidence-register">
+            {conflicts.map((conflict, index) => (
+              <div key={`${conflict.finding_id}-${conflict.scanner_source}-${conflict.deterministic_source}-${index}`}>
+                <span>{conflict.finding_title}</span>
+                <MonoRef>{conflict.scanner_source}</MonoRef>
+                <p>{conflict.conflict_summary}</p>
+                <em>
+                  scanner {conflict.scanner_freshness} - deterministic {conflict.deterministic_freshness}
+                </em>
+                <p>{conflict.confidence_impact}</p>
+                <p>{conflict.recommended_verification}</p>
+                <MonoRef>{conflict.deterministic_source}</MonoRef>
+              </div>
+            ))}
+          </div>
+        </Card>
+      )}
       <Card eyebrow="EVIDENCE REGISTER" title={evidenceRegisterTitle}>
         <div className="dw-evidence-register">
           {evidenceItems.length === 0 && evidenceCounts.total > 0 ? (
@@ -1006,10 +1032,12 @@ export function ReportScreen() {
   const [activeTab, setActiveTab] = useState(searchParams.get("tab") || "overview");
   const [toast, setToast] = useState<string | null>(null);
   const comparePrevious = searchParams.get("compare") === "previous";
+  const queryClient = useQueryClient();
+  const reportQueryKey = ["report", reportId, publicView, comparePrevious];
 
   const reportQuery = useQuery({
     enabled: Number.isFinite(reportId),
-    queryKey: ["report", reportId, publicView, comparePrevious],
+    queryKey: reportQueryKey,
     queryFn: () => getReportDetail(reportId, { publicView, comparePrevious }),
     retry: false,
   });
@@ -1026,7 +1054,13 @@ export function ReportScreen() {
     return <ReportLoading />;
   }
   if (reportQuery.error instanceof ApiClientError && reportQuery.error.status === 401 && publicView) {
-    return <PasswordGate reportId={reportId} onUnlocked={() => void reportQuery.refetch()} />;
+    return (
+      <PasswordGate
+        comparePrevious={comparePrevious}
+        reportId={reportId}
+        onUnlocked={(report) => queryClient.setQueryData(reportQueryKey, report)}
+      />
+    );
   }
   if (reportQuery.isError || !reportQuery.data) {
     return (

--- a/services/analysis_service.py
+++ b/services/analysis_service.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import html
 import json
 import math
 from datetime import UTC, datetime
@@ -276,6 +277,26 @@ class ShareSummaryContext(BaseModel):
     summary: str = Field(..., description="Short context completeness summary")
 
 
+class ShareSummaryScannerConflict(BaseModel):
+    finding_id: str = Field(..., description="Finding with conflicting scanner context")
+    finding_title: str = Field(..., description="Reviewer-facing finding title")
+    scanner_source: str = Field(..., description="Scanner evidence source reference")
+    scanner_freshness: str = Field(..., description="Scanner source freshness status")
+    deterministic_source: str = Field(
+        ..., description="DeployWhisper deterministic evidence source"
+    )
+    deterministic_freshness: str = Field(
+        ..., description="DeployWhisper deterministic source freshness status"
+    )
+    conflict_summary: str = Field(..., description="Short conflict explanation")
+    confidence_impact: str = Field(
+        ..., description="How the conflict affects confidence interpretation"
+    )
+    recommended_verification: str = Field(
+        ..., description="Reviewer action for resolving the conflict"
+    )
+
+
 class ShareSummaryJsonPayload(BaseModel):
     version: str = Field(default="v1", description="Share-summary payload version")
     report_schema_version: str = Field(
@@ -306,6 +327,10 @@ class ShareSummaryJsonPayload(BaseModel):
     external_evidence_summary: str | None = Field(
         default=None,
         description="How external scanner context should be interpreted",
+    )
+    scanner_conflicts: list[ShareSummaryScannerConflict] = Field(
+        default_factory=list,
+        description="Scanner-vs-deterministic/context conflicts requiring review",
     )
     blast_radius_summary: str = Field(..., description="Concise blast-radius summary")
     rollback_summary: str = Field(..., description="Concise rollback summary")
@@ -1498,18 +1523,32 @@ def _finding_evidence_count(
 def _finding_evidence_items(
     finding: dict, evidence_items: list[dict[str, object]]
 ) -> list[dict[str, object]]:
-    finding_id = finding.get("finding_id")
-    matched = [item for item in evidence_items if item.get("finding_id") == finding_id]
+    finding_id = str(finding.get("finding_id") or "").strip()
+    matched = (
+        [
+            item
+            for item in evidence_items
+            if str(item.get("finding_id") or "").strip() == finding_id
+        ]
+        if finding_id
+        else []
+    )
     refs = {str(ref) for ref in finding.get("evidence_refs") or []}
     ref_items = [
         item for item in evidence_items if str(item.get("evidence_id") or "") in refs
     ]
-    merged = {
-        str(item.get("evidence_id") or ""): item
-        for item in [*matched, *ref_items]
-        if str(item.get("evidence_id") or "")
-    }
-    return list(merged.values())
+    merged: list[dict[str, object]] = []
+    seen: set[tuple[str, str | int]] = set()
+    for item in [*matched, *ref_items]:
+        evidence_id = str(item.get("evidence_id") or "").strip()
+        identity: tuple[str, str | int] = (
+            ("evidence_id", evidence_id) if evidence_id else ("object", id(item))
+        )
+        if identity in seen:
+            continue
+        seen.add(identity)
+        merged.append(item)
+    return merged
 
 
 def _is_external_scanner_evidence(item: dict[str, object]) -> bool:
@@ -1777,6 +1816,419 @@ def _external_scanner_evidence_summary(count: int) -> str | None:
     )
 
 
+def _evidence_context_source(item: dict[str, object]) -> dict[str, object]:
+    context_source = item.get("context_source")
+    return context_source if isinstance(context_source, dict) else {}
+
+
+def _evidence_freshness(item: dict[str, object]) -> str:
+    context_source = _evidence_context_source(item)
+    freshness = str(context_source.get("freshness_status") or "").strip().lower()
+    return freshness or "unknown"
+
+
+def _evidence_severity_signal(item: dict[str, object]) -> str:
+    for key in ("severity_hint", "severity", "level"):
+        value = str(item.get(key) or "").strip().lower()
+        if value:
+            return value
+    return "unknown"
+
+
+def _evidence_source_detail(item: dict[str, object]) -> str:
+    for key in ("source_ref", "evidence_id", "artifact", "location"):
+        value = str(item.get(key) or "").strip()
+        if value:
+            return value
+    return "unknown source"
+
+
+def _scanner_identity_detail(item: dict[str, object], index: int) -> str:
+    evidence_id = str(item.get("evidence_id") or "").strip()
+    if evidence_id:
+        return evidence_id
+    artifact = str(item.get("artifact") or "").strip()
+    location = str(item.get("location") or "").strip()
+    if artifact or location:
+        return f"{artifact}:{location}"
+    source_ref = str(item.get("source_ref") or "").strip()
+    if source_ref:
+        return f"{source_ref}#{index}"
+    return f"scanner-evidence-{index}"
+
+
+def _context_conflict_signals(item: dict[str, object]) -> list[str]:
+    context_source = _evidence_context_source(item)
+    signals: list[str] = []
+    for field_name in ("conflicts", "limitations"):
+        values = context_source.get(field_name)
+        if values is None:
+            continue
+        if not isinstance(values, list | tuple):
+            values = [values]
+        signals.extend(str(value).strip() for value in values if str(value).strip())
+    return signals
+
+
+_CONFLICTING_FRESHNESS_STATUSES = frozenset(
+    {"conflicting", "stale", "incomplete", "missing"}
+)
+_COMPACT_SCANNER_CONFLICT_LIMIT = 1
+_PLAIN_SCANNER_CONFLICT_LIMIT = 3
+_MARKDOWN_ESCAPE_CHARS = frozenset("\\`*_{}[]()#+!|")
+
+
+def _clean_inline_text(value: object) -> str:
+    return " ".join(str(value or "").split())
+
+
+def _markdown_escape_inline(value: object) -> str:
+    escaped = html.escape(_clean_inline_text(value), quote=False)
+    return "".join(
+        f"\\{char}" if char in _MARKDOWN_ESCAPE_CHARS else char for char in escaped
+    )
+
+
+def _scanner_conflict_source_summary(
+    *,
+    scanner_conflicts: list[str],
+    deterministic_conflicts: list[str],
+) -> str | None:
+    parts: list[str] = []
+    if scanner_conflicts:
+        parts.append("scanner: " + "; ".join(scanner_conflicts[:2]))
+    if deterministic_conflicts:
+        parts.append("deterministic: " + "; ".join(deterministic_conflicts[:2]))
+    if not parts:
+        return None
+    return "Evidence carries conflicting context (" + " | ".join(parts) + ")."
+
+
+def _freshness_conflict_summary(
+    *, scanner_freshness: str, deterministic_freshness: str
+) -> str:
+    if scanner_freshness == deterministic_freshness:
+        return (
+            "Scanner and deterministic evidence freshness are both "
+            f"{scanner_freshness}."
+        )
+    return (
+        f"Scanner freshness is {scanner_freshness} while deterministic "
+        f"evidence freshness is {deterministic_freshness}."
+    )
+
+
+def _scanner_conflict_summary(
+    *,
+    scanner_severity: str,
+    finding_severity: str,
+    deterministic_severity: str,
+    scanner_freshness: str,
+    deterministic_freshness: str,
+    scanner_context_conflicts: list[str],
+    deterministic_context_conflicts: list[str],
+    has_severity_conflict: bool,
+    has_deterministic_severity_conflict: bool,
+    has_freshness_conflict: bool,
+) -> str:
+    parts: list[str] = []
+    if has_severity_conflict:
+        parts.append(
+            f"Scanner severity {scanner_severity} differs from "
+            f"DeployWhisper severity {finding_severity}."
+        )
+    if has_deterministic_severity_conflict:
+        parts.append(
+            f"Scanner severity {scanner_severity} differs from "
+            f"deterministic evidence severity {deterministic_severity}."
+        )
+    source_summary = _scanner_conflict_source_summary(
+        scanner_conflicts=scanner_context_conflicts,
+        deterministic_conflicts=deterministic_context_conflicts,
+    )
+    if source_summary is not None:
+        parts.append(source_summary)
+    if has_freshness_conflict:
+        parts.append(
+            _freshness_conflict_summary(
+                scanner_freshness=scanner_freshness,
+                deterministic_freshness=deterministic_freshness,
+            )
+        )
+    return " ".join(parts)
+
+
+def _share_scanner_conflict_detail(
+    conflict: ShareSummaryScannerConflict,
+    *,
+    summary_limit: int,
+    source_limit: int | None = None,
+    markdown: bool = False,
+) -> str:
+    format_text = _markdown_escape_inline if markdown else _clean_inline_text
+    finding_label = _clean_inline_text(conflict.finding_title)
+    if conflict.finding_id and conflict.finding_id not in finding_label:
+        finding_label = f"{finding_label} ({conflict.finding_id})"
+    conflict_summary = _shorten(
+        _clean_inline_text(conflict.conflict_summary), summary_limit
+    )
+    scanner_source = _clean_inline_text(conflict.scanner_source)
+    deterministic_source = _clean_inline_text(conflict.deterministic_source)
+    if source_limit is not None:
+        scanner_source = _shorten(scanner_source, source_limit)
+        deterministic_source = _shorten(deterministic_source, source_limit)
+    return (
+        f"Finding: {format_text(finding_label)}. "
+        f"{format_text(conflict_summary)} "
+        f"Scanner source: {format_text(scanner_source)} "
+        f"({format_text(conflict.scanner_freshness)}); deterministic source: "
+        f"{format_text(deterministic_source)} "
+        f"({format_text(conflict.deterministic_freshness)}). "
+        f"Verification: {format_text(conflict.recommended_verification)} "
+        f"{format_text(conflict.confidence_impact)}"
+    )
+
+
+def _scanner_conflict_priority(
+    conflict: ShareSummaryScannerConflict,
+) -> tuple[int, int, int]:
+    summary = conflict.conflict_summary.lower()
+    severity_priority = (
+        2 if "scanner severity" in summary and "differs" in summary else 0
+    )
+    freshness_priority = max(
+        (
+            {
+                "conflicting": 4,
+                "missing": 3,
+                "stale": 2,
+                "incomplete": 2,
+                "unknown": 1,
+            }.get(status, 0)
+            for status in (
+                conflict.scanner_freshness.lower(),
+                conflict.deterministic_freshness.lower(),
+            )
+        ),
+        default=0,
+    )
+    context_priority = 1 if "conflicting context" in summary else 0
+    return severity_priority, freshness_priority, context_priority
+
+
+def _prioritized_scanner_conflicts(
+    scanner_conflicts: list[ShareSummaryScannerConflict],
+) -> list[ShareSummaryScannerConflict]:
+    return [
+        conflict
+        for _, conflict in sorted(
+            enumerate(scanner_conflicts),
+            key=lambda indexed: (
+                *_scanner_conflict_priority(indexed[1]),
+                -indexed[0],
+            ),
+            reverse=True,
+        )
+    ]
+
+
+def _share_scanner_conflict_markdown_lines(
+    scanner_conflicts: list[ShareSummaryScannerConflict],
+    *,
+    compact: bool = False,
+) -> list[str]:
+    if not scanner_conflicts:
+        return []
+    conflict_limit = (
+        _COMPACT_SCANNER_CONFLICT_LIMIT if compact else len(scanner_conflicts)
+    )
+    summary_limit = 120 if compact else 640
+    rendered_conflicts = (
+        _prioritized_scanner_conflicts(scanner_conflicts)
+        if compact
+        else scanner_conflicts
+    )
+    lines = [
+        "- Scanner conflict: "
+        + _share_scanner_conflict_detail(
+            conflict,
+            summary_limit=summary_limit,
+            source_limit=96 if compact else None,
+            markdown=True,
+        )
+        for conflict in rendered_conflicts[:conflict_limit]
+    ]
+    omitted_count = len(scanner_conflicts) - conflict_limit
+    if omitted_count > 0:
+        lines.append(
+            "- Scanner conflicts: "
+            f"{omitted_count} additional conflicts are available in the JSON "
+            "payload/report; review all before acting."
+        )
+    return lines
+
+
+def _share_scanner_conflict_plain_text(
+    scanner_conflicts: list[ShareSummaryScannerConflict],
+) -> str:
+    if not scanner_conflicts:
+        return ""
+    conflict_limit = _PLAIN_SCANNER_CONFLICT_LIMIT
+    rendered_conflicts = _prioritized_scanner_conflicts(scanner_conflicts)
+    parts = [
+        "Scanner conflict: "
+        + _share_scanner_conflict_detail(
+            conflict,
+            summary_limit=180,
+        )
+        for conflict in rendered_conflicts[:conflict_limit]
+    ]
+    omitted_count = len(scanner_conflicts) - conflict_limit
+    if omitted_count > 0:
+        parts.append(
+            f"{omitted_count} additional scanner conflicts are available in "
+            "the JSON payload/report."
+        )
+    return " ".join(parts)
+
+
+def _scanner_conflicts(report: dict) -> list[ShareSummaryScannerConflict]:
+    evidence_items = _mapping_items(report.get("evidence_items"))
+    findings = _mapping_items(report.get("findings"))
+    conflicts: list[ShareSummaryScannerConflict] = []
+    seen: set[tuple[str, str, str]] = set()
+    for finding in findings:
+        linked_items = _finding_evidence_items(finding, evidence_items)
+        scanner_items = [
+            item for item in linked_items if _is_external_scanner_evidence(item)
+        ]
+        deterministic_items = [
+            item
+            for item in linked_items
+            if _is_deploywhisper_evidence(item)
+            and _truthy_bool_signal(item.get("deterministic"))
+            and str(item.get("determinism_level") or "deterministic").lower()
+            == "deterministic"
+        ]
+        if not scanner_items or not deterministic_items:
+            continue
+        finding_severity = str(finding.get("severity") or "unknown").lower()
+        finding_confidence = _share_finding_confidence(finding.get("confidence"))
+        for scanner_index, scanner_item in enumerate(scanner_items):
+            scanner_severity = _evidence_severity_signal(scanner_item)
+            scanner_freshness = _evidence_freshness(scanner_item)
+            scanner_context_conflicts = _context_conflict_signals(scanner_item)
+            has_severity_conflict = (
+                scanner_severity != "unknown"
+                and finding_severity != "unknown"
+                and scanner_severity != finding_severity
+            )
+            scanner_source = _evidence_source_detail(scanner_item)
+            scanner_identity = _scanner_identity_detail(scanner_item, scanner_index)
+            finding_id = str(finding.get("finding_id") or "").strip()
+            finding_identity = finding_id or f"finding-object:{id(finding)}"
+            for deterministic_item in deterministic_items:
+                deterministic_severity = _evidence_severity_signal(deterministic_item)
+                deterministic_freshness = _evidence_freshness(deterministic_item)
+                deterministic_context_conflicts = _context_conflict_signals(
+                    deterministic_item
+                )
+                has_deterministic_severity_conflict = (
+                    scanner_severity != "unknown"
+                    and deterministic_severity != "unknown"
+                    and scanner_severity != deterministic_severity
+                )
+                has_freshness_conflict = scanner_freshness != deterministic_freshness
+                if not (
+                    has_severity_conflict
+                    or has_deterministic_severity_conflict
+                    or has_freshness_conflict
+                    or scanner_context_conflicts
+                    or deterministic_context_conflicts
+                ):
+                    continue
+                deterministic_source = str(
+                    deterministic_item.get("evidence_id")
+                    or _evidence_source_detail(deterministic_item)
+                )
+                conflict_key = (
+                    finding_identity,
+                    scanner_identity,
+                    deterministic_source,
+                )
+                if conflict_key in seen:
+                    continue
+                seen.add(conflict_key)
+                confidence_impact = (
+                    f"Scanner confidence impact: scanner signal is {scanner_severity}; "
+                    f"DeployWhisper confidence remains {finding_confidence:.2f} and "
+                    f"severity remains {finding_severity} under Evidence Law."
+                )
+                conflicts.append(
+                    ShareSummaryScannerConflict(
+                        finding_id=finding_id,
+                        finding_title=_shorten(
+                            str(finding.get("title") or finding_id), 96
+                        ),
+                        scanner_source=scanner_source,
+                        scanner_freshness=scanner_freshness,
+                        deterministic_source=deterministic_source,
+                        deterministic_freshness=deterministic_freshness,
+                        conflict_summary=_scanner_conflict_summary(
+                            scanner_severity=scanner_severity,
+                            finding_severity=finding_severity,
+                            deterministic_severity=deterministic_severity,
+                            scanner_freshness=scanner_freshness,
+                            deterministic_freshness=deterministic_freshness,
+                            scanner_context_conflicts=scanner_context_conflicts,
+                            deterministic_context_conflicts=(
+                                deterministic_context_conflicts
+                            ),
+                            has_severity_conflict=has_severity_conflict,
+                            has_deterministic_severity_conflict=(
+                                has_deterministic_severity_conflict
+                            ),
+                            has_freshness_conflict=has_freshness_conflict,
+                        ),
+                        confidence_impact=confidence_impact,
+                        recommended_verification=(
+                            "Review scanner evidence against deterministic evidence "
+                            "before acting."
+                        ),
+                    )
+                )
+    return conflicts
+
+
+def _redacted_scanner_conflicts(
+    scanner_conflicts: list[ShareSummaryScannerConflict],
+) -> list[ShareSummaryScannerConflict]:
+    return [
+        conflict.model_copy(
+            update={
+                "finding_id": "detail omitted",
+                "finding_title": "Finding detail omitted",
+                "scanner_source": "scanner evidence detail omitted",
+                "scanner_freshness": "detail omitted",
+                "deterministic_source": "deterministic evidence detail omitted",
+                "deterministic_freshness": "detail omitted",
+                "conflict_summary": (
+                    "Scanner evidence conflicts with deterministic evidence; "
+                    "source details are omitted for this view."
+                ),
+                "confidence_impact": (
+                    "Scanner conflict exists, but evidence detail is omitted; "
+                    "DeployWhisper confidence and severity remain evidence-law bounded."
+                ),
+                "recommended_verification": (
+                    "Open the private report or underlying evidence before acting."
+                ),
+            }
+        )
+        for conflict in scanner_conflicts
+    ]
+
+
 def _share_finding_line(finding: ShareSummaryFinding) -> str:
     label = f"[{finding.evidence_label}] " if finding.evidence_label else ""
     return (
@@ -1812,6 +2264,9 @@ def build_share_summary(
     external_evidence_summary = _external_scanner_evidence_summary(
         external_evidence_count
     )
+    scanner_conflicts = _scanner_conflicts(report)
+    if not evidence_detail_available:
+        scanner_conflicts = _redacted_scanner_conflicts(scanner_conflicts)
     evidence_status, evidence_detail = evidence_law_status(
         report, evidence_detail_available=evidence_detail_available
     )
@@ -1862,6 +2317,7 @@ def build_share_summary(
         evidence_count=evidence_count,
         external_evidence_count=external_evidence_count,
         external_evidence_summary=external_evidence_summary,
+        scanner_conflicts=scanner_conflicts,
         blast_radius_summary=blast_radius_summary,
         rollback_summary=rollback_summary,
         context_completeness=context_summary,
@@ -1877,6 +2333,7 @@ def build_share_summary(
         markdown_lines.append(
             f"- External scanner context: {external_evidence_summary}"
         )
+    markdown_lines.extend(_share_scanner_conflict_markdown_lines(scanner_conflicts))
     markdown_lines.extend(
         _share_finding_line(finding) for finding in json_payload.top_findings
     )
@@ -1912,6 +2369,12 @@ def build_share_summary(
                     if external_evidence_summary is not None
                     else []
                 ),
+                *(
+                    _share_scanner_conflict_markdown_lines(
+                        scanner_conflicts,
+                        compact=True,
+                    )
+                ),
                 *finding_lines,
                 f"- Blast radius: {_shorten(blast_radius_summary, 120)}",
                 (
@@ -1939,6 +2402,7 @@ def build_share_summary(
                 if external_evidence_summary is not None
                 else ""
             ),
+            _share_scanner_conflict_plain_text(scanner_conflicts),
             f"Blast radius: {blast_radius_summary}.",
             f"Rollback: {rollback_summary}.",
             f"Evidence Law: {evidence_status} - {evidence_detail}.",

--- a/tests/test_api/test_analyses.py
+++ b/tests/test_api/test_analyses.py
@@ -276,6 +276,95 @@ class AnalysesApiTests(unittest.TestCase):
             persisted_report=persisted_report,
         )
 
+    def _persisted_report_with_scanner_conflict(self) -> dict:
+        analysis_id = self.persisted["id"]
+        persisted_report = dict(self.persisted)
+        persisted_report.update(
+            {
+                "severity": "medium",
+                "recommendation": "caution",
+                "top_risk": "Scanner severity disagrees with deterministic proof.",
+                "narrative_opening": (
+                    "CAUTION: scanner output needs deterministic reconciliation."
+                ),
+                "findings": [
+                    {
+                        "finding_id": "finding-001",
+                        "analysis_id": analysis_id,
+                        "title": "MEDIUM: aws_security_group.main",
+                        "description": "Security group exposure should be reviewed.",
+                        "explanation": "Scanner severity disagrees with proof.",
+                        "guidance": ["Review scanner evidence before acting."],
+                        "severity": "medium",
+                        "category": "network",
+                        "deterministic": True,
+                        "confidence": 0.62,
+                        "evidence_classification": "deterministic",
+                        "evidence_refs": ["ev-det", "ev-scan"],
+                    }
+                ],
+                "evidence_items": [
+                    {
+                        "evidence_id": "ev-det",
+                        "analysis_id": analysis_id,
+                        "finding_id": "finding-001",
+                        "source_type": "artifact",
+                        "source_ref": "terraform://plan#aws_security_group.main",
+                        "artifact": "plan.json",
+                        "location": "plan.json",
+                        "resource": "aws_security_group.main",
+                        "operation": "modify",
+                        "source_kind": "artifact",
+                        "summary": "Terraform proof marks the finding medium.",
+                        "severity_hint": "medium",
+                        "deterministic": True,
+                        "determinism_level": "deterministic",
+                        "confidence": 0.9,
+                        "context_source": {
+                            "source_id": "evidence:terraform:plan",
+                            "source_type": "artifact",
+                            "source_ref": "plan.json",
+                            "scope": "project:payments",
+                            "freshness_status": "current",
+                            "confidence": 0.9,
+                            "conflicts": [],
+                            "limitations": [],
+                        },
+                    },
+                    {
+                        "evidence_id": "ev-scan",
+                        "analysis_id": analysis_id,
+                        "finding_id": "finding-001",
+                        "source_type": "external_scanner",
+                        "source_ref": "semgrep://results/api-conflict",
+                        "artifact": "semgrep.sarif",
+                        "location": "main.tf:12",
+                        "resource": "aws_security_group.main",
+                        "operation": "scan",
+                        "source_kind": "external_scanner",
+                        "summary": "Semgrep marks the same exposure high.",
+                        "severity_hint": "high",
+                        "deterministic": True,
+                        "determinism_level": "deterministic",
+                        "confidence": 0.88,
+                        "context_source": {
+                            "source_id": "scanner:semgrep:semgrep.sarif",
+                            "source_type": "external_scanner",
+                            "source_ref": "semgrep.sarif",
+                            "scope": "project:payments",
+                            "freshness_status": "current",
+                            "confidence": 0.88,
+                            "conflicts": [],
+                            "limitations": [],
+                        },
+                    },
+                ],
+                "top_risk_contributors": ["ev-det"],
+                "context_completeness": {"context_score": 0.84},
+            }
+        )
+        return persisted_report
+
     def test_list_analyses_returns_persisted_reports(self) -> None:
         response = self.client.get("/api/v1/analyses")
         self.assertEqual(response.status_code, 200)
@@ -1462,6 +1551,57 @@ class AnalysesApiTests(unittest.TestCase):
         self.assertEqual(unlocked_response.status_code, 200)
         self.assertTrue(unlocked_response.json()["data"]["share"]["redact_filenames"])
 
+    def test_unlock_shared_report_preserves_requested_previous_comparison(
+        self,
+    ) -> None:
+        report_service_module.configure_report_share(
+            self.persisted["id"],
+            password="s3cret-pass",
+            redact_filenames=True,
+        )
+        comparison_payload = {
+            "risk_score_delta": 7,
+            "summary": {"warnings": []},
+        }
+
+        with patch(
+            "api.routes.analyses.fetch_shared_report_comparison",
+            return_value=comparison_payload,
+        ) as comparison_mock:
+            response = self.client.post(
+                f"/api/v1/analyses/{self.persisted['id']}/shared/unlock?compare=previous",
+                json={"password": "s3cret-pass"},
+            )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()["data"]["comparison"], comparison_payload)
+        comparison_mock.assert_called_once_with(
+            self.persisted["id"],
+            bypass_password=True,
+            previous_bypass_password=True,
+        )
+
+    def test_unlock_shared_report_does_not_fail_when_comparison_is_unavailable(
+        self,
+    ) -> None:
+        report_service_module.configure_report_share(
+            self.persisted["id"],
+            password="s3cret-pass",
+            redact_filenames=True,
+        )
+
+        with patch(
+            "api.routes.analyses.fetch_shared_report_comparison",
+            side_effect=ValueError("comparison cannot be built"),
+        ):
+            response = self.client.post(
+                f"/api/v1/analyses/{self.persisted['id']}/shared/unlock?compare=previous",
+                json={"password": "s3cret-pass"},
+            )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIsNone(response.json()["data"]["comparison"])
+
     def test_create_analysis_masks_foreign_workspace_for_scoped_actor(self) -> None:
         allowed = project_service_module.create_project(
             project_key="payments",
@@ -1950,6 +2090,42 @@ class AnalysesApiTests(unittest.TestCase):
             [name for name, _ in raw_files],
             [".github/CODEOWNERS", "services/payments/plan.json"],
         )
+
+    def test_create_analysis_serializes_scanner_conflict_share_summary_payload(
+        self,
+    ) -> None:
+        project_service_module.create_project(
+            project_key="payments-api-conflict",
+            display_name="Payments API Conflict",
+        )
+        persisted_report = self._persisted_report_with_scanner_conflict()
+
+        with patch(
+            "api.routes.analyses.analyze_uploaded_files",
+            return_value=self._analysis_result_with_persisted_report(persisted_report),
+        ):
+            response = self.client.post(
+                "/api/v1/analyses",
+                files={"files": ("plan.json", b'{"resource_changes": []}')},
+                data={"project_key": "payments-api-conflict"},
+            )
+
+        self.assertEqual(response.status_code, 200)
+        share_summary = response.json()["data"]["share_summary"]
+        conflicts = share_summary["json_payload"]["scanner_conflicts"]
+        self.assertEqual(len(conflicts), 1)
+        self.assertEqual(
+            conflicts[0]["scanner_source"], "semgrep://results/api-conflict"
+        )
+        self.assertEqual(
+            conflicts[0]["deterministic_source"],
+            "ev-det",
+        )
+        self.assertEqual(conflicts[0]["scanner_freshness"], "current")
+        self.assertEqual(conflicts[0]["deterministic_freshness"], "current")
+        self.assertIn("Evidence Law", conflicts[0]["confidence_impact"])
+        self.assertIn("recommended_verification", conflicts[0])
+        self.assertIn("Scanner conflict", share_summary["markdown"])
 
     def test_create_analysis_does_not_trust_pathlike_filenames_without_metadata(
         self,

--- a/tests/test_cli/test_analyze.py
+++ b/tests/test_cli/test_analyze.py
@@ -19,7 +19,9 @@ import models.tables as tables_module
 import services.report_service as report_service_module
 import services.analysis_service as analysis_service_module
 import services.project_service as project_service_module
+from analysis.blast_radius import BlastRadiusResult
 from analysis.incident_matcher import IncidentMatch
+from analysis.rollback_planner import RollbackPlan
 from analysis.risk_scorer import RiskAssessment, RiskContributor
 from cli.analyze import _load_artifacts, main
 from importlib import reload
@@ -61,6 +63,201 @@ class AnalyzeCliTests(unittest.TestCase):
         os.environ.pop("APP_BASE_URL", None)
         self.tempdir.cleanup()
 
+    def _persisted_report_with_scanner_conflict(self) -> dict:
+        parse_batch = ParseBatchResult(
+            files=[
+                ParsedFileResult(
+                    file_name="plan.json",
+                    tool="terraform",
+                    status="parsed",
+                    changes=[
+                        UnifiedChange(
+                            source_file="plan.json",
+                            tool="terraform",
+                            resource_id="aws_security_group.main",
+                            action="modify",
+                            summary="Terraform changed a security group.",
+                        )
+                    ],
+                )
+            ]
+        )
+        assessment = RiskAssessment(
+            score=56,
+            severity="medium",
+            recommendation="caution",
+            top_risk="Scanner severity disagrees with deterministic proof.",
+            contributors=[
+                RiskContributor(
+                    evidence_id="ev-det",
+                    source_file="plan.json",
+                    tool="terraform",
+                    resource_id="aws_security_group.main",
+                    action="modify",
+                    contribution=20,
+                    summary="Terraform proof marks the finding medium.",
+                    severity="medium",
+                    reasoning="Terraform proof marks the finding medium.",
+                )
+            ],
+            interaction_risks=[],
+            partial_context=False,
+            warnings=[],
+        )
+        narrative = NarrativeResult(
+            opening_sentence=(
+                "CAUTION: scanner output needs deterministic reconciliation."
+            ),
+            explanation="Scanner output disagrees with deterministic proof.",
+            guidance=["Review scanner evidence before acting."],
+            degraded=False,
+            warnings=[],
+        )
+        persisted_report = report_service_module.persist_analysis_report(
+            parse_batch,
+            assessment,
+            narrative,
+        )
+        analysis_id = persisted_report["id"]
+        persisted_report.update(
+            {
+                "findings": [
+                    {
+                        "finding_id": "finding-001",
+                        "analysis_id": analysis_id,
+                        "title": "MEDIUM: aws_security_group.main",
+                        "description": "Security group exposure should be reviewed.",
+                        "explanation": "Scanner severity disagrees with proof.",
+                        "guidance": ["Review scanner evidence before acting."],
+                        "severity": "medium",
+                        "category": "network",
+                        "deterministic": True,
+                        "confidence": 0.62,
+                        "evidence_classification": "deterministic",
+                        "evidence_refs": ["ev-det", "ev-scan"],
+                    }
+                ],
+                "evidence_items": [
+                    {
+                        "evidence_id": "ev-det",
+                        "analysis_id": analysis_id,
+                        "finding_id": "finding-001",
+                        "source_type": "artifact",
+                        "source_ref": "terraform://plan#aws_security_group.main",
+                        "artifact": "plan.json",
+                        "location": "plan.json",
+                        "resource": "aws_security_group.main",
+                        "operation": "modify",
+                        "source_kind": "artifact",
+                        "summary": "Terraform proof marks the finding medium.",
+                        "severity_hint": "medium",
+                        "deterministic": True,
+                        "determinism_level": "deterministic",
+                        "confidence": 0.9,
+                        "context_source": {
+                            "source_id": "evidence:terraform:plan",
+                            "source_type": "artifact",
+                            "source_ref": "plan.json",
+                            "scope": "project:payments",
+                            "freshness_status": "current",
+                            "confidence": 0.9,
+                            "conflicts": [],
+                            "limitations": [],
+                        },
+                    },
+                    {
+                        "evidence_id": "ev-scan",
+                        "analysis_id": analysis_id,
+                        "finding_id": "finding-001",
+                        "source_type": "external_scanner",
+                        "source_ref": "semgrep://results/cli-conflict",
+                        "artifact": "semgrep.sarif",
+                        "location": "main.tf:12",
+                        "resource": "aws_security_group.main",
+                        "operation": "scan",
+                        "source_kind": "external_scanner",
+                        "summary": "Semgrep marks the same exposure high.",
+                        "severity_hint": "high",
+                        "deterministic": True,
+                        "determinism_level": "deterministic",
+                        "confidence": 0.88,
+                        "context_source": {
+                            "source_id": "scanner:semgrep:semgrep.sarif",
+                            "source_type": "external_scanner",
+                            "source_ref": "semgrep.sarif",
+                            "scope": "project:payments",
+                            "freshness_status": "current",
+                            "confidence": 0.88,
+                            "conflicts": [],
+                            "limitations": [],
+                        },
+                    },
+                ],
+                "top_risk_contributors": ["ev-det"],
+                "context_completeness": {"context_score": 0.84},
+            }
+        )
+        return persisted_report
+
+    def _analysis_result_with_persisted_report(
+        self,
+        persisted_report: dict,
+    ) -> analysis_service_module.AnalysisRunResult:
+        parse_batch = ParseBatchResult(
+            files=[
+                ParsedFileResult(
+                    file_name="plan.json",
+                    tool="terraform",
+                    status="parsed",
+                    changes=[
+                        UnifiedChange(
+                            source_file="plan.json",
+                            tool="terraform",
+                            resource_id="aws_security_group.main",
+                            action="modify",
+                            summary="Terraform changed a security group.",
+                        )
+                    ],
+                )
+            ]
+        )
+        return analysis_service_module.AnalysisRunResult(
+            parse_batch=parse_batch,
+            evidence_items=[],
+            findings=[],
+            assessment=RiskAssessment(
+                score=56,
+                severity="medium",
+                recommendation="caution",
+                top_risk="Scanner severity disagrees with deterministic proof.",
+                contributors=[],
+                interaction_risks=[],
+                partial_context=False,
+                warnings=[],
+            ),
+            blast_radius=BlastRadiusResult(
+                affected=[],
+                direct_count=0,
+                transitive_count=0,
+            ),
+            rollback_plan=RollbackPlan(
+                steps=[],
+                complexity="low",
+                complexity_score=1,
+            ),
+            incident_matches=[],
+            narrative=NarrativeResult(
+                opening_sentence=(
+                    "CAUTION: scanner output needs deterministic reconciliation."
+                ),
+                explanation="Scanner output disagrees with deterministic proof.",
+                guidance=[],
+                degraded=False,
+                warnings=[],
+            ),
+            persisted_report=persisted_report,
+        )
+
     def test_load_artifacts_preserves_relative_paths_for_common_parent(self) -> None:
         repo = Path(self.tempdir.name) / "repo"
         codeowners_path = repo / ".github" / "CODEOWNERS"
@@ -78,6 +275,57 @@ class AnalyzeCliTests(unittest.TestCase):
             [name for name, _ in artifacts],
             [".github/CODEOWNERS", "services/payments/plan.json"],
         )
+
+    def test_analyze_command_serializes_scanner_conflict_share_summary_payload(
+        self,
+    ) -> None:
+        project_service_module.create_project(
+            project_key="payments",
+            display_name="Payments",
+        )
+        artifact_path = Path(self.tempdir.name) / "plan.json"
+        artifact_path.write_text('{"resource_changes": []}', encoding="utf-8")
+        output = io.StringIO()
+        persisted_report = self._persisted_report_with_scanner_conflict()
+
+        with (
+            patch(
+                "cli.analyze.analyze_uploaded_files",
+                return_value=self._analysis_result_with_persisted_report(
+                    persisted_report
+                ),
+            ),
+            patch(
+                "sys.argv",
+                [
+                    "deploywhisper",
+                    "analyze",
+                    "--project",
+                    "payments",
+                    str(artifact_path),
+                ],
+            ),
+            redirect_stdout(output),
+        ):
+            with self.assertRaises(SystemExit) as ctx:
+                main()
+
+        self.assertEqual(ctx.exception.code, 0)
+        share_summary = json.loads(output.getvalue())["data"]["share_summary"]
+        conflicts = share_summary["json_payload"]["scanner_conflicts"]
+        self.assertEqual(len(conflicts), 1)
+        self.assertEqual(
+            conflicts[0]["scanner_source"], "semgrep://results/cli-conflict"
+        )
+        self.assertEqual(
+            conflicts[0]["deterministic_source"],
+            "ev-det",
+        )
+        self.assertEqual(conflicts[0]["scanner_freshness"], "current")
+        self.assertEqual(conflicts[0]["deterministic_freshness"], "current")
+        self.assertIn("Evidence Law", conflicts[0]["confidence_impact"])
+        self.assertIn("recommended_verification", conflicts[0])
+        self.assertIn("Scanner conflict", share_summary["markdown"])
 
     def test_load_artifacts_preserves_mixed_relative_codeowners_absolute_artifact(
         self,

--- a/tests/test_services/test_adapter_output_contract.py
+++ b/tests/test_services/test_adapter_output_contract.py
@@ -315,6 +315,59 @@ class AdapterOutputContractTests(unittest.TestCase):
         )
         self.assertIn("external scanner evidence item", summary.plain_text)
 
+    def test_adapter_contract_preserves_scanner_conflict_payload(self) -> None:
+        payload = _report_payload()
+        payload["findings"][0]["evidence_refs"].append("ev-scanner")
+        payload["evidence_items"][0]["context_source"] = {
+            "freshness_status": "current",
+        }
+        payload["evidence_items"].append(
+            {
+                "evidence_id": "ev-scanner",
+                "finding_id": "finding-001",
+                "source_type": "external_scanner",
+                "source_kind": "external_scanner",
+                "source_ref": "semgrep://results/sg-1",
+                "severity_hint": "critical",
+                "deterministic": True,
+                "determinism_level": "deterministic",
+                "context_source": {
+                    "freshness_status": "current",
+                    "conflicts": [],
+                    "limitations": [],
+                },
+            }
+        )
+        summary = build_share_summary(payload)
+
+        contract = build_adapter_output_contract(
+            summary,
+            AdapterMetadata(
+                adapter="github-actions",
+                format="pr_comment",
+                project_key="payments",
+            ),
+        )
+
+        conflicts = contract.canonical_summary.json_payload.scanner_conflicts
+        self.assertEqual(len(conflicts), 1)
+        conflict = conflicts[0]
+        self.assertEqual(conflict.finding_id, "finding-001")
+        self.assertEqual(conflict.scanner_source, "semgrep://results/sg-1")
+        self.assertEqual(conflict.scanner_freshness, "current")
+        self.assertEqual(conflict.deterministic_source, "ev-001")
+        self.assertEqual(conflict.deterministic_freshness, "current")
+        self.assertIn("critical", conflict.conflict_summary)
+        self.assertIn("Evidence Law", conflict.confidence_impact)
+        self.assertIn("Review scanner evidence", conflict.recommended_verification)
+        dumped = contract.model_dump(mode="json")
+        dumped_conflict = dumped["canonical_summary"]["json_payload"][
+            "scanner_conflicts"
+        ][0]
+        self.assertEqual(dumped_conflict["scanner_source"], "semgrep://results/sg-1")
+        self.assertEqual(dumped_conflict["deterministic_source"], "ev-001")
+        self.assertIn("scanner_conflicts", contract.model_dump_json())
+
     def test_share_summary_preserves_external_context_when_evidence_rows_omitted(
         self,
     ) -> None:

--- a/tests/test_services/test_analysis_service.py
+++ b/tests/test_services/test_analysis_service.py
@@ -2852,6 +2852,1004 @@ class AnalysisServiceTests(unittest.TestCase):
             summary.json_payload.context_completeness.label, "STRONG CONTEXT"
         )
 
+    def test_build_share_summary_surfaces_scanner_conflicts_without_overriding_severity(
+        self,
+    ) -> None:
+        report = self._share_report_payload()
+        self._satisfy_share_payload_evidence_law(report)
+        report["findings"][0]["severity"] = "medium"
+        report["findings"][0]["confidence"] = 0.62
+        report["findings"][0]["evidence_refs"].append("ev-scanner")
+        report["findings"][1]["severity"] = "low"
+        report["findings"][2]["severity"] = "low"
+        report["evidence_items"][0]["context_source"] = {
+            "freshness_status": "current",
+        }
+        report["evidence_items"][1]["context_source"] = {
+            "freshness_status": "current",
+        }
+        report["evidence_items"].append(
+            {
+                "evidence_id": "ev-scanner",
+                "finding_id": "finding-001",
+                "source_type": "external_scanner",
+                "source_kind": "external_scanner",
+                "source_ref": "semgrep://results/sg-1",
+                "artifact": "semgrep.sarif",
+                "location": "main.tf:12",
+                "resource": "aws_security_group.main",
+                "operation": "scan",
+                "summary": "Semgrep marked public ingress as high severity.",
+                "severity_hint": "high",
+                "deterministic": True,
+                "determinism_level": "deterministic",
+                "confidence": 0.9,
+                "context_source": {
+                    "source_id": "scanner:semgrep:semgrep.sarif",
+                    "source_type": "scanner",
+                    "source_ref": "semgrep.sarif",
+                    "scope": "project:payments",
+                    "freshness_status": "current",
+                    "confidence": 0.9,
+                    "conflicts": ["DeployWhisper finding severity is medium."],
+                    "limitations": [],
+                },
+            }
+        )
+
+        summary = build_share_summary(report)
+
+        self.assertEqual(summary.json_payload.top_findings[0].severity, "medium")
+        self.assertEqual(len(summary.json_payload.scanner_conflicts), 2)
+        conflict = summary.json_payload.scanner_conflicts[0]
+        self.assertEqual(conflict.finding_id, "finding-001")
+        self.assertEqual(conflict.scanner_source, "semgrep://results/sg-1")
+        self.assertEqual(conflict.scanner_freshness, "current")
+        self.assertEqual(conflict.deterministic_source, "ev-001")
+        self.assertEqual(conflict.deterministic_freshness, "current")
+        self.assertIn("high", conflict.confidence_impact)
+        self.assertIn("medium", conflict.confidence_impact)
+        self.assertIn("Review scanner evidence", conflict.recommended_verification)
+        self.assertIn("Scanner conflict", summary.markdown)
+        self.assertIn("finding-001", summary.markdown)
+        self.assertIn("semgrep://results/sg-1", summary.markdown)
+        self.assertIn("scanner confidence impact", summary.plain_text.lower())
+        self.assertIn("finding-001", summary.plain_text)
+
+    def test_build_share_summary_surfaces_stale_deterministic_conflict(
+        self,
+    ) -> None:
+        report = self._share_report_payload()
+        self._satisfy_share_payload_evidence_law(report)
+        report["findings"][0]["severity"] = "high"
+        report["findings"][0]["evidence_refs"].append("ev-scanner")
+        report["evidence_items"][0]["context_source"] = {
+            "freshness_status": "stale",
+        }
+        report["evidence_items"][1]["context_source"] = {
+            "freshness_status": "current",
+        }
+        report["evidence_items"].append(
+            {
+                "evidence_id": "ev-scanner",
+                "finding_id": "finding-001",
+                "source_type": "external_scanner",
+                "source_kind": "external_scanner",
+                "source_ref": "semgrep://results/sg-1",
+                "severity_hint": "high",
+                "deterministic": True,
+                "determinism_level": "deterministic",
+                "context_source": {
+                    "freshness_status": "current",
+                    "conflicts": [],
+                    "limitations": [],
+                },
+            }
+        )
+
+        summary = build_share_summary(report)
+
+        self.assertEqual(len(summary.json_payload.scanner_conflicts), 1)
+        conflict = summary.json_payload.scanner_conflicts[0]
+        self.assertEqual(conflict.scanner_freshness, "current")
+        self.assertEqual(conflict.deterministic_freshness, "stale")
+        self.assertIn(
+            "Scanner freshness is current while deterministic evidence freshness is stale.",
+            conflict.conflict_summary,
+        )
+
+    def test_build_share_summary_surfaces_each_conflicting_deterministic_source(
+        self,
+    ) -> None:
+        report = self._share_report_payload()
+        self._satisfy_share_payload_evidence_law(report)
+        report["findings"][0]["severity"] = "high"
+        report["findings"][0]["evidence_refs"].extend(
+            ["ev-scanner", "ev-deterministic-context"]
+        )
+        report["evidence_items"][0]["context_source"] = {
+            "freshness_status": "current",
+        }
+        report["evidence_items"][1]["context_source"] = {
+            "freshness_status": "stale",
+        }
+        report["evidence_items"].extend(
+            [
+                {
+                    "evidence_id": "ev-deterministic-context",
+                    "finding_id": "finding-001",
+                    "deterministic": True,
+                    "determinism_level": "deterministic",
+                    "context_source": {
+                        "freshness_status": "current",
+                        "conflicts": ["topology scope differs from scanner scope"],
+                    },
+                },
+                {
+                    "evidence_id": "ev-scanner",
+                    "finding_id": "finding-001",
+                    "source_type": "external_scanner",
+                    "source_kind": "external_scanner",
+                    "source_ref": "semgrep://results/sg-1",
+                    "severity_hint": "high",
+                    "deterministic": True,
+                    "determinism_level": "deterministic",
+                    "context_source": {
+                        "freshness_status": "current",
+                        "conflicts": [],
+                        "limitations": [],
+                    },
+                },
+            ]
+        )
+
+        summary = build_share_summary(report)
+
+        conflicts = summary.json_payload.scanner_conflicts
+        self.assertEqual(
+            {conflict.deterministic_source for conflict in conflicts},
+            {"ev-002", "ev-deterministic-context"},
+        )
+        by_source = {conflict.deterministic_source: conflict for conflict in conflicts}
+        self.assertEqual(by_source["ev-002"].deterministic_freshness, "stale")
+        self.assertIn(
+            "deterministic: topology scope differs from scanner scope",
+            by_source["ev-deterministic-context"].conflict_summary,
+        )
+        self.assertNotIn(
+            "ev-001",
+            {conflict.deterministic_source for conflict in conflicts},
+        )
+
+    def test_build_share_summary_surfaces_deterministic_severity_conflict(
+        self,
+    ) -> None:
+        report = self._share_report_payload()
+        self._satisfy_share_payload_evidence_law(report)
+        report["findings"][0]["severity"] = "high"
+        report["findings"][0]["evidence_refs"].append("ev-scanner")
+        report["evidence_items"][0]["severity_hint"] = "medium"
+        report["evidence_items"][0]["context_source"] = {
+            "freshness_status": "current",
+        }
+        report["evidence_items"][1]["context_source"] = {
+            "freshness_status": "current",
+        }
+        report["evidence_items"].append(
+            {
+                "evidence_id": "ev-scanner",
+                "finding_id": "finding-001",
+                "source_type": "external_scanner",
+                "source_kind": "external_scanner",
+                "source_ref": "semgrep://results/sg-1",
+                "severity_hint": "high",
+                "deterministic": True,
+                "determinism_level": "deterministic",
+                "context_source": {
+                    "freshness_status": "current",
+                    "conflicts": [],
+                    "limitations": [],
+                },
+            }
+        )
+
+        summary = build_share_summary(report)
+
+        conflicts = summary.json_payload.scanner_conflicts
+        self.assertEqual(len(conflicts), 1)
+        conflict = conflicts[0]
+        self.assertEqual(conflict.deterministic_source, "ev-001")
+        self.assertIn(
+            "Scanner severity high differs from deterministic evidence severity medium.",
+            conflict.conflict_summary,
+        )
+        self.assertEqual(summary.json_payload.top_findings[0].severity, "high")
+
+    def test_build_share_summary_keeps_all_scanner_only_deterministic_sources(
+        self,
+    ) -> None:
+        report = self._share_report_payload()
+        self._satisfy_share_payload_evidence_law(report)
+        report["findings"][0]["severity"] = "medium"
+        report["findings"][0]["evidence_refs"].append("ev-scanner")
+        for item in report["evidence_items"]:
+            item["context_source"] = {"freshness_status": "current"}
+        report["evidence_items"].append(
+            {
+                "evidence_id": "ev-scanner",
+                "finding_id": "finding-001",
+                "source_type": "external_scanner",
+                "source_kind": "external_scanner",
+                "source_ref": "semgrep://results/sg-1",
+                "severity_hint": "high",
+                "deterministic": True,
+                "determinism_level": "deterministic",
+                "context_source": {
+                    "freshness_status": "current",
+                    "conflicts": [],
+                    "limitations": [],
+                },
+            }
+        )
+
+        summary = build_share_summary(report)
+
+        self.assertEqual(
+            {
+                conflict.deterministic_source
+                for conflict in summary.json_payload.scanner_conflicts
+            },
+            {"ev-001", "ev-002"},
+        )
+
+    def test_build_share_summary_ignores_string_false_deterministic_signal(
+        self,
+    ) -> None:
+        report = self._share_report_payload()
+        self._satisfy_share_payload_evidence_law(report)
+        report["findings"][0]["severity"] = "medium"
+        report["findings"][0]["evidence_refs"].append("ev-scanner")
+        report["evidence_items"][0]["deterministic"] = "false"
+        report["evidence_items"][0]["context_source"] = {
+            "freshness_status": "current",
+        }
+        report["evidence_items"][1]["deterministic"] = False
+        report["evidence_items"][1]["context_source"] = {
+            "freshness_status": "current",
+        }
+        report["evidence_items"].append(
+            {
+                "evidence_id": "ev-scanner",
+                "finding_id": "finding-001",
+                "source_type": "external_scanner",
+                "source_kind": "external_scanner",
+                "source_ref": "semgrep://results/sg-1",
+                "severity_hint": "high",
+                "deterministic": True,
+                "determinism_level": "deterministic",
+                "context_source": {
+                    "freshness_status": "current",
+                    "conflicts": [],
+                    "limitations": [],
+                },
+            }
+        )
+
+        summary = build_share_summary(report)
+
+        self.assertEqual(summary.json_payload.scanner_conflicts, [])
+
+    def test_build_share_summary_keeps_distinct_scanner_rows_with_same_source(
+        self,
+    ) -> None:
+        report = self._share_report_payload()
+        self._satisfy_share_payload_evidence_law(report)
+        report["findings"][0]["severity"] = "high"
+        report["findings"][0]["evidence_refs"].extend(["ev-scanner-a", "ev-scanner-b"])
+        report["evidence_items"][0]["context_source"] = {
+            "freshness_status": "current",
+        }
+        report["evidence_items"][1]["context_source"] = {
+            "freshness_status": "current",
+        }
+        for scanner_id, conflict_text in (
+            ("ev-scanner-a", "scanner result A disagrees with deterministic scope"),
+            ("ev-scanner-b", "scanner result B disagrees with deterministic scope"),
+        ):
+            report["evidence_items"].append(
+                {
+                    "evidence_id": scanner_id,
+                    "finding_id": "finding-001",
+                    "source_type": "external_scanner",
+                    "source_kind": "external_scanner",
+                    "source_ref": "semgrep://results/shared-source",
+                    "severity_hint": "high",
+                    "deterministic": True,
+                    "determinism_level": "deterministic",
+                    "context_source": {
+                        "freshness_status": "current",
+                        "conflicts": [conflict_text],
+                        "limitations": [],
+                    },
+                }
+            )
+
+        summary = build_share_summary(report)
+
+        conflicts = summary.json_payload.scanner_conflicts
+        self.assertEqual(len(conflicts), 4)
+        self.assertEqual(
+            [conflict.scanner_source for conflict in conflicts],
+            [
+                "semgrep://results/shared-source",
+                "semgrep://results/shared-source",
+                "semgrep://results/shared-source",
+                "semgrep://results/shared-source",
+            ],
+        )
+        self.assertIn("scanner result A", conflicts[0].conflict_summary)
+        self.assertIn("scanner result A", conflicts[1].conflict_summary)
+        self.assertIn("scanner result B", conflicts[2].conflict_summary)
+        self.assertIn("scanner result B", conflicts[3].conflict_summary)
+
+    def test_build_share_summary_ignores_missing_only_scanner_conflict(
+        self,
+    ) -> None:
+        report = self._share_report_payload()
+        self._satisfy_share_payload_evidence_law(report)
+        report["findings"][0]["severity"] = "high"
+        report["findings"][0]["evidence_refs"].append("ev-scanner")
+        report["evidence_items"][1]["deterministic"] = False
+        report["evidence_items"].append(
+            {
+                "evidence_id": "ev-scanner",
+                "finding_id": "finding-001",
+                "source_type": "external_scanner",
+                "source_kind": "external_scanner",
+                "source_ref": "scanner://missing-freshness",
+                "severity_hint": "high",
+                "deterministic": True,
+                "determinism_level": "deterministic",
+            }
+        )
+
+        summary = build_share_summary(report)
+
+        self.assertEqual(summary.json_payload.scanner_conflicts, [])
+        self.assertNotIn("scanner://missing-freshness", summary.markdown)
+
+    def test_build_share_summary_ignores_equal_degraded_freshness_only_conflict(
+        self,
+    ) -> None:
+        report = self._share_report_payload()
+        self._satisfy_share_payload_evidence_law(report)
+        report["findings"][0]["severity"] = "high"
+        report["findings"][0]["evidence_refs"].append("ev-scanner")
+        report["evidence_items"][0]["context_source"] = {
+            "freshness_status": "Stale",
+        }
+        report["evidence_items"][1]["deterministic"] = False
+        report["evidence_items"].append(
+            {
+                "evidence_id": "ev-scanner",
+                "finding_id": "finding-001",
+                "source_type": "external_scanner",
+                "source_kind": "external_scanner",
+                "source_ref": "scanner://same-stale-freshness",
+                "severity_hint": "high",
+                "deterministic": True,
+                "determinism_level": "deterministic",
+                "context_source": {
+                    "freshness_status": "STALE",
+                },
+            }
+        )
+
+        summary = build_share_summary(report)
+
+        self.assertEqual(summary.json_payload.scanner_conflicts, [])
+        self.assertNotIn("same-stale-freshness", summary.markdown)
+
+    def test_build_share_summary_reports_unknown_when_only_one_side_has_freshness(
+        self,
+    ) -> None:
+        report = self._share_report_payload()
+        self._satisfy_share_payload_evidence_law(report)
+        report["findings"][0]["severity"] = "high"
+        report["findings"][0]["evidence_refs"].append("ev-scanner")
+        report["evidence_items"][0]["context_source"] = {
+            "freshness_status": "current",
+        }
+        report["evidence_items"][1]["deterministic"] = False
+        report["evidence_items"].append(
+            {
+                "evidence_id": "ev-scanner",
+                "finding_id": "finding-001",
+                "source_type": "external_scanner",
+                "source_kind": "external_scanner",
+                "source_ref": "scanner://missing-freshness",
+                "severity_hint": "high",
+                "deterministic": True,
+                "determinism_level": "deterministic",
+            }
+        )
+
+        summary = build_share_summary(report)
+
+        self.assertEqual(len(summary.json_payload.scanner_conflicts), 1)
+        conflict = summary.json_payload.scanner_conflicts[0]
+        self.assertEqual(conflict.scanner_freshness, "unknown")
+        self.assertEqual(conflict.deterministic_freshness, "current")
+        self.assertIn("scanner://missing-freshness", summary.markdown)
+
+    def test_build_share_summary_normalizes_freshness_case_for_conflicts(
+        self,
+    ) -> None:
+        report = self._share_report_payload()
+        self._satisfy_share_payload_evidence_law(report)
+        report["findings"][0]["severity"] = "high"
+        report["findings"][0]["evidence_refs"].append("ev-scanner")
+        report["evidence_items"][0]["context_source"] = {
+            "freshness_status": "Current",
+        }
+        report["evidence_items"][1]["deterministic"] = False
+        report["evidence_items"].append(
+            {
+                "evidence_id": "ev-scanner",
+                "finding_id": "finding-001",
+                "source_type": "external_scanner",
+                "source_kind": "external_scanner",
+                "source_ref": "scanner://case-normalized-freshness",
+                "severity_hint": "high",
+                "deterministic": True,
+                "determinism_level": "deterministic",
+                "context_source": {
+                    "freshness_status": "current",
+                },
+            }
+        )
+
+        summary = build_share_summary(report)
+
+        self.assertEqual(summary.json_payload.scanner_conflicts, [])
+        self.assertNotIn("case-normalized-freshness", summary.markdown)
+
+    def test_build_share_summary_compact_markdown_prioritizes_severity_conflict(
+        self,
+    ) -> None:
+        report = self._share_report_payload()
+        self._satisfy_share_payload_evidence_law(report)
+        report["findings"][0]["severity"] = "medium"
+        report["findings"][0]["evidence_refs"].extend(
+            ["ev-scanner-context", "ev-scanner-priority"]
+        )
+        report["context_completeness"] = {
+            "context_score": 0.5,
+            "uncertainty": "Reviewer context remains intentionally verbose. " * 80,
+        }
+        report["evidence_items"][0]["severity_hint"] = "medium"
+        report["evidence_items"][0]["context_source"] = {
+            "freshness_status": "current",
+        }
+        report["evidence_items"][1]["deterministic"] = False
+        report["evidence_items"].extend(
+            [
+                {
+                    "evidence_id": "ev-scanner-context",
+                    "finding_id": "finding-001",
+                    "source_type": "external_scanner",
+                    "source_kind": "external_scanner",
+                    "source_ref": "semgrep://results/context-only",
+                    "severity_hint": "medium",
+                    "deterministic": True,
+                    "determinism_level": "deterministic",
+                    "context_source": {
+                        "freshness_status": "current",
+                        "conflicts": ["scanner scope needs reviewer reconciliation"],
+                        "limitations": [],
+                    },
+                },
+                {
+                    "evidence_id": "ev-scanner-priority",
+                    "finding_id": "finding-001",
+                    "source_type": "external_scanner",
+                    "source_kind": "external_scanner",
+                    "source_ref": "semgrep://results/priority-severity",
+                    "severity_hint": "high",
+                    "deterministic": True,
+                    "determinism_level": "deterministic",
+                    "context_source": {
+                        "freshness_status": "current",
+                        "conflicts": [],
+                        "limitations": [],
+                    },
+                },
+            ]
+        )
+
+        summary = build_share_summary(report)
+
+        self.assertLessEqual(len(summary.markdown), 1500)
+        self.assertIn("semgrep://results/priority-severity", summary.markdown)
+        self.assertNotIn("semgrep://results/context-only (current)", summary.markdown)
+
+    def test_build_share_summary_escapes_scanner_conflict_markdown(self) -> None:
+        report = self._share_report_payload()
+        self._satisfy_share_payload_evidence_law(report)
+        report["findings"][0]["severity"] = "medium"
+        report["findings"][0]["evidence_refs"].append("ev-scanner")
+        report["evidence_items"][0]["severity_hint"] = "medium"
+        report["evidence_items"][0]["context_source"] = {
+            "freshness_status": "current",
+        }
+        report["evidence_items"][1]["deterministic"] = False
+        report["evidence_items"].append(
+            {
+                "evidence_id": "ev-scanner",
+                "finding_id": "finding-001",
+                "source_type": "external_scanner",
+                "source_kind": "external_scanner",
+                "source_ref": "scanner://[bad](https://example.test)<b>&raw</b>\n@here",
+                "severity_hint": "medium",
+                "deterministic": True,
+                "determinism_level": "deterministic",
+                "context_source": {
+                    "freshness_status": "current",
+                    "conflicts": ["scanner says **override severity** <i>&now</i>"],
+                    "limitations": [],
+                },
+            }
+        )
+
+        summary = build_share_summary(report)
+
+        self.assertNotIn("[bad](https://example.test)", summary.markdown)
+        self.assertNotIn("scanner says **override severity**", summary.markdown)
+        self.assertNotIn("<b>", summary.markdown)
+        self.assertNotIn("<i>", summary.markdown)
+        self.assertIn(
+            "scanner://\\[bad\\]\\(https://example.test\\)&lt;b&gt;&amp;raw&lt;/b&gt; @here",
+            summary.markdown,
+        )
+        self.assertIn(
+            "scanner says \\*\\*override severity\\*\\* &lt;i&gt;&amp;now&lt;/i&gt;",
+            summary.markdown,
+        )
+        self.assertNotIn("\n@here", summary.plain_text)
+
+    def test_build_share_summary_redacts_scanner_conflicts_without_evidence_detail(
+        self,
+    ) -> None:
+        report = self._share_report_payload()
+        self._satisfy_share_payload_evidence_law(report)
+        report["findings"][0]["severity"] = "medium"
+        report["findings"][0]["evidence_refs"].append("ev-scanner")
+        report["evidence_items"][0]["context_source"] = {
+            "freshness_status": "current",
+        }
+        report["evidence_items"][1]["deterministic"] = False
+        report["evidence_items"].append(
+            {
+                "evidence_id": "ev-scanner",
+                "finding_id": "finding-001",
+                "source_type": "external_scanner",
+                "source_kind": "external_scanner",
+                "source_ref": "semgrep://results/hidden-when-detail-omitted",
+                "severity_hint": "high",
+                "deterministic": True,
+                "determinism_level": "deterministic",
+                "context_source": {
+                    "freshness_status": "current",
+                    "conflicts": [],
+                    "limitations": [],
+                },
+            }
+        )
+
+        summary = build_share_summary(report, evidence_detail_available=False)
+
+        self.assertEqual(len(summary.json_payload.scanner_conflicts), 1)
+        conflict = summary.json_payload.scanner_conflicts[0]
+        self.assertEqual(conflict.scanner_source, "scanner evidence detail omitted")
+        self.assertEqual(
+            conflict.deterministic_source, "deterministic evidence detail omitted"
+        )
+        self.assertEqual(conflict.finding_id, "detail omitted")
+        self.assertEqual(conflict.finding_title, "Finding detail omitted")
+        self.assertEqual(conflict.scanner_freshness, "detail omitted")
+        self.assertEqual(conflict.deterministic_freshness, "detail omitted")
+        self.assertIn("source details are omitted", conflict.conflict_summary)
+        self.assertNotIn("hidden-when-detail-omitted", summary.markdown)
+        self.assertNotIn("hidden-when-detail-omitted", summary.plain_text)
+        self.assertIn("scanner evidence detail omitted", summary.markdown)
+        self.assertIn("scanner evidence detail omitted", summary.plain_text)
+
+    def test_build_share_summary_surfaces_context_limitations_as_conflicts(
+        self,
+    ) -> None:
+        report = self._share_report_payload()
+        self._satisfy_share_payload_evidence_law(report)
+        report["findings"][0]["severity"] = "medium"
+        report["findings"][0]["evidence_refs"].append("ev-scanner")
+        report["evidence_items"][0]["severity_hint"] = "medium"
+        report["evidence_items"][0]["context_source"] = {
+            "freshness_status": "current",
+        }
+        report["evidence_items"][1]["deterministic"] = False
+        report["evidence_items"].append(
+            {
+                "evidence_id": "ev-scanner",
+                "finding_id": "finding-001",
+                "source_type": "external_scanner",
+                "source_kind": "external_scanner",
+                "source_ref": "semgrep://results/limitation-only",
+                "severity_hint": "medium",
+                "deterministic": True,
+                "determinism_level": "deterministic",
+                "context_source": {
+                    "freshness_status": "current",
+                    "limitations": ["scanner scope excludes generated manifests"],
+                },
+            }
+        )
+
+        summary = build_share_summary(report)
+
+        self.assertEqual(len(summary.json_payload.scanner_conflicts), 1)
+        conflict = summary.json_payload.scanner_conflicts[0]
+        self.assertIn(
+            "scanner scope excludes generated manifests", conflict.conflict_summary
+        )
+        self.assertIn("limitation-only", summary.markdown)
+
+    def test_build_share_summary_normalizes_scalar_context_conflict_signals(
+        self,
+    ) -> None:
+        report = self._share_report_payload()
+        self._satisfy_share_payload_evidence_law(report)
+        report["findings"][0]["severity"] = "medium"
+        report["findings"][0]["evidence_refs"].append("ev-scanner")
+        report["evidence_items"][0]["severity_hint"] = "medium"
+        report["evidence_items"][0]["context_source"] = {
+            "freshness_status": "current",
+            "conflicts": "deterministic scalar conflict",
+        }
+        report["evidence_items"][1]["deterministic"] = False
+        report["evidence_items"].append(
+            {
+                "evidence_id": "ev-scanner",
+                "finding_id": "finding-001",
+                "source_type": "external_scanner",
+                "source_kind": "external_scanner",
+                "source_ref": "semgrep://results/scalar-context",
+                "severity_hint": "medium",
+                "deterministic": True,
+                "determinism_level": "deterministic",
+                "context_source": {
+                    "freshness_status": "current",
+                    "limitations": "scanner scalar limitation",
+                },
+            }
+        )
+
+        summary = build_share_summary(report)
+
+        self.assertEqual(len(summary.json_payload.scanner_conflicts), 1)
+        conflict = summary.json_payload.scanner_conflicts[0]
+        self.assertIn("deterministic scalar conflict", conflict.conflict_summary)
+        self.assertIn("scanner scalar limitation", conflict.conflict_summary)
+        self.assertIn("scalar-context", summary.markdown)
+
+    def test_build_share_summary_isolates_idless_findings_by_evidence_refs(
+        self,
+    ) -> None:
+        report = self._share_report_payload()
+        self._satisfy_share_payload_evidence_law(report)
+        report["findings"] = [
+            {
+                "title": "First idless finding",
+                "severity": "medium",
+                "confidence": 0.7,
+                "evidence_refs": ["det-a", "scan-a"],
+            },
+            {
+                "title": "Second idless finding",
+                "severity": "medium",
+                "confidence": 0.7,
+                "evidence_refs": ["det-b", "scan-b"],
+            },
+        ]
+        report["evidence_items"] = [
+            {
+                "evidence_id": "det-a",
+                "source_ref": "terraform://a",
+                "severity_hint": "medium",
+                "deterministic": True,
+                "determinism_level": "deterministic",
+                "context_source": {"freshness_status": "current"},
+            },
+            {
+                "evidence_id": "scan-a",
+                "source_type": "external_scanner",
+                "source_kind": "external_scanner",
+                "source_ref": "semgrep://results/a",
+                "severity_hint": "high",
+                "deterministic": True,
+                "determinism_level": "deterministic",
+                "context_source": {"freshness_status": "current"},
+            },
+            {
+                "evidence_id": "det-b",
+                "source_ref": "terraform://b",
+                "severity_hint": "medium",
+                "deterministic": True,
+                "determinism_level": "deterministic",
+                "context_source": {"freshness_status": "current"},
+            },
+            {
+                "evidence_id": "scan-b",
+                "source_type": "external_scanner",
+                "source_kind": "external_scanner",
+                "source_ref": "semgrep://results/b",
+                "severity_hint": "high",
+                "deterministic": True,
+                "determinism_level": "deterministic",
+                "context_source": {"freshness_status": "current"},
+            },
+        ]
+
+        summary = build_share_summary(report)
+
+        conflict_pairs = {
+            (
+                conflict.finding_title,
+                conflict.scanner_source,
+                conflict.deterministic_source,
+            )
+            for conflict in summary.json_payload.scanner_conflicts
+        }
+        self.assertEqual(
+            conflict_pairs,
+            {
+                ("First idless finding", "semgrep://results/a", "det-a"),
+                ("Second idless finding", "semgrep://results/b", "det-b"),
+            },
+        )
+
+    def test_build_share_summary_compares_idless_linked_evidence_rows(self) -> None:
+        report = self._share_report_payload()
+        self._satisfy_share_payload_evidence_law(report)
+        report["findings"][0]["severity"] = "medium"
+        report["findings"][0]["evidence_refs"] = ["ev-scanner"]
+        report["evidence_items"] = [
+            {
+                "finding_id": "finding-001",
+                "source_ref": "terraform://plan#aws_security_group.main",
+                "severity_hint": "medium",
+                "deterministic": True,
+                "determinism_level": "deterministic",
+                "context_source": {
+                    "freshness_status": "current",
+                },
+            },
+            {
+                "evidence_id": "ev-scanner",
+                "finding_id": "finding-001",
+                "source_type": "external_scanner",
+                "source_kind": "external_scanner",
+                "source_ref": "semgrep://results/idless-linked-row",
+                "severity_hint": "high",
+                "deterministic": True,
+                "determinism_level": "deterministic",
+                "context_source": {
+                    "freshness_status": "current",
+                    "conflicts": [],
+                    "limitations": [],
+                },
+            },
+        ]
+
+        summary = build_share_summary(report)
+
+        self.assertEqual(len(summary.json_payload.scanner_conflicts), 1)
+        conflict = summary.json_payload.scanner_conflicts[0]
+        self.assertEqual(
+            conflict.deterministic_source,
+            "terraform://plan#aws_security_group.main",
+        )
+        self.assertIn("idless-linked-row", conflict.scanner_source)
+
+    def test_build_share_summary_compact_markdown_keeps_conflict_fields(
+        self,
+    ) -> None:
+        report = self._share_report_payload()
+        self._satisfy_share_payload_evidence_law(report)
+        report["findings"][0]["severity"] = "high"
+        report["findings"][0]["evidence_refs"].append("ev-scanner")
+        report["context_completeness"] = {
+            "context_score": 0.5,
+            "uncertainty": "Reviewer context remains intentionally verbose. " * 80,
+        }
+        report["evidence_items"][0]["context_source"] = {
+            "freshness_status": "stale",
+        }
+        report["evidence_items"][1]["context_source"] = {
+            "freshness_status": "current",
+        }
+        report["evidence_items"].append(
+            {
+                "evidence_id": "ev-scanner",
+                "finding_id": "finding-001",
+                "source_type": "external_scanner",
+                "source_kind": "external_scanner",
+                "source_ref": "semgrep://results/sg-1",
+                "severity_hint": "high",
+                "deterministic": True,
+                "determinism_level": "deterministic",
+                "context_source": {
+                    "freshness_status": "current",
+                    "conflicts": [],
+                    "limitations": [],
+                },
+            }
+        )
+
+        summary = build_share_summary(report)
+
+        self.assertLessEqual(len(summary.markdown), 1500)
+        self.assertIn("finding-001", summary.markdown)
+        self.assertIn("semgrep://results/sg-1 (current)", summary.markdown)
+        self.assertIn("ev-001 (stale)", summary.markdown)
+        self.assertIn("Verification: Review scanner evidence", summary.markdown)
+        self.assertIn("Scanner confidence impact", summary.markdown)
+
+    def test_build_share_summary_compact_markdown_preserves_fields_after_long_conflict(
+        self,
+    ) -> None:
+        report = self._share_report_payload()
+        self._satisfy_share_payload_evidence_law(report)
+        report["findings"][0]["severity"] = "high"
+        report["findings"][0]["evidence_refs"].append("ev-scanner")
+        report["context_completeness"] = {
+            "context_score": 0.5,
+            "uncertainty": "Reviewer context remains intentionally verbose. " * 80,
+        }
+        report["evidence_items"][0]["context_source"] = {
+            "freshness_status": "stale",
+            "conflicts": ["deterministic context " + "very long detail " * 60],
+        }
+        report["evidence_items"][1]["context_source"] = {
+            "freshness_status": "current",
+        }
+        report["evidence_items"].append(
+            {
+                "evidence_id": "ev-scanner",
+                "finding_id": "finding-001",
+                "source_type": "external_scanner",
+                "source_kind": "external_scanner",
+                "source_ref": "semgrep://results/sg-1",
+                "severity_hint": "high",
+                "deterministic": True,
+                "determinism_level": "deterministic",
+                "context_source": {
+                    "freshness_status": "current",
+                    "conflicts": ["scanner context " + "very long detail " * 60],
+                    "limitations": [],
+                },
+            }
+        )
+
+        summary = build_share_summary(report)
+
+        self.assertLessEqual(len(summary.markdown), 1500)
+        self.assertIn("finding-001", summary.markdown)
+        self.assertIn("semgrep://results/sg-1 (current)", summary.markdown)
+        self.assertIn("ev-001 (stale)", summary.markdown)
+        self.assertIn("Verification: Review scanner evidence", summary.markdown)
+        self.assertIn("Scanner confidence impact", summary.markdown)
+
+    def test_build_share_summary_compact_markdown_caps_long_sources(self) -> None:
+        report = self._share_report_payload()
+        self._satisfy_share_payload_evidence_law(report)
+        report["findings"][0]["severity"] = "high"
+        report["findings"][0]["evidence_refs"].append("ev-scanner")
+        report["context_completeness"] = {
+            "context_score": 0.5,
+            "uncertainty": "Reviewer context remains intentionally verbose. " * 80,
+        }
+        report["evidence_items"][0].pop("evidence_id")
+        report["evidence_items"][0]["source_ref"] = "terraform://" + "a" * 1000
+        report["evidence_items"][0]["context_source"] = {
+            "freshness_status": "stale",
+        }
+        report["evidence_items"][1]["context_source"] = {
+            "freshness_status": "current",
+        }
+        report["evidence_items"].append(
+            {
+                "evidence_id": "ev-scanner",
+                "finding_id": "finding-001",
+                "source_type": "external_scanner",
+                "source_kind": "external_scanner",
+                "source_ref": "semgrep://" + "b" * 1000,
+                "severity_hint": "high",
+                "deterministic": True,
+                "determinism_level": "deterministic",
+                "context_source": {
+                    "freshness_status": "current",
+                    "conflicts": [],
+                    "limitations": [],
+                },
+            }
+        )
+
+        summary = build_share_summary(report)
+
+        self.assertLessEqual(len(summary.markdown), 1500)
+        self.assertIn("Scanner source: semgrep://", summary.markdown)
+        self.assertIn("deterministic source: terraform://", summary.markdown)
+
+    def test_build_share_summary_compact_markdown_caps_multiple_conflicts(
+        self,
+    ) -> None:
+        report = self._share_report_payload()
+        self._satisfy_share_payload_evidence_law(report)
+        report["findings"][0]["severity"] = "high"
+        report["findings"][0]["evidence_refs"].append("ev-scanner")
+        report["context_completeness"] = {
+            "context_score": 0.5,
+            "uncertainty": "Reviewer context remains intentionally verbose. " * 80,
+        }
+        report["evidence_items"][0]["context_source"] = {
+            "freshness_status": "current",
+        }
+        report["evidence_items"][1]["context_source"] = {
+            "freshness_status": "current",
+        }
+        for index in range(8):
+            evidence_id = f"ev-conflicting-{index}"
+            report["findings"][0]["evidence_refs"].append(evidence_id)
+            report["evidence_items"].append(
+                {
+                    "evidence_id": evidence_id,
+                    "finding_id": "finding-001",
+                    "deterministic": True,
+                    "determinism_level": "deterministic",
+                    "context_source": {
+                        "freshness_status": "stale",
+                        "conflicts": [
+                            f"scanner scope conflicts with deterministic scope {index}"
+                        ],
+                    },
+                }
+            )
+        report["evidence_items"].append(
+            {
+                "evidence_id": "ev-scanner",
+                "finding_id": "finding-001",
+                "source_type": "external_scanner",
+                "source_kind": "external_scanner",
+                "source_ref": "semgrep://results/sg-many",
+                "severity_hint": "high",
+                "deterministic": True,
+                "determinism_level": "deterministic",
+                "context_source": {
+                    "freshness_status": "current",
+                    "conflicts": [],
+                    "limitations": [],
+                },
+            }
+        )
+
+        summary = build_share_summary(report)
+
+        self.assertEqual(len(summary.json_payload.scanner_conflicts), 8)
+        self.assertLessEqual(len(summary.markdown), 1500)
+        self.assertIn("semgrep://results/sg-many (current)", summary.markdown)
+        self.assertIn("ev-conflicting-0 (stale)", summary.markdown)
+        self.assertIn("additional conflicts are available", summary.markdown)
+        self.assertIn("JSON payload/report", summary.plain_text)
+
     def test_build_share_summary_requires_attention_for_unsatisfied_evidence_law(
         self,
     ) -> None:


### PR DESCRIPTION
Story 8.4 adds scanner conflict handling across the analysis core, report schemas, CLI/API serialization, docs, and UI report flows. The review follow-up keeps protected shared report comparison unlocks working, makes optional comparison lookup non-blocking, and validates the composed localhost UI path expected by the project contract.

Constraint: Story 8.4 requires advisory-first scanner conflict handling without breaking shared report access or composed React validation
Rejected: Fail protected shared unlock when previous comparison cannot be loaded | comparison context is optional and should not block a valid password unlock
Confidence: high
Scope-risk: moderate
Directive: Keep shared report comparison retrieval non-blocking unless product requirements make comparison mandatory for unlock
Tested: ./.venv/bin/python -m unittest discover -q; ./.venv/bin/ruff check .; ./.venv/bin/ruff format --check .; npm --prefix frontend run typecheck; npm --prefix frontend run test; BASE_URL=http://localhost:8080 npm --prefix frontend exec -- playwright test --config=frontend/playwright.config.ts frontend/e2e/report.spec.ts; BASE_URL=http://localhost:8080 npm run test:ui-review
Not-tested: External real scanner uploads beyond synthetic fixtures

## What does this PR do?

<!-- Brief description of changes -->

## Type of change
- [ ] Feature (new functionality)
- [ ] Bugfix (non-breaking fix)
- [ ] Release preparation
- [ ] Hotfix (critical production fix)
- [ ] Docs / refactor / chore

## Checklist
- [ ] I have followed the branch naming convention
- [ ] Tests pass locally (`pytest tests/ -v`)
- [ ] Linting passes (`ruff check .`)
- [ ] Docker build succeeds
- [ ] I have updated docs if needed
- [ ] No secrets or .env values committed

## Related issue
Closes #