### PR TITLE
Story 9.4: add safe configured-source Skill installer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,7 @@ permissions:
 
 env:
   PYTHON_VERSION: "3.11"
+  RUFF_VERSION: "0.15.11"
   PIP_DISABLE_PIP_VERSION_CHECK: "1"
   PIP_NO_PYTHON_VERSION_WARNING: "1"
   COVERAGE_THRESHOLD: "70"  # fail if new code drops below this %
@@ -68,7 +69,9 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
-          pip install ruff mypy
+          # Keep CI aligned with the version used by scripts/ci-local.sh.
+          # Unpinned Ruff upgrades can enable new rules across untouched files.
+          pip install "ruff==${RUFF_VERSION}" mypy
 
       - name: Lint with Ruff
         run: ruff check . --output-format=github

--- a/_bmad-output/implementation-artifacts/9-4-skills-installer-cli.md
+++ b/_bmad-output/implementation-artifacts/9-4-skills-installer-cli.md
@@ -40,6 +40,14 @@ So that self-hosted teams can manage extensions without manual file copying.
 - [x] [Review][Patch] Add the ignored Story 9.4 artifact to the delivered change set so its File List and review record are auditable [\_bmad-output/implementation-artifacts/9-4-skills-installer-cli.md:110]
 - [x] [Review][Patch] Include `PUBLIC_APP_URL` in no-source remediation because it participates in registry URL resolution [services/skill_installer_service.py:153]
 
+### Review Findings (Re-run 2026-07-24)
+
+- [x] [Review][Patch] Bound local Skill source size before reading to prevent memory exhaustion from oversized Markdown [services/skill_installer_service.py:485]
+- [x] [Review][Patch] Add CLI-path regression coverage for local-source install/update behavior and surfaced errors [tests/test_cli/test_analyze.py:1215]
+- [x] [Review][Patch] Replace remaining registry-only update guidance with configured-source behavior [docs/skills/installer-cli.md:63]
+- [x] [Review][Patch] Clarify Dev Agent Record fallback wording so it does not imply registry fallback after a local source is selected [\_bmad-output/implementation-artifacts/9-4-skills-installer-cli.md:100]
+- [x] [Review][Patch] Make installed Skill replacement atomic so update write failures cannot corrupt the existing file [services/skill_installer_service.py:734]
+
 ## Dev Notes
 
 ### Epic Context
@@ -97,7 +105,7 @@ OpenAI Codex (GPT-5.4)
 
 - Reuse the existing registry-backed installer and shared CLI/service path rather than introducing a second installer.
 - Add an optional local self-hosted source with explicit precedence, strict manifest validation, and path-containment checks.
-- Preserve registry behavior as the fallback and verify both focused behavior and the repository's exact CI test lanes.
+- Preserve registry behavior when no local source is configured and verify both focused behavior and the repository's exact CI test lanes.
 
 ### Debug Log References
 
@@ -113,16 +121,23 @@ OpenAI Codex (GPT-5.4)
 - Review CI services shard: `COVERAGE_FILE=/tmp/deploywhisper-story-9-4-review-services.coverage ./.venv/bin/python -m pytest tests/test_services --cov=. --cov-report=xml:/tmp/coverage-services-9-4-review.xml --cov-report=term-missing -v --tb=short` — 853 passed, 554 warnings, 171 subtests passed.
 - Review CI API/CLI/infra shard: `COVERAGE_FILE=/tmp/deploywhisper-story-9-4-review-api-cli-infra.coverage ./.venv/bin/python -m pytest tests/test_api tests/test_cli tests/test_infra --cov=. --cov-report=xml:/tmp/coverage-api-cli-infra-9-4-review.xml --cov-report=term-missing -v --tb=short` — 339 passed, 330 warnings, 15 subtests passed.
 - Review full local CI: `bash scripts/ci-local.sh` — passed Ruff, formatting, dependency validation, Bandit, compilation, Skill benchmark corpus, and all unittest discovery lanes; services reported 853 tests passed.
+- Review re-run RED: selected oversized-source and atomic-update regressions — 2 failed before implementation, proving unbounded reads and direct destination writes remained.
+- Review re-run targeted GREEN: selected service regressions — 2 passed; CLI local-source install/update/error regressions — 2 passed.
+- Review re-run focused cross-layer regression: `./.venv/bin/python -m pytest tests/test_services/test_skill_installer_service.py tests/test_api/test_skills.py tests/test_cli/test_analyze.py -q --tb=short` — 135 passed, 94 warnings, 6 subtests passed.
+- Review re-run CI services shard: `COVERAGE_FILE=/tmp/deploywhisper-story-9-4-rerun-services.coverage ./.venv/bin/python -m pytest tests/test_services --cov=. --cov-report=xml:/tmp/coverage-services-9-4-rerun.xml --cov-report=term-missing -v --tb=short` — 855 passed, 554 warnings, 171 subtests passed.
+- Review re-run CI API/CLI/infra shard: `COVERAGE_FILE=/tmp/deploywhisper-story-9-4-rerun-api-cli-infra.coverage ./.venv/bin/python -m pytest tests/test_api tests/test_cli tests/test_infra --cov=. --cov-report=xml:/tmp/coverage-api-cli-infra-9-4-rerun.xml --cov-report=term-missing -v --tb=short` — 341 passed, 335 warnings, 15 subtests passed.
+- Review re-run full local CI: `bash scripts/ci-local.sh` — passed Ruff, formatting, dependency validation, Bandit, compilation, Skill benchmark corpus, and all unittest discovery lanes; services reported 855 tests passed.
 - UI validation not applicable: no React route, component, interaction, or accessibility behavior changed.
 
 ### Completion Notes List
 
 - Added `DEPLOYWHISPER_SKILLS_SOURCE_DIR` for private, organization-owned, and air-gapped Skill Markdown sources.
-- Local sources take precedence over the registry, while existing registry installation remains the unchanged fallback.
+- Local sources take precedence without network fallback; registry installation remains available when no local source is configured.
 - Local files must be UTF-8 regular files contained within the configured source directory; symlinks and special files are rejected.
 - Local reads are anchored to an open directory descriptor and verify file identity before reading, closing the review-reported path-swap race.
+- Local source reads are capped at 1 MiB and use a bounded binary buffer before UTF-8 decoding.
 - Source Markdown is strictly parsed and validated as data before writes and is never imported, evaluated, or executed.
-- Invalid installs write nothing, invalid updates preserve the installed Skill, and actionable source/configuration errors are returned.
+- Installs and updates use same-directory atomic replacement; invalid inputs and write failures preserve the installed Skill.
 - Missing, unavailable, invalid, and unreadable sources have distinct error contracts, including complete configuration remediation.
 - Updated CLI help and operator documentation for configured source resolution and validation behavior.
 
@@ -135,6 +150,7 @@ OpenAI Codex (GPT-5.4)
 - `config.py`
 - `docs/skills/installer-cli.md`
 - `services/skill_installer_service.py`
+- `tests/test_cli/test_analyze.py`
 - `tests/test_services/test_skill_installer_service.py`
 
 ## Change Log
@@ -142,3 +158,4 @@ OpenAI Codex (GPT-5.4)
 - 2026-05-01: Story created/aligned from updated PRD, architecture, epics, sprint status, and readiness report.
 - 2026-07-23: Implemented and verified registry/local-source Skill install and update behavior, safe validation, CLI help, tests, and operator documentation.
 - 2026-07-24: Resolved all code-review findings with descriptor-anchored local reads, precise error contracts, expanded regression coverage, and full CI verification.
+- 2026-07-24: Resolved the review re-run with bounded source reads, atomic writes, CLI-path regressions, corrected operator guidance, and repeat full-CI verification.

--- a/_bmad-output/implementation-artifacts/9-4-skills-installer-cli.md
+++ b/_bmad-output/implementation-artifacts/9-4-skills-installer-cli.md
@@ -127,6 +127,7 @@ OpenAI Codex (GPT-5.4)
 - Review re-run CI services shard: `COVERAGE_FILE=/tmp/deploywhisper-story-9-4-rerun-services.coverage ./.venv/bin/python -m pytest tests/test_services --cov=. --cov-report=xml:/tmp/coverage-services-9-4-rerun.xml --cov-report=term-missing -v --tb=short` — 855 passed, 554 warnings, 171 subtests passed.
 - Review re-run CI API/CLI/infra shard: `COVERAGE_FILE=/tmp/deploywhisper-story-9-4-rerun-api-cli-infra.coverage ./.venv/bin/python -m pytest tests/test_api tests/test_cli tests/test_infra --cov=. --cov-report=xml:/tmp/coverage-api-cli-infra-9-4-rerun.xml --cov-report=term-missing -v --tb=short` — 341 passed, 335 warnings, 15 subtests passed.
 - Review re-run full local CI: `bash scripts/ci-local.sh` — passed Ruff, formatting, dependency validation, Bandit, compilation, Skill benchmark corpus, and all unittest discovery lanes; services reported 855 tests passed.
+- Review re-run remote CI diagnosis: GitHub installed unpinned Ruff 0.16.0 while local CI used Ruff 0.15.11, enabling new repository-wide rules and stopping the test matrix before execution; the workflow now pins Ruff 0.15.11 to the locally verified toolchain.
 - UI validation not applicable: no React route, component, interaction, or accessibility behavior changed.
 
 ### Completion Notes List
@@ -143,6 +144,7 @@ OpenAI Codex (GPT-5.4)
 
 ### File List
 
+- `.github/workflows/ci.yml`
 - `_bmad-output/implementation-artifacts/9-4-skills-installer-cli.md`
 - `_bmad-output/implementation-artifacts/deferred-work.md`
 - `_bmad-output/implementation-artifacts/sprint-status.yaml`
@@ -159,3 +161,4 @@ OpenAI Codex (GPT-5.4)
 - 2026-07-23: Implemented and verified registry/local-source Skill install and update behavior, safe validation, CLI help, tests, and operator documentation.
 - 2026-07-24: Resolved all code-review findings with descriptor-anchored local reads, precise error contracts, expanded regression coverage, and full CI verification.
 - 2026-07-24: Resolved the review re-run with bounded source reads, atomic writes, CLI-path regressions, corrected operator guidance, and repeat full-CI verification.
+- 2026-07-24: Pinned the CI Ruff version to the locally verified release so tool upgrades cannot introduce unrelated repository-wide lint failures between stories.

--- a/_bmad-output/implementation-artifacts/9-4-skills-installer-cli.md
+++ b/_bmad-output/implementation-artifacts/9-4-skills-installer-cli.md
@@ -47,6 +47,7 @@ So that self-hosted teams can manage extensions without manual file copying.
 - [x] [Review][Patch] Replace remaining registry-only update guidance with configured-source behavior [docs/skills/installer-cli.md:63]
 - [x] [Review][Patch] Clarify Dev Agent Record fallback wording so it does not imply registry fallback after a local source is selected [\_bmad-output/implementation-artifacts/9-4-skills-installer-cli.md:100]
 - [x] [Review][Patch] Make installed Skill replacement atomic so update write failures cannot corrupt the existing file [services/skill_installer_service.py:734]
+- [x] [Review][Patch] Scope the unreadable-source test double to descriptor-anchored source stats so it behaves consistently on CI Python 3.11 and local Python 3.14 [tests/test_services/test_skill_installer_service.py:477]
 
 ## Dev Notes
 
@@ -128,6 +129,7 @@ OpenAI Codex (GPT-5.4)
 - Review re-run CI API/CLI/infra shard: `COVERAGE_FILE=/tmp/deploywhisper-story-9-4-rerun-api-cli-infra.coverage ./.venv/bin/python -m pytest tests/test_api tests/test_cli tests/test_infra --cov=. --cov-report=xml:/tmp/coverage-api-cli-infra-9-4-rerun.xml --cov-report=term-missing -v --tb=short` — 341 passed, 335 warnings, 15 subtests passed.
 - Review re-run full local CI: `bash scripts/ci-local.sh` — passed Ruff, formatting, dependency validation, Bandit, compilation, Skill benchmark corpus, and all unittest discovery lanes; services reported 855 tests passed.
 - Review re-run remote CI diagnosis: GitHub installed unpinned Ruff 0.16.0 while local CI used Ruff 0.15.11, enabling new repository-wide rules and stopping the test matrix before execution; the workflow now pins Ruff 0.15.11 to the locally verified toolchain.
+- Review re-run fast-feedback diagnosis: CI Python 3.11 propagated a broadly mocked destination `stat` error that local Python 3.14 suppresses in `Path.exists`; the mock now denies only descriptor-anchored source-file stats. Installer service regression: 41 passed, 6 subtests passed.
 - UI validation not applicable: no React route, component, interaction, or accessibility behavior changed.
 
 ### Completion Notes List
@@ -162,3 +164,4 @@ OpenAI Codex (GPT-5.4)
 - 2026-07-24: Resolved all code-review findings with descriptor-anchored local reads, precise error contracts, expanded regression coverage, and full CI verification.
 - 2026-07-24: Resolved the review re-run with bounded source reads, atomic writes, CLI-path regressions, corrected operator guidance, and repeat full-CI verification.
 - 2026-07-24: Pinned the CI Ruff version to the locally verified release so tool upgrades cannot introduce unrelated repository-wide lint failures between stories.
+- 2026-07-24: Made the unreadable local-source regression portable across the repository's local Python 3.14 and CI Python 3.11 runtimes.

--- a/_bmad-output/implementation-artifacts/9-4-skills-installer-cli.md
+++ b/_bmad-output/implementation-artifacts/9-4-skills-installer-cli.md
@@ -1,0 +1,144 @@
+# Story 9.4: Skills Installer CLI
+
+Status: done
+
+<!-- Generated from updated PRD/architecture/epics plus implementation-readiness-report-2026-05-01.md. -->
+
+## Story
+
+As a platform admin,
+I want to install, update, and remove Skills from the CLI,
+So that self-hosted teams can manage extensions without manual file copying.
+
+## Acceptance Criteria
+
+1. Given a Skill registry or local Skill source is configured, When the CLI install/update/remove commands run, Then Skills are validated, stored, listed, and removable. And errors never execute untrusted Skill content.
+
+### Requirement Traceability
+
+- Primary PRD requirements: Epic 9 coverage: SKL-01..09, ADM-05, DOC-13, NFR-OSS-05.
+- Supporting PRD / NFR / differentiation requirements: See `_bmad-output/planning-artifacts/prd.md`, `_bmad-output/planning-artifacts/architecture.md`, and `_bmad-output/planning-artifacts/implementation-readiness-report-2026-05-01.md`.
+- Coverage intent: Baseline + Delta.
+- Story alignment note: This story was created from the updated Epic 9 plan after the 2026-05-01 readiness rerun. The readiness report verified 187/187 PRD functional requirement IDs in the epics artifact, 38 NFR IDs present, and no critical or major readiness defects.
+
+## Tasks / Subtasks
+
+- [x] Implement and verify acceptance criterion 1. (AC: 1)
+- [x] Reuse existing services, repositories, schemas, and UI/CLI/API helpers before adding new abstractions. (AC: all)
+- [x] Add or update deterministic regression coverage for the changed behavior. (AC: all)
+- [x] Update relevant docs or examples if the story changes user-visible, operator, API, CLI, integration, or contribution behavior. (AC: all)
+- [x] Run required validation and record commands/results in the Dev Agent Record. (AC: all)
+
+### Review Findings
+
+- [x] [Review][Patch] Close the local-source check/read race so a file cannot be replaced with an escaping symlink after validation [services/skill_installer_service.py:474]
+- [x] [Review][Patch] Distinguish a genuinely missing local Skill from permission, symlink-loop, and other resolution failures instead of reporting all as not found [services/skill_installer_service.py:474]
+- [x] [Review][Patch] Replace the registry-specific no-source error code with a configured-source error contract [services/skill_installer_service.py:153]
+- [x] [Review][Patch] Update source payload/result field descriptions that still claim every checksum and URI comes from the registry [services/skill_installer_service.py:69]
+- [x] [Review][Patch] Add regression coverage for unavailable, non-directory, non-UTF-8, and unreadable local source paths [tests/test_services/test_skill_installer_service.py:228]
+- [x] [Review][Patch] Add regression coverage for an unchanged local-source update [tests/test_services/test_skill_installer_service.py:116]
+- [x] [Review][Patch] Add the ignored Story 9.4 artifact to the delivered change set so its File List and review record are auditable [\_bmad-output/implementation-artifacts/9-4-skills-installer-cli.md:110]
+- [x] [Review][Patch] Include `PUBLIC_APP_URL` in no-source remediation because it participates in registry URL resolution [services/skill_installer_service.py:153]
+
+## Dev Notes
+
+### Epic Context
+
+- Epic: 9. Skills Ecosystem
+- Epic goal: Grow community knowledge safely through non-executable, tested, versioned Skills.
+- Epic coverage: SKL-01..09, ADM-05, DOC-13, NFR-OSS-05
+
+### Architecture and Product Guardrails
+
+- Preserve DeployWhisper's local-first raw artifact boundary: raw IaC, scanner artifacts, incident exports, and sensitive context stay in the user's infrastructure by default.
+- Preserve the advisory-first core. Optional adapters may interpret report outputs, but canonical report semantics remain advisory unless explicit story scope says otherwise.
+- Reuse the shared analysis core and service layer before adapting UI, API, CLI, GitHub, or future workflow surfaces.
+- Keep Evidence Law behavior intact: no high or critical finding without deterministic evidence.
+- Keep project/workspace scope explicit for reports, incidents, topology, outcomes, feedback, scanner imports, and connector-related data.
+- Do not introduce new dependencies unless the active story explicitly requires and justifies them.
+
+### Source Tree Guidance
+
+- API routes belong under `api/routes/` and should use existing `ApiRoute` / `ApiError` envelope patterns.
+- Shared orchestration belongs in `services/`; parsers normalize input, analysis modules score/derive risk, and surfaces adapt outputs.
+- UI work belongs under `frontend/src/screens/` and `frontend/src/components/`, following the existing retired Python UI composition style.
+- CLI behavior belongs under `cli/` and must call the same service-layer paths as UI/API flows.
+- Persistence work belongs under `models/` with Alembic migrations when schema changes are required.
+- Documentation required by a story should be updated in the same workstream.
+
+### Testing Requirements
+
+- Use standard-library `unittest` in the existing `tests/test_*` layout.
+- Add focused regression tests for the layer changed by the story before broad refactors.
+- For Python changes, run `./.venv/bin/ruff check .`, `./.venv/bin/ruff format --check .`, and `./.venv/bin/python -m unittest discover -q` before closing implementation.
+- Use `bash scripts/ci-local.sh` for broader or cross-layer changes.
+
+### Project Structure Notes
+
+- Follow the current repository shape documented in `_bmad-output/project-context.md` and `AGENTS.md`.
+- If implementation reveals a conflict between this story and the current code baseline, keep the smallest compatible change and update the story notes rather than silently drifting from the PRD.
+
+### References
+
+- `_bmad-output/planning-artifacts/epics.md` - source Epic 9 / Story 9.4 definition.
+- `_bmad-output/planning-artifacts/prd.md` - functional and non-functional requirements.
+- `_bmad-output/planning-artifacts/architecture.md` - target architecture, boundaries, and guardrails.
+- `_bmad-output/planning-artifacts/ux-design-specification.md` - UX expectations for user-facing stories.
+- `_bmad-output/planning-artifacts/implementation-readiness-report-2026-05-01.md` - readiness verdict and residual story-format concern.
+- `_bmad-output/project-context.md` - repository-specific implementation rules.
+
+## Dev Agent Record
+
+### Agent Model Used
+
+OpenAI Codex (GPT-5.4)
+
+### Implementation Plan
+
+- Reuse the existing registry-backed installer and shared CLI/service path rather than introducing a second installer.
+- Add an optional local self-hosted source with explicit precedence, strict manifest validation, and path-containment checks.
+- Preserve registry behavior as the fallback and verify both focused behavior and the repository's exact CI test lanes.
+
+### Debug Log References
+
+- RED: `./.venv/bin/python -m pytest tests/test_services/test_skill_installer_service.py -q --tb=short` — 3 failed, 26 passed, 6 subtests passed; the new local-source install/update tests proved the baseline still used the registry.
+- GREEN: `./.venv/bin/python -m pytest tests/test_services/test_skill_installer_service.py -q --tb=short` — 32 passed, 6 subtests passed.
+- Focused cross-layer regression: `./.venv/bin/python -m pytest tests/test_services/test_skill_installer_service.py tests/test_api/test_skills.py tests/test_cli/test_analyze.py -q --tb=short` — 125 passed, 92 warnings, 6 subtests passed.
+- CI services shard: `COVERAGE_FILE=/tmp/deploywhisper-story-9-4-services.coverage ./.venv/bin/python -m pytest tests/test_services --cov=. --cov-report=xml:/tmp/coverage-services-9-4.xml --cov-report=term-missing -v --tb=short` — 847 passed, 554 warnings, 171 subtests passed.
+- CI API/CLI/infra shard: `COVERAGE_FILE=/tmp/deploywhisper-story-9-4-api-cli-infra-rerun.coverage ./.venv/bin/python -m pytest tests/test_api tests/test_cli tests/test_infra --cov=. --cov-report=xml:/tmp/coverage-api-cli-infra-9-4-rerun.xml --cov-report=term-missing -v --tb=short` — 339 passed, 330 warnings, 15 subtests passed.
+- Full local CI: `bash scripts/ci-local.sh` — passed Ruff, formatting, dependency validation, Bandit, compilation, Skill benchmark corpus, and all unittest discovery lanes; services reported 847 tests passed.
+- Review RED: `./.venv/bin/python -m pytest tests/test_services/test_skill_installer_service.py -q --tb=short` — 3 failed, 36 passed, 6 subtests passed; failures covered the stale source error code and unimplemented descriptor-based race/error handling.
+- Review GREEN: `./.venv/bin/python -m pytest tests/test_services/test_skill_installer_service.py -q --tb=short` — 39 passed, 6 subtests passed.
+- Review focused cross-layer regression: `./.venv/bin/python -m pytest tests/test_services/test_skill_installer_service.py tests/test_api/test_skills.py tests/test_cli/test_analyze.py -q --tb=short` — 131 passed, 92 warnings, 6 subtests passed.
+- Review CI services shard: `COVERAGE_FILE=/tmp/deploywhisper-story-9-4-review-services.coverage ./.venv/bin/python -m pytest tests/test_services --cov=. --cov-report=xml:/tmp/coverage-services-9-4-review.xml --cov-report=term-missing -v --tb=short` — 853 passed, 554 warnings, 171 subtests passed.
+- Review CI API/CLI/infra shard: `COVERAGE_FILE=/tmp/deploywhisper-story-9-4-review-api-cli-infra.coverage ./.venv/bin/python -m pytest tests/test_api tests/test_cli tests/test_infra --cov=. --cov-report=xml:/tmp/coverage-api-cli-infra-9-4-review.xml --cov-report=term-missing -v --tb=short` — 339 passed, 330 warnings, 15 subtests passed.
+- Review full local CI: `bash scripts/ci-local.sh` — passed Ruff, formatting, dependency validation, Bandit, compilation, Skill benchmark corpus, and all unittest discovery lanes; services reported 853 tests passed.
+- UI validation not applicable: no React route, component, interaction, or accessibility behavior changed.
+
+### Completion Notes List
+
+- Added `DEPLOYWHISPER_SKILLS_SOURCE_DIR` for private, organization-owned, and air-gapped Skill Markdown sources.
+- Local sources take precedence over the registry, while existing registry installation remains the unchanged fallback.
+- Local files must be UTF-8 regular files contained within the configured source directory; symlinks and special files are rejected.
+- Local reads are anchored to an open directory descriptor and verify file identity before reading, closing the review-reported path-swap race.
+- Source Markdown is strictly parsed and validated as data before writes and is never imported, evaluated, or executed.
+- Invalid installs write nothing, invalid updates preserve the installed Skill, and actionable source/configuration errors are returned.
+- Missing, unavailable, invalid, and unreadable sources have distinct error contracts, including complete configuration remediation.
+- Updated CLI help and operator documentation for configured source resolution and validation behavior.
+
+### File List
+
+- `_bmad-output/implementation-artifacts/9-4-skills-installer-cli.md`
+- `_bmad-output/implementation-artifacts/deferred-work.md`
+- `_bmad-output/implementation-artifacts/sprint-status.yaml`
+- `cli/analyze.py`
+- `config.py`
+- `docs/skills/installer-cli.md`
+- `services/skill_installer_service.py`
+- `tests/test_services/test_skill_installer_service.py`
+
+## Change Log
+
+- 2026-05-01: Story created/aligned from updated PRD, architecture, epics, sprint status, and readiness report.
+- 2026-07-23: Implemented and verified registry/local-source Skill install and update behavior, safe validation, CLI help, tests, and operator documentation.
+- 2026-07-24: Resolved all code-review findings with descriptor-anchored local reads, precise error contracts, expanded regression coverage, and full CI verification.

--- a/_bmad-output/implementation-artifacts/deferred-work.md
+++ b/_bmad-output/implementation-artifacts/deferred-work.md
@@ -53,3 +53,7 @@
 ## Deferred from: code review of 9-4-skills-installer-cli.md (2026-07-23)
 
 - Resolved 2026-07-24: The no-source remediation text now includes `PUBLIC_APP_URL`, matching the documented registry URL resolution order [services/skill_installer_service.py:153].
+
+## Deferred from: code review of 9-4-skills-installer-cli.md (2026-07-24)
+
+- Resolved 2026-07-24: Skill install and update now write a same-directory temporary file and atomically replace the destination, preserving the prior installed file when writes or replacement fail [services/skill_installer_service.py:625].

--- a/_bmad-output/implementation-artifacts/deferred-work.md
+++ b/_bmad-output/implementation-artifacts/deferred-work.md
@@ -1,0 +1,55 @@
+## Deferred from: code review of 2-1-submission-manifest-and-provenance.md (2026-05-07)
+
+- Resolved 2026-05-07: Share filename redaction can over-replace ordinary basename text in prose [services/report_service.py:119]. The fix keeps exact full-path replacement while limiting basename prose replacement to file-like names with extensions.
+
+## Deferred from: code review of 2-5-evidence-law-runtime-gate.md (2026-05-09)
+
+- Evidence Law status is not yet explicitly visible in UI/API/CLI report surfaces [frontend/src/components/report_detail_page.py:82]. Deferred because Story 2.5 only gates persistence; visible report header/table status is covered by later report-surface stories 3.1 and 3.2, but should remain tracked so those stories render the persisted Evidence Law warning/status instead of hiding it.
+
+## Deferred from: code review of 2-7-narrative-after-scoring-and-degraded-fallback.md (2026-05-12)
+
+- Resolved 2026-05-12: Blank APP_HOST still builds a malformed share URL [services/report_service.py:181]. The share-link host helper now normalizes blank APP_HOST to localhost.
+- Resolved 2026-05-12: Bracketed non-IP APP_HOST values still build malformed share URLs [services/report_service.py:181]. The share-link host helper now unwraps bracketed non-IP hostnames before URL construction.
+
+## Deferred from: code review of 2-7-narrative-after-scoring-and-degraded-fallback.md (2026-05-12)
+
+- APP_HOST URL-like values can still produce malformed share links [services/report_service.py:197]. Deferred as pre-existing configuration hardening because APP_BASE_URL/PUBLIC_APP_URL are the intended full-URL settings and Story 2.7 only touched host fallback normalization.
+- Non-numeric APP_PORT can still crash share-link fallback generation [services/report_service.py:179]. Deferred as pre-existing configuration validation outside the narrative-fallback acceptance criterion.
+- Share-link environment parsing remains outside centralized settings [services/report_service.py:172]. Deferred as pre-existing architecture cleanup; the story changed defensive normalization but did not introduce the direct environment reads.
+
+## Deferred from: code review of 2-7-narrative-after-scoring-and-degraded-fallback.md (2026-05-12)
+
+- Resolved 2026-05-12: Unbracketed IPv6 APP_HOST values with common 4-digit embedded-port-looking suffixes remain ambiguous with valid numeric IPv6 hextets [services/report_service.py:188]. The share-link host helper now strips a bounded set of common copied web/dev ports while still preserving ordinary numeric IPv6 hextets such as `:1234`.
+
+## Deferred from: code review of 3-3-evidence-inspector-panel.md (2026-05-15)
+
+- Extend the UI review browser gate beyond WebKit for focus-sensitive keyboard behavior [playwright.config.cjs:29]. Deferred as pre-existing browser-matrix hardening; Story 3.3 currently uses the approved `APP_PORT=18080 npm run test:ui-review` WebKit UI E2E substitute for the local manual screen-reader blocker.
+
+## Deferred from: code review of 3-3-evidence-inspector-panel.md (2026-05-15)
+
+- Add a direct narrative sanitization regression that covers redacted, sensitive-blocked, and unknown redaction states together for raw `source_ref` and `summary` leakage [frontend/e2e/test_history_page.py:49]. Deferred as supplemental coverage hardening because current focused tests already cover sensitive-blocked and unknown-redaction narrative leakage and mixed-redaction reference selection.
+
+## Deferred from: code review of 5-1-versioned-api-report-contract.md (2026-05-25)
+
+- List endpoint masks forbidden/conflicting scoped reads as empty success instead of an error envelope [api/routes/analyses.py:425]. Deferred as pre-existing behavior locked by existing scoped-read tests; it should be revisited as a project/workspace authorization contract cleanup separate from Story 5.1 report contract payload work.
+
+## Deferred from: code review of 6-2-benchmark-runner.md (2026-06-02)
+
+- Resolved 2026-06-02: Benchmark runs are not explicitly isolated from ambient topology/narrative service behavior [services/benchmark_runner_service.py:346]. The runner now calls the shared artifact builder with an explicit deterministic benchmark profile that disables ambient topology, incident lookup, narrative generation, and LLM scoring assists while preserving the shared parser/evidence/scoring/finding path.
+
+## Deferred from: code review of 7-3-kubernetes-live-state-connector.md (2026-06-10)
+
+- Malformed non-object Kubernetes manifest documents still abort parsing [parsers/kubernetes_parser.py:17]. Deferred as pre-existing parser hardening because the unguarded `document.get(...)` behavior existed before Story 7.3; this story only added namespace-aware resource IDs and aliases inside the existing parser loop.
+
+## Deferred from: code review of 8-1-sarif-ingestion.md (2026-06-19)
+
+- Resolved 2026-06-19: Incremental scanner rescan/update semantics need product decision [services/scanner_import_service.py:198]. Story 8.1 now upserts same-scope SARIF rescans, refreshes existing evidence severity/message/source metadata, and imports new findings from mixed duplicate/new runs.
+- Resolved 2026-06-19: Workspace deletion should decide between preserving scanner history and preventing workspace-scope promotion [models/tables.py:162]. Scanner workspace FKs now preserve history with `SET NULL`, while project-scope listing and uniqueness exclude orphaned workspace evidence via retained `workspace_key`.
+
+## Deferred from: code review of 9-1-skill-manifest-spec-v1.md (2026-07-20)
+
+- Expose parsed trust level and related manifest metadata through registry/API/install listing surfaces [services/skill_registry_service.py:28]. Deferred to Stories 9.2/9.5 where registry API and browser trust-level visibility are in scope; Story 9.1 only formalizes and validates the manifest schema.
+
+## Deferred from: code review of 9-4-skills-installer-cli.md (2026-07-23)
+
+- Resolved 2026-07-24: The no-source remediation text now includes `PUBLIC_APP_URL`, matching the documented registry URL resolution order [services/skill_installer_service.py:153].

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -1,5 +1,5 @@
 # generated: 2026-05-01
-# last_updated: 2026-07-23
+# last_updated: 2026-07-24
 # project: deploywhisper
 # project_key: NOKEY
 # tracking_system: file-system
@@ -35,7 +35,7 @@
 # - Dev moves story to review, then runs code-review
 
 generated: 2026-05-01
-last_updated: 2026-07-23
+last_updated: 2026-07-24
 project: deploywhisper
 project_key: NOKEY
 tracking_system: file-system
@@ -129,7 +129,7 @@ development_status:
   9-1-skill-manifest-spec-v1: done
   9-2-skills-registry-api: done
   9-3-skill-test-harness: done
-  9-4-skills-installer-cli: ready-for-dev
+  9-4-skills-installer-cli: done
   9-5-skills-browser-ui: ready-for-dev
   9-6-skill-contribution-workflow: ready-for-dev
   9-7-skill-analytics-and-deprecation-signals: ready-for-dev

--- a/cli/analyze.py
+++ b/cli/analyze.py
@@ -1102,7 +1102,7 @@ def build_parser() -> argparse.ArgumentParser:
     )
     skill_subparsers = skill_parser.add_subparsers(dest="skill_command")
     skill_install_parser = skill_subparsers.add_parser(
-        "install", help="Fetch and install a registry skill into skills/custom."
+        "install", help="Install a Skill from the configured source into skills/custom."
     )
     skill_install_parser.add_argument("skill_id", help="Skill id to install.")
     skill_list_parser = skill_subparsers.add_parser(
@@ -1131,7 +1131,7 @@ def build_parser() -> argparse.ArgumentParser:
         help="Emit machine-readable JSON instead of human-readable output.",
     )
     skill_update_parser = skill_subparsers.add_parser(
-        "update", help="Refresh an installed skill to the latest registry version."
+        "update", help="Refresh an installed Skill from the configured source."
     )
     skill_update_parser.add_argument("skill_id", help="Installed skill id to update.")
     skill_remove_parser = skill_subparsers.add_parser(

--- a/config.py
+++ b/config.py
@@ -72,6 +72,9 @@ class Settings:
         or os.getenv("PUBLIC_APP_URL")
         or None
     )
+    skills_local_source_dir: str | None = (
+        os.getenv("DEPLOYWHISPER_SKILLS_SOURCE_DIR") or None
+    )
     public_skills_registry_url: str = os.getenv(
         "DEPLOYWHISPER_PUBLIC_SKILLS_REGISTRY_URL",
         "https://deploywhisper.github.io/skills-registry/",

--- a/docs/skills/installer-cli.md
+++ b/docs/skills/installer-cli.md
@@ -61,10 +61,11 @@ commands fail with a clear configuration error instead of guessing a source.
   the same filename
 - Skill ids must use lowercase letters, digits, and hyphens only
 - `deploywhisper skill install` refuses to overwrite an existing custom file;
-  use `deploywhisper skill update` when you intentionally want the latest
-  registry version
-- `deploywhisper skill update` also restores the canonical registry copy when
-  the installed file has drifted locally but still reports the same version
+  use `deploywhisper skill update` when you intentionally want to refresh from
+  the currently configured source
+- `deploywhisper skill update` also restores the configured source copy when
+  the installed file has drifted locally but still reports the same version;
+  with a local source configured, it does not fall back to the registry
 
 ## Validation behavior
 
@@ -74,6 +75,7 @@ commands fail with a clear configuration error instead of guessing a source.
 - Local source paths must be regular UTF-8 files inside the configured
   directory; symlinks and special files are rejected, and reads are anchored
   to the validated directory to prevent path-swap races
+- Local source files are limited to 1 MiB and are read with a bounded buffer
 - Skill Markdown is parsed as data and is never imported, evaluated, or
   executed, including on validation errors
 - `deploywhisper skill list` reports both active installed skills and ignored

--- a/docs/skills/installer-cli.md
+++ b/docs/skills/installer-cli.md
@@ -1,12 +1,12 @@
 # Skills Installer CLI
 
-Story 4.4 adds registry-backed install lifecycle commands under
+Story 9.4 completes configured-source install lifecycle commands under
 `deploywhisper skill ...` so users can manage local skill cache files without
 copying markdown by hand.
 
 ## Commands
 
-Install the latest published version of a skill into `skills/custom/`:
+Install the configured version of a Skill into `skills/custom/`:
 
 ```bash
 deploywhisper skill install helm
@@ -24,7 +24,7 @@ List the shared registry catalog with analytics signals:
 deploywhisper skill list --catalog
 ```
 
-Update an installed custom skill to the latest registry version:
+Update an installed custom Skill from the configured source:
 
 ```bash
 deploywhisper skill update helm
@@ -36,17 +36,23 @@ Remove an installed custom skill:
 deploywhisper skill remove helm
 ```
 
-## Registry URL resolution
+## Source resolution
 
-The installer fetches metadata and raw markdown from the configured Skills
-Registry API. It resolves the base URL in this order:
+Set `DEPLOYWHISPER_SKILLS_SOURCE_DIR` to a local directory containing
+`<skill-id>.md` files for private, organization-owned, or air-gapped Skills.
+When configured, this local source takes precedence and install/update commands
+do not make a registry request.
+
+Without a local source directory, the installer fetches metadata and raw
+markdown from the configured Skills Registry API. It resolves the base URL in
+this order:
 
 1. `DEPLOYWHISPER_SKILLS_REGISTRY_URL`
 2. `APP_BASE_URL`
 3. `PUBLIC_APP_URL`
 
-If none of those are configured, install and update commands fail with a clear
-configuration error instead of guessing a remote endpoint.
+If neither a local source nor a registry URL is configured, install and update
+commands fail with a clear configuration error instead of guessing a source.
 
 ## Install location and precedence
 
@@ -62,9 +68,14 @@ configuration error instead of guessing a remote endpoint.
 
 ## Validation behavior
 
-- Registry payloads are validated against manifest v1 before being written to
-  disk
+- Registry and local-source payloads are validated against manifest v1 before
+  being written to disk
 - The installer verifies the registry-provided SHA-256 checksum before saving
+- Local source paths must be regular UTF-8 files inside the configured
+  directory; symlinks and special files are rejected, and reads are anchored
+  to the validated directory to prevent path-swap races
+- Skill Markdown is parsed as data and is never imported, evaluated, or
+  executed, including on validation errors
 - `deploywhisper skill list` reports both active installed skills and ignored
   files when a custom manifest is invalid
 - `deploywhisper skill list --catalog` shows registry analytics including

--- a/services/skill_installer_service.py
+++ b/services/skill_installer_service.py
@@ -10,6 +10,7 @@ import os
 from pathlib import Path
 import re
 import stat
+import tempfile
 from typing import Literal
 from urllib import error, parse, request
 
@@ -28,6 +29,7 @@ CUSTOM_DIR = SKILLS_DIR / "custom"
 SkillInstallMode = Literal["override", "new"]
 _SKILL_ID_PATTERN = re.compile(r"^[a-z0-9]+(?:-[a-z0-9]+)*$")
 MISSING_MANIFEST_WARNING = "Skill manifest frontmatter is required."
+MAX_SKILL_SOURCE_BYTES = 1024 * 1024
 
 
 class SkillInstallerError(ValueError):
@@ -507,6 +509,17 @@ def fetch_local_skill_content(
                 "Local Skill source must be a regular file, not a symlink or special file.",
                 {"skill_id": normalized_id, "path": str(candidate)},
             )
+        if initial_stat.st_size > MAX_SKILL_SOURCE_BYTES:
+            raise SkillInstallerError(
+                "skill_source_too_large",
+                "Local Skill source exceeds the maximum allowed size.",
+                {
+                    "skill_id": normalized_id,
+                    "path": str(candidate),
+                    "size_bytes": str(initial_stat.st_size),
+                    "max_bytes": str(MAX_SKILL_SOURCE_BYTES),
+                },
+            )
 
         open_flags = os.O_RDONLY | getattr(os, "O_BINARY", 0)
         open_flags |= getattr(os, "O_NOFOLLOW", 0)
@@ -562,9 +575,20 @@ def fetch_local_skill_content(
             )
 
         try:
-            with os.fdopen(file_fd, encoding="utf-8") as source_file:
+            with os.fdopen(file_fd, "rb") as source_file:
                 file_fd = None
-                content = source_file.read()
+                payload = source_file.read(MAX_SKILL_SOURCE_BYTES + 1)
+            if len(payload) > MAX_SKILL_SOURCE_BYTES:
+                raise SkillInstallerError(
+                    "skill_source_too_large",
+                    "Local Skill source exceeds the maximum allowed size.",
+                    {
+                        "skill_id": normalized_id,
+                        "path": str(candidate),
+                        "max_bytes": str(MAX_SKILL_SOURCE_BYTES),
+                    },
+                )
+            content = payload.decode("utf-8")
         except (OSError, UnicodeDecodeError) as exc:
             raise SkillInstallerError(
                 "skill_source_unreadable",
@@ -599,6 +623,40 @@ def fetch_configured_skill_content(skill_id: str) -> SkillRemoteContent:
     if local_source_dir is not None:
         return fetch_local_skill_content(skill_id, local_source_dir)
     return fetch_registry_skill_content(skill_id)
+
+
+def _replace_skill_content(destination: Path, content: str) -> None:
+    """Atomically replace an installed Skill while preserving the old file on errors."""
+
+    file_descriptor: int | None = None
+    temporary_path: Path | None = None
+    try:
+        file_descriptor, temporary_name = tempfile.mkstemp(
+            dir=destination.parent,
+            prefix=f".{destination.name}.",
+            suffix=".tmp",
+        )
+        temporary_path = Path(temporary_name)
+        with os.fdopen(file_descriptor, "w", encoding="utf-8") as temporary_file:
+            file_descriptor = None
+            temporary_file.write(content)
+            temporary_file.flush()
+            os.fsync(temporary_file.fileno())
+        temporary_path.replace(destination)
+    except (OSError, UnicodeEncodeError) as exc:
+        raise SkillInstallerError(
+            "skill_write_failed",
+            "Installed Skill could not be written safely.",
+            {"path": str(destination)},
+        ) from exc
+    finally:
+        if file_descriptor is not None:
+            os.close(file_descriptor)
+        if temporary_path is not None:
+            try:
+                temporary_path.unlink(missing_ok=True)
+            except OSError:
+                pass
 
 
 def list_installed_skills() -> list[InstalledSkillEntry]:
@@ -692,7 +750,7 @@ def install_skill(skill_id: str) -> SkillInstallResult:
 
     source = fetch_configured_skill_content(normalized_id)
     CUSTOM_DIR.mkdir(parents=True, exist_ok=True)
-    destination.write_text(source.content, encoding="utf-8")
+    _replace_skill_content(destination, source.content)
     return SkillInstallResult(
         action="installed",
         skill_id=normalized_id,
@@ -731,7 +789,7 @@ def update_skill(skill_id: str) -> SkillInstallResult:
             source_url=source.source_url,
         )
 
-    destination.write_text(source.content, encoding="utf-8")
+    _replace_skill_content(destination, source.content)
     return SkillInstallResult(
         action="updated",
         skill_id=normalized_id,

--- a/services/skill_installer_service.py
+++ b/services/skill_installer_service.py
@@ -1,12 +1,15 @@
-"""Registry-backed installer operations for custom skills."""
+"""Configured-source installer operations for custom skills."""
 
 from __future__ import annotations
 
+import errno
 from hashlib import sha256
 import ipaddress
 import json
+import os
 from pathlib import Path
 import re
+import stat
 from typing import Literal
 from urllib import error, parse, request
 
@@ -63,13 +66,13 @@ class InstalledSkillEntry(BaseModel):
 
 
 class SkillRemoteContent(BaseModel):
-    """Registry-delivered markdown payload for an installable skill."""
+    """Validated markdown payload from a configured Skill source."""
 
     id: str = Field(..., description="Stable skill identifier.")
-    version: str = Field(..., description="Registry version for the returned skill.")
+    version: str = Field(..., description="Manifest version for the returned skill.")
     content: str = Field(..., description="Raw markdown content including frontmatter.")
-    sha256: str = Field(..., description="SHA-256 checksum of the registry payload.")
-    source_url: str = Field(..., description="Registry endpoint used for retrieval.")
+    sha256: str = Field(..., description="SHA-256 checksum of the source payload.")
+    source_url: str = Field(..., description="Source URI used for retrieval.")
 
 
 class SkillInstallResult(BaseModel):
@@ -90,10 +93,10 @@ class SkillInstallResult(BaseModel):
         ..., description="Whether the installed skill is a new file or override."
     )
     sha256: str | None = Field(
-        default=None, description="Checksum for the written registry payload."
+        default=None, description="Checksum for the written source payload."
     )
     source_url: str | None = Field(
-        default=None, description="Registry URL used for install or update."
+        default=None, description="Source URI used for install or update."
     )
 
 
@@ -151,8 +154,9 @@ def _registry_base_url() -> str:
         )
         return configured.rstrip("/")
     raise SkillInstallerError(
-        "skills_registry_unconfigured",
-        "Skill registry URL is not configured. Set DEPLOYWHISPER_SKILLS_REGISTRY_URL or APP_BASE_URL.",
+        "skills_source_unconfigured",
+        "Skill source is not configured. Set DEPLOYWHISPER_SKILLS_SOURCE_DIR, "
+        "DEPLOYWHISPER_SKILLS_REGISTRY_URL, APP_BASE_URL, or PUBLIC_APP_URL.",
     )
 
 
@@ -386,10 +390,27 @@ def fetch_registry_skill_content(
             {"url": url},
         )
 
+    return _validate_source_content(
+        normalized_id,
+        content,
+        source_url=url,
+        advertised_checksum=str(data.get("sha256") or "").strip(),
+    )
+
+
+def _validate_source_content(
+    skill_id: str,
+    content: str,
+    *,
+    source_url: str,
+    advertised_checksum: str = "",
+) -> SkillRemoteContent:
+    """Validate source markdown without evaluating or executing its body."""
+
     try:
         document = parse_skill_document(
             content,
-            expected_name=normalized_id,
+            expected_name=skill_id,
             strict_manifest=True,
             project_root=None,
         )
@@ -407,21 +428,177 @@ def fetch_registry_skill_content(
             {"issues": "Skill manifest frontmatter is required."},
         )
     checksum = sha256(content.encode("utf-8")).hexdigest()
-    advertised_checksum = str(data.get("sha256") or "").strip()
     if advertised_checksum and advertised_checksum != checksum:
         raise SkillInstallerError(
             "skill_checksum_mismatch",
             "Fetched skill checksum did not match the registry metadata.",
-            {"skill_id": normalized_id},
+            {"skill_id": skill_id},
         )
 
     return SkillRemoteContent(
-        id=normalized_id,
+        id=skill_id,
         version=document.manifest.version,
         content=content,
         sha256=checksum,
-        source_url=url,
+        source_url=source_url,
     )
+
+
+def _configured_local_source_dir() -> Path | None:
+    configured = str(getattr(settings, "skills_local_source_dir", "") or "").strip()
+    if not configured:
+        return None
+    source_dir = Path(configured).expanduser()
+    try:
+        resolved = source_dir.resolve(strict=True)
+    except (OSError, RuntimeError) as exc:
+        raise SkillInstallerError(
+            "skills_local_source_unavailable",
+            "Configured local Skill source directory is unavailable.",
+            {"path": str(source_dir)},
+        ) from exc
+    if not resolved.is_dir():
+        raise SkillInstallerError(
+            "skills_local_source_invalid",
+            "Configured local Skill source must be a directory.",
+            {"path": str(resolved)},
+        )
+    return resolved
+
+
+def fetch_local_skill_content(
+    skill_id: str,
+    source_dir: Path,
+) -> SkillRemoteContent:
+    """Read and validate one Skill from a local self-hosted source directory."""
+
+    normalized_id = _normalize_skill_id(skill_id)
+    filename = f"{normalized_id}.md"
+    candidate = source_dir / filename
+    directory_fd: int | None = None
+    file_fd: int | None = None
+    try:
+        directory_fd = os.open(
+            source_dir,
+            os.O_RDONLY | getattr(os, "O_DIRECTORY", 0),
+        )
+        try:
+            initial_stat = os.stat(
+                filename,
+                dir_fd=directory_fd,
+                follow_symlinks=False,
+            )
+        except FileNotFoundError as exc:
+            raise SkillInstallerError(
+                "skill_source_not_found",
+                "Skill was not found in the configured local source.",
+                {"skill_id": normalized_id, "path": str(candidate)},
+            ) from exc
+        except OSError as exc:
+            raise SkillInstallerError(
+                "skill_source_unreadable",
+                "Local Skill source could not be inspected.",
+                {"skill_id": normalized_id, "path": str(candidate)},
+            ) from exc
+
+        if not stat.S_ISREG(initial_stat.st_mode):
+            raise SkillInstallerError(
+                "skills_local_source_invalid",
+                "Local Skill source must be a regular file, not a symlink or special file.",
+                {"skill_id": normalized_id, "path": str(candidate)},
+            )
+
+        open_flags = os.O_RDONLY | getattr(os, "O_BINARY", 0)
+        open_flags |= getattr(os, "O_NOFOLLOW", 0)
+        try:
+            file_fd = os.open(
+                filename,
+                open_flags,
+                dir_fd=directory_fd,
+            )
+        except FileNotFoundError as exc:
+            raise SkillInstallerError(
+                "skill_source_not_found",
+                "Skill was not found in the configured local source.",
+                {"skill_id": normalized_id, "path": str(candidate)},
+            ) from exc
+        except OSError as exc:
+            if exc.errno == errno.ELOOP:
+                raise SkillInstallerError(
+                    "skills_local_source_invalid",
+                    "Local Skill source must not be a symlink.",
+                    {"skill_id": normalized_id, "path": str(candidate)},
+                ) from exc
+            raise SkillInstallerError(
+                "skill_source_unreadable",
+                "Local Skill source could not be opened.",
+                {"skill_id": normalized_id, "path": str(candidate)},
+            ) from exc
+
+        opened_stat = os.fstat(file_fd)
+        try:
+            current_stat = os.stat(
+                filename,
+                dir_fd=directory_fd,
+                follow_symlinks=False,
+            )
+        except OSError as exc:
+            raise SkillInstallerError(
+                "skills_local_source_invalid",
+                "Local Skill source changed while it was being opened.",
+                {"skill_id": normalized_id, "path": str(candidate)},
+            ) from exc
+        expected_identity = (initial_stat.st_dev, initial_stat.st_ino)
+        if (
+            not stat.S_ISREG(opened_stat.st_mode)
+            or not stat.S_ISREG(current_stat.st_mode)
+            or (opened_stat.st_dev, opened_stat.st_ino) != expected_identity
+            or (current_stat.st_dev, current_stat.st_ino) != expected_identity
+        ):
+            raise SkillInstallerError(
+                "skills_local_source_invalid",
+                "Local Skill source changed while it was being opened.",
+                {"skill_id": normalized_id, "path": str(candidate)},
+            )
+
+        try:
+            with os.fdopen(file_fd, encoding="utf-8") as source_file:
+                file_fd = None
+                content = source_file.read()
+        except (OSError, UnicodeDecodeError) as exc:
+            raise SkillInstallerError(
+                "skill_source_unreadable",
+                "Local Skill source could not be read as UTF-8.",
+                {"skill_id": normalized_id, "path": str(candidate)},
+            ) from exc
+    except SkillInstallerError:
+        raise
+    except OSError as exc:
+        raise SkillInstallerError(
+            "skills_local_source_unavailable",
+            "Configured local Skill source directory became unavailable.",
+            {"path": str(source_dir)},
+        ) from exc
+    finally:
+        if file_fd is not None:
+            os.close(file_fd)
+        if directory_fd is not None:
+            os.close(directory_fd)
+
+    return _validate_source_content(
+        normalized_id,
+        content,
+        source_url=candidate.as_uri(),
+    )
+
+
+def fetch_configured_skill_content(skill_id: str) -> SkillRemoteContent:
+    """Fetch from the configured local source, falling back to the registry."""
+
+    local_source_dir = _configured_local_source_dir()
+    if local_source_dir is not None:
+        return fetch_local_skill_content(skill_id, local_source_dir)
+    return fetch_registry_skill_content(skill_id)
 
 
 def list_installed_skills() -> list[InstalledSkillEntry]:
@@ -502,7 +679,7 @@ def list_installed_skills() -> list[InstalledSkillEntry]:
 
 
 def install_skill(skill_id: str) -> SkillInstallResult:
-    """Install a skill from the configured registry into skills/custom."""
+    """Install a skill from the configured source into skills/custom."""
 
     normalized_id = _normalize_skill_id(skill_id)
     destination = _skill_destination(normalized_id)
@@ -513,22 +690,22 @@ def install_skill(skill_id: str) -> SkillInstallResult:
             {"skill_id": normalized_id, "path": str(destination)},
         )
 
-    remote = fetch_registry_skill_content(normalized_id)
+    source = fetch_configured_skill_content(normalized_id)
     CUSTOM_DIR.mkdir(parents=True, exist_ok=True)
-    destination.write_text(remote.content, encoding="utf-8")
+    destination.write_text(source.content, encoding="utf-8")
     return SkillInstallResult(
         action="installed",
         skill_id=normalized_id,
-        version=remote.version,
+        version=source.version,
         destination=str(destination),
         mode=_install_mode(normalized_id),
-        sha256=remote.sha256,
-        source_url=remote.source_url,
+        sha256=source.sha256,
+        source_url=source.source_url,
     )
 
 
 def update_skill(skill_id: str) -> SkillInstallResult:
-    """Refresh an installed skill to the latest registry version."""
+    """Refresh an installed skill from the configured source."""
 
     normalized_id = _normalize_skill_id(skill_id)
     destination = _skill_destination(normalized_id)
@@ -541,29 +718,29 @@ def update_skill(skill_id: str) -> SkillInstallResult:
 
     previous_version = _current_version(destination)
     previous_checksum = _current_checksum(destination)
-    remote = fetch_registry_skill_content(normalized_id)
-    if previous_version == remote.version and previous_checksum == remote.sha256:
+    source = fetch_configured_skill_content(normalized_id)
+    if previous_version == source.version and previous_checksum == source.sha256:
         return SkillInstallResult(
             action="unchanged",
             skill_id=normalized_id,
-            version=remote.version,
+            version=source.version,
             previous_version=previous_version,
             destination=str(destination),
             mode=_install_mode(normalized_id),
-            sha256=remote.sha256,
-            source_url=remote.source_url,
+            sha256=source.sha256,
+            source_url=source.source_url,
         )
 
-    destination.write_text(remote.content, encoding="utf-8")
+    destination.write_text(source.content, encoding="utf-8")
     return SkillInstallResult(
         action="updated",
         skill_id=normalized_id,
-        version=remote.version,
+        version=source.version,
         previous_version=previous_version,
         destination=str(destination),
         mode=_install_mode(normalized_id),
-        sha256=remote.sha256,
-        source_url=remote.source_url,
+        sha256=source.sha256,
+        source_url=source.source_url,
     )
 
 

--- a/tests/test_cli/test_analyze.py
+++ b/tests/test_cli/test_analyze.py
@@ -1239,6 +1239,151 @@ class AnalyzeCliTests(unittest.TestCase):
         self.assertIn("Installed helm@1.2.0", output.getvalue())
         self.assertIn("skills/custom/helm.md", output.getvalue())
 
+    def test_skill_install_and_update_commands_use_environment_local_source(
+        self,
+    ) -> None:
+        output = io.StringIO()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            repo_root = Path(tmpdir)
+            skills_dir = repo_root / "skills"
+            custom_dir = skills_dir / "custom"
+            source_dir = repo_root / "private-skills"
+            skills_dir.mkdir()
+            source_dir.mkdir()
+
+            def local_content(version: str, guidance: str) -> str:
+                return (
+                    "---\n"
+                    "name: helm\n"
+                    f"version: {version}\n"
+                    "author: Community\n"
+                    "license: MIT\n"
+                    "triggers: [Chart.yaml]\n"
+                    "token_budget: 900\n"
+                    "tags: [helm]\n"
+                    "description: Helm rollout checks.\n"
+                    "test_suite_path: tests/skill-tests/helm\n"
+                    "supported_toolchains: [helm]\n"
+                    "trust_level: verified\n"
+                    "scenario_references: [tests/skill-tests/helm]\n"
+                    "documentation_links: [docs/skills/helm.md]\n"
+                    "---\n"
+                    f"# Helm\n{guidance}\n"
+                )
+
+            source_path = source_dir / "helm.md"
+            source_path.write_text(
+                local_content("1.0.0", "Initial guidance."),
+                encoding="utf-8",
+            )
+            try:
+                with patch.dict(
+                    os.environ,
+                    {"DEPLOYWHISPER_SKILLS_SOURCE_DIR": str(source_dir)},
+                ):
+                    reload(config_module)
+                    with (
+                        patch(
+                            "services.skill_installer_service.SKILLS_DIR",
+                            skills_dir,
+                        ),
+                        patch(
+                            "services.skill_installer_service.CUSTOM_DIR",
+                            custom_dir,
+                        ),
+                        patch(
+                            "services.skill_installer_service.settings",
+                            config_module.settings,
+                        ),
+                        patch(
+                            "sys.argv",
+                            ["deploywhisper", "skill", "install", "helm"],
+                        ),
+                        redirect_stdout(output),
+                    ):
+                        with self.assertRaises(SystemExit) as install_ctx:
+                            main()
+
+                    source_path.write_text(
+                        local_content("2.0.0", "Updated guidance."),
+                        encoding="utf-8",
+                    )
+                    with (
+                        patch(
+                            "services.skill_installer_service.SKILLS_DIR",
+                            skills_dir,
+                        ),
+                        patch(
+                            "services.skill_installer_service.CUSTOM_DIR",
+                            custom_dir,
+                        ),
+                        patch(
+                            "services.skill_installer_service.settings",
+                            config_module.settings,
+                        ),
+                        patch(
+                            "sys.argv",
+                            ["deploywhisper", "skill", "update", "helm"],
+                        ),
+                        redirect_stdout(output),
+                    ):
+                        with self.assertRaises(SystemExit) as update_ctx:
+                            main()
+            finally:
+                reload(config_module)
+
+            self.assertEqual(install_ctx.exception.code, 0)
+            self.assertEqual(update_ctx.exception.code, 0)
+            installed = (custom_dir / "helm.md").read_text(encoding="utf-8")
+            self.assertIn("version: 2.0.0", installed)
+            self.assertIn("Updated guidance.", installed)
+            self.assertIn("Installed helm@1.0.0", output.getvalue())
+            self.assertIn("Updated helm 1.0.0 -> 2.0.0", output.getvalue())
+
+    def test_skill_install_command_surfaces_local_source_error(self) -> None:
+        error_output = io.StringIO()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            repo_root = Path(tmpdir)
+            skills_dir = repo_root / "skills"
+            source_dir = repo_root / "private-skills"
+            skills_dir.mkdir()
+            source_dir.mkdir()
+            try:
+                with patch.dict(
+                    os.environ,
+                    {"DEPLOYWHISPER_SKILLS_SOURCE_DIR": str(source_dir)},
+                ):
+                    reload(config_module)
+                    with (
+                        patch(
+                            "services.skill_installer_service.SKILLS_DIR",
+                            skills_dir,
+                        ),
+                        patch(
+                            "services.skill_installer_service.CUSTOM_DIR",
+                            skills_dir / "custom",
+                        ),
+                        patch(
+                            "services.skill_installer_service.settings",
+                            config_module.settings,
+                        ),
+                        patch(
+                            "sys.argv",
+                            ["deploywhisper", "skill", "install", "helm"],
+                        ),
+                        redirect_stderr(error_output),
+                    ):
+                        with self.assertRaises(SystemExit) as ctx:
+                            main()
+            finally:
+                reload(config_module)
+
+            self.assertEqual(ctx.exception.code, 2)
+            self.assertIn(
+                "Skill was not found in the configured local source.",
+                error_output.getvalue(),
+            )
+
     def test_skill_list_command_prints_installed_skill_inventory(self) -> None:
         output = io.StringIO()
 

--- a/tests/test_services/test_skill_installer_service.py
+++ b/tests/test_services/test_skill_installer_service.py
@@ -1,9 +1,10 @@
-"""Tests for registry-backed skill installer operations."""
+"""Tests for configured-source skill installer operations."""
 
 from __future__ import annotations
 
 from hashlib import sha256
 import json
+import os
 import tempfile
 import unittest
 from pathlib import Path
@@ -51,6 +52,467 @@ class _FakeHttpResponse:
 
 
 class SkillInstallerServiceTests(unittest.TestCase):
+    @staticmethod
+    def _local_skill_content(
+        *,
+        version: str = "1.2.0",
+        guidance: str = "Community guidance.",
+    ) -> str:
+        return (
+            "---\n"
+            "name: helm\n"
+            f"version: {version}\n"
+            "author: Community\n"
+            "license: MIT\n"
+            "triggers: [Chart.yaml]\n"
+            "token_budget: 900\n"
+            "tags: [helm]\n"
+            "description: Helm rollout checks.\n"
+            "test_suite_path: tests/skill-tests/helm\n"
+            "supported_toolchains: [helm]\n"
+            "trust_level: verified\n"
+            "scenario_references: [tests/skill-tests/helm]\n"
+            "documentation_links: [https://docs.deploywhisper.example/skills/helm]\n"
+            "---\n"
+            f"# Helm\n{guidance}\n"
+        )
+
+    def test_install_skill_reads_configured_local_source_without_network(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            repo_root = Path(tmpdir)
+            skills_dir = repo_root / "skills"
+            custom_dir = skills_dir / "custom"
+            source_dir = repo_root / "private-skills"
+            skills_dir.mkdir(parents=True)
+            source_dir.mkdir()
+            content = self._local_skill_content()
+            source_path = source_dir / "helm.md"
+            source_path.write_text(content, encoding="utf-8")
+
+            with (
+                patch("services.skill_installer_service.SKILLS_DIR", skills_dir),
+                patch("services.skill_installer_service.CUSTOM_DIR", custom_dir),
+                patch(
+                    "services.skill_installer_service.settings",
+                    SimpleNamespace(
+                        skills_local_source_dir=str(source_dir),
+                        skills_registry_base_url="https://registry.example.com",
+                    ),
+                ),
+                patch(
+                    "services.skill_installer_service._open_registry_request"
+                ) as mocked_open,
+            ):
+                result = install_skill("helm")
+
+            self.assertEqual(result.action, "installed")
+            self.assertEqual(result.version, "1.2.0")
+            self.assertEqual(result.source_url, source_path.resolve().as_uri())
+            self.assertEqual(
+                (custom_dir / "helm.md").read_text(encoding="utf-8"),
+                content,
+            )
+            mocked_open.assert_not_called()
+
+    def test_update_skill_refreshes_from_configured_local_source(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            repo_root = Path(tmpdir)
+            skills_dir = repo_root / "skills"
+            custom_dir = skills_dir / "custom"
+            source_dir = repo_root / "private-skills"
+            custom_dir.mkdir(parents=True)
+            source_dir.mkdir()
+            installed_path = custom_dir / "helm.md"
+            installed_path.write_text(
+                self._local_skill_content(
+                    version="1.0.0",
+                    guidance="Old guidance.",
+                ),
+                encoding="utf-8",
+            )
+            source_content = self._local_skill_content(
+                version="1.2.0",
+                guidance="New private guidance.",
+            )
+            (source_dir / "helm.md").write_text(source_content, encoding="utf-8")
+
+            with (
+                patch("services.skill_installer_service.SKILLS_DIR", skills_dir),
+                patch("services.skill_installer_service.CUSTOM_DIR", custom_dir),
+                patch(
+                    "services.skill_installer_service.settings",
+                    SimpleNamespace(
+                        skills_local_source_dir=str(source_dir),
+                        skills_registry_base_url=None,
+                    ),
+                ),
+            ):
+                result = update_skill("helm")
+
+            self.assertEqual(result.action, "updated")
+            self.assertEqual(result.previous_version, "1.0.0")
+            self.assertEqual(result.version, "1.2.0")
+            self.assertEqual(installed_path.read_text(encoding="utf-8"), source_content)
+
+    def test_invalid_local_source_never_writes_or_executes_skill_content(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            repo_root = Path(tmpdir)
+            skills_dir = repo_root / "skills"
+            custom_dir = skills_dir / "custom"
+            source_dir = repo_root / "private-skills"
+            marker_path = repo_root / "untrusted-content-executed"
+            skills_dir.mkdir(parents=True)
+            source_dir.mkdir()
+            (source_dir / "helm.md").write_text(
+                "---\n"
+                "name: ../helm\n"
+                "version: not-semver\n"
+                "---\n"
+                f"# Untrusted\nopen({str(marker_path)!r}, 'w').write('executed')\n",
+                encoding="utf-8",
+            )
+
+            with (
+                patch("services.skill_installer_service.SKILLS_DIR", skills_dir),
+                patch("services.skill_installer_service.CUSTOM_DIR", custom_dir),
+                patch(
+                    "services.skill_installer_service.settings",
+                    SimpleNamespace(
+                        skills_local_source_dir=str(source_dir),
+                        skills_registry_base_url=None,
+                    ),
+                ),
+            ):
+                with self.assertRaises(SkillInstallerError) as ctx:
+                    install_skill("helm")
+
+            self.assertEqual(ctx.exception.code, "invalid_skill_manifest")
+            self.assertFalse((custom_dir / "helm.md").exists())
+            self.assertFalse(marker_path.exists())
+
+    def test_invalid_local_update_preserves_installed_skill(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            repo_root = Path(tmpdir)
+            skills_dir = repo_root / "skills"
+            custom_dir = skills_dir / "custom"
+            source_dir = repo_root / "private-skills"
+            custom_dir.mkdir(parents=True)
+            source_dir.mkdir()
+            installed_path = custom_dir / "helm.md"
+            installed_content = self._local_skill_content(version="1.0.0")
+            installed_path.write_text(installed_content, encoding="utf-8")
+            (source_dir / "helm.md").write_text(
+                "---\nname: wrong-name\nversion: 2.0.0\n---\n# Invalid\n",
+                encoding="utf-8",
+            )
+
+            with (
+                patch("services.skill_installer_service.SKILLS_DIR", skills_dir),
+                patch("services.skill_installer_service.CUSTOM_DIR", custom_dir),
+                patch(
+                    "services.skill_installer_service.settings",
+                    SimpleNamespace(
+                        skills_local_source_dir=str(source_dir),
+                        skills_registry_base_url=None,
+                    ),
+                ),
+            ):
+                with self.assertRaises(SkillInstallerError) as ctx:
+                    update_skill("helm")
+
+            self.assertEqual(ctx.exception.code, "invalid_skill_manifest")
+            self.assertEqual(
+                installed_path.read_text(encoding="utf-8"),
+                installed_content,
+            )
+
+    def test_local_source_rejects_missing_skill_with_actionable_error(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            repo_root = Path(tmpdir)
+            skills_dir = repo_root / "skills"
+            source_dir = repo_root / "private-skills"
+            skills_dir.mkdir()
+            source_dir.mkdir()
+
+            with (
+                patch("services.skill_installer_service.SKILLS_DIR", skills_dir),
+                patch(
+                    "services.skill_installer_service.CUSTOM_DIR",
+                    skills_dir / "custom",
+                ),
+                patch(
+                    "services.skill_installer_service.settings",
+                    SimpleNamespace(
+                        skills_local_source_dir=str(source_dir),
+                        skills_registry_base_url=None,
+                    ),
+                ),
+            ):
+                with self.assertRaises(SkillInstallerError) as ctx:
+                    install_skill("helm")
+
+            self.assertEqual(ctx.exception.code, "skill_source_not_found")
+            self.assertEqual(ctx.exception.details["skill_id"], "helm")
+
+    def test_install_skill_reports_all_supported_source_configuration_options(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            skills_dir = Path(tmpdir) / "skills"
+            skills_dir.mkdir()
+            with (
+                patch("services.skill_installer_service.SKILLS_DIR", skills_dir),
+                patch(
+                    "services.skill_installer_service.CUSTOM_DIR",
+                    skills_dir / "custom",
+                ),
+                patch(
+                    "services.skill_installer_service.settings",
+                    SimpleNamespace(
+                        skills_local_source_dir=None,
+                        skills_registry_base_url=None,
+                    ),
+                ),
+            ):
+                with self.assertRaises(SkillInstallerError) as ctx:
+                    install_skill("helm")
+
+        self.assertEqual(ctx.exception.code, "skills_source_unconfigured")
+        self.assertIn("DEPLOYWHISPER_SKILLS_SOURCE_DIR", ctx.exception.message)
+        self.assertIn("DEPLOYWHISPER_SKILLS_REGISTRY_URL", ctx.exception.message)
+
+    def test_local_source_rejects_symlink_outside_configured_directory(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            repo_root = Path(tmpdir)
+            skills_dir = repo_root / "skills"
+            source_dir = repo_root / "private-skills"
+            outside_dir = repo_root / "outside"
+            skills_dir.mkdir()
+            source_dir.mkdir()
+            outside_dir.mkdir()
+            outside_path = outside_dir / "helm.md"
+            outside_path.write_text(self._local_skill_content(), encoding="utf-8")
+            (source_dir / "helm.md").symlink_to(outside_path)
+
+            with (
+                patch("services.skill_installer_service.SKILLS_DIR", skills_dir),
+                patch(
+                    "services.skill_installer_service.CUSTOM_DIR",
+                    skills_dir / "custom",
+                ),
+                patch(
+                    "services.skill_installer_service.settings",
+                    SimpleNamespace(
+                        skills_local_source_dir=str(source_dir),
+                        skills_registry_base_url=None,
+                    ),
+                ),
+            ):
+                with self.assertRaises(SkillInstallerError) as ctx:
+                    install_skill("helm")
+
+            self.assertEqual(ctx.exception.code, "skills_local_source_invalid")
+
+    def test_local_source_rejects_symlink_swap_between_validation_and_read(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            repo_root = Path(tmpdir)
+            skills_dir = repo_root / "skills"
+            source_dir = repo_root / "private-skills"
+            outside_path = repo_root / "outside.md"
+            skills_dir.mkdir()
+            source_dir.mkdir()
+            source_path = source_dir / "helm.md"
+            source_path.write_text(self._local_skill_content(), encoding="utf-8")
+            outside_path.write_text(self._local_skill_content(), encoding="utf-8")
+            real_open = os.open
+            source_opened = False
+
+            def swap_before_file_open(path, flags, *args, **kwargs):
+                nonlocal source_opened
+                if kwargs.get("dir_fd") is not None and not source_opened:
+                    source_opened = True
+                    source_path.unlink()
+                    source_path.symlink_to(outside_path)
+                return real_open(path, flags, *args, **kwargs)
+
+            with (
+                patch("services.skill_installer_service.SKILLS_DIR", skills_dir),
+                patch(
+                    "services.skill_installer_service.CUSTOM_DIR",
+                    skills_dir / "custom",
+                ),
+                patch(
+                    "services.skill_installer_service.settings",
+                    SimpleNamespace(
+                        skills_local_source_dir=str(source_dir),
+                        skills_registry_base_url=None,
+                    ),
+                ),
+                patch(
+                    "services.skill_installer_service.os.open",
+                    side_effect=swap_before_file_open,
+                ),
+            ):
+                with self.assertRaises(SkillInstallerError) as ctx:
+                    install_skill("helm")
+
+            self.assertEqual(ctx.exception.code, "skills_local_source_invalid")
+            self.assertFalse((skills_dir / "custom" / "helm.md").exists())
+
+    def test_local_source_reports_non_utf8_file_as_unreadable(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            repo_root = Path(tmpdir)
+            skills_dir = repo_root / "skills"
+            source_dir = repo_root / "private-skills"
+            skills_dir.mkdir()
+            source_dir.mkdir()
+            (source_dir / "helm.md").write_bytes(b"\xff\xfe\x00")
+
+            with (
+                patch("services.skill_installer_service.SKILLS_DIR", skills_dir),
+                patch(
+                    "services.skill_installer_service.CUSTOM_DIR",
+                    skills_dir / "custom",
+                ),
+                patch(
+                    "services.skill_installer_service.settings",
+                    SimpleNamespace(
+                        skills_local_source_dir=str(source_dir),
+                        skills_registry_base_url=None,
+                    ),
+                ),
+            ):
+                with self.assertRaises(SkillInstallerError) as ctx:
+                    install_skill("helm")
+
+            self.assertEqual(ctx.exception.code, "skill_source_unreadable")
+
+    def test_local_source_reports_permission_failure_as_unreadable(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            repo_root = Path(tmpdir)
+            skills_dir = repo_root / "skills"
+            source_dir = repo_root / "private-skills"
+            skills_dir.mkdir()
+            source_dir.mkdir()
+            (source_dir / "helm.md").write_text(
+                self._local_skill_content(),
+                encoding="utf-8",
+            )
+            real_stat = os.stat
+
+            def deny_skill_stat(path, *args, **kwargs):
+                if Path(path).name == "helm.md":
+                    raise PermissionError("permission denied")
+                return real_stat(path, *args, **kwargs)
+
+            with (
+                patch("services.skill_installer_service.SKILLS_DIR", skills_dir),
+                patch(
+                    "services.skill_installer_service.CUSTOM_DIR",
+                    skills_dir / "custom",
+                ),
+                patch(
+                    "services.skill_installer_service.settings",
+                    SimpleNamespace(
+                        skills_local_source_dir=str(source_dir),
+                        skills_registry_base_url=None,
+                    ),
+                ),
+                patch(
+                    "services.skill_installer_service.os.stat",
+                    side_effect=deny_skill_stat,
+                ),
+            ):
+                with self.assertRaises(SkillInstallerError) as ctx:
+                    install_skill("helm")
+
+            self.assertEqual(ctx.exception.code, "skill_source_unreadable")
+
+    def test_configured_local_source_reports_missing_directory(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            repo_root = Path(tmpdir)
+            skills_dir = repo_root / "skills"
+            missing_source_dir = repo_root / "missing-private-skills"
+            skills_dir.mkdir()
+
+            with (
+                patch("services.skill_installer_service.SKILLS_DIR", skills_dir),
+                patch(
+                    "services.skill_installer_service.CUSTOM_DIR",
+                    skills_dir / "custom",
+                ),
+                patch(
+                    "services.skill_installer_service.settings",
+                    SimpleNamespace(
+                        skills_local_source_dir=str(missing_source_dir),
+                        skills_registry_base_url=None,
+                    ),
+                ),
+            ):
+                with self.assertRaises(SkillInstallerError) as ctx:
+                    install_skill("helm")
+
+            self.assertEqual(ctx.exception.code, "skills_local_source_unavailable")
+
+    def test_configured_local_source_rejects_regular_file(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            repo_root = Path(tmpdir)
+            skills_dir = repo_root / "skills"
+            source_path = repo_root / "private-skills"
+            skills_dir.mkdir()
+            source_path.write_text("not a directory", encoding="utf-8")
+
+            with (
+                patch("services.skill_installer_service.SKILLS_DIR", skills_dir),
+                patch(
+                    "services.skill_installer_service.CUSTOM_DIR",
+                    skills_dir / "custom",
+                ),
+                patch(
+                    "services.skill_installer_service.settings",
+                    SimpleNamespace(
+                        skills_local_source_dir=str(source_path),
+                        skills_registry_base_url=None,
+                    ),
+                ),
+            ):
+                with self.assertRaises(SkillInstallerError) as ctx:
+                    install_skill("helm")
+
+            self.assertEqual(ctx.exception.code, "skills_local_source_invalid")
+
+    def test_update_skill_reports_unchanged_for_matching_local_source(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            repo_root = Path(tmpdir)
+            skills_dir = repo_root / "skills"
+            custom_dir = skills_dir / "custom"
+            source_dir = repo_root / "private-skills"
+            custom_dir.mkdir(parents=True)
+            source_dir.mkdir()
+            content = self._local_skill_content()
+            installed_path = custom_dir / "helm.md"
+            installed_path.write_text(content, encoding="utf-8")
+            (source_dir / "helm.md").write_text(content, encoding="utf-8")
+
+            with (
+                patch("services.skill_installer_service.SKILLS_DIR", skills_dir),
+                patch("services.skill_installer_service.CUSTOM_DIR", custom_dir),
+                patch(
+                    "services.skill_installer_service.settings",
+                    SimpleNamespace(
+                        skills_local_source_dir=str(source_dir),
+                        skills_registry_base_url=None,
+                    ),
+                ),
+            ):
+                result = update_skill("helm")
+
+            self.assertEqual(result.action, "unchanged")
+            self.assertEqual(result.previous_version, "1.2.0")
+            self.assertEqual(installed_path.read_text(encoding="utf-8"), content)
+
     def test_install_skill_fetches_registry_content_into_custom_dir(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             repo_root = Path(tmpdir)

--- a/tests/test_services/test_skill_installer_service.py
+++ b/tests/test_services/test_skill_installer_service.py
@@ -476,7 +476,7 @@ class SkillInstallerServiceTests(unittest.TestCase):
             real_stat = os.stat
 
             def deny_skill_stat(path, *args, **kwargs):
-                if Path(path).name == "helm.md":
+                if Path(path).name == "helm.md" and kwargs.get("dir_fd") is not None:
                     raise PermissionError("permission denied")
                 return real_stat(path, *args, **kwargs)
 

--- a/tests/test_services/test_skill_installer_service.py
+++ b/tests/test_services/test_skill_installer_service.py
@@ -226,6 +226,44 @@ class SkillInstallerServiceTests(unittest.TestCase):
                 installed_content,
             )
 
+    def test_update_write_failure_preserves_installed_skill(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            repo_root = Path(tmpdir)
+            skills_dir = repo_root / "skills"
+            custom_dir = skills_dir / "custom"
+            source_dir = repo_root / "private-skills"
+            custom_dir.mkdir(parents=True)
+            source_dir.mkdir()
+            installed_path = custom_dir / "helm.md"
+            installed_content = self._local_skill_content(version="1.0.0")
+            installed_path.write_text(installed_content, encoding="utf-8")
+            (source_dir / "helm.md").write_text(
+                self._local_skill_content(version="2.0.0"),
+                encoding="utf-8",
+            )
+
+            with (
+                patch("services.skill_installer_service.SKILLS_DIR", skills_dir),
+                patch("services.skill_installer_service.CUSTOM_DIR", custom_dir),
+                patch(
+                    "services.skill_installer_service.settings",
+                    SimpleNamespace(
+                        skills_local_source_dir=str(source_dir),
+                        skills_registry_base_url=None,
+                    ),
+                ),
+                patch.object(Path, "replace", side_effect=OSError("disk full")),
+            ):
+                with self.assertRaises(SkillInstallerError) as ctx:
+                    update_skill("helm")
+
+            self.assertEqual(ctx.exception.code, "skill_write_failed")
+            self.assertEqual(
+                installed_path.read_text(encoding="utf-8"),
+                installed_content,
+            )
+            self.assertEqual(list(custom_dir.glob(".helm.md.*.tmp")), [])
+
     def test_local_source_rejects_missing_skill_with_actionable_error(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             repo_root = Path(tmpdir)
@@ -388,6 +426,41 @@ class SkillInstallerServiceTests(unittest.TestCase):
                     install_skill("helm")
 
             self.assertEqual(ctx.exception.code, "skill_source_unreadable")
+
+    def test_local_source_rejects_oversized_file_before_install(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            repo_root = Path(tmpdir)
+            skills_dir = repo_root / "skills"
+            source_dir = repo_root / "private-skills"
+            skills_dir.mkdir()
+            source_dir.mkdir()
+            content = self._local_skill_content()
+            (source_dir / "helm.md").write_text(content, encoding="utf-8")
+
+            with (
+                patch("services.skill_installer_service.SKILLS_DIR", skills_dir),
+                patch(
+                    "services.skill_installer_service.CUSTOM_DIR",
+                    skills_dir / "custom",
+                ),
+                patch(
+                    "services.skill_installer_service.settings",
+                    SimpleNamespace(
+                        skills_local_source_dir=str(source_dir),
+                        skills_registry_base_url=None,
+                    ),
+                ),
+                patch(
+                    "services.skill_installer_service.MAX_SKILL_SOURCE_BYTES",
+                    len(content.encode("utf-8")) - 1,
+                    create=True,
+                ),
+            ):
+                with self.assertRaises(SkillInstallerError) as ctx:
+                    install_skill("helm")
+
+            self.assertEqual(ctx.exception.code, "skill_source_too_large")
+            self.assertFalse((skills_dir / "custom" / "helm.md").exists())
 
     def test_local_source_reports_permission_failure_as_unreadable(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:


### PR DESCRIPTION
## Summary
- add private and air-gapped local Skill source configuration with registry fallback
- validate local files as non-executable Markdown using directory-anchored, identity-checked reads
- add precise source errors, CLI help, documentation, and review regression coverage

## Review findings resolved
- closed the check/read symlink-swap race
- distinguished missing, invalid, unavailable, and unreadable source failures
- generalized source metadata and configuration errors
- added missing path, encoding, permission, and unchanged-update tests
- included Story 9.4 and review records in the delivered change set

## Verification
- installer tests: 39 passed, 6 subtests
- focused service/API/CLI: 131 passed, 92 warnings, 6 subtests
- services CI shard: 853 passed, 554 warnings, 171 subtests
- API/CLI/infra CI shard: 339 passed, 330 warnings, 15 subtests
- full scripts/ci-local.sh: passed
- Ruff, formatting, Bandit, dependency validation, and diff checks: passed
- UI validation: not applicable