### PR TITLE
Story 9.3: enforce deterministic Skill trust coverage

### DIFF
--- a/_bmad-output/implementation-artifacts/9-3-skill-test-harness.md
+++ b/_bmad-output/implementation-artifacts/9-3-skill-test-harness.md
@@ -1,0 +1,142 @@
+# Story 9.3: Skill Test Harness
+
+Status: done
+
+<!-- Generated from updated PRD/architecture/epics plus implementation-readiness-report-2026-05-01.md. -->
+
+## Story
+
+As a maintainer,
+I want every verified/core Skill tested against deterministic scenarios,
+So that Skills do not add ungrounded guidance.
+
+## Acceptance Criteria
+
+1. Given a Skill declares test scenarios, When the harness runs, Then expected triggers, outputs, evidence assumptions, and safety constraints are verified. And verified/core trust levels require passing tests.
+
+### Requirement Traceability
+
+- Primary PRD requirements: Epic 9 coverage: SKL-01..09, ADM-05, DOC-13, NFR-OSS-05.
+- Supporting PRD / NFR / differentiation requirements: See `_bmad-output/planning-artifacts/prd.md`, `_bmad-output/planning-artifacts/architecture.md`, and `_bmad-output/planning-artifacts/implementation-readiness-report-2026-05-01.md`.
+- Coverage intent: Baseline + Delta.
+- Story alignment note: This story was created from the updated Epic 9 plan after the 2026-05-01 readiness rerun. The readiness report verified 187/187 PRD functional requirement IDs in the epics artifact, 38 NFR IDs present, and no critical or major readiness defects.
+
+## Tasks / Subtasks
+
+- [x] Implement and verify acceptance criterion 1. (AC: 1)
+- [x] Reuse existing services, repositories, schemas, and UI/CLI/API helpers before adding new abstractions. (AC: all)
+- [x] Add or update deterministic regression coverage for the changed behavior. (AC: all)
+- [x] Update relevant docs or examples if the story changes user-visible, operator, API, CLI, integration, or contribution behavior. (AC: all)
+- [x] Run required validation and record commands/results in the Dev Agent Record. (AC: all)
+
+### Review Findings
+
+- [x] [Review][Patch] Count coverage categories only when their scenarios actually pass [services/skill_test_harness_service.py:244]
+- [x] [Review][Patch] Match full-path triggers exactly like the runtime resolver [services/skill_test_harness_service.py:216]
+- [x] [Review][Patch] Do not report a synthetic suite-coverage sentinel as a failed declared scenario [services/skill_test_harness_service.py:300]
+
+## Dev Notes
+
+### Epic Context
+
+- Epic: 9. Skills Ecosystem
+- Epic goal: Grow community knowledge safely through non-executable, tested, versioned Skills.
+- Epic coverage: SKL-01..09, ADM-05, DOC-13, NFR-OSS-05
+
+### Architecture and Product Guardrails
+
+- Preserve DeployWhisper's local-first raw artifact boundary: raw IaC, scanner artifacts, incident exports, and sensitive context stay in the user's infrastructure by default.
+- Preserve the advisory-first core. Optional adapters may interpret report outputs, but canonical report semantics remain advisory unless explicit story scope says otherwise.
+- Reuse the shared analysis core and service layer before adapting UI, API, CLI, GitHub, or future workflow surfaces.
+- Keep Evidence Law behavior intact: no high or critical finding without deterministic evidence.
+- Keep project/workspace scope explicit for reports, incidents, topology, outcomes, feedback, scanner imports, and connector-related data.
+- Do not introduce new dependencies unless the active story explicitly requires and justifies them.
+
+### Source Tree Guidance
+
+- API routes belong under `api/routes/` and should use existing `ApiRoute` / `ApiError` envelope patterns.
+- Shared orchestration belongs in `services/`; parsers normalize input, analysis modules score/derive risk, and surfaces adapt outputs.
+- UI work belongs under `frontend/src/screens/` and `frontend/src/components/`, following the existing retired Python UI composition style.
+- CLI behavior belongs under `cli/` and must call the same service-layer paths as UI/API flows.
+- Persistence work belongs under `models/` with Alembic migrations when schema changes are required.
+- Documentation required by a story should be updated in the same workstream.
+
+### Testing Requirements
+
+- Use standard-library `unittest` in the existing `tests/test_*` layout.
+- Add focused regression tests for the layer changed by the story before broad refactors.
+- For Python changes, run `./.venv/bin/ruff check .`, `./.venv/bin/ruff format --check .`, and `./.venv/bin/python -m unittest discover -q` before closing implementation.
+- Use `bash scripts/ci-local.sh` for broader or cross-layer changes.
+
+### Project Structure Notes
+
+- Follow the current repository shape documented in `_bmad-output/project-context.md` and `AGENTS.md`.
+- If implementation reveals a conflict between this story and the current code baseline, keep the smallest compatible change and update the story notes rather than silently drifting from the PRD.
+
+### References
+
+- `_bmad-output/planning-artifacts/epics.md` - source Epic 9 / Story 9.3 definition.
+- `_bmad-output/planning-artifacts/prd.md` - functional and non-functional requirements.
+- `_bmad-output/planning-artifacts/architecture.md` - target architecture, boundaries, and guardrails.
+- `_bmad-output/planning-artifacts/ux-design-specification.md` - UX expectations for user-facing stories.
+- `_bmad-output/planning-artifacts/implementation-readiness-report-2026-05-01.md` - readiness verdict and residual story-format concern.
+- `_bmad-output/project-context.md` - repository-specific implementation rules.
+
+## Dev Agent Record
+
+### Agent Model Used
+
+OpenAI Codex (GPT-5.4)
+
+### Debug Log References
+
+- RED: `./.venv/bin/python -m unittest tests.test_services.test_skill_test_harness_service -q` — failed with 30 missing coverage/trust result errors, proving the existing harness did not expose Story 9.3's required contract.
+- RED integration: focused API/CLI pytest run — failed because the test-results API omitted coverage and trust decisions and the CLI returned success for an unsatisfied verified/core trust gate.
+- GREEN focused: `./.venv/bin/python -m pytest tests/test_services/test_skill_test_harness_service.py tests/test_api/test_skills.py tests/test_cli/test_analyze.py -q --tb=short` — 100 tests and 28 subtests passed.
+- Skill catalog: `./.venv/bin/python cli.py skill test` — all 28 built-in verified/core Skill suites passed with complete trigger, output, evidence-assumption, and safety-constraint coverage.
+- CI parity, services: the first exact shard found two new test fixtures missing the required contributor evidence summary; after fixing those fixtures, `./.venv/bin/python -m pytest tests/test_services --cov=. --cov-report=xml:/tmp/coverage-services.xml --cov-report=term-missing -v --tb=short` passed 838 tests and 171 subtests.
+- CI parity, API/CLI/infra: `./.venv/bin/python -m pytest tests/test_api tests/test_cli tests/test_infra --cov=. --cov-report=xml:/tmp/coverage-api-cli-infra.xml --cov-report=term-missing -v --tb=short` passed 339 tests and 15 subtests.
+- FULL: `bash scripts/ci-local.sh` — Ruff lint and repo-wide formatting, dependency validation, Bandit high/high gate, compileall, all 28 Skill suites, and explicit per-directory discovery passed; 838 Python tests passed.
+- REVIEW RED: the three reviewer regressions failed before the patch, proving that failed scenarios could claim coverage, full-path trigger matching diverged from runtime behavior, and the synthetic coverage sentinel leaked into declared-scenario failures.
+- REVIEW GREEN focused: `./.venv/bin/python -m pytest tests/test_services/test_skill_test_harness_service.py tests/test_api/test_skills.py tests/test_cli/test_analyze.py -q --tb=short` — 102 tests and 28 subtests passed.
+- REVIEW CI parity, services: `COVERAGE_FILE=/tmp/deploywhisper-story-9-3-review-services.coverage ./.venv/bin/python -m pytest tests/test_services --cov=. --cov-report=xml:/tmp/coverage-services-review.xml --cov-report=term-missing -v --tb=short` — 840 tests and 171 subtests passed.
+- REVIEW CI parity, API/CLI/infra: `COVERAGE_FILE=/tmp/deploywhisper-story-9-3-review-api-cli-infra.coverage ./.venv/bin/python -m pytest tests/test_api tests/test_cli tests/test_infra --cov=. --cov-report=xml:/tmp/coverage-api-cli-infra-review.xml --cov-report=term-missing -v --tb=short` — 339 tests and 15 subtests passed.
+- REVIEW FULL: `bash scripts/ci-local.sh` — all quality gates and 840 Python tests passed.
+
+### Completion Notes List
+
+- Added explicit suite coverage decisions for expected triggers, expected guidance outputs, evidence assumptions, and negative-selection safety constraints.
+- Added a trust-level requirement result: verified/core Skills now require complete deterministic coverage and every declared scenario to pass; incomplete high-trust suites become failing results with actionable reasons.
+- Preserved experimental/deprecated behavior: scenarios still execute and failures remain nonzero, while incomplete coverage alone does not claim those trust levels are invalid.
+- Exposed coverage and trust decisions through the public test-results API and JSON CLI, and made human-readable CLI output explain trust-gate failures.
+- Added negative safety scenarios for the seven foundational core Skills that previously had only positive selection scenarios.
+- Updated authoring, harness, and registry API documentation with the completed Story 9.3 contract.
+- Resolved all three code-review findings: coverage now derives only from passing scenarios, full-path trigger matching mirrors runtime resolution, and synthetic coverage failures are not described as failed declared scenarios.
+- UI validation not applicable: no React route, component, browser interaction, keyboard behavior, or accessibility semantics changed.
+
+### File List
+
+- `_bmad-output/implementation-artifacts/9-3-skill-test-harness.md`
+- `_bmad-output/implementation-artifacts/sprint-status.yaml`
+- `api/schemas.py`
+- `cli/analyze.py`
+- `docs/skills/authoring-guide.md`
+- `docs/skills/registry-api.md`
+- `docs/skills/test-harness.md`
+- `services/skill_test_harness_service.py`
+- `tests/skill-tests/ansible/non-match.json`
+- `tests/skill-tests/cloudformation/non-match.json`
+- `tests/skill-tests/docker/non-match.json`
+- `tests/skill-tests/git/non-match.json`
+- `tests/skill-tests/jenkins/non-match.json`
+- `tests/skill-tests/kubernetes/non-match.json`
+- `tests/skill-tests/terraform/non-match.json`
+- `tests/test_api/test_skills.py`
+- `tests/test_cli/test_analyze.py`
+- `tests/test_services/test_skill_test_harness_service.py`
+
+## Change Log
+
+- 2026-05-01: Story created/aligned from updated PRD, architecture, epics, sprint status, and readiness report.
+- 2026-07-23: Completed Story 9.3 with deterministic coverage classification, verified/core trust enforcement, public API/CLI results, negative safety fixtures, and CI-parity regression coverage.
+- 2026-07-23: Addressed code review findings — 3 items resolved and verified with focused, shard-level, and full local CI coverage.

--- a/_bmad-output/implementation-artifacts/9-3-skill-test-harness.md
+++ b/_bmad-output/implementation-artifacts/9-3-skill-test-harness.md
@@ -34,6 +34,8 @@ So that Skills do not add ungrounded guidance.
 - [x] [Review][Patch] Count coverage categories only when their scenarios actually pass [services/skill_test_harness_service.py:244]
 - [x] [Review][Patch] Match full-path triggers exactly like the runtime resolver [services/skill_test_harness_service.py:216]
 - [x] [Review][Patch] Do not report a synthetic suite-coverage sentinel as a failed declared scenario [services/skill_test_harness_service.py:300]
+- [x] [Review][Patch] Keep suite-level coverage failures out of the public declared-scenarios list [services/skill_test_harness_service.py:340]
+- [x] [Review][Patch] Do not assume every future built-in Skill requires verified/core gating [tests/test_services/test_skill_test_harness_service.py:293]
 
 ## Dev Notes
 
@@ -102,6 +104,11 @@ OpenAI Codex (GPT-5.4)
 - REVIEW CI parity, services: `COVERAGE_FILE=/tmp/deploywhisper-story-9-3-review-services.coverage ./.venv/bin/python -m pytest tests/test_services --cov=. --cov-report=xml:/tmp/coverage-services-review.xml --cov-report=term-missing -v --tb=short` — 840 tests and 171 subtests passed.
 - REVIEW CI parity, API/CLI/infra: `COVERAGE_FILE=/tmp/deploywhisper-story-9-3-review-api-cli-infra.coverage ./.venv/bin/python -m pytest tests/test_api tests/test_cli tests/test_infra --cov=. --cov-report=xml:/tmp/coverage-api-cli-infra-review.xml --cov-report=term-missing -v --tb=short` — 339 tests and 15 subtests passed.
 - REVIEW FULL: `bash scripts/ci-local.sh` — all quality gates and 840 Python tests passed.
+- RE-REVIEW RED: `./.venv/bin/python -m pytest tests/test_services/test_skill_test_harness_service.py -q --tb=short` — failed because incomplete verified coverage still added a synthetic second scenario.
+- RE-REVIEW GREEN focused: `./.venv/bin/python -m pytest tests/test_services/test_skill_test_harness_service.py tests/test_api/test_skills.py tests/test_cli/test_analyze.py -q --tb=short` — 102 tests and 28 subtests passed.
+- RE-REVIEW CI parity, services: `COVERAGE_FILE=/tmp/deploywhisper-story-9-3-rereview-services.coverage ./.venv/bin/python -m pytest tests/test_services --cov=. --cov-report=xml:/tmp/coverage-services-rereview.xml --cov-report=term-missing -v --tb=short` — 840 tests and 171 subtests passed.
+- RE-REVIEW CI parity, API/CLI/infra: `COVERAGE_FILE=/tmp/deploywhisper-story-9-3-rereview-api-cli-infra.coverage ./.venv/bin/python -m pytest tests/test_api tests/test_cli tests/test_infra --cov=. --cov-report=xml:/tmp/coverage-api-cli-infra-rereview.xml --cov-report=term-missing -v --tb=short` — 339 tests and 15 subtests passed.
+- RE-REVIEW FULL: after applying the required Ruff formatting, `bash scripts/ci-local.sh` passed all quality gates and 840 Python tests.
 
 ### Completion Notes List
 
@@ -112,6 +119,7 @@ OpenAI Codex (GPT-5.4)
 - Added negative safety scenarios for the seven foundational core Skills that previously had only positive selection scenarios.
 - Updated authoring, harness, and registry API documentation with the completed Story 9.3 contract.
 - Resolved all three code-review findings: coverage now derives only from passing scenarios, full-path trigger matching mirrors runtime resolution, and synthetic coverage failures are not described as failed declared scenarios.
+- Resolved the fresh code-review findings: trust-gate failures now affect suite status without entering the declared-scenarios list, and catalog assertions derive enforcement from each Skill's trust level.
 - UI validation not applicable: no React route, component, browser interaction, keyboard behavior, or accessibility semantics changed.
 
 ### File List
@@ -140,3 +148,4 @@ OpenAI Codex (GPT-5.4)
 - 2026-05-01: Story created/aligned from updated PRD, architecture, epics, sprint status, and readiness report.
 - 2026-07-23: Completed Story 9.3 with deterministic coverage classification, verified/core trust enforcement, public API/CLI results, negative safety fixtures, and CI-parity regression coverage.
 - 2026-07-23: Addressed code review findings — 3 items resolved and verified with focused, shard-level, and full local CI coverage.
+- 2026-07-23: Addressed fresh code review findings — 2 additional items resolved and verified through focused, shard-level, and full local CI coverage.

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -128,7 +128,7 @@ development_status:
   epic-9: in-progress
   9-1-skill-manifest-spec-v1: done
   9-2-skills-registry-api: done
-  9-3-skill-test-harness: ready-for-dev
+  9-3-skill-test-harness: done
   9-4-skills-installer-cli: ready-for-dev
   9-5-skills-browser-ui: ready-for-dev
   9-6-skill-contribution-workflow: ready-for-dev

--- a/api/schemas.py
+++ b/api/schemas.py
@@ -2034,10 +2034,46 @@ class SkillTestScenarioResultData(BaseModel):
     )
 
 
+class SkillTestCoverageData(BaseModel):
+    expected_triggers: bool = Field(
+        ..., description="Whether deterministic trigger selection is covered."
+    )
+    expected_outputs: bool = Field(
+        ..., description="Whether expected guidance output is covered."
+    )
+    evidence_assumptions: bool = Field(
+        ..., description="Whether scenarios declare deterministic evidence inputs."
+    )
+    safety_constraints: bool = Field(
+        ..., description="Whether non-selection safety behavior is covered."
+    )
+    complete: bool = Field(
+        ..., description="Whether all required harness coverage categories are present."
+    )
+
+
+class SkillTrustRequirementData(BaseModel):
+    trust_level: SkillTrustLevel = Field(
+        ..., description="Manifest trust level evaluated by the harness."
+    )
+    required: bool = Field(
+        ..., description="Whether this trust level requires a passing complete suite."
+    )
+    satisfied: bool = Field(
+        ..., description="Whether the suite satisfies its trust-level requirement."
+    )
+    failures: list[str] = Field(
+        default_factory=list,
+        description="Actionable reasons the trust requirement was not satisfied.",
+    )
+
+
 class SkillTestResultsData(BaseModel):
     skill_id: str = Field(..., description="Stable skill identifier.")
     version: str = Field(..., description="Skill version under test.")
     summary: SkillTestResultsSummaryData
+    coverage: SkillTestCoverageData
+    trust_requirement: SkillTrustRequirementData
     scenarios: list[SkillTestScenarioResultData] = Field(default_factory=list)
 
 

--- a/cli/analyze.py
+++ b/cli/analyze.py
@@ -407,9 +407,15 @@ def _run_skill_test(skill_ids: list[str], *, emit_json: bool = False) -> int:
                 if scenario.passed:
                     continue
                 print(f"  - {scenario.name}: {'; '.join(scenario.failures)}")
+            for failure in result.trust_requirement.failures:
+                print(f"  - trust requirement: {failure}")
     return (
         0
-        if results and all(result.summary.status == "passing" for result in results)
+        if results
+        and all(
+            result.summary.status == "passing" and result.trust_requirement.satisfied
+            for result in results
+        )
         else 1
     )
 

--- a/docs/skills/authoring-guide.md
+++ b/docs/skills/authoring-guide.md
@@ -22,8 +22,7 @@ Required frontmatter fields:
 - `token_budget`: positive integer budget for narrator context assembly.
 - `tags`: search/filter tags used by the registry and browser experiences.
 - `description`: short summary shown in registry and authoring surfaces.
-- `test_suite_path`: repo-relative path for the skill harness introduced by the
-  next story.
+- `test_suite_path`: repo-relative path for the deterministic Skill harness.
 - `supported_toolchains`: toolchains, runtimes, or artifact families that the
   skill supports.
 - `trust_level`: governance classification. Accepted values are `experimental`,
@@ -88,6 +87,8 @@ deploywhisper skill test terraform
 ```
 
 Scenario layout and harness behavior are documented in `docs/skills/test-harness.md`.
+Verified and core Skills must include positive trigger/output/evidence scenarios
+and a negative safety scenario, and every declared scenario must pass.
 
 Validation fails when:
 

--- a/docs/skills/registry-api.md
+++ b/docs/skills/registry-api.md
@@ -17,6 +17,9 @@ contract.
 - `GET /api/v1/skills/{id}/versions`
   Returns the discoverable bundled-catalog version history for a single skill
   id.
+- `GET /api/v1/skills/{id}/test-results`
+  Returns deterministic scenario results, required coverage categories, and
+  the verified/core trust requirement decision.
 
 ## Notes
 
@@ -24,6 +27,10 @@ contract.
   `skills/*.md`.
 - List, detail, and version responses expose each Skill's manifest trust level,
   latest deterministic test summary, source, and last-update timestamp.
+- Test-result responses expose `coverage` for expected triggers, outputs,
+  evidence assumptions, and safety constraints plus actionable
+  `trust_requirement.failures` when a verified/core Skill is not eligible for
+  its declared trust level.
 - Installed or team-local cache files under `skills/custom/*.md` are excluded
   from this API so the browser and installer surfaces do not drift per
   instance.

--- a/docs/skills/test-harness.md
+++ b/docs/skills/test-harness.md
@@ -1,12 +1,32 @@
 # Skills Test Harness
 
-Story 4.3 adds a deterministic harness for built-in skill suites. The harness
+Story 9.3 completes the deterministic harness for built-in Skill suites. The harness
 does not try to execute skill prose. Instead, it validates the real runtime
 behavior that exists today:
 
 - the target skill is selected in isolation
 - trigger-based skills load from representative raw files
 - the emitted skill context contains required guidance snippets
+- unrelated evidence does not load the Skill or leak its guidance
+
+Every suite reports four coverage categories:
+
+- `expected_triggers`: a positive scenario selects the Skill through its tool,
+  filename trigger, or declared content marker
+- `expected_outputs`: a positive scenario checks one or more required guidance
+  substrings
+- `evidence_assumptions`: a positive scenario provides an explicit assessment
+  tool, contributor summary, and deterministic raw-file fixture
+- `safety_constraints`: a negative scenario proves unrelated evidence does not
+  select the Skill and checks that Skill guidance is absent
+
+The `coverage.complete` field is true only when all four categories are present.
+The `trust_requirement` result evaluates the manifest `trust_level`.
+`verified` and `core` Skills require complete coverage and every scenario to
+pass. Missing or incomplete suites fail that trust requirement and cause the
+CLI/CI harness command to exit nonzero. Experimental and deprecated Skills
+still report coverage and scenario failures, but incomplete coverage alone does
+not block their trust classification.
 
 Harness summary states:
 
@@ -46,6 +66,11 @@ Scenario file shape:
 }
 ```
 
+Positive scenarios declare evidence through `assessment_tool`,
+`contributor_summary`, and `raw_files`; `expected_substrings` verifies emitted
+guidance. Add a negative scenario with `expect_selected: false` and at least one
+`expected_absent_substrings` entry to lock the suite's safety boundary.
+
 ## CLI usage
 
 Run all built-in skill suites:
@@ -79,3 +104,6 @@ The skills API exposes harness status through:
 - `GET /api/v1/skills`
 - `GET /api/v1/skills/{id}`
 - `GET /api/v1/skills/{id}/test-results`
+
+The test-results response includes scenario results, coverage by required
+category, and the trust-level requirement decision with actionable failures.

--- a/services/skill_test_harness_service.py
+++ b/services/skill_test_harness_service.py
@@ -139,6 +139,8 @@ def _timestamp() -> str:
 def _build_summary(
     skill_id: str,
     scenario_results: list[SkillTestScenarioResult],
+    *,
+    suite_failed: bool = False,
 ) -> SkillTestSummary:
     total = len(scenario_results)
     passed = sum(1 for result in scenario_results if result.passed)
@@ -146,7 +148,7 @@ def _build_summary(
     status: SkillHarnessStatus
     if total == 0:
         status = "missing"
-    elif failed > 0:
+    elif failed > 0 or suite_failed:
         status = "failing"
     else:
         status = "passing"
@@ -336,30 +338,22 @@ def _build_suite_result(
     scenario_results: list[SkillTestScenarioResult],
 ) -> SkillTestSuiteResult:
     coverage = _evaluate_coverage(active_skill, scenarios, scenario_results)
-    effective_results = list(scenario_results)
-    if scenarios and trust_level in {"verified", "core"} and not coverage.complete:
-        effective_results.append(
-            SkillTestScenarioResult(
-                name="suite-coverage",
-                description="Required deterministic coverage categories.",
-                passed=False,
-                failures=[
-                    "Verified/core suites must cover expected triggers, expected "
-                    "outputs, evidence assumptions, and safety constraints."
-                ],
-            )
-        )
+    trust_requirement = _evaluate_trust_requirement(
+        trust_level,
+        coverage,
+        scenario_results,
+    )
     return SkillTestSuiteResult(
         skill_id=skill_id,
         version=version,
-        summary=_build_summary(skill_id, effective_results),
-        coverage=coverage,
-        trust_requirement=_evaluate_trust_requirement(
-            trust_level,
-            coverage,
+        summary=_build_summary(
+            skill_id,
             scenario_results,
+            suite_failed=trust_requirement.required and not trust_requirement.satisfied,
         ),
-        scenarios=effective_results,
+        coverage=coverage,
+        trust_requirement=trust_requirement,
+        scenarios=scenario_results,
     )
 
 

--- a/services/skill_test_harness_service.py
+++ b/services/skill_test_harness_service.py
@@ -10,7 +10,11 @@ from pydantic import BaseModel, Field, ValidationError, field_validator
 
 from analysis.risk_scorer import RiskAssessment, RiskContributor
 from llm.skill_context import ActiveSkill, build_skill_context_from_active_skills
-from services.skill_manifest_service import REPO_ROOT, load_skill_document
+from services.skill_manifest_service import (
+    REPO_ROOT,
+    SkillTrustLevel,
+    load_skill_document,
+)
 
 
 SKILLS_DIR = REPO_ROOT / "skills"
@@ -28,11 +32,12 @@ class SkillTestScenarioDefinition(BaseModel):
         ..., description="Contributor tool name used to build assessment context."
     )
     contributor_summary: str = Field(
-        default="Exercise skill guidance.",
+        ...,
         description="Summary used for the single contributor in the scenario.",
     )
     raw_files: dict[str, str] = Field(
-        default_factory=dict,
+        ...,
+        min_length=1,
         description="Filename to text payload map supplied to skill resolution.",
     )
     expect_selected: bool = Field(
@@ -88,12 +93,33 @@ class SkillTestSummary(BaseModel):
     generated_at: str
 
 
+class SkillTestCoverage(BaseModel):
+    """Coverage of the deterministic assertions required by Story 9.3."""
+
+    expected_triggers: bool
+    expected_outputs: bool
+    evidence_assumptions: bool
+    safety_constraints: bool
+    complete: bool
+
+
+class SkillTrustRequirement(BaseModel):
+    """Whether the harness result satisfies the Skill's trust-level gate."""
+
+    trust_level: SkillTrustLevel
+    required: bool
+    satisfied: bool
+    failures: list[str] = Field(default_factory=list)
+
+
 class SkillTestSuiteResult(BaseModel):
     """Complete harness result for one skill."""
 
     skill_id: str
     version: str
     summary: SkillTestSummary
+    coverage: SkillTestCoverage
+    trust_requirement: SkillTrustRequirement
     scenarios: list[SkillTestScenarioResult] = Field(default_factory=list)
 
 
@@ -157,7 +183,9 @@ def _load_scenarios(suite_dir: Path) -> list[SkillTestScenarioDefinition]:
     return scenarios
 
 
-def _load_active_skill(skill_id: str) -> tuple[ActiveSkill, str, Path] | None:
+def _load_active_skill(
+    skill_id: str,
+) -> tuple[ActiveSkill, str, SkillTrustLevel, Path] | None:
     path = SKILLS_DIR / f"{skill_id}.md"
     if not path.exists():
         return None
@@ -180,7 +208,158 @@ def _load_active_skill(skill_id: str) -> tuple[ActiveSkill, str, Path] | None:
             trigger_content_patterns=list(document.manifest.trigger_content_patterns),
         ),
         document.manifest.version,
+        document.manifest.trust_level,
         REPO_ROOT / document.manifest.test_suite_path,
+    )
+
+
+def _filename_matches_trigger(filename: str, trigger: str) -> bool:
+    normalized_filename = filename.lower()
+    normalized_trigger = trigger.lower()
+    if normalized_trigger.startswith("."):
+        return normalized_filename.endswith(normalized_trigger)
+    if normalized_filename == normalized_trigger:
+        return True
+    return Path(normalized_filename).name == normalized_trigger
+
+
+def _scenario_has_expected_trigger(
+    active_skill: ActiveSkill,
+    scenario: SkillTestScenarioDefinition,
+) -> bool:
+    if not scenario.expect_selected:
+        return False
+    if scenario.assessment_tool.lower() == active_skill.name:
+        return True
+    if any(
+        _filename_matches_trigger(filename, trigger)
+        for filename in scenario.raw_files
+        for trigger in active_skill.triggers
+    ):
+        return True
+    raw_blob = "\n".join([*scenario.raw_files, *scenario.raw_files.values()]).lower()
+    return any(
+        pattern.lower() in raw_blob for pattern in active_skill.trigger_content_patterns
+    )
+
+
+def _evaluate_coverage(
+    active_skill: ActiveSkill,
+    scenarios: list[SkillTestScenarioDefinition],
+    scenario_results: list[SkillTestScenarioResult],
+) -> SkillTestCoverage:
+    passing_scenarios = [
+        scenario
+        for scenario, result in zip(scenarios, scenario_results, strict=False)
+        if result.passed
+    ]
+    positive_scenarios = [
+        scenario for scenario in passing_scenarios if scenario.expect_selected
+    ]
+    expected_triggers = any(
+        _scenario_has_expected_trigger(active_skill, scenario)
+        for scenario in positive_scenarios
+    )
+    expected_outputs = any(
+        scenario.expected_substrings for scenario in positive_scenarios
+    )
+    evidence_assumptions = any(
+        scenario.raw_files and scenario.assessment_tool and scenario.contributor_summary
+        for scenario in positive_scenarios
+    )
+    safety_constraints = any(
+        not scenario.expect_selected and scenario.expected_absent_substrings
+        for scenario in passing_scenarios
+    )
+    return SkillTestCoverage(
+        expected_triggers=expected_triggers,
+        expected_outputs=expected_outputs,
+        evidence_assumptions=evidence_assumptions,
+        safety_constraints=safety_constraints,
+        complete=all(
+            (
+                expected_triggers,
+                expected_outputs,
+                evidence_assumptions,
+                safety_constraints,
+            )
+        ),
+    )
+
+
+def _evaluate_trust_requirement(
+    trust_level: SkillTrustLevel,
+    coverage: SkillTestCoverage,
+    scenario_results: list[SkillTestScenarioResult],
+) -> SkillTrustRequirement:
+    required = trust_level in {"verified", "core"}
+    if not required:
+        return SkillTrustRequirement(
+            trust_level=trust_level,
+            required=False,
+            satisfied=True,
+        )
+
+    failures: list[str] = []
+    if not scenario_results:
+        failures.append(
+            "A verified/core Skill must have at least one passing scenario."
+        )
+    elif any(not result.passed for result in scenario_results):
+        failures.append("Every declared scenario must pass for verified/core trust.")
+    coverage_labels = (
+        ("expected triggers", coverage.expected_triggers),
+        ("expected outputs", coverage.expected_outputs),
+        ("evidence assumptions", coverage.evidence_assumptions),
+        ("safety constraints", coverage.safety_constraints),
+    )
+    missing_coverage = [label for label, present in coverage_labels if not present]
+    if missing_coverage:
+        failures.append(
+            "Verified/core suites must cover " + ", ".join(missing_coverage) + "."
+        )
+    return SkillTrustRequirement(
+        trust_level=trust_level,
+        required=True,
+        satisfied=not failures,
+        failures=failures,
+    )
+
+
+def _build_suite_result(
+    *,
+    skill_id: str,
+    version: str,
+    trust_level: SkillTrustLevel,
+    active_skill: ActiveSkill,
+    scenarios: list[SkillTestScenarioDefinition],
+    scenario_results: list[SkillTestScenarioResult],
+) -> SkillTestSuiteResult:
+    coverage = _evaluate_coverage(active_skill, scenarios, scenario_results)
+    effective_results = list(scenario_results)
+    if scenarios and trust_level in {"verified", "core"} and not coverage.complete:
+        effective_results.append(
+            SkillTestScenarioResult(
+                name="suite-coverage",
+                description="Required deterministic coverage categories.",
+                passed=False,
+                failures=[
+                    "Verified/core suites must cover expected triggers, expected "
+                    "outputs, evidence assumptions, and safety constraints."
+                ],
+            )
+        )
+    return SkillTestSuiteResult(
+        skill_id=skill_id,
+        version=version,
+        summary=_build_summary(skill_id, effective_results),
+        coverage=coverage,
+        trust_requirement=_evaluate_trust_requirement(
+            trust_level,
+            coverage,
+            scenario_results,
+        ),
+        scenarios=effective_results,
     )
 
 
@@ -250,7 +429,7 @@ def run_skill_test_suite(skill_id: str) -> SkillTestSuiteResult | None:
     loaded = _load_active_skill(skill_id)
     if loaded is None:
         return None
-    active_skill, version, suite_dir = loaded
+    active_skill, version, trust_level, suite_dir = loaded
     try:
         loaded_scenarios = _load_scenarios(suite_dir)
     except SkillScenarioLoadError as exc:
@@ -262,21 +441,25 @@ def run_skill_test_suite(skill_id: str) -> SkillTestSuiteResult | None:
                 failures=[f"{exc.path.name}: {exc.message}"],
             )
         ]
-        return SkillTestSuiteResult(
+        return _build_suite_result(
             skill_id=skill_id,
             version=version,
-            summary=_build_summary(skill_id, scenario_results),
-            scenarios=scenario_results,
+            trust_level=trust_level,
+            active_skill=active_skill,
+            scenarios=[],
+            scenario_results=scenario_results,
         )
 
     scenario_results = [
         _run_scenario(skill_id, active_skill, scenario) for scenario in loaded_scenarios
     ]
-    return SkillTestSuiteResult(
+    return _build_suite_result(
         skill_id=skill_id,
         version=version,
-        summary=_build_summary(skill_id, scenario_results),
-        scenarios=scenario_results,
+        trust_level=trust_level,
+        active_skill=active_skill,
+        scenarios=loaded_scenarios,
+        scenario_results=scenario_results,
     )
 
 

--- a/tests/skill-tests/ansible/non-match.json
+++ b/tests/skill-tests/ansible/non-match.json
@@ -1,0 +1,13 @@
+{
+  "name": "ansible-non-match",
+  "description": "Does not load the Ansible skill without Ansible evidence.",
+  "assessment_tool": "unrelated",
+  "contributor_summary": "A documentation-only change with no Ansible artifacts.",
+  "raw_files": {
+    "notes.txt": "Documentation update only.\n"
+  },
+  "expect_selected": false,
+  "expected_absent_substrings": [
+    "shell or command module with user-controlled input"
+  ]
+}

--- a/tests/skill-tests/cloudformation/non-match.json
+++ b/tests/skill-tests/cloudformation/non-match.json
@@ -1,0 +1,13 @@
+{
+  "name": "cloudformation-non-match",
+  "description": "Does not load the CloudFormation skill without CloudFormation evidence.",
+  "assessment_tool": "unrelated",
+  "contributor_summary": "A documentation-only change with no CloudFormation artifacts.",
+  "raw_files": {
+    "notes.txt": "Documentation update only.\n"
+  },
+  "expect_selected": false,
+  "expected_absent_substrings": [
+    "Stack policy removal or weakening"
+  ]
+}

--- a/tests/skill-tests/docker/non-match.json
+++ b/tests/skill-tests/docker/non-match.json
@@ -1,0 +1,13 @@
+{
+  "name": "docker-non-match",
+  "description": "Does not load the Docker skill without container evidence.",
+  "assessment_tool": "unrelated",
+  "contributor_summary": "A documentation-only change with no container artifacts.",
+  "raw_files": {
+    "notes.txt": "Documentation update only.\n"
+  },
+  "expect_selected": false,
+  "expected_absent_substrings": [
+    "No `USER` instruction in the Dockerfile"
+  ]
+}

--- a/tests/skill-tests/git/non-match.json
+++ b/tests/skill-tests/git/non-match.json
@@ -1,0 +1,13 @@
+{
+  "name": "git-non-match",
+  "description": "Does not load the Git skill without repository-change evidence.",
+  "assessment_tool": "unrelated",
+  "contributor_summary": "An unrelated runtime observation with no Git artifact.",
+  "raw_files": {
+    "notes.txt": "Runtime observation only.\n"
+  },
+  "expect_selected": false,
+  "expected_absent_substrings": [
+    "Force push to shared branch"
+  ]
+}

--- a/tests/skill-tests/jenkins/non-match.json
+++ b/tests/skill-tests/jenkins/non-match.json
@@ -1,0 +1,13 @@
+{
+  "name": "jenkins-non-match",
+  "description": "Does not load the Jenkins skill without pipeline evidence.",
+  "assessment_tool": "unrelated",
+  "contributor_summary": "A documentation-only change with no Jenkins artifacts.",
+  "raw_files": {
+    "notes.txt": "Documentation update only.\n"
+  },
+  "expect_selected": false,
+  "expected_absent_substrings": [
+    "Secrets echoed to console"
+  ]
+}

--- a/tests/skill-tests/kubernetes/non-match.json
+++ b/tests/skill-tests/kubernetes/non-match.json
@@ -1,0 +1,13 @@
+{
+  "name": "kubernetes-non-match",
+  "description": "Does not load the Kubernetes skill without Kubernetes evidence.",
+  "assessment_tool": "unrelated",
+  "contributor_summary": "A documentation-only change with no Kubernetes artifacts.",
+  "raw_files": {
+    "notes.txt": "Documentation update only.\n"
+  },
+  "expect_selected": false,
+  "expected_absent_substrings": [
+    "Container running as root"
+  ]
+}

--- a/tests/skill-tests/terraform/non-match.json
+++ b/tests/skill-tests/terraform/non-match.json
@@ -1,0 +1,13 @@
+{
+  "name": "terraform-non-match",
+  "description": "Does not load the Terraform skill without Terraform evidence.",
+  "assessment_tool": "unrelated",
+  "contributor_summary": "A documentation-only change with no Terraform artifacts.",
+  "raw_files": {
+    "notes.txt": "Documentation update only.\n"
+  },
+  "expect_selected": false,
+  "expected_absent_substrings": [
+    "Security group or firewall rule with `0.0.0.0/0`"
+  ]
+}

--- a/tests/test_api/test_skills.py
+++ b/tests/test_api/test_skills.py
@@ -335,6 +335,9 @@ class SkillsApiTests(unittest.TestCase):
             "trust_level",
             payload["components"]["schemas"]["SkillRegistryData"]["required"],
         )
+        test_results_schema = payload["components"]["schemas"]["SkillTestResultsData"]
+        self.assertIn("coverage", test_results_schema["required"])
+        self.assertIn("trust_requirement", test_results_schema["required"])
 
     def test_schema_route_publishes_skill_manifest_v1(self) -> None:
         response = self.client.get("/schemas/skill-manifest-v1.json")
@@ -353,6 +356,14 @@ class SkillsApiTests(unittest.TestCase):
         payload = response.json()
         self.assertEqual(payload["data"]["skill_id"], "terraform")
         self.assertEqual(payload["data"]["summary"]["status"], "passing")
+        self.assertTrue(payload["data"]["coverage"]["expected_triggers"])
+        self.assertTrue(payload["data"]["coverage"]["expected_outputs"])
+        self.assertTrue(payload["data"]["coverage"]["evidence_assumptions"])
+        self.assertTrue(payload["data"]["coverage"]["safety_constraints"])
+        self.assertTrue(payload["data"]["coverage"]["complete"])
+        self.assertEqual(payload["data"]["trust_requirement"]["trust_level"], "core")
+        self.assertTrue(payload["data"]["trust_requirement"]["required"])
+        self.assertTrue(payload["data"]["trust_requirement"]["satisfied"])
         self.assertGreaterEqual(len(payload["data"]["scenarios"]), 1)
 
     def test_skill_api_exposes_editorial_curation_metadata(self) -> None:

--- a/tests/test_cli/test_analyze.py
+++ b/tests/test_cli/test_analyze.py
@@ -37,9 +37,11 @@ from services.benchmark_runner_service import BenchmarkRunResult, BenchmarkRunSu
 from services.skill_installer_service import InstalledSkillEntry, SkillInstallResult
 from services.skill_registry_service import SkillRegistryEntry
 from services.skill_test_harness_service import (
+    SkillTestCoverage,
     SkillTestScenarioResult,
     SkillTestSuiteResult,
     SkillTestSummary,
+    SkillTrustRequirement,
 )
 
 
@@ -1080,6 +1082,8 @@ class AnalyzeCliTests(unittest.TestCase):
         payload = json.loads(output.getvalue())
         self.assertEqual(payload["data"][0]["skill_id"], "terraform")
         self.assertEqual(payload["data"][0]["summary"]["status"], "passing")
+        self.assertTrue(payload["data"][0]["coverage"]["complete"])
+        self.assertTrue(payload["data"][0]["trust_requirement"]["satisfied"])
 
     def test_skill_test_command_rejects_unknown_skill_id(self) -> None:
         stderr = io.StringIO()
@@ -1132,6 +1136,21 @@ class AnalyzeCliTests(unittest.TestCase):
                 display_text="0/0 scenarios passing",
                 generated_at="2026-04-24T00:00:00Z",
             ),
+            coverage=SkillTestCoverage(
+                expected_triggers=False,
+                expected_outputs=False,
+                evidence_assumptions=False,
+                safety_constraints=False,
+                complete=False,
+            ),
+            trust_requirement=SkillTrustRequirement(
+                trust_level="core",
+                required=True,
+                satisfied=False,
+                failures=[
+                    "A verified/core Skill must have at least one passing scenario."
+                ],
+            ),
             scenarios=[SkillTestScenarioResult(name="suite-missing", passed=False)],
         )
 
@@ -1145,6 +1164,53 @@ class AnalyzeCliTests(unittest.TestCase):
 
         self.assertEqual(ctx.exception.code, 1)
         self.assertIn("[missing]", output.getvalue())
+
+    def test_skill_test_command_enforces_verified_core_trust_requirement(
+        self,
+    ) -> None:
+        output = io.StringIO()
+        result = SkillTestSuiteResult(
+            skill_id="terraform",
+            version="1.0.0",
+            summary=SkillTestSummary(
+                skill_id="terraform",
+                total_scenarios=1,
+                passed_scenarios=1,
+                failed_scenarios=0,
+                pass_rate=1.0,
+                status="passing",
+                display_text="1/1 scenarios passing",
+                generated_at="2026-07-23T00:00:00Z",
+            ),
+            coverage=SkillTestCoverage(
+                expected_triggers=True,
+                expected_outputs=True,
+                evidence_assumptions=True,
+                safety_constraints=False,
+                complete=False,
+            ),
+            trust_requirement=SkillTrustRequirement(
+                trust_level="core",
+                required=True,
+                satisfied=False,
+                failures=["Verified/core suites must cover safety constraints."],
+            ),
+            scenarios=[SkillTestScenarioResult(name="positive", passed=True)],
+        )
+
+        with (
+            patch("cli.analyze.run_skill_test_suites", return_value=[result]),
+            patch("sys.argv", ["deploywhisper", "skill", "test", "terraform"]),
+            redirect_stdout(output),
+        ):
+            with self.assertRaises(SystemExit) as ctx:
+                main()
+
+        self.assertEqual(ctx.exception.code, 1)
+        self.assertIn(
+            "Verified/core suites must cover safety constraints.",
+            output.getvalue(),
+        )
 
     def test_skill_install_command_reports_install_location(self) -> None:
         output = io.StringIO()

--- a/tests/test_services/test_skill_test_harness_service.py
+++ b/tests/test_services/test_skill_test_harness_service.py
@@ -7,7 +7,12 @@ import unittest
 from pathlib import Path
 from unittest.mock import patch
 
+from llm.skill_context import ActiveSkill
 from services.skill_test_harness_service import (
+    SkillTestScenarioDefinition,
+    SkillTestScenarioResult,
+    _evaluate_coverage,
+    _filename_matches_trigger,
     iter_built_in_skill_ids,
     run_skill_test_suite,
     run_skill_test_suites,
@@ -16,6 +21,53 @@ from services.skill_test_harness_service import (
 
 
 class SkillTestHarnessServiceTests(unittest.TestCase):
+    def test_full_path_trigger_matching_stays_in_parity_with_runtime(self) -> None:
+        self.assertTrue(
+            _filename_matches_trigger(
+                "environments/prod/custom.trigger",
+                "environments/prod/custom.trigger",
+            )
+        )
+
+    def test_failed_scenarios_do_not_claim_verified_coverage(self) -> None:
+        active_skill = ActiveSkill(
+            name="terraform",
+            source="built-in",
+            path="skills/terraform.md",
+            content="Guidance.",
+            triggers=[".tf"],
+        )
+        positive = SkillTestScenarioDefinition(
+            name="positive",
+            assessment_tool="terraform",
+            contributor_summary="Terraform evidence.",
+            raw_files={"main.tf": "resource {}"},
+            expected_substrings=["missing output"],
+        )
+        negative = SkillTestScenarioDefinition(
+            name="negative",
+            assessment_tool="unrelated",
+            contributor_summary="Unrelated evidence.",
+            raw_files={"notes.txt": "documentation"},
+            expect_selected=False,
+            expected_absent_substrings=["Guidance."],
+        )
+
+        coverage = _evaluate_coverage(
+            active_skill,
+            [positive, negative],
+            [
+                SkillTestScenarioResult(name="positive", passed=False),
+                SkillTestScenarioResult(name="negative", passed=True),
+            ],
+        )
+
+        self.assertFalse(coverage.expected_triggers)
+        self.assertFalse(coverage.expected_outputs)
+        self.assertFalse(coverage.evidence_assumptions)
+        self.assertTrue(coverage.safety_constraints)
+        self.assertFalse(coverage.complete)
+
     def test_run_skill_test_suite_reports_passing_summary(self) -> None:
         result = run_skill_test_suite("terraform")
 
@@ -25,6 +77,14 @@ class SkillTestHarnessServiceTests(unittest.TestCase):
         self.assertGreaterEqual(result.summary.total_scenarios, 1)
         self.assertEqual(result.summary.failed_scenarios, 0)
         self.assertTrue(all(scenario.passed for scenario in result.scenarios))
+        self.assertTrue(result.coverage.expected_triggers)
+        self.assertTrue(result.coverage.expected_outputs)
+        self.assertTrue(result.coverage.evidence_assumptions)
+        self.assertTrue(result.coverage.safety_constraints)
+        self.assertTrue(result.coverage.complete)
+        self.assertTrue(result.trust_requirement.required)
+        self.assertTrue(result.trust_requirement.satisfied)
+        self.assertEqual(result.trust_requirement.failures, [])
 
     def test_summarize_skill_test_suite_returns_public_display_text(self) -> None:
         summary = summarize_skill_test_suite("docker")
@@ -75,6 +135,13 @@ class SkillTestHarnessServiceTests(unittest.TestCase):
         self.assertEqual(result.summary.status, "missing")
         self.assertEqual(result.summary.total_scenarios, 0)
         self.assertEqual(result.summary.pass_rate, 0.0)
+        self.assertFalse(result.coverage.complete)
+        self.assertTrue(result.trust_requirement.required)
+        self.assertFalse(result.trust_requirement.satisfied)
+        self.assertIn(
+            "A verified/core Skill must have at least one passing scenario.",
+            result.trust_requirement.failures,
+        )
 
     def test_invalid_scenario_json_is_reported_as_failing_suite(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -118,6 +185,103 @@ class SkillTestHarnessServiceTests(unittest.TestCase):
         self.assertEqual(result.summary.failed_scenarios, 1)
         self.assertEqual(result.scenarios[0].name, "suite-load-error")
         self.assertIn("broken.json", result.scenarios[0].failures[0])
+        self.assertFalse(result.trust_requirement.satisfied)
+
+    def test_verified_suite_requires_complete_deterministic_coverage(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            repo_root = Path(tmpdir)
+            skills_dir = repo_root / "skills"
+            suite_dir = repo_root / "tests" / "skill-tests" / "terraform"
+            skills_dir.mkdir(parents=True, exist_ok=True)
+            suite_dir.mkdir(parents=True, exist_ok=True)
+            (skills_dir / "terraform.md").write_text(
+                "---\n"
+                "name: terraform\n"
+                "version: 1.0.0\n"
+                "author: Community Maintainer\n"
+                "license: MIT\n"
+                "triggers: [.tf]\n"
+                "token_budget: 1500\n"
+                "tags: [terraform]\n"
+                "description: Terraform guidance.\n"
+                "test_suite_path: tests/skill-tests/terraform\n"
+                "supported_toolchains: [terraform]\n"
+                "trust_level: verified\n"
+                "scenario_references: [tests/skill-tests/terraform]\n"
+                "documentation_links: [https://docs.deploywhisper.example/skills/terraform]\n"
+                "---\n"
+                "# Terraform\nGuidance.\n",
+                encoding="utf-8",
+            )
+            (suite_dir / "positive.json").write_text(
+                '{"name":"positive","assessment_tool":"terraform",'
+                '"contributor_summary":"Terraform resource evidence.",'
+                '"raw_files":{"main.tf":"resource {}"},'
+                '"expected_substrings":["Guidance."]}',
+                encoding="utf-8",
+            )
+
+            with (
+                patch("services.skill_test_harness_service.REPO_ROOT", repo_root),
+                patch("services.skill_test_harness_service.SKILLS_DIR", skills_dir),
+            ):
+                result = run_skill_test_suite("terraform")
+
+        assert result is not None
+        self.assertEqual(result.summary.status, "failing")
+        self.assertFalse(result.coverage.safety_constraints)
+        self.assertFalse(result.trust_requirement.satisfied)
+        self.assertEqual(result.scenarios[-1].name, "suite-coverage")
+        self.assertNotIn(
+            "Every declared scenario must pass for verified/core trust.",
+            result.trust_requirement.failures,
+        )
+
+    def test_experimental_suite_reports_coverage_without_enforcing_gate(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            repo_root = Path(tmpdir)
+            skills_dir = repo_root / "skills"
+            suite_dir = repo_root / "tests" / "skill-tests" / "terraform"
+            skills_dir.mkdir(parents=True, exist_ok=True)
+            suite_dir.mkdir(parents=True, exist_ok=True)
+            (skills_dir / "terraform.md").write_text(
+                "---\n"
+                "name: terraform\n"
+                "version: 1.0.0\n"
+                "author: Community Maintainer\n"
+                "license: MIT\n"
+                "triggers: [.tf]\n"
+                "token_budget: 1500\n"
+                "tags: [terraform]\n"
+                "description: Terraform guidance.\n"
+                "test_suite_path: tests/skill-tests/terraform\n"
+                "supported_toolchains: [terraform]\n"
+                "trust_level: experimental\n"
+                "scenario_references: [tests/skill-tests/terraform]\n"
+                "documentation_links: [https://docs.deploywhisper.example/skills/terraform]\n"
+                "---\n"
+                "# Terraform\nGuidance.\n",
+                encoding="utf-8",
+            )
+            (suite_dir / "positive.json").write_text(
+                '{"name":"positive","assessment_tool":"terraform",'
+                '"contributor_summary":"Terraform resource evidence.",'
+                '"raw_files":{"main.tf":"resource {}"},'
+                '"expected_substrings":["Guidance."]}',
+                encoding="utf-8",
+            )
+
+            with (
+                patch("services.skill_test_harness_service.REPO_ROOT", repo_root),
+                patch("services.skill_test_harness_service.SKILLS_DIR", skills_dir),
+            ):
+                result = run_skill_test_suite("terraform")
+
+        assert result is not None
+        self.assertEqual(result.summary.status, "passing")
+        self.assertFalse(result.coverage.complete)
+        self.assertFalse(result.trust_requirement.required)
+        self.assertTrue(result.trust_requirement.satisfied)
 
     def test_run_skill_test_suites_defaults_to_all_built_in_skills(self) -> None:
         results = run_skill_test_suites()
@@ -126,6 +290,11 @@ class SkillTestHarnessServiceTests(unittest.TestCase):
             {result.skill_id for result in results},
             set(iter_built_in_skill_ids()),
         )
+        for result in results:
+            with self.subTest(skill_id=result.skill_id):
+                self.assertTrue(result.coverage.complete)
+                self.assertTrue(result.trust_requirement.required)
+                self.assertTrue(result.trust_requirement.satisfied)
 
 
 if __name__ == "__main__":

--- a/tests/test_services/test_skill_test_harness_service.py
+++ b/tests/test_services/test_skill_test_harness_service.py
@@ -229,9 +229,12 @@ class SkillTestHarnessServiceTests(unittest.TestCase):
 
         assert result is not None
         self.assertEqual(result.summary.status, "failing")
+        self.assertEqual(result.summary.total_scenarios, 1)
+        self.assertEqual(result.summary.passed_scenarios, 1)
+        self.assertEqual(result.summary.failed_scenarios, 0)
         self.assertFalse(result.coverage.safety_constraints)
         self.assertFalse(result.trust_requirement.satisfied)
-        self.assertEqual(result.scenarios[-1].name, "suite-coverage")
+        self.assertEqual([scenario.name for scenario in result.scenarios], ["positive"])
         self.assertNotIn(
             "Every declared scenario must pass for verified/core trust.",
             result.trust_requirement.failures,
@@ -292,9 +295,15 @@ class SkillTestHarnessServiceTests(unittest.TestCase):
         )
         for result in results:
             with self.subTest(skill_id=result.skill_id):
-                self.assertTrue(result.coverage.complete)
-                self.assertTrue(result.trust_requirement.required)
+                requires_gate = result.trust_requirement.trust_level in {
+                    "verified",
+                    "core",
+                }
+                self.assertEqual(result.trust_requirement.required, requires_gate)
+                if requires_gate:
+                    self.assertTrue(result.coverage.complete)
                 self.assertTrue(result.trust_requirement.satisfied)
+                self.assertEqual(result.summary.status, "passing")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- enforce deterministic trigger, output, evidence-assumption, and safety coverage for verified/core Skills
- expose coverage and trust-gate decisions through the API and CLI
- add negative safety scenarios for foundational core Skills
- resolve all three BMad code-review findings by counting only passing scenarios, matching full-path triggers like runtime, and separating synthetic coverage failures from declared-scenario failures

## Verification
- focused service/API/CLI: 102 passed, 28 subtests
- services CI shard: 840 passed, 171 subtests
- API/CLI/infra CI shard: 339 passed, 15 subtests
- `bash scripts/ci-local.sh`: Ruff, formatting, dependency validation, Bandit, compileall, all 28 Skill suites, and 840 Python tests passed
- UI validation not applicable

## BMad
- Story 9.3 status: done
- Review findings resolved: 3/3