### PR TITLE
Story 9.6: enforce the Skill contribution workflow

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/skill.md
+++ b/.github/PULL_REQUEST_TEMPLATE/skill.md
@@ -22,7 +22,7 @@
 
 ## Reviewer Assignment
 
-- Requested maintainer or domain reviewer:
+- Additional domain reviewer (if any):
 - Review focus:
 
 <!-- CODEOWNERS requests the Skill maintainer automatically. Name any additional

--- a/.github/PULL_REQUEST_TEMPLATE/skill.md
+++ b/.github/PULL_REQUEST_TEMPLATE/skill.md
@@ -20,9 +20,13 @@
 - [ ] `deploywhisper skill test <skill>`
 - [ ] Added or updated scenarios under `tests/skill-tests/<skill>/`
 
-## Reviewer Notes
+## Reviewer Assignment
 
-<!-- Call out any areas that need domain review, follow-up stories, or curation attention. -->
+- Requested maintainer or domain reviewer:
+- Review focus:
+
+<!-- CODEOWNERS requests the Skill maintainer automatically. Name any additional
+domain reviewer and explain the expertise needed for this contribution. -->
 
 ## Checklist
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -280,12 +280,8 @@ jobs:
         env:
           BASE_REF: origin/${{ github.base_ref }}
         run: |
-          if [ -f scripts/test-changed-skills.sh ]; then
-            bash scripts/test-changed-skills.sh 2>&1 | tee changed-skill-harness.log
-            test ${PIPESTATUS[0]} -eq 0
-          else
-            echo "scripts/test-changed-skills.sh not found — skipping changed skill lint and harness checks"
-          fi
+          bash scripts/test-changed-skills.sh 2>&1 | tee changed-skill-harness.log
+          test ${PIPESTATUS[0]} -eq 0
 
       - name: Upload changed-test logs
         if: failure()

--- a/.github/workflows/publish-skills-registry.yml
+++ b/.github/workflows/publish-skills-registry.yml
@@ -65,6 +65,25 @@ jobs:
         if: steps.config.outputs.configured == 'true' && steps.changed.outputs.skill_ids == ''
         run: echo "No skill changes detected for publish."
 
+      - name: Validate changed skills before publish
+        if: steps.config.outputs.configured == 'true' && steps.changed.outputs.skill_ids != ''
+        env:
+          SKILL_IDS: ${{ steps.changed.outputs.skill_ids }}
+        run: |
+          IFS=',' read -r -a changed_skill_ids <<< "$SKILL_IDS"
+          active_skill_ids=()
+          for skill_id in "${changed_skill_ids[@]}"; do
+            if [ ! -f "skills/${skill_id}.md" ]; then
+              echo "Skill ${skill_id} was removed; its registry entry will be removed."
+              continue
+            fi
+            python cli.py skill lint "skills/${skill_id}.md"
+            active_skill_ids+=("$skill_id")
+          done
+          if [ "${#active_skill_ids[@]}" -gt 0 ]; then
+            python cli.py skill test "${active_skill_ids[@]}"
+          fi
+
       - name: Checkout registry repository
         if: steps.config.outputs.configured == 'true' && steps.changed.outputs.skill_ids != ''
         env:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -392,7 +392,9 @@ def calculate_risk_score(changes: list[ParsedChange], context: AnalysisContext) 
 ### Project structure rules
 
 - Parsers go in `parsers/`, one file per IaC tool.
-- AI Skills go in `skills/`, one markdown file per tool.
+- AI Skills go in `skills/`, one markdown file per tool. Follow the dedicated
+  workflow in `docs/contributing/skills.md` for the Skill PR template,
+  deterministic harness, reviewer routing, and publication gates.
 - API routes go in `api/routes/`, grouped by domain.
 - All database models live in `models/`.
 - Tests mirror the source structure under `tests/`.

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -131,7 +131,7 @@ development_status:
   9-3-skill-test-harness: done
   9-4-skills-installer-cli: done
   9-5-skills-browser-ui: done
-  9-6-skill-contribution-workflow: review
+  9-6-skill-contribution-workflow: done
   9-7-skill-analytics-and-deprecation-signals: ready-for-dev
   epic-9-retrospective: optional
 

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -131,7 +131,7 @@ development_status:
   9-3-skill-test-harness: done
   9-4-skills-installer-cli: done
   9-5-skills-browser-ui: done
-  9-6-skill-contribution-workflow: ready-for-dev
+  9-6-skill-contribution-workflow: review
   9-7-skill-analytics-and-deprecation-signals: ready-for-dev
   epic-9-retrospective: optional
 

--- a/docs/contributing/skills.md
+++ b/docs/contributing/skills.md
@@ -1,6 +1,6 @@
 # Contributing Skills
 
-Story 4.6 defines the repository workflow for contributing or updating built-in
+Story 9.6 defines the repository workflow for contributing or updating built-in
 skills. The goal is to make skill changes reviewable, deterministic, and
 publishable without requiring contributors to guess the review bar.
 
@@ -22,12 +22,13 @@ deploywhisper skill test <skill>
 
 ## Pull request workflow
 
-- Use the skill template at `.github/PULL_REQUEST_TEMPLATE/skill.md`
+- Target `develop` from a Git Flow `feature/*` branch.
+- Select the Skill template at `.github/PULL_REQUEST_TEMPLATE/skill.md`.
 - Skill PRs should include:
   - the skill id and version
   - the risk patterns introduced or changed
   - the lint and harness commands that were run
-  - notes for domain reviewers or curators when needed
+  - the requested maintainer or domain reviewer and review focus
 
 ## Automated checks on skill PRs
 
@@ -37,6 +38,10 @@ For skill changes specifically, the changed-skill automation now does both:
 - manifest lint for changed `skills/*.md`
 - deterministic harness execution for changed skills and their scenario suites
 
+Failures include field- or scenario-specific output in the job log. CI also
+uploads `changed-skill-harness.log` on failure so contributors can inspect the
+same actionable feedback after the job ends.
+
 The changed-skill gate watches:
 
 - `skills/*.md`
@@ -45,7 +50,7 @@ The changed-skill gate watches:
 ## Reviewer assignment
 
 Skill contribution surfaces are covered explicitly in `.github/CODEOWNERS` so
-GitHub can assign the maintainer review path for:
+GitHub requests the Skill maintainer review path for:
 
 - `skills/`
 - `tests/skill-tests/`
@@ -69,6 +74,12 @@ under `skills/<skill>/` with:
 - `skill.md`
 - `manifest.json`
 - `tests/scenarios/`
+
+A failed manifest lint or harness check stops the workflow before any registry
+checkout, commit, or push. The publish job repeats both checks after a merge so
+the registry does not depend only on pull-request branch protection. No pull
+request event can publish a Skill; publication runs only from `main` or by an
+authorized manual dispatch.
 
 If the token is not configured, the workflow exits cleanly with a notice
 instead of failing unrelated merges.

--- a/docs/contributing/skills.md
+++ b/docs/contributing/skills.md
@@ -28,7 +28,7 @@ deploywhisper skill test <skill>
   - the skill id and version
   - the risk patterns introduced or changed
   - the lint and harness commands that were run
-  - the requested maintainer or domain reviewer and review focus
+  - any additional domain reviewer and the review focus
 
 ## Automated checks on skill PRs
 

--- a/docs/skills/authoring-guide.md
+++ b/docs/skills/authoring-guide.md
@@ -89,6 +89,8 @@ deploywhisper skill test terraform
 Scenario layout and harness behavior are documented in `docs/skills/test-harness.md`.
 Verified and core Skills must include positive trigger/output/evidence scenarios
 and a negative safety scenario, and every declared scenario must pass.
+The complete pull-request, reviewer-routing, CI feedback, and publication
+workflow is documented in `docs/contributing/skills.md`.
 
 Validation fails when:
 

--- a/scripts/test-changed-skills.sh
+++ b/scripts/test-changed-skills.sh
@@ -5,14 +5,22 @@ BASE_REF="${BASE_REF:-origin/main}"
 PYTHON_BIN="${PYTHON_BIN:-python}"
 
 if ! git rev-parse --verify "$BASE_REF" >/dev/null 2>&1; then
-  echo "Base ref '$BASE_REF' is unavailable. Skipping changed-skill harness feedback."
-  exit 0
+  echo "Base ref '$BASE_REF' is unavailable; changed Skill validation cannot run." >&2
+  exit 2
 fi
 
 CHANGED_PATHS=()
-while IFS= read -r path; do
-  CHANGED_PATHS+=("$path")
-done < <(git diff --name-only "$BASE_REF"...HEAD || true)
+DIFF_OUTPUT="$(git diff --name-only "$BASE_REF"...HEAD)"
+if [ -n "$DIFF_OUTPUT" ]; then
+  while IFS= read -r path; do
+    CHANGED_PATHS+=("$path")
+  done <<< "$DIFF_OUTPUT"
+fi
+
+if [ "${#CHANGED_PATHS[@]}" -eq 0 ]; then
+  echo "No changed built-in skills detected relative to $BASE_REF."
+  exit 0
+fi
 
 SKILLS=()
 for path in "${CHANGED_PATHS[@]}"; do

--- a/tests/test_infra/test_skill_contribution_workflow.py
+++ b/tests/test_infra/test_skill_contribution_workflow.py
@@ -12,6 +12,8 @@ from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import patch
 
+import yaml
+
 from scripts.collect_changed_skills import _changed_skill_ids
 from scripts.publish_skills_registry import publish_skill
 from scripts.refresh_skill_analytics import (
@@ -32,7 +34,8 @@ class SkillContributionWorkflowTests(unittest.TestCase):
         self.assertIn("deploywhisper skill lint", template)
         self.assertIn("deploywhisper skill test", template)
         self.assertIn("## Reviewer Assignment", template)
-        self.assertIn("Requested maintainer or domain reviewer:", template)
+        self.assertIn("Additional domain reviewer (if any):", template)
+        self.assertNotIn("Requested maintainer or domain reviewer:", template)
 
     def test_codeowners_contains_explicit_skill_contribution_paths(self) -> None:
         rules: dict[str, tuple[str, ...]] = {}
@@ -43,17 +46,15 @@ class SkillContributionWorkflowTests(unittest.TestCase):
             pattern, *owners = stripped.split()
             rules[pattern] = tuple(owners)
 
-        expected_paths = (
-            "/skills/",
-            "/tests/skill-tests/",
-            "/.github/PULL_REQUEST_TEMPLATE/skill.md",
-            "/docs/contributing/skills.md",
-        )
-        for path in expected_paths:
+        expected_routes = {
+            "/skills/": ("@pramodksahoo",),
+            "/tests/skill-tests/": ("@pramodksahoo",),
+            "/.github/PULL_REQUEST_TEMPLATE/skill.md": ("@pramodksahoo",),
+            "/docs/contributing/skills.md": ("@pramodksahoo",),
+        }
+        for path, expected_owners in expected_routes.items():
             with self.subTest(path=path):
-                self.assertIn(path, rules)
-                self.assertTrue(rules[path])
-                self.assertTrue(all(owner.startswith("@") for owner in rules[path]))
+                self.assertEqual(rules.get(path), expected_owners)
 
     def test_changed_skill_script_runs_lint_before_harness(self) -> None:
         script = Path("scripts/test-changed-skills.sh").read_text(encoding="utf-8")
@@ -64,10 +65,18 @@ class SkillContributionWorkflowTests(unittest.TestCase):
 
     def test_changed_skill_ci_preserves_actionable_failure_logs(self) -> None:
         workflow = Path(".github/workflows/ci.yml").read_text(encoding="utf-8")
+        payload = yaml.load(workflow, Loader=yaml.BaseLoader)
+        steps = payload["jobs"]["changed-tests"]["steps"]
+        upload_step = next(
+            step for step in steps if step["name"] == "Upload changed-test logs"
+        )
 
         self.assertIn("Run changed skill lint and harness checks", workflow)
-        self.assertIn("changed-skill-harness.log", workflow)
-        self.assertIn("if: failure()", workflow)
+        self.assertEqual(upload_step["if"], "failure()")
+        self.assertIn(
+            "changed-skill-harness.log",
+            upload_step["with"]["path"].splitlines(),
+        )
         self.assertNotIn(
             "if [ -f scripts/test-changed-skills.sh ]; then",
             workflow,
@@ -154,15 +163,16 @@ class SkillContributionWorkflowTests(unittest.TestCase):
         workflow = Path(".github/workflows/publish-skills-registry.yml").read_text(
             encoding="utf-8"
         )
+        payload = yaml.load(workflow, Loader=yaml.BaseLoader)
+        triggers = payload["on"]
 
         self.assertIn("Publish Skills Registry", workflow)
-        self.assertIn("branches:", workflow)
-        self.assertIn("- main", workflow)
-        self.assertIn("skills/*.md", workflow)
+        self.assertEqual(set(triggers), {"push", "workflow_dispatch"})
+        self.assertEqual(triggers["push"]["branches"], ["main"])
+        self.assertIn("skills/*.md", triggers["push"]["paths"])
         self.assertIn("REGISTRY_REPO: deploywhisper/skills-registry", workflow)
         self.assertIn("DEPLOYWHISPER_SKILLS_REGISTRY_PUSH_TOKEN", workflow)
         self.assertIn("scripts/publish_skills_registry.py", workflow)
-        self.assertNotIn("pull_request:", workflow)
 
     def test_publish_workflow_revalidates_before_registry_checkout(self) -> None:
         workflow = Path(".github/workflows/publish-skills-registry.yml").read_text(

--- a/tests/test_infra/test_skill_contribution_workflow.py
+++ b/tests/test_infra/test_skill_contribution_workflow.py
@@ -3,6 +3,9 @@
 from __future__ import annotations
 
 import json
+import os
+import subprocess
+import sys
 import tempfile
 import unittest
 from pathlib import Path
@@ -28,14 +31,29 @@ class SkillContributionWorkflowTests(unittest.TestCase):
         self.assertIn("## Skill Summary", template)
         self.assertIn("deploywhisper skill lint", template)
         self.assertIn("deploywhisper skill test", template)
+        self.assertIn("## Reviewer Assignment", template)
+        self.assertIn("Requested maintainer or domain reviewer:", template)
 
     def test_codeowners_contains_explicit_skill_contribution_paths(self) -> None:
-        codeowners = Path(".github/CODEOWNERS").read_text(encoding="utf-8")
+        rules: dict[str, tuple[str, ...]] = {}
+        for line in Path(".github/CODEOWNERS").read_text(encoding="utf-8").splitlines():
+            stripped = line.strip()
+            if not stripped or stripped.startswith("#"):
+                continue
+            pattern, *owners = stripped.split()
+            rules[pattern] = tuple(owners)
 
-        self.assertIn("/skills/", codeowners)
-        self.assertIn("/tests/skill-tests/", codeowners)
-        self.assertIn("/.github/PULL_REQUEST_TEMPLATE/skill.md", codeowners)
-        self.assertIn("/docs/contributing/skills.md", codeowners)
+        expected_paths = (
+            "/skills/",
+            "/tests/skill-tests/",
+            "/.github/PULL_REQUEST_TEMPLATE/skill.md",
+            "/docs/contributing/skills.md",
+        )
+        for path in expected_paths:
+            with self.subTest(path=path):
+                self.assertIn(path, rules)
+                self.assertTrue(rules[path])
+                self.assertTrue(all(owner.startswith("@") for owner in rules[path]))
 
     def test_changed_skill_script_runs_lint_before_harness(self) -> None:
         script = Path("scripts/test-changed-skills.sh").read_text(encoding="utf-8")
@@ -43,6 +61,76 @@ class SkillContributionWorkflowTests(unittest.TestCase):
         self.assertIn("^skills/([^/]+)\\.md$", script)
         self.assertIn('cli.py skill lint "skills/${skill}.md"', script)
         self.assertIn('cli.py skill test "${UNIQUE_SKILLS[@]}"', script)
+
+    def test_changed_skill_ci_preserves_actionable_failure_logs(self) -> None:
+        workflow = Path(".github/workflows/ci.yml").read_text(encoding="utf-8")
+
+        self.assertIn("Run changed skill lint and harness checks", workflow)
+        self.assertIn("changed-skill-harness.log", workflow)
+        self.assertIn("if: failure()", workflow)
+        self.assertNotIn(
+            "if [ -f scripts/test-changed-skills.sh ]; then",
+            workflow,
+        )
+
+    def test_changed_skill_script_handles_an_empty_diff(self) -> None:
+        result = subprocess.run(
+            ["bash", "scripts/test-changed-skills.sh"],
+            check=False,
+            capture_output=True,
+            env={
+                **os.environ,
+                "BASE_REF": "HEAD",
+                "PYTHON_BIN": sys.executable,
+            },
+            text=True,
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("No changed built-in skills detected", result.stdout)
+
+    def test_changed_skill_script_fails_closed_when_base_is_missing(self) -> None:
+        result = subprocess.run(
+            ["bash", "scripts/test-changed-skills.sh"],
+            check=False,
+            capture_output=True,
+            env={
+                **os.environ,
+                "BASE_REF": "missing/story-9-6-base",
+                "PYTHON_BIN": sys.executable,
+            },
+            text=True,
+        )
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("Base ref 'missing/story-9-6-base' is unavailable", result.stderr)
+
+    def test_changed_skill_script_fails_closed_when_diff_fails(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            fake_git = Path(tmpdir) / "git"
+            fake_git.write_text(
+                "#!/bin/sh\n"
+                'if [ "$1" = "rev-parse" ]; then exit 0; fi\n'
+                'if [ "$1" = "diff" ]; then echo "diff failed" >&2; exit 7; fi\n'
+                "exit 1\n",
+                encoding="utf-8",
+            )
+            fake_git.chmod(0o755)
+            result = subprocess.run(
+                ["bash", "scripts/test-changed-skills.sh"],
+                check=False,
+                capture_output=True,
+                env={
+                    **os.environ,
+                    "BASE_REF": "develop",
+                    "PATH": f"{tmpdir}{os.pathsep}{os.environ['PATH']}",
+                    "PYTHON_BIN": sys.executable,
+                },
+                text=True,
+            )
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("diff failed", result.stderr)
 
     def test_changed_skill_script_excludes_nested_skill_docs(self) -> None:
         diff_output = "\n".join(
@@ -74,6 +162,36 @@ class SkillContributionWorkflowTests(unittest.TestCase):
         self.assertIn("REGISTRY_REPO: deploywhisper/skills-registry", workflow)
         self.assertIn("DEPLOYWHISPER_SKILLS_REGISTRY_PUSH_TOKEN", workflow)
         self.assertIn("scripts/publish_skills_registry.py", workflow)
+        self.assertNotIn("pull_request:", workflow)
+
+    def test_publish_workflow_revalidates_before_registry_checkout(self) -> None:
+        workflow = Path(".github/workflows/publish-skills-registry.yml").read_text(
+            encoding="utf-8"
+        )
+
+        validation_index = workflow.index("Validate changed skills before publish")
+        checkout_index = workflow.index("Checkout registry repository")
+        publish_index = workflow.index("scripts/publish_skills_registry.py")
+
+        self.assertLess(validation_index, checkout_index)
+        self.assertLess(validation_index, publish_index)
+        self.assertIn("python cli.py skill lint", workflow)
+        self.assertIn("python cli.py skill test", workflow)
+
+    def test_contribution_docs_define_failure_and_publish_boundary(self) -> None:
+        guide = Path("docs/contributing/skills.md").read_text(encoding="utf-8")
+        normalized_guide = " ".join(guide.split())
+        contributing = Path("CONTRIBUTING.md").read_text(encoding="utf-8")
+        authoring = Path("docs/skills/authoring-guide.md").read_text(encoding="utf-8")
+
+        self.assertIn("Story 9.6", guide)
+        self.assertIn(
+            "A failed manifest lint or harness check stops the workflow before",
+            normalized_guide,
+        )
+        self.assertIn("No pull request event can publish a Skill", normalized_guide)
+        self.assertIn("docs/contributing/skills.md", contributing)
+        self.assertIn("docs/contributing/skills.md", authoring)
 
     def test_daily_skill_analytics_refresh_workflow_exists(self) -> None:
         workflow = Path(".github/workflows/refresh-skill-analytics.yml").read_text(


### PR DESCRIPTION
## Summary

- make changed-Skill CI fail closed when its validation script, base revision, or diff is unavailable
- repeat manifest linting and deterministic harness checks before any registry checkout, commit, or push
- make reviewer assignment explicit while preserving CODEOWNERS routing
- document the Git Flow contribution path, actionable failure feedback, and publication boundary

## BMad / design references

- Story: `_bmad-output/implementation-artifacts/9-6-skill-contribution-workflow.md`
- Epic: `_bmad-output/planning-artifacts/epics.md` — Epic 9, Story 9.6
- Requirements: SKL-01..09, ADM-05, DOC-13, NFR-OSS-05
- Architecture: `_bmad-output/planning-artifacts/architecture.md`
- Project context: `_bmad-output/project-context.md`

## Verification

- focused contribution and ownership regressions: 19 passed
- related manifest, harness, CLI, contribution, and ownership suites: 132 passed
- exact API/CLI/infra GitHub shard: 347 passed, 19 subtests passed
- `bash scripts/ci-local.sh`: all gates and 855 per-directory tests passed
- root `unittest discover`: 360 passed, 1 skipped
- Ruff lint and format checks passed
- Bandit reported no high-severity issues
- shell syntax, GitHub workflow YAML, manifest lint, and deterministic Skill harness checks passed

## UI validation

Not applicable. This change does not touch a React route, component, rendered
surface, browser interaction, keyboard behavior, or accessibility semantic.
Screenshots are therefore not applicable.

## Publication safety

The external registry push-token path was not exercised locally. The workflow
is structurally covered by regression tests and now validates all active changed
Skills before registry mutation. Removed Skills remain eligible for registry
deletion.
