### PR TITLE
Clarify scanner boundaries for deployment review

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Artifacts -> Parse -> Normalize -> Score -> Blast Radius -> Rollback -> Narrativ
 - **Day-zero risk patterns**: fresh installs can flag built-in public risk patterns such as wide-open administrative ingress or stateful resource deletion, separately labeled from organization incident memory.
 - **Safe sample incident pack**: optional synthetic incidents for demos, with provenance and limitations documented in `docs/sample-incident-pack.md`.
 - **Incident file import**: project-scoped Markdown, YAML, and JSON incident records with validation for source and redaction metadata, documented in `docs/incident-import.md`.
-- **Scanner imports**: project-scoped SARIF and Semgrep JSON findings are normalized as external scanner evidence, documented in `docs/scanner-imports.md`.
+- **Scanner imports**: project-scoped SARIF and Semgrep JSON findings are normalized as external scanner evidence, documented in `docs/scanner-imports.md`, with complementary-tool positioning in `docs/comparisons/deploywhisper-alongside-security-tools.md`.
 - Incident-history matching for operational memory
 - API, CLI, and web entrypoints over one shared analysis pipeline
 - Local-first security model that keeps raw IaC local and avoids persisting API keys
@@ -596,6 +596,7 @@ Project documentation currently lives in a few places:
 - [Project Model Guide](./docs/concepts/project-model.md)
 - [Project Workspaces](./docs/project-workspaces.md)
 - [Scanner Imports](./docs/scanner-imports.md)
+- [DeployWhisper Alongside Security Tools](./docs/comparisons/deploywhisper-alongside-security-tools.md)
 - [Kubernetes Live-State Connector](./docs/kubernetes-live-state-connector.md)
 - [Evidence Model Foundation](./docs/evidence-model.md)
 - [CI Guide](./docs/ci.md)

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -1,5 +1,5 @@
 # generated: 2026-05-01
-# last_updated: 2026-06-26
+# last_updated: 2026-07-16
 # project: deploywhisper
 # project_key: NOKEY
 # tracking_system: file-system
@@ -35,7 +35,7 @@
 # - Dev moves story to review, then runs code-review
 
 generated: 2026-05-01
-last_updated: 2026-06-26
+last_updated: 2026-07-16
 project: deploywhisper
 project_key: NOKEY
 tracking_system: file-system
@@ -122,7 +122,7 @@ development_status:
   8-2-scanner-json-adapter-v1: done
   8-3-external-evidence-report-context: done
   8-4-scanner-conflict-handling: done
-  8-5-existing-security-tools-comparison-guide: ready-for-dev
+  8-5-existing-security-tools-comparison-guide: done
   epic-8-retrospective: optional
 
   epic-9: in-progress

--- a/docs/comparisons/deploywhisper-alongside-security-tools.md
+++ b/docs/comparisons/deploywhisper-alongside-security-tools.md
@@ -1,0 +1,126 @@
+# DeployWhisper Alongside Security Tools
+
+DeployWhisper does not replace scanners. Keep SAST, SCA, container, secrets,
+CSPM, policy-as-code, and IaC scanners in the workflow for the vulnerability,
+misconfiguration, policy, and inventory classes they already cover.
+DeployWhisper consumes selected scanner output as external evidence, then adds
+deployment context: blast radius, rollback readiness, topology freshness,
+incident memory, ownership, confidence, uncertainty, and an advisory briefing
+for the change under review.
+
+Deployment context is DeployWhisper's domain: what changed, where it is being
+deployed, what depends on it, how fresh the supporting context is, and how hard
+rollback will be if the deployment fails.
+
+## Responsibility Split
+
+| Responsibility | Scanners and policy tools | DeployWhisper |
+| --- | --- | --- |
+| Primary question | Does this code, dependency, image, cloud resource, or policy violate a known rule? | What does this deployment change mean in its project, workspace, topology, rollback, and incident context? |
+| Best inputs | Source code, dependencies, container images, IaC, cloud inventory, policy bundles, baseline scanner rules. | IaC diffs, Terraform plans, Kubernetes manifests, scanner output, topology, ownership, incidents, deployment outcomes, and project/workspace metadata. |
+| Output ownership | Rule IDs, scanner severity, vulnerability metadata, policy pass/fail, remediation text. | Evidence-backed deployment briefing, advisory severity, recommendation, conflict context, confidence, and next verification steps. |
+| Enforcement fit | Use scanner gates for known vulnerability, policy, and secret classes. | Use DeployWhisper for deployment-specific risk briefing and human review context. |
+
+External scanner evidence is review context. It can enrich a report, support a
+finding when combined with deterministic DeployWhisper evidence, and explain why
+reviewers should investigate. But scanner severity alone must not become a high
+or critical DeployWhisper finding. High and critical DeployWhisper findings
+still require Evidence Law-backed deterministic evidence and scoring.
+
+## Ingestion Setup
+
+DeployWhisper currently documents two scanner ingestion paths:
+
+- SARIF 2.1.0: `POST /api/v1/scanner-imports/sarif`
+- Semgrep native JSON: `POST /api/v1/scanner-imports/semgrep`
+
+Each import should include a project scope such as `project_key` or
+`project_id`. Use `workspace_key` or `workspace_id` when the scanner result
+belongs to a specific environment, deployment lane, or workspace. DeployWhisper
+stores normalized scanner fields such as tool, rule, severity, location,
+source identity, and bounded report-safe metadata. Raw scanner artifacts and
+arbitrary scanner-defined fields stay outside the persisted report contract.
+
+Use [Scanner Imports](../scanner-imports.md) for endpoint payloads, validation
+rules, supported scanner fields, and local-first boundaries. Use
+[CI Advisory Consumption](../ci-advisory-consumption.md) when wiring scanner
+context into PR comments, CI annotations, or workflow summaries.
+
+## Conflict Handling
+
+DeployWhisper does not silently choose one source when scanner output conflicts
+with deterministic evidence or context. Reports expose conflicts through
+`share_summary.json_payload.scanner_conflicts`. Each conflict should preserve:
+
+- scanner source and deterministic evidence source
+- scanner freshness and deterministic context freshness
+- confidence impact
+- recommended verification
+
+Reviewers should treat conflicts as investigation prompts, not automatic
+severity overrides. If scanner output is current but DeployWhisper context is
+stale, refresh topology or runtime context before acting. If DeployWhisper has
+strong deterministic evidence but scanner output is stale or scoped to the
+wrong workspace, keep the scanner result visible while prioritizing the fresh
+deployment evidence.
+
+## Team Usage
+
+AppSec teams should keep scanner ownership for rule tuning, vulnerability
+triage, policy exceptions, and scanner-specific remediation. DeployWhisper can
+show which scanner signals matter for a deployment, whether they affect a
+critical service, and which verification step would reduce uncertainty.
+
+Platform teams should import scanner findings into the same project/workspace
+scope used for reports, topology, ownership, and workflow summaries. That keeps
+scanner context from leaking across projects and gives reviewers one briefing
+instead of a separate scanner tab, plan diff, topology view, and incident search.
+
+SRE teams should use DeployWhisper to connect scanner output to operational
+blast radius, rollback complexity, stale context, incidents, and deployment
+history. A scanner can say a rule fired; DeployWhisper should explain whether
+the deployment context makes that signal urgent, uncertain, or lower priority.
+
+## Examples
+
+### Scanner reports critical public ingress
+
+An IaC scanner reports critical public ingress in a security group change.
+DeployWhisper should label the scanner result as external evidence, inspect the
+deployment artifact and topology context, and explain whether the changed
+resource fronts a critical service, has stale topology, or needs owner review.
+If deterministic evidence supports exposure, the briefing can elevate the
+deployment risk under DeployWhisper scoring. If deterministic evidence is
+missing, the scanner signal remains visible without becoming high or critical
+by itself.
+
+### Scanner reports no issue, but DeployWhisper flags high rollback risk
+
+A scanner passes the change because no vulnerability or policy rule fires.
+DeployWhisper may still flag high deployment risk if a Terraform plan replaces
+stateful infrastructure, rollback steps are complex, topology shows downstream
+dependencies, or incident history suggests similar changes failed. Scanner
+success does not clear deployment risk.
+
+### Scanner output is stale
+
+A SARIF or Semgrep result is imported from an older branch or workspace.
+DeployWhisper should surface freshness and scope uncertainty instead of hiding
+the scanner result or treating it as current proof. Reviewers should rerun the
+scanner in the correct project/workspace, refresh live context when needed, and
+then compare the updated scanner evidence with deterministic deployment
+evidence.
+
+## Operating Rules
+
+- Keep scanners in CI and security workflows for their owned detection classes.
+- Import scanner output into DeployWhisper when it helps deployment review.
+- Preserve project and workspace scope for every scanner import.
+- Render scanner findings as external evidence, not DeployWhisper severity
+  proof.
+- Preserve `share_summary.json_payload.scanner_conflicts` in PR comments and
+  workflow summaries.
+- Do not silently choose one source when scanner output and deterministic
+  evidence disagree.
+- Escalate or de-escalate only through DeployWhisper evidence, scoring,
+  confidence, and human review, not through scanner severity passthrough.

--- a/docs/scanner-imports.md
+++ b/docs/scanner-imports.md
@@ -4,7 +4,9 @@ DeployWhisper can ingest SARIF 2.1.0 output and Semgrep native JSON output from
 external scanners, then store each scanner result as project-scoped external
 evidence. Scanner severity stays labeled as scanner context; it does not
 automatically become a high or critical DeployWhisper finding without
-DeployWhisper evidence and scoring.
+DeployWhisper evidence and scoring. For positioning guidance across scanners,
+policy tools, and DeployWhisper, see the
+[security tools comparison guide](./comparisons/deploywhisper-alongside-security-tools.md).
 
 ## SARIF Endpoint
 

--- a/tests/test_docs/test_security_tools_comparison_guide.py
+++ b/tests/test_docs/test_security_tools_comparison_guide.py
@@ -42,7 +42,9 @@ class SecurityToolsComparisonGuideTests(unittest.TestCase):
             "POST /api/v1/scanner-imports/sarif",
             "POST /api/v1/scanner-imports/semgrep",
             "`project_key`",
+            "`project_id`",
             "`workspace_key`",
+            "`workspace_id`",
             "`share_summary.json_payload.scanner_conflicts`",
             "recommended verification",
             "freshness",
@@ -66,30 +68,41 @@ class SecurityToolsComparisonGuideTests(unittest.TestCase):
                 self.assertTrue((COMPARISON_GUIDE.parent / expected_href).exists())
 
     def test_comparison_guide_includes_team_usage_examples(self) -> None:
-        content = self._normalized_prose(COMPARISON_GUIDE.read_text(encoding="utf-8"))
+        content = COMPARISON_GUIDE.read_text(encoding="utf-8")
+        normalized_content = self._normalized_prose(content)
+        team_usage = self._normalized_prose(
+            content.split("## Team Usage", maxsplit=1)[1].split(
+                "## Examples",
+                maxsplit=1,
+            )[0]
+        )
 
-        self.assert_section_exists(content, "Examples")
+        self.assert_section_exists(normalized_content, "Examples")
+        for expected in ("AppSec", "Platform", "SRE"):
+            with self.subTest(section="team_usage", expected=expected):
+                self.assertIn(expected, team_usage)
+
         expected_clauses = (
-            "AppSec",
-            "Platform",
-            "SRE",
             "Scanner reports critical public ingress",
             "Scanner reports no issue, but DeployWhisper flags high rollback risk",
             "Scanner output is stale",
         )
         for expected in expected_clauses:
             with self.subTest(expected=expected):
-                self.assertIn(expected, content)
+                self.assertIn(expected, normalized_content)
 
     def test_primary_docs_link_to_comparison_guide(self) -> None:
         guide_relative = "docs/comparisons/deploywhisper-alongside-security-tools.md"
         readme_content = README.read_text(encoding="utf-8")
         scanner_doc_content = SCANNER_IMPORTS_DOC.read_text(encoding="utf-8")
+        key_features_content = readme_content.split("## Key Features", maxsplit=1)[
+            1
+        ].split("## Screenshots And Demo", maxsplit=1)[0]
         readme_links = self._markdown_links_by_label(readme_content)
         scanner_links = self._markdown_links_by_label(scanner_doc_content)
 
         self.assertRegex(
-            self._normalized_prose(readme_content),
+            self._normalized_prose(key_features_content),
             r"\*\*Scanner imports\*\*:.*docs/comparisons/deploywhisper-alongside-security-tools\.md",
         )
         self.assertEqual(

--- a/tests/test_docs/test_security_tools_comparison_guide.py
+++ b/tests/test_docs/test_security_tools_comparison_guide.py
@@ -1,0 +1,133 @@
+"""Documentation checks for security tools comparison guidance."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import re
+import unittest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+COMPARISON_GUIDE = (
+    REPO_ROOT / "docs" / "comparisons" / "deploywhisper-alongside-security-tools.md"
+)
+SCANNER_IMPORTS_DOC = REPO_ROOT / "docs" / "scanner-imports.md"
+README = REPO_ROOT / "README.md"
+
+
+class SecurityToolsComparisonGuideTests(unittest.TestCase):
+    def test_comparison_guide_documents_complementary_tool_roles(self) -> None:
+        content = self._normalized_prose(COMPARISON_GUIDE.read_text(encoding="utf-8"))
+
+        self.assert_section_exists(content, "Responsibility Split")
+        self.assert_section_exists(content, "Team Usage")
+        expected_clauses = (
+            "DeployWhisper does not replace scanners",
+            "SAST, SCA, container, secrets, CSPM, policy-as-code, and IaC scanners",
+            "External scanner evidence is review context",
+            "scanner severity alone must not become a high or critical DeployWhisper finding",
+            "Use scanner gates for known vulnerability, policy, and secret classes",
+            "Use DeployWhisper for deployment-specific risk briefing",
+        )
+        for expected in expected_clauses:
+            with self.subTest(expected=expected):
+                self.assertIn(expected, content)
+
+    def test_comparison_guide_documents_ingestion_and_conflict_handling(self) -> None:
+        content = self._normalized_prose(COMPARISON_GUIDE.read_text(encoding="utf-8"))
+
+        self.assert_section_exists(content, "Ingestion Setup")
+        self.assert_section_exists(content, "Conflict Handling")
+        expected_clauses = (
+            "POST /api/v1/scanner-imports/sarif",
+            "POST /api/v1/scanner-imports/semgrep",
+            "`project_key`",
+            "`workspace_key`",
+            "`share_summary.json_payload.scanner_conflicts`",
+            "recommended verification",
+            "freshness",
+            "Do not silently choose one source",
+        )
+        for expected in expected_clauses:
+            with self.subTest(expected=expected):
+                self.assertIn(expected, content)
+
+    def test_comparison_guide_links_to_supporting_docs(self) -> None:
+        content = COMPARISON_GUIDE.read_text(encoding="utf-8")
+        actual_links = self._markdown_links_by_label(content)
+
+        expected_links = {
+            "Scanner Imports": "../scanner-imports.md",
+            "CI Advisory Consumption": "../ci-advisory-consumption.md",
+        }
+        for label, expected_href in expected_links.items():
+            with self.subTest(label=label):
+                self.assertEqual(expected_href, actual_links.get(label))
+                self.assertTrue((COMPARISON_GUIDE.parent / expected_href).exists())
+
+    def test_comparison_guide_includes_team_usage_examples(self) -> None:
+        content = self._normalized_prose(COMPARISON_GUIDE.read_text(encoding="utf-8"))
+
+        self.assert_section_exists(content, "Examples")
+        expected_clauses = (
+            "AppSec",
+            "Platform",
+            "SRE",
+            "Scanner reports critical public ingress",
+            "Scanner reports no issue, but DeployWhisper flags high rollback risk",
+            "Scanner output is stale",
+        )
+        for expected in expected_clauses:
+            with self.subTest(expected=expected):
+                self.assertIn(expected, content)
+
+    def test_primary_docs_link_to_comparison_guide(self) -> None:
+        guide_relative = "docs/comparisons/deploywhisper-alongside-security-tools.md"
+        readme_content = README.read_text(encoding="utf-8")
+        scanner_doc_content = SCANNER_IMPORTS_DOC.read_text(encoding="utf-8")
+        readme_links = self._markdown_links_by_label(readme_content)
+        scanner_links = self._markdown_links_by_label(scanner_doc_content)
+
+        self.assertRegex(
+            self._normalized_prose(readme_content),
+            r"\*\*Scanner imports\*\*:.*docs/comparisons/deploywhisper-alongside-security-tools\.md",
+        )
+        self.assertEqual(
+            f"./{guide_relative}",
+            readme_links.get("DeployWhisper Alongside Security Tools"),
+        )
+        self.assertEqual(
+            "./comparisons/deploywhisper-alongside-security-tools.md",
+            scanner_links.get("security tools comparison guide"),
+        )
+
+        for href, source in (
+            (readme_links["DeployWhisper Alongside Security Tools"], README),
+            (scanner_links["security tools comparison guide"], SCANNER_IMPORTS_DOC),
+        ):
+            with self.subTest(source=source.name, href=href):
+                self.assertTrue((source.parent / href).resolve().exists())
+
+    def assert_section_exists(self, content: str, heading: str) -> None:
+        self.assertIn(f"## {heading}", content)
+
+    @staticmethod
+    def _markdown_links(content: str) -> list[tuple[str, str]]:
+        return re.findall(r"\[([^\]]+)\]\(([^)]+)\)", content)
+
+    @staticmethod
+    def _markdown_links_by_label(content: str) -> dict[str, str]:
+        return {
+            label.replace("`", "").strip(): href.strip()
+            for label, href in SecurityToolsComparisonGuideTests._markdown_links(
+                content
+            )
+        }
+
+    @staticmethod
+    def _normalized_prose(value: str) -> str:
+        return re.sub(r"\s+", " ", value).strip()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Add the Story 8.5 comparison guide for using DeployWhisper alongside scanners and policy tools
- Link the guide from README and scanner import docs
- Add docs regression tests for complementary roles, ingestion setup, conflict handling, examples, and Markdown links

## Validation
- ./.venv/bin/python -m unittest tests.test_docs.test_security_tools_comparison_guide -q
- ./.venv/bin/python -m unittest discover tests/test_docs -q
- ./.venv/bin/ruff check .
- ./.venv/bin/ruff format --check .
- ./.venv/bin/bandit -q tests/test_docs/test_security_tools_comparison_guide.py
- ./.venv/bin/python -m unittest discover -q

UI validation not applicable: documentation-only change.