### PR TITLE
Story 9.5: expose Skills trust and test status

### DIFF
--- a/_bmad-output/implementation-artifacts/deferred-work.md
+++ b/_bmad-output/implementation-artifacts/deferred-work.md
@@ -57,3 +57,8 @@
 ## Deferred from: code review of 9-4-skills-installer-cli.md (2026-07-24)
 
 - Resolved 2026-07-24: Skill install and update now write a same-directory temporary file and atomically replace the destination, preserving the prior installed file when writes or replacement fail [services/skill_installer_service.py:625].
+
+## Deferred from: code review of 9-5-skills-browser-ui.md (2026-07-27)
+
+- Render the full deterministic harness summary and analytics refresh timestamp on the Skill detail page [frontend/src/screens/Skills.tsx:224]. Deferred as a pre-existing documentation-to-UI gap: Story 9.5 adds the required trust and test-status visibility but did not introduce the missing detail metadata.
+- Expose registry contributors through `SkillRegistryData` and render them on the Skill detail page [api/schemas.py:2080]. Deferred as a pre-existing API/UI contract gap outside Story 9.5's search, filter, trust, test-status, source, and install-instruction acceptance criterion.

--- a/_bmad-output/implementation-artifacts/deferred-work.md
+++ b/_bmad-output/implementation-artifacts/deferred-work.md
@@ -60,5 +60,5 @@
 
 ## Deferred from: code review of 9-5-skills-browser-ui.md (2026-07-27)
 
-- Render the full deterministic harness summary and analytics refresh timestamp on the Skill detail page [frontend/src/screens/Skills.tsx:224]. Deferred as a pre-existing documentation-to-UI gap: Story 9.5 adds the required trust and test-status visibility but did not introduce the missing detail metadata.
-- Expose registry contributors through `SkillRegistryData` and render them on the Skill detail page [api/schemas.py:2080]. Deferred as a pre-existing API/UI contract gap outside Story 9.5's search, filter, trust, test-status, source, and install-instruction acceptance criterion.
+- Resolved 2026-07-27: The Skill detail page now renders the full deterministic harness summary together with harness-run and analytics-refresh timestamps [frontend/src/screens/Skills.tsx:224].
+- Resolved 2026-07-27: `SkillRegistryData` now requires visible contributors, the generated frontend contract includes them, and the Skill detail page renders them [api/schemas.py:2080].

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -1,5 +1,5 @@
 # generated: 2026-05-01
-# last_updated: 2026-07-24
+# last_updated: 2026-07-27
 # project: deploywhisper
 # project_key: NOKEY
 # tracking_system: file-system
@@ -35,7 +35,7 @@
 # - Dev moves story to review, then runs code-review
 
 generated: 2026-05-01
-last_updated: 2026-07-24
+last_updated: 2026-07-27
 project: deploywhisper
 project_key: NOKEY
 tracking_system: file-system
@@ -130,7 +130,7 @@ development_status:
   9-2-skills-registry-api: done
   9-3-skill-test-harness: done
   9-4-skills-installer-cli: done
-  9-5-skills-browser-ui: ready-for-dev
+  9-5-skills-browser-ui: done
   9-6-skill-contribution-workflow: ready-for-dev
   9-7-skill-analytics-and-deprecation-signals: ready-for-dev
   epic-9-retrospective: optional

--- a/api/schemas.py
+++ b/api/schemas.py
@@ -2118,6 +2118,10 @@ class SkillRegistryData(BaseModel):
     trigger_content_patterns: list[str] = Field(
         default_factory=list, description="Content markers used for matching"
     )
+    contributors: list[str] = Field(
+        ...,
+        description="Visible contributor names for the Skills browser.",
+    )
     install_count: int = Field(
         default=0, description="Current install count from the analytics snapshot"
     )

--- a/docs/skills/browser-ui.md
+++ b/docs/skills/browser-ui.md
@@ -29,7 +29,7 @@ The shared skills catalog is exposed through the React SPA:
 Each skill detail page surfaces:
 
 - description
-- trust level (`Experimental`, `Verified`, `Core`, or `Deprecated`)
+- trust label (`Experimental trust`, `Verified trust`, `Core trust`, or `Deprecated trust`)
 - deterministic test status (`Tests passing`, `Tests failing`, or `Tests missing`)
 - source (`Public registry`, `Local override`, or `Private local`)
 - editorial badges for `Official` and curated-community `Featured` states

--- a/docs/skills/browser-ui.md
+++ b/docs/skills/browser-ui.md
@@ -11,6 +11,13 @@ The shared skills catalog is exposed through the React SPA:
   registry and installer surfaces.
 - Tool and author filters use the same canonical metadata returned by the shared
   registry service.
+- Every catalog result exposes its manifest trust level and deterministic harness
+  status. The detail view repeats both values alongside the install command.
+- Source labels distinguish registry content from organization-owned content:
+  - `Public registry` identifies bundled/public registry Skills.
+  - `Local override` identifies a private Skill replacing a registry Skill.
+  - `Private local` identifies a private Skill available only in the self-hosted
+    installation.
 - Sorting supports:
   - `popularity` using the seeded browser download/star snapshot in the shared
     registry service
@@ -22,6 +29,9 @@ The shared skills catalog is exposed through the React SPA:
 Each skill detail page surfaces:
 
 - description
+- trust level (`Experimental`, `Verified`, `Core`, or `Deprecated`)
+- deterministic test status (`Tests passing`, `Tests failing`, or `Tests missing`)
+- source (`Public registry`, `Local override`, or `Private local`)
 - editorial badges for `Official` and curated-community `Featured` states
 - install command
 - latest harness summary and pass rate

--- a/frontend/e2e/phase6.spec.ts
+++ b/frontend/e2e/phase6.spec.ts
@@ -127,9 +127,16 @@ test.describe("Phase 6 settings, incidents, and skills", () => {
   test("skills supports filtering and detail navigation", async ({ page }) => {
     await page.goto("/skills?search=terraform&sort=recency", { waitUntil: "networkidle" });
     await expect(page.getByRole("heading", { name: "Skills" })).toBeVisible();
-    await expect(page.locator('a[href="/skills/terraform"]')).toBeVisible();
-    await page.locator('a[href="/skills/terraform"]').click();
+    const terraformSkill = page.locator('a[href="/skills/terraform"]');
+    await expect(terraformSkill).toBeVisible();
+    await expect(terraformSkill.getByText("Core trust")).toBeVisible();
+    await expect(terraformSkill.getByText("Public registry")).toBeVisible();
+    await expect(terraformSkill.getByText("Tests missing")).toBeVisible();
+    await terraformSkill.click();
     await expect(page).toHaveURL(/\/skills\/terraform/);
+    await expect(page.getByText("Core trust")).toBeVisible();
+    await expect(page.getByText("Public registry")).toBeVisible();
+    await expect(page.getByText("Tests missing")).toBeVisible();
     await expect(page.getByText(/deploywhisper skill install terraform/)).toBeVisible();
     await expect(page.getByText("Version history")).toBeVisible();
     await expectNoSeriousA11y(page);

--- a/frontend/e2e/phase6.spec.ts
+++ b/frontend/e2e/phase6.spec.ts
@@ -125,18 +125,53 @@ test.describe("Phase 6 settings, incidents, and skills", () => {
   });
 
   test("skills supports filtering and detail navigation", async ({ page }) => {
+    const skillResponse = await page.request.get("/api/v1/skills/terraform");
+    expect(skillResponse.ok()).toBeTruthy();
+    const skillPayload = await skillResponse.json() as {
+      data: {
+        trust_level: string;
+        source: "built-in" | "custom-override" | "custom-new";
+        contributors: string[];
+        test_results: {
+          status: "passing" | "failing" | "missing";
+          display_text: string;
+        } | null;
+      };
+    };
+    const registrySkill = skillPayload.data;
+    const trustLabel = `${registrySkill.trust_level.charAt(0).toUpperCase()}${registrySkill.trust_level.slice(1)} trust`;
+    const sourceLabel = {
+      "built-in": "Public registry",
+      "custom-override": "Local override",
+      "custom-new": "Private local",
+    }[registrySkill.source];
+    const testStatusLabel = registrySkill.test_results?.status === "passing"
+      ? "Tests passing"
+      : registrySkill.test_results?.status === "failing"
+        ? "Tests failing"
+        : "Tests missing";
+
     await page.goto("/skills?search=terraform&sort=recency", { waitUntil: "networkidle" });
     await expect(page.getByRole("heading", { name: "Skills" })).toBeVisible();
     const terraformSkill = page.locator('a[href="/skills/terraform"]');
     await expect(terraformSkill).toBeVisible();
-    await expect(terraformSkill.getByText("Core trust")).toBeVisible();
-    await expect(terraformSkill.getByText("Public registry")).toBeVisible();
-    await expect(terraformSkill.getByText("Tests missing")).toBeVisible();
+    await expect(terraformSkill.getByText(trustLabel)).toBeVisible();
+    await expect(terraformSkill.getByText(sourceLabel)).toBeVisible();
+    await expect(terraformSkill.getByText(testStatusLabel)).toBeVisible();
     await terraformSkill.click();
     await expect(page).toHaveURL(/\/skills\/terraform/);
-    await expect(page.getByText("Core trust")).toBeVisible();
-    await expect(page.getByText("Public registry")).toBeVisible();
-    await expect(page.getByText("Tests missing")).toBeVisible();
+    await expect(page.getByText(trustLabel)).toBeVisible();
+    await expect(page.getByText(sourceLabel)).toBeVisible();
+    await expect(page.getByText(testStatusLabel)).toBeVisible();
+    await expect(page.getByText("Harness run")).toBeVisible();
+    await expect(page.getByText("Analytics refreshed", { exact: false })).toBeVisible();
+    if (registrySkill.test_results) {
+      await expect(page.getByText(registrySkill.test_results.display_text)).toBeVisible();
+    }
+    const contributors = page.locator('section[aria-labelledby="skill-contributors-title"]');
+    for (const contributor of registrySkill.contributors) {
+      await expect(contributors.getByText(contributor, { exact: true })).toBeVisible();
+    }
     await expect(page.getByText(/deploywhisper skill install terraform/)).toBeVisible();
     await expect(page.getByText("Version history")).toBeVisible();
     await expectNoSeriousA11y(page);

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -3822,6 +3822,11 @@ export interface components {
              */
             trigger_content_patterns?: string[];
             /**
+             * Contributors
+             * @description Visible contributor names for the Skills browser.
+             */
+            contributors: string[];
+            /**
              * Install Count
              * @description Current install count from the analytics snapshot
              * @default 0
@@ -4033,6 +4038,11 @@ export interface components {
              * @description Content markers used for matching
              */
             trigger_content_patterns?: string[];
+            /**
+             * Contributors
+             * @description Visible contributor names for the Skills browser.
+             */
+            contributors: string[];
             /**
              * Install Count
              * @description Current install count from the analytics snapshot
@@ -4936,7 +4946,7 @@ export interface operations {
                     "application/json": components["schemas"]["ErrorResponse"];
                 };
             };
-            /** @description Unprocessable Content */
+            /** @description Unprocessable Entity */
             422: {
                 headers: {
                     [name: string]: unknown;
@@ -5020,7 +5030,7 @@ export interface operations {
                     "application/json": components["schemas"]["ErrorResponse"];
                 };
             };
-            /** @description Content Too Large */
+            /** @description Request Entity Too Large */
             413: {
                 headers: {
                     [name: string]: unknown;
@@ -5029,7 +5039,7 @@ export interface operations {
                     "application/json": components["schemas"]["ErrorResponse"];
                 };
             };
-            /** @description Unprocessable Content */
+            /** @description Unprocessable Entity */
             422: {
                 headers: {
                     [name: string]: unknown;
@@ -5101,7 +5111,7 @@ export interface operations {
                     "application/json": components["schemas"]["ErrorResponse"];
                 };
             };
-            /** @description Unprocessable Content */
+            /** @description Unprocessable Entity */
             422: {
                 headers: {
                     [name: string]: unknown;
@@ -5185,7 +5195,7 @@ export interface operations {
                     "application/json": components["schemas"]["ErrorResponse"];
                 };
             };
-            /** @description Unprocessable Content */
+            /** @description Unprocessable Entity */
             422: {
                 headers: {
                     [name: string]: unknown;
@@ -5245,7 +5255,7 @@ export interface operations {
                     "application/json": components["schemas"]["ErrorResponse"];
                 };
             };
-            /** @description Unprocessable Content */
+            /** @description Unprocessable Entity */
             422: {
                 headers: {
                     [name: string]: unknown;
@@ -5309,7 +5319,7 @@ export interface operations {
                     "application/json": components["schemas"]["ErrorResponse"];
                 };
             };
-            /** @description Unprocessable Content */
+            /** @description Unprocessable Entity */
             422: {
                 headers: {
                     [name: string]: unknown;
@@ -5384,7 +5394,7 @@ export interface operations {
                     "application/json": components["schemas"]["ErrorResponse"];
                 };
             };
-            /** @description Unprocessable Content */
+            /** @description Unprocessable Entity */
             422: {
                 headers: {
                     [name: string]: unknown;
@@ -5459,7 +5469,7 @@ export interface operations {
                     "application/json": components["schemas"]["ErrorResponse"];
                 };
             };
-            /** @description Unprocessable Content */
+            /** @description Unprocessable Entity */
             422: {
                 headers: {
                     [name: string]: unknown;
@@ -5526,7 +5536,7 @@ export interface operations {
                     "application/json": components["schemas"]["ErrorResponse"];
                 };
             };
-            /** @description Unprocessable Content */
+            /** @description Unprocessable Entity */
             422: {
                 headers: {
                     [name: string]: unknown;
@@ -5590,7 +5600,7 @@ export interface operations {
                     "application/json": components["schemas"]["ErrorResponse"];
                 };
             };
-            /** @description Unprocessable Content */
+            /** @description Unprocessable Entity */
             422: {
                 headers: {
                     [name: string]: unknown;
@@ -6126,7 +6136,7 @@ export interface operations {
                     "application/json": components["schemas"]["SkillRegistryListResponse"];
                 };
             };
-            /** @description Unprocessable Content */
+            /** @description Unprocessable Entity */
             422: {
                 headers: {
                     [name: string]: unknown;
@@ -6175,7 +6185,7 @@ export interface operations {
                     "application/json": components["schemas"]["ErrorResponse"];
                 };
             };
-            /** @description Unprocessable Content */
+            /** @description Unprocessable Entity */
             422: {
                 headers: {
                     [name: string]: unknown;
@@ -6224,7 +6234,7 @@ export interface operations {
                     "application/json": components["schemas"]["ErrorResponse"];
                 };
             };
-            /** @description Unprocessable Content */
+            /** @description Unprocessable Entity */
             422: {
                 headers: {
                     [name: string]: unknown;
@@ -6276,7 +6286,7 @@ export interface operations {
                     "application/json": components["schemas"]["ErrorResponse"];
                 };
             };
-            /** @description Unprocessable Content */
+            /** @description Unprocessable Entity */
             422: {
                 headers: {
                     [name: string]: unknown;
@@ -6325,7 +6335,7 @@ export interface operations {
                     "application/json": components["schemas"]["ErrorResponse"];
                 };
             };
-            /** @description Unprocessable Content */
+            /** @description Unprocessable Entity */
             422: {
                 headers: {
                     [name: string]: unknown;

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -3547,54 +3547,6 @@ export interface components {
              */
             evidence_label?: string | null;
         };
-        /** ShareSummaryScannerConflictData */
-        ShareSummaryScannerConflictData: {
-            /**
-             * Finding Id
-             * @description Finding with conflicting scanner context
-             */
-            finding_id: string;
-            /**
-             * Finding Title
-             * @description Reviewer-facing finding title
-             */
-            finding_title: string;
-            /**
-             * Scanner Source
-             * @description Scanner evidence source reference
-             */
-            scanner_source: string;
-            /**
-             * Scanner Freshness
-             * @description Scanner source freshness status
-             */
-            scanner_freshness: string;
-            /**
-             * Deterministic Source
-             * @description DeployWhisper deterministic evidence source
-             */
-            deterministic_source: string;
-            /**
-             * Deterministic Freshness
-             * @description DeployWhisper deterministic source freshness status
-             */
-            deterministic_freshness: string;
-            /**
-             * Conflict Summary
-             * @description Short conflict explanation
-             */
-            conflict_summary: string;
-            /**
-             * Confidence Impact
-             * @description How the conflict affects confidence interpretation
-             */
-            confidence_impact: string;
-            /**
-             * Recommended Verification
-             * @description Reviewer action for resolving the conflict
-             */
-            recommended_verification: string;
-        };
         /** ShareSummaryJsonPayloadData */
         ShareSummaryJsonPayloadData: {
             /**
@@ -3656,8 +3608,9 @@ export interface components {
             /**
              * External Evidence Count
              * @description External scanner evidence items included as review context
+             * @default 0
              */
-            external_evidence_count?: number;
+            external_evidence_count: number;
             /**
              * External Evidence Summary
              * @description How external scanner context should be interpreted
@@ -3685,6 +3638,54 @@ export interface components {
              * @description Advisory-only review summary
              */
             advisory_summary: string;
+        };
+        /** ShareSummaryScannerConflictData */
+        ShareSummaryScannerConflictData: {
+            /**
+             * Finding Id
+             * @description Finding with conflicting scanner context
+             */
+            finding_id: string;
+            /**
+             * Finding Title
+             * @description Reviewer-facing finding title
+             */
+            finding_title: string;
+            /**
+             * Scanner Source
+             * @description Scanner evidence source reference
+             */
+            scanner_source: string;
+            /**
+             * Scanner Freshness
+             * @description Scanner source freshness status
+             */
+            scanner_freshness: string;
+            /**
+             * Deterministic Source
+             * @description DeployWhisper deterministic evidence source
+             */
+            deterministic_source: string;
+            /**
+             * Deterministic Freshness
+             * @description DeployWhisper deterministic source freshness status
+             */
+            deterministic_freshness: string;
+            /**
+             * Conflict Summary
+             * @description Short conflict explanation
+             */
+            conflict_summary: string;
+            /**
+             * Confidence Impact
+             * @description How the conflict affects confidence interpretation
+             */
+            confidence_impact: string;
+            /**
+             * Recommended Verification
+             * @description Reviewer action for resolving the conflict
+             */
+            recommended_verification: string;
         };
         /** SharedReportAccessResponse */
         SharedReportAccessResponse: {
@@ -3744,6 +3745,12 @@ export interface components {
              * @description Current effective version
              */
             version: string;
+            /**
+             * Trust Level
+             * @description Manifest trust classification for the skill
+             * @enum {string}
+             */
+            trust_level: "experimental" | "verified" | "core" | "deprecated";
             /**
              * Source
              * @description Where the skill definition currently resolves from
@@ -3951,6 +3958,12 @@ export interface components {
              */
             version: string;
             /**
+             * Trust Level
+             * @description Manifest trust classification for the skill
+             * @enum {string}
+             */
+            trust_level: "experimental" | "verified" | "core" | "deprecated";
+            /**
              * Source
              * @description Where the skill definition currently resolves from
              * @enum {string}
@@ -4076,6 +4089,34 @@ export interface components {
             data: components["schemas"]["SkillRegistryVersionData"][];
             meta: components["schemas"]["SkillRegistryResourceMetaPayload"];
         };
+        /** SkillTestCoverageData */
+        SkillTestCoverageData: {
+            /**
+             * Expected Triggers
+             * @description Whether deterministic trigger selection is covered.
+             */
+            expected_triggers: boolean;
+            /**
+             * Expected Outputs
+             * @description Whether expected guidance output is covered.
+             */
+            expected_outputs: boolean;
+            /**
+             * Evidence Assumptions
+             * @description Whether scenarios declare deterministic evidence inputs.
+             */
+            evidence_assumptions: boolean;
+            /**
+             * Safety Constraints
+             * @description Whether non-selection safety behavior is covered.
+             */
+            safety_constraints: boolean;
+            /**
+             * Complete
+             * @description Whether all required harness coverage categories are present.
+             */
+            complete: boolean;
+        };
         /** SkillTestResultsData */
         SkillTestResultsData: {
             /**
@@ -4089,6 +4130,8 @@ export interface components {
              */
             version: string;
             summary: components["schemas"]["SkillTestResultsSummaryData"];
+            coverage: components["schemas"]["SkillTestCoverageData"];
+            trust_requirement: components["schemas"]["SkillTrustRequirementData"];
             /** Scenarios */
             scenarios?: components["schemas"]["SkillTestScenarioResultData"][];
         };
@@ -4151,6 +4194,30 @@ export interface components {
             /**
              * Failures
              * @description Failure reasons when the scenario did not pass.
+             */
+            failures?: string[];
+        };
+        /** SkillTrustRequirementData */
+        SkillTrustRequirementData: {
+            /**
+             * Trust Level
+             * @description Manifest trust level evaluated by the harness.
+             * @enum {string}
+             */
+            trust_level: "experimental" | "verified" | "core" | "deprecated";
+            /**
+             * Required
+             * @description Whether this trust level requires a passing complete suite.
+             */
+            required: boolean;
+            /**
+             * Satisfied
+             * @description Whether the suite satisfies its trust-level requirement.
+             */
+            satisfied: boolean;
+            /**
+             * Failures
+             * @description Actionable reasons the trust requirement was not satisfied.
              */
             failures?: string[];
         };

--- a/frontend/src/screens/Report.test.tsx
+++ b/frontend/src/screens/Report.test.tsx
@@ -216,6 +216,7 @@ const report = {
       headline: "Ingress widened",
       top_findings: [],
       evidence_count: 1,
+      external_evidence_count: 0,
       blast_radius_summary: "1 service affected",
       rollback_summary: "1 rollback step",
       context_completeness: { score: 0.72, label: "medium", summary: "Context mostly complete." },

--- a/frontend/src/screens/Skills.test.tsx
+++ b/frontend/src/screens/Skills.test.tsx
@@ -1,9 +1,17 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { renderToStaticMarkup } from "react-dom/server";
 import { MemoryRouter } from "react-router-dom";
 import { describe, expect, it } from "vitest";
 
 import type { SkillRegistryItem } from "../api/phase6";
-import { SkillCard, skillSourceLabel, skillTestStatusLabel, skillTrustLabel } from "./Skills";
+import {
+  SkillCard,
+  SkillDetailContent,
+  SkillsListContent,
+  skillSourceLabel,
+  skillTestStatusLabel,
+  skillTrustLabel,
+} from "./Skills";
 
 const skill: SkillRegistryItem = {
   id: "terraform",
@@ -32,6 +40,7 @@ const skill: SkillRegistryItem = {
   },
   triggers: [".tf"],
   trigger_content_patterns: [],
+  contributors: ["DeployWhisper", "Platform Safety"],
   install_count: 12,
   active_issue_count: 0,
   analytics_updated_at: "2026-07-27T00:00:00Z",
@@ -42,13 +51,23 @@ const skill: SkillRegistryItem = {
   install_command: "deploywhisper skill install terraform",
 };
 
+function renderWithQuery(node: React.ReactElement, client: QueryClient) {
+  return renderToStaticMarkup(
+    <QueryClientProvider client={client}>
+      <MemoryRouter>{node}</MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
 describe("Skills browser labels", () => {
   it("uses explicit trust, source, and deterministic test-status labels", () => {
     expect(skillTrustLabel("core")).toBe("Core trust");
     expect(skillSourceLabel("built-in")).toBe("Public registry");
     expect(skillSourceLabel("custom-override")).toBe("Local override");
     expect(skillSourceLabel("custom-new")).toBe("Private local");
+    expect(skillSourceLabel("future-source" as SkillRegistryItem["source"])).toBe("Unknown source");
     expect(skillTestStatusLabel(skill.test_results)).toBe("Tests passing");
+    expect(skillTestStatusLabel({ ...skill.test_results!, status: "failing" })).toBe("Tests failing");
     expect(skillTestStatusLabel(null)).toBe("Tests missing");
   });
 
@@ -84,5 +103,43 @@ describe("Skills browser labels", () => {
     expect(markup).toContain("Experimental trust");
     expect(markup).toContain("Private local");
     expect(markup).not.toContain("Public registry");
+  });
+
+  it("renders accessible search semantics from preloaded registry data", () => {
+    const client = new QueryClient();
+    const envelope = {
+      data: [skill],
+      meta: {
+        app: "deploywhisper",
+        version: "test",
+        count: 1,
+        total_count: 1,
+        page: 1,
+        page_size: 100,
+        filters: {},
+      },
+    };
+    client.setQueryData(["skills", "", "", "", "", "popularity"], envelope);
+    client.setQueryData(["skills", "all-options"], envelope);
+
+    const markup = renderWithQuery(<SkillsListContent />, client);
+
+    expect(markup).toContain('aria-label="Search skills"');
+    expect(markup).toContain("Core trust");
+    expect(markup).toContain("Public registry");
+  });
+
+  it("renders harness freshness, analytics freshness, and contributors in detail", () => {
+    const client = new QueryClient();
+    client.setQueryData(["skill", "terraform"], skill);
+    client.setQueryData(["skill-versions", "terraform"], []);
+
+    const markup = renderWithQuery(<SkillDetailContent skillId="terraform" />, client);
+
+    expect(markup).toContain("3/3 scenarios passed");
+    expect(markup).toContain("Harness run");
+    expect(markup).toContain("Analytics refreshed");
+    expect(markup).toContain("DeployWhisper");
+    expect(markup).toContain("Platform Safety");
   });
 });

--- a/frontend/src/screens/Skills.test.tsx
+++ b/frontend/src/screens/Skills.test.tsx
@@ -1,0 +1,88 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { MemoryRouter } from "react-router-dom";
+import { describe, expect, it } from "vitest";
+
+import type { SkillRegistryItem } from "../api/phase6";
+import { SkillCard, skillSourceLabel, skillTestStatusLabel, skillTrustLabel } from "./Skills";
+
+const skill: SkillRegistryItem = {
+  id: "terraform",
+  name: "Terraform",
+  version: "1.0.0",
+  trust_level: "core",
+  source: "built-in",
+  author: "DeployWhisper",
+  maintainer: "DeployWhisper",
+  is_official: true,
+  is_featured: false,
+  license: "Apache-2.0",
+  description: "Evidence-backed Terraform deployment guidance.",
+  tool: "terraform",
+  tags: ["iac"],
+  token_budget: 1200,
+  test_suite_path: "tests/skill-tests/terraform",
+  test_results: {
+    total_scenarios: 3,
+    passed_scenarios: 3,
+    failed_scenarios: 0,
+    pass_rate: 1,
+    status: "passing",
+    display_text: "3/3 scenarios passed",
+    generated_at: "2026-07-27T00:00:00Z",
+  },
+  triggers: [".tf"],
+  trigger_content_patterns: [],
+  install_count: 12,
+  active_issue_count: 0,
+  analytics_updated_at: "2026-07-27T00:00:00Z",
+  download_count: 12,
+  star_count: 4,
+  updated_at: "2026-07-27T00:00:00Z",
+  available_versions: 1,
+  install_command: "deploywhisper skill install terraform",
+};
+
+describe("Skills browser labels", () => {
+  it("uses explicit trust, source, and deterministic test-status labels", () => {
+    expect(skillTrustLabel("core")).toBe("Core trust");
+    expect(skillSourceLabel("built-in")).toBe("Public registry");
+    expect(skillSourceLabel("custom-override")).toBe("Local override");
+    expect(skillSourceLabel("custom-new")).toBe("Private local");
+    expect(skillTestStatusLabel(skill.test_results)).toBe("Tests passing");
+    expect(skillTestStatusLabel(null)).toBe("Tests missing");
+  });
+
+  it("renders trust, public source, and test status in each catalog result", () => {
+    const markup = renderToStaticMarkup(
+      <MemoryRouter>
+        <SkillCard skill={skill} />
+      </MemoryRouter>,
+    );
+
+    expect(markup).toContain("Core trust");
+    expect(markup).toContain("Public registry");
+    expect(markup).toContain("Tests passing");
+    expect(markup).toContain("100%");
+  });
+
+  it("distinguishes private local skills from public registry skills", () => {
+    const markup = renderToStaticMarkup(
+      <MemoryRouter>
+        <SkillCard
+          skill={{
+            ...skill,
+            id: "organization-guardrails",
+            name: "Organization guardrails",
+            trust_level: "experimental",
+            source: "custom-new",
+            is_official: false,
+          }}
+        />
+      </MemoryRouter>,
+    );
+
+    expect(markup).toContain("Experimental trust");
+    expect(markup).toContain("Private local");
+    expect(markup).not.toContain("Public registry");
+  });
+});

--- a/frontend/src/screens/Skills.tsx
+++ b/frontend/src/screens/Skills.tsx
@@ -1,7 +1,7 @@
 import { useMemo } from "react";
 import { Link, useParams, useSearchParams } from "react-router-dom";
 import { useQuery } from "@tanstack/react-query";
-import { ExternalLink, GitBranch, PackageCheck, Search, ShieldCheck } from "lucide-react";
+import { Clock3, ExternalLink, GitBranch, PackageCheck, Search, ShieldCheck, UsersRound } from "lucide-react";
 
 import { getSkill, getSkills, getSkillVersions, type SkillRegistryItem } from "../api/phase6";
 import { Button, Card, EvidenceTag, MonoRef, SkeletonCard } from "../components/ui";
@@ -17,6 +17,18 @@ function formatDate(value: string) {
   return new Intl.DateTimeFormat("en-US", { month: "short", day: "2-digit", year: "numeric" }).format(parsed);
 }
 
+function formatTimestamp(value: string) {
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) {
+    return value;
+  }
+  return new Intl.DateTimeFormat("en-US", {
+    dateStyle: "medium",
+    timeStyle: "short",
+    timeZone: "UTC",
+  }).format(parsed);
+}
+
 function passRate(skill: SkillRegistryItem) {
   const summary = skill.test_results;
   if (!summary || summary.status === "missing") {
@@ -30,13 +42,19 @@ export function skillTrustLabel(trustLevel: SkillRegistryItem["trust_level"]) {
 }
 
 export function skillSourceLabel(source: SkillRegistryItem["source"]) {
-  if (source === "custom-override") {
-    return "Local override";
+  switch (source) {
+    case "built-in":
+      return "Public registry";
+    case "custom-override":
+      return "Local override";
+    case "custom-new":
+      return "Private local";
+    default: {
+      const unknownSource: never = source;
+      void unknownSource;
+      return "Unknown source";
+    }
   }
-  if (source === "custom-new") {
-    return "Private local";
-  }
-  return "Public registry";
 }
 
 export function skillTestStatusLabel(testResults: SkillRegistryItem["test_results"]) {
@@ -75,7 +93,7 @@ export function SkillCard({ skill }: { skill: SkillRegistryItem }) {
   );
 }
 
-function SkillsListContent() {
+export function SkillsListContent() {
   const [searchParams, setSearchParams] = useSearchParams();
   const search = searchParams.get("search") ?? "";
   const tool = searchParams.get("tool") ?? "";
@@ -185,7 +203,7 @@ function SkillsListContent() {
   );
 }
 
-function SkillDetailContent({ skillId }: { skillId: string }) {
+export function SkillDetailContent({ skillId }: { skillId: string }) {
   const skillQuery = useQuery({ queryFn: () => getSkill(skillId), queryKey: ["skill", skillId] });
   const versionsQuery = useQuery({ queryFn: () => getSkillVersions(skillId), queryKey: ["skill-versions", skillId] });
   const skill = skillQuery.data;
@@ -228,8 +246,36 @@ function SkillDetailContent({ skillId }: { skillId: string }) {
                   <div className="dw-phase6-stat"><strong>{skill.install_count}</strong><span>Installs</span></div>
                   <div className="dw-phase6-stat"><strong>{passRate(skill)}</strong><span>Pass rate</span></div>
                 </div>
+                <section aria-labelledby="skill-contributors-title" className="dw-phase6-stack">
+                  <div className="dw-phase6-row">
+                    <UsersRound size={16} />
+                    <span className="dw-phase6-list-copy" id="skill-contributors-title">Contributors</span>
+                  </div>
+                  <div className="dw-skill-tags">
+                    {skill.contributors.length > 0
+                      ? skill.contributors.map((contributor) => <EvidenceTag key={contributor}>{contributor}</EvidenceTag>)
+                      : <span className="dw-phase6-list-copy">No contributors listed</span>}
+                  </div>
+                </section>
                 <div className="dw-skill-tags">
                   {skill.tags?.map((tag) => <EvidenceTag key={tag}>{tag}</EvidenceTag>)}
+                </div>
+              </div>
+            </Card>
+            <Card eyebrow="Validation" title="Deterministic harness">
+              <div className="dw-phase6-stack">
+                <div className="dw-phase6-row">
+                  <ShieldCheck size={16} />
+                  <span className="dw-phase6-list-copy">
+                    {skill.test_results?.display_text ?? "No deterministic harness result available."}
+                  </span>
+                </div>
+                <div className="dw-phase6-row">
+                  <Clock3 size={16} />
+                  <span className="dw-phase6-list-copy">Harness run</span>
+                  {skill.test_results
+                    ? <MonoRef><time dateTime={skill.test_results.generated_at}>{formatTimestamp(skill.test_results.generated_at)}</time></MonoRef>
+                    : <MonoRef>Not available</MonoRef>}
                 </div>
               </div>
             </Card>
@@ -249,6 +295,12 @@ function SkillDetailContent({ skillId }: { skillId: string }) {
                 <div className="dw-phase6-row"><PackageCheck size={16} /> <span className="dw-phase6-list-copy">{skill.available_versions} tracked versions</span></div>
                 <div className="dw-phase6-row"><ShieldCheck size={16} /> <span className="dw-phase6-list-copy">{skill.active_issue_count} active issues</span></div>
                 <div className="dw-phase6-row"><GitBranch size={16} /> <span className="dw-phase6-list-copy">Updated {formatDate(skill.updated_at)}</span></div>
+                <div className="dw-phase6-row">
+                  <Clock3 size={16} />
+                  <span className="dw-phase6-list-copy">
+                    Analytics refreshed <time dateTime={skill.analytics_updated_at}>{formatTimestamp(skill.analytics_updated_at)}</time>
+                  </span>
+                </div>
               </div>
             </Card>
             <Card eyebrow="Versions" title="Version history">

--- a/frontend/src/screens/Skills.tsx
+++ b/frontend/src/screens/Skills.tsx
@@ -25,17 +25,41 @@ function passRate(skill: SkillRegistryItem) {
   return `${Math.round(summary.pass_rate * 100)}%`;
 }
 
+export function skillTrustLabel(trustLevel: SkillRegistryItem["trust_level"]) {
+  return `${trustLevel.charAt(0).toUpperCase()}${trustLevel.slice(1)} trust`;
+}
+
+export function skillSourceLabel(source: SkillRegistryItem["source"]) {
+  if (source === "custom-override") {
+    return "Local override";
+  }
+  if (source === "custom-new") {
+    return "Private local";
+  }
+  return "Public registry";
+}
+
+export function skillTestStatusLabel(testResults: SkillRegistryItem["test_results"]) {
+  if (!testResults || testResults.status === "missing") {
+    return "Tests missing";
+  }
+  return testResults.status === "passing" ? "Tests passing" : "Tests failing";
+}
+
 function unique(values: (string | undefined)[]) {
   return Array.from(new Set(values.filter(Boolean) as string[])).sort();
 }
 
-function SkillCard({ skill }: { skill: SkillRegistryItem }) {
+export function SkillCard({ skill }: { skill: SkillRegistryItem }) {
   return (
     <Link className="dw-phase6-list-item dw-skill-card" to={`/skills/${skill.id}`}>
       <div className="dw-phase6-row">
         <div className="dw-phase6-list-title">{skill.name}</div>
         {skill.is_official && <EvidenceTag>Official</EvidenceTag>}
         {skill.is_featured && <EvidenceTag>Featured</EvidenceTag>}
+        <EvidenceTag>{skillTrustLabel(skill.trust_level)}</EvidenceTag>
+        <EvidenceTag>{skillSourceLabel(skill.source)}</EvidenceTag>
+        <EvidenceTag>{skillTestStatusLabel(skill.test_results)}</EvidenceTag>
       </div>
       <div className="dw-phase6-list-copy">{skill.description}</div>
       <div className="dw-skill-tags">
@@ -104,7 +128,12 @@ function SkillsListContent() {
             <span>Search</span>
             <div className="dw-phase6-row">
               <Search size={15} />
-              <input className="dw-phase6-search" onChange={(event) => updateFilter("search", event.target.value)} value={search} />
+              <input
+                aria-label="Search skills"
+                className="dw-phase6-search"
+                onChange={(event) => updateFilter("search", event.target.value)}
+                value={search}
+              />
             </div>
           </label>
           <label className="dw-field">
@@ -188,7 +217,9 @@ function SkillDetailContent({ skillId }: { skillId: string }) {
                 <div className="dw-phase6-row">
                   {skill.is_official && <EvidenceTag>Official</EvidenceTag>}
                   {skill.is_featured && <EvidenceTag>Featured</EvidenceTag>}
-                  <EvidenceTag>{skill.source}</EvidenceTag>
+                  <EvidenceTag>{skillTrustLabel(skill.trust_level)}</EvidenceTag>
+                  <EvidenceTag>{skillSourceLabel(skill.source)}</EvidenceTag>
+                  <EvidenceTag>{skillTestStatusLabel(skill.test_results)}</EvidenceTag>
                 </div>
                 <div className="dw-skill-command-box">{skill.install_command}</div>
                 <div className="dw-phase6-stat-grid">

--- a/tests/test_api/test_skills.py
+++ b/tests/test_api/test_skills.py
@@ -121,6 +121,7 @@ class SkillsApiTests(unittest.TestCase):
         self.assertIn("install_count", payload["data"][0])
         self.assertIn("active_issue_count", payload["data"][0])
         self.assertIn("analytics_updated_at", payload["data"][0])
+        self.assertEqual(payload["data"][0]["contributors"], ["DeployWhisper"])
         self.assertEqual(payload["data"][0]["test_results"]["status"], "passing")
         self.assertEqual(payload["data"][0]["triggers"], [".tf"])
 
@@ -190,6 +191,7 @@ class SkillsApiTests(unittest.TestCase):
         self.assertIn("install_count", detail_payload["data"])
         self.assertIn("active_issue_count", detail_payload["data"])
         self.assertIn("analytics_updated_at", detail_payload["data"])
+        self.assertEqual(detail_payload["data"]["contributors"], ["DeployWhisper"])
         self.assertEqual(detail_payload["data"]["test_results"]["status"], "passing")
         self.assertEqual(detail_payload["meta"]["id"], "terraform")
 
@@ -333,6 +335,10 @@ class SkillsApiTests(unittest.TestCase):
         self.assertIn("/api/v1/skills/{skill_id}/versions", payload["paths"])
         self.assertIn(
             "trust_level",
+            payload["components"]["schemas"]["SkillRegistryData"]["required"],
+        )
+        self.assertIn(
+            "contributors",
             payload["components"]["schemas"]["SkillRegistryData"]["required"],
         )
         test_results_schema = payload["components"]["schemas"]["SkillTestResultsData"]


### PR DESCRIPTION
## What does this PR do?

Completes Story 9.5 and resolves every BMad reviewer finding for the Skills browser. Registry trust, deterministic test status, public-versus-local source, contributors, the full deterministic harness summary, and harness/analytics freshness are visible on the catalog/detail surfaces. Existing search, filters, navigation, version history, and install instructions remain backed by the shared registry API.

The backend-for-UI change is additive: `contributors` is now a required field in `SkillRegistryData`, is populated from the existing registry service, and is reflected in regenerated frontend OpenAPI types. No persistence, analysis-core, CLI, or runtime dependency changes were introduced.

## Design and plan references

- Story: `_bmad-output/implementation-artifacts/9-5-skills-browser-ui.md`
- Approved mockups: `docs/design/phase-6-skills-1440.png`, `docs/design/phase-6-skills-760.png`, `docs/design/phase-6-skill-detail-1440.png`
- Current UI contract: `docs/design/deploywhisper-redesign-v3.jsx`

## Reviewer findings resolved

- [x] Render full deterministic harness summary and harness/analytics timestamps
- [x] Expose and render contributors
- [x] Make source-label mapping exhaustive with an unknown-source fallback
- [x] Cover failing status, detail metadata, contributors, and accessible search
- [x] Derive composed-app metadata assertions from the live API
- [x] Align docs with exact rendered trust-label wording

## Documentation updated

- `docs/skills/browser-ui.md`: exact trust labels and visible metadata semantics
- Story and sprint records moved back to done after reviewer-fix verification
- Both previously deferred Story 9.5 metadata gaps marked resolved

## Verification

- [x] `./.venv/bin/python -m pytest tests/test_api/test_skills.py -q` — 11 passed
- [x] `./.venv/bin/python -m pytest tests/test_api tests/test_cli tests/test_infra -v --tb=short` — 341 passed, 15 subtests passed
- [x] `npm --prefix frontend run test` — 51 passed across 6 files
- [x] `npm --prefix frontend run typecheck`
- [x] `npm --prefix frontend run build`
- [x] `./.venv/bin/ruff check .`
- [x] `./.venv/bin/ruff format --check .` — 256 files formatted
- [x] Docker Compose production build and API health check
- [x] `BASE_URL=http://localhost:8080 npm run test:ui-review` — 9 passed, including axe
- [x] Remaining CLI/docs/infra/LLM/models/parsers/services CI targets — 855 passed
- [x] Visual verdict against approved desktop, compact, and detail references — 95/100, pass
- [x] `docker compose down` — no services left running

One full local CI pass stopped on a single environment-sensitive CLI narrative assertion after its preceding lanes passed. The exact test passed alone, the complete 83-test CLI directory passed, and the full remaining 855-test target set passed. No Story 9.5 code was implicated.

## Screenshots

Captured from the composed production app during reviewer-fix verification:

- Skills desktop: `/private/tmp/story-9-5-review-skills-1440.png`
- Skills compact: `/private/tmp/story-9-5-review-skills-760.png`
- Skill detail desktop: `/private/tmp/story-9-5-review-detail-1440.png`

The local CLI cannot attach binary images to the GitHub PR body; these paths identify the reviewed captures, while the committed approved mockups remain the visual reference.

## Checklist

- [x] Branch follows the feature naming convention
- [x] Reviewer findings resolved
- [x] Focused and broad tests pass locally
- [x] Docker build and composed browser suite pass
- [x] Documentation updated
- [x] No secrets or environment values committed
