### PR TITLE
Story 9.7: Skill analytics and deprecation signals

### DIFF
--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -1,5 +1,5 @@
 # generated: 2026-05-01
-# last_updated: 2026-07-27
+# last_updated: 2026-07-28
 # project: deploywhisper
 # project_key: NOKEY
 # tracking_system: file-system
@@ -35,7 +35,7 @@
 # - Dev moves story to review, then runs code-review
 
 generated: 2026-05-01
-last_updated: 2026-07-27
+last_updated: 2026-07-28
 project: deploywhisper
 project_key: NOKEY
 tracking_system: file-system

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -132,7 +132,7 @@ development_status:
   9-4-skills-installer-cli: done
   9-5-skills-browser-ui: done
   9-6-skill-contribution-workflow: done
-  9-7-skill-analytics-and-deprecation-signals: ready-for-dev
+  9-7-skill-analytics-and-deprecation-signals: done
   epic-9-retrospective: optional
 
   epic-10: in-progress

--- a/cli/analyze.py
+++ b/cli/analyze.py
@@ -472,8 +472,12 @@ def _run_skill_catalog_list() -> int:
             if item.test_results is not None and item.test_results.status != "missing"
             else "n/a"
         )
+        deprecated = item.trust_level == "deprecated"
         print(
-            f"{item.id} installs={item.install_count} "
+            f"{item.id} trust={item.trust_level} "
+            f"source={item.source} "
+            f"deprecated={str(deprecated).lower()} "
+            f"installs={item.install_count} "
             f"pass-rate={pass_rate} "
             f"active-issues={item.active_issue_count} "
             f"updated={item.updated_at[:10]} "

--- a/docs/skills/analytics.md
+++ b/docs/skills/analytics.md
@@ -1,7 +1,8 @@
 # Skills Analytics
 
-Story 4.8 adds a shared analytics layer for the skills marketplace so the same
-per-skill signals are available in the API, browser, and CLI.
+Story 9.7 completes the shared analytics and deprecation signals for the Skills
+marketplace so the same per-Skill evidence is available in the API, browser,
+and CLI.
 
 ## Metrics
 
@@ -12,6 +13,17 @@ Each registry skill now exposes:
 - `updated_at`
 - `active_issue_count`
 - `analytics_updated_at`
+- `trust_level`
+- `source`
+
+The Skills browser shows installs, deterministic test pass rate, active issue
+count, last update, trust level, and source on each catalog card and repeats the
+signals on the detail view. Skills whose `trust_level` is `deprecated` include
+an explicit warning that they may no longer be maintained.
+
+`deploywhisper skill list --catalog` emits the same inspection evidence as
+stable key-value fields, including `trust`, `source`, and the explicit
+`deprecated=true|false` lifecycle marker.
 
 ## Data source
 

--- a/frontend/e2e/phase6.spec.ts
+++ b/frontend/e2e/phase6.spec.ts
@@ -94,6 +94,7 @@ function formatSkillDate(value: string) {
     month: "short",
     day: "2-digit",
     year: "numeric",
+    timeZone: "UTC",
   }).format(new Date(value));
 }
 

--- a/frontend/e2e/phase6.spec.ts
+++ b/frontend/e2e/phase6.spec.ts
@@ -267,6 +267,8 @@ test.describe("Phase 6 settings, incidents, and skills", () => {
     await expect(
       page.getByText("This Skill is deprecated and may no longer be maintained.", { exact: true }),
     ).toBeVisible();
+    await expect(page.getByText("Install", { exact: true })).toBeVisible();
+    await expect(page.getByText("Installs", { exact: true })).toHaveCount(0);
     await expect(page.getByText("1 active issue", { exact: true })).toBeVisible();
     await expectNoSeriousA11y(page);
   });

--- a/frontend/e2e/phase6.spec.ts
+++ b/frontend/e2e/phase6.spec.ts
@@ -7,6 +7,7 @@ import os from "node:os";
 const runId = Date.now();
 const projectKey = `phase-6-${runId}`;
 const projectName = `Phase 6 ${runId}`;
+const deprecatedSkillId = `deprecated-phase6-${runId}`;
 
 type ApiEnvelope<T> = { data: T };
 type Project = { id: number; project_key: string; name: string; env_label: string };
@@ -88,6 +89,18 @@ async function expectNoSeriousA11y(page: Page) {
   expect(violations).toEqual([]);
 }
 
+function formatSkillDate(value: string) {
+  return new Intl.DateTimeFormat("en-US", {
+    month: "short",
+    day: "2-digit",
+    year: "numeric",
+  }).format(new Date(value));
+}
+
+function countLabel(count: number, singular: string) {
+  return `${count} ${singular}${count === 1 ? "" : "s"}`;
+}
+
 test.describe("Phase 6 settings, incidents, and skills", () => {
   let project: Project;
 
@@ -132,9 +145,14 @@ test.describe("Phase 6 settings, incidents, and skills", () => {
         trust_level: string;
         source: "built-in" | "custom-override" | "custom-new";
         contributors: string[];
+        author: string;
+        install_count: number;
+        active_issue_count: number;
+        updated_at: string;
         test_results: {
           status: "passing" | "failing" | "missing";
           display_text: string;
+          pass_rate: number;
         } | null;
       };
     };
@@ -150,6 +168,10 @@ test.describe("Phase 6 settings, incidents, and skills", () => {
       : registrySkill.test_results?.status === "failing"
         ? "Tests failing"
         : "Tests missing";
+    const passRateLabel = !registrySkill.test_results || registrySkill.test_results.status === "missing"
+      ? "n/a"
+      : `${Math.round(registrySkill.test_results.pass_rate * 100)}%`;
+    const updatedDate = formatSkillDate(registrySkill.updated_at);
 
     await page.goto("/skills?search=terraform&sort=recency", { waitUntil: "networkidle" });
     await expect(page.getByRole("heading", { name: "Skills" })).toBeVisible();
@@ -158,6 +180,12 @@ test.describe("Phase 6 settings, incidents, and skills", () => {
     await expect(terraformSkill.getByText(trustLabel)).toBeVisible();
     await expect(terraformSkill.getByText(sourceLabel)).toBeVisible();
     await expect(terraformSkill.getByText(testStatusLabel)).toBeVisible();
+    await expect(terraformSkill.getByLabel(countLabel(registrySkill.install_count, "install"))).toBeVisible();
+    await expect(terraformSkill.getByLabel(countLabel(registrySkill.active_issue_count, "active issue"))).toBeVisible();
+    await expect(
+      terraformSkill.getByText(`${registrySkill.author} / Updated ${updatedDate}`, { exact: true }),
+    ).toBeVisible();
+    await expect(terraformSkill.getByLabel(`${passRateLabel} test pass rate`)).toBeVisible();
     await terraformSkill.click();
     await expect(page).toHaveURL(/\/skills\/terraform/);
     await expect(page.getByText(trustLabel)).toBeVisible();
@@ -165,6 +193,8 @@ test.describe("Phase 6 settings, incidents, and skills", () => {
     await expect(page.getByText(testStatusLabel)).toBeVisible();
     await expect(page.getByText("Harness run")).toBeVisible();
     await expect(page.getByText("Analytics refreshed", { exact: false })).toBeVisible();
+    await expect(page.getByText(countLabel(registrySkill.active_issue_count, "active issue"))).toBeVisible();
+    await expect(page.getByText(`Updated ${updatedDate}`, { exact: true })).toBeVisible();
     if (registrySkill.test_results) {
       await expect(page.getByText(registrySkill.test_results.display_text)).toBeVisible();
     }
@@ -174,6 +204,70 @@ test.describe("Phase 6 settings, incidents, and skills", () => {
     }
     await expect(page.getByText(/deploywhisper skill install terraform/)).toBeVisible();
     await expect(page.getByText("Version history")).toBeVisible();
+    await expectNoSeriousA11y(page);
+  });
+
+  test("deprecated skill is clearly marked in catalog and detail routes", async ({ page }) => {
+    const skillResponse = await page.request.get("/api/v1/skills/terraform");
+    expect(skillResponse.ok()).toBeTruthy();
+    const skillPayload = await skillResponse.json() as {
+      data: Record<string, unknown>;
+      meta: Record<string, unknown>;
+    };
+    const deprecatedSkillData = {
+      ...skillPayload.data,
+      id: deprecatedSkillId,
+      name: "Deprecated Phase 6 Skill",
+      trust_level: "deprecated",
+      author: "Phase 6 Test",
+      maintainer: "Phase 6 Test",
+      is_official: false,
+      is_featured: false,
+      description: "Synthetic deprecated Skill for composed browser coverage.",
+      install_count: 1,
+      active_issue_count: 1,
+      install_command: `deploywhisper skill install ${deprecatedSkillId}`,
+    };
+    const listPayload = {
+      data: [deprecatedSkillData],
+      meta: {
+        ...skillPayload.meta,
+        count: 1,
+        total_count: 1,
+        page: 1,
+        page_size: 100,
+        filters: {},
+      },
+    };
+
+    await page.route("**/api/v1/skills?*", async (route) => {
+      await route.fulfill({ contentType: "application/json", json: listPayload });
+    });
+    await page.route(`**/api/v1/skills/${deprecatedSkillId}/versions`, async (route) => {
+      await route.fulfill({ contentType: "application/json", json: { data: [], meta: skillPayload.meta } });
+    });
+    await page.route(`**/api/v1/skills/${deprecatedSkillId}`, async (route) => {
+      await route.fulfill({
+        contentType: "application/json",
+        json: { data: deprecatedSkillData, meta: skillPayload.meta },
+      });
+    });
+
+    await page.goto(`/skills?search=${deprecatedSkillId}`, { waitUntil: "networkidle" });
+    const deprecatedSkill = page.locator(`a[href="/skills/${deprecatedSkillId}"]`);
+    await expect(deprecatedSkill).toBeVisible();
+    await expect(deprecatedSkill.getByText("Deprecated trust", { exact: true })).toBeVisible();
+    await expect(deprecatedSkill.getByText("This Skill is deprecated.", { exact: true })).toBeVisible();
+    await expect(deprecatedSkill.getByLabel("1 install")).toBeVisible();
+    await expect(deprecatedSkill.getByLabel("1 active issue")).toBeVisible();
+
+    await deprecatedSkill.click();
+    await expect(page).toHaveURL(new RegExp(`/skills/${deprecatedSkillId}$`));
+    await expect(page.getByText("Deprecated trust", { exact: true })).toBeVisible();
+    await expect(
+      page.getByText("This Skill is deprecated and may no longer be maintained.", { exact: true }),
+    ).toBeVisible();
+    await expect(page.getByText("1 active issue", { exact: true })).toBeVisible();
     await expectNoSeriousA11y(page);
   });
 });

--- a/frontend/src/screens/Skills.test.tsx
+++ b/frontend/src/screens/Skills.test.tsx
@@ -82,6 +82,34 @@ describe("Skills browser labels", () => {
     expect(markup).toContain("Public registry");
     expect(markup).toContain("Tests passing");
     expect(markup).toContain("100%");
+    expect(markup).toContain("0 active issues");
+    expect(markup).toContain("Updated Jul 27, 2026");
+  });
+
+  it("clearly marks deprecated skills in catalog results", () => {
+    const markup = renderToStaticMarkup(
+      <MemoryRouter>
+        <SkillCard skill={{ ...skill, trust_level: "deprecated" }} />
+      </MemoryRouter>,
+    );
+
+    expect(markup).toContain("Deprecated");
+    expect(markup).toContain("This Skill is deprecated");
+  });
+
+  it("uses singular analytics labels for one install and one active issue", () => {
+    const markup = renderToStaticMarkup(
+      <MemoryRouter>
+        <SkillCard
+          skill={{ ...skill, install_count: 1, active_issue_count: 1 }}
+        />
+      </MemoryRouter>,
+    );
+
+    expect(markup).toContain("1 install");
+    expect(markup).not.toContain("1 installs");
+    expect(markup).toContain("1 active issue");
+    expect(markup).not.toContain("1 active issues");
   });
 
   it("distinguishes private local skills from public registry skills", () => {
@@ -141,5 +169,26 @@ describe("Skills browser labels", () => {
     expect(markup).toContain("Analytics refreshed");
     expect(markup).toContain("DeployWhisper");
     expect(markup).toContain("Platform Safety");
+  });
+
+  it("warns before installing a deprecated skill from detail", () => {
+    const client = new QueryClient();
+    client.setQueryData(
+      ["skill", "terraform"],
+      { ...skill, trust_level: "deprecated", active_issue_count: 1 },
+    );
+    client.setQueryData(["skill-versions", "terraform"], []);
+
+    const markup = renderWithQuery(
+      <SkillDetailContent skillId="terraform" />,
+      client,
+    );
+
+    expect(markup).toContain("Deprecated");
+    expect(markup).toContain(
+      "This Skill is deprecated and may no longer be maintained.",
+    );
+    expect(markup).toContain("1 active issue");
+    expect(markup).not.toContain("1 active issues");
   });
 });

--- a/frontend/src/screens/Skills.test.tsx
+++ b/frontend/src/screens/Skills.test.tsx
@@ -175,7 +175,12 @@ describe("Skills browser labels", () => {
     const client = new QueryClient();
     client.setQueryData(
       ["skill", "terraform"],
-      { ...skill, trust_level: "deprecated", active_issue_count: 1 },
+      {
+        ...skill,
+        trust_level: "deprecated",
+        install_count: 1,
+        active_issue_count: 1,
+      },
     );
     client.setQueryData(["skill-versions", "terraform"], []);
 
@@ -188,6 +193,8 @@ describe("Skills browser labels", () => {
     expect(markup).toContain(
       "This Skill is deprecated and may no longer be maintained.",
     );
+    expect(markup).toContain("<strong>1</strong><span>Install</span>");
+    expect(markup).not.toContain("<strong>1</strong><span>Installs</span>");
     expect(markup).toContain("1 active issue");
     expect(markup).not.toContain("1 active issues");
   });

--- a/frontend/src/screens/Skills.test.tsx
+++ b/frontend/src/screens/Skills.test.tsx
@@ -86,6 +86,30 @@ describe("Skills browser labels", () => {
     expect(markup).toContain("Updated Jul 27, 2026");
   });
 
+  it("keeps date-only analytics labels stable west of UTC", () => {
+    const environment = (globalThis as unknown as {
+      process: { env: Record<string, string | undefined> };
+    }).process.env;
+    const originalTimezone = environment.TZ;
+    environment.TZ = "America/Los_Angeles";
+
+    try {
+      const markup = renderToStaticMarkup(
+        <MemoryRouter>
+          <SkillCard skill={skill} />
+        </MemoryRouter>,
+      );
+
+      expect(markup).toContain("Updated Jul 27, 2026");
+    } finally {
+      if (originalTimezone === undefined) {
+        delete environment.TZ;
+      } else {
+        environment.TZ = originalTimezone;
+      }
+    }
+  });
+
   it("clearly marks deprecated skills in catalog results", () => {
     const markup = renderToStaticMarkup(
       <MemoryRouter>

--- a/frontend/src/screens/Skills.tsx
+++ b/frontend/src/screens/Skills.tsx
@@ -274,7 +274,10 @@ export function SkillDetailContent({ skillId }: { skillId: string }) {
                 <div className="dw-phase6-stat-grid">
                   <div className="dw-phase6-stat"><strong>{skill.author}</strong><span>Author</span></div>
                   <div className="dw-phase6-stat"><strong>{skill.maintainer}</strong><span>Maintainer</span></div>
-                  <div className="dw-phase6-stat"><strong>{skill.install_count}</strong><span>Installs</span></div>
+                  <div className="dw-phase6-stat">
+                    <strong>{skill.install_count}</strong>
+                    <span>{skill.install_count === 1 ? "Install" : "Installs"}</span>
+                  </div>
                   <div className="dw-phase6-stat"><strong>{passRate(skill)}</strong><span>Pass rate</span></div>
                 </div>
                 <section aria-labelledby="skill-contributors-title" className="dw-phase6-stack">

--- a/frontend/src/screens/Skills.tsx
+++ b/frontend/src/screens/Skills.tsx
@@ -68,7 +68,15 @@ function unique(values: (string | undefined)[]) {
   return Array.from(new Set(values.filter(Boolean) as string[])).sort();
 }
 
+function countLabel(count: number, singular: string) {
+  return `${count} ${singular}${count === 1 ? "" : "s"}`;
+}
+
 export function SkillCard({ skill }: { skill: SkillRegistryItem }) {
+  const isDeprecated = skill.trust_level === "deprecated";
+  const issueCountLabel = countLabel(skill.active_issue_count, "active issue");
+  const installCountLabel = countLabel(skill.install_count, "install");
+
   return (
     <Link className="dw-phase6-list-item dw-skill-card" to={`/skills/${skill.id}`}>
       <div className="dw-phase6-row">
@@ -79,16 +87,34 @@ export function SkillCard({ skill }: { skill: SkillRegistryItem }) {
         <EvidenceTag>{skillSourceLabel(skill.source)}</EvidenceTag>
         <EvidenceTag>{skillTestStatusLabel(skill.test_results)}</EvidenceTag>
       </div>
+      {isDeprecated && (
+        <div className="dw-phase6-note dw-phase6-warning" role="note">
+          This Skill is deprecated.
+        </div>
+      )}
       <div className="dw-phase6-list-copy">{skill.description}</div>
       <div className="dw-skill-tags">
         <EvidenceTag>{skill.tool}</EvidenceTag>
         {skill.tags?.slice(0, 4).map((tag) => <EvidenceTag key={tag}>{tag}</EvidenceTag>)}
+        <span aria-label={issueCountLabel}>
+          <EvidenceTag>{issueCountLabel}</EvidenceTag>
+        </span>
       </div>
       <div className="dw-phase6-stat-grid">
-        <div className="dw-phase6-stat"><strong>{skill.install_count}</strong><span>Installs</span></div>
-        <div className="dw-phase6-stat"><strong>{passRate(skill)}</strong><span>Pass rate</span></div>
+        <div
+          aria-label={installCountLabel}
+          className="dw-phase6-stat"
+        >
+          <strong>{skill.install_count}</strong><span>{skill.install_count === 1 ? "Install" : "Installs"}</span>
+        </div>
+        <div
+          aria-label={`${passRate(skill)} test pass rate`}
+          className="dw-phase6-stat"
+        >
+          <strong>{passRate(skill)}</strong><span>Pass rate</span>
+        </div>
       </div>
-      <MonoRef>{skill.author} / {formatDate(skill.updated_at)}</MonoRef>
+      <MonoRef>{skill.author} / Updated {formatDate(skill.updated_at)}</MonoRef>
     </Link>
   );
 }
@@ -239,6 +265,11 @@ export function SkillDetailContent({ skillId }: { skillId: string }) {
                   <EvidenceTag>{skillSourceLabel(skill.source)}</EvidenceTag>
                   <EvidenceTag>{skillTestStatusLabel(skill.test_results)}</EvidenceTag>
                 </div>
+                {skill.trust_level === "deprecated" && (
+                  <div className="dw-phase6-note dw-phase6-warning" role="note">
+                    This Skill is deprecated and may no longer be maintained.
+                  </div>
+                )}
                 <div className="dw-skill-command-box">{skill.install_command}</div>
                 <div className="dw-phase6-stat-grid">
                   <div className="dw-phase6-stat"><strong>{skill.author}</strong><span>Author</span></div>
@@ -293,7 +324,7 @@ export function SkillDetailContent({ skillId }: { skillId: string }) {
             <Card eyebrow="Readiness" title="Registry snapshot">
               <div className="dw-phase6-stack">
                 <div className="dw-phase6-row"><PackageCheck size={16} /> <span className="dw-phase6-list-copy">{skill.available_versions} tracked versions</span></div>
-                <div className="dw-phase6-row"><ShieldCheck size={16} /> <span className="dw-phase6-list-copy">{skill.active_issue_count} active issues</span></div>
+                <div className="dw-phase6-row"><ShieldCheck size={16} /> <span className="dw-phase6-list-copy">{countLabel(skill.active_issue_count, "active issue")}</span></div>
                 <div className="dw-phase6-row"><GitBranch size={16} /> <span className="dw-phase6-list-copy">Updated {formatDate(skill.updated_at)}</span></div>
                 <div className="dw-phase6-row">
                   <Clock3 size={16} />

--- a/frontend/src/screens/Skills.tsx
+++ b/frontend/src/screens/Skills.tsx
@@ -14,7 +14,12 @@ function formatDate(value: string) {
   if (Number.isNaN(parsed.getTime())) {
     return value;
   }
-  return new Intl.DateTimeFormat("en-US", { month: "short", day: "2-digit", year: "numeric" }).format(parsed);
+  return new Intl.DateTimeFormat("en-US", {
+    month: "short",
+    day: "2-digit",
+    year: "numeric",
+    timeZone: "UTC",
+  }).format(parsed);
 }
 
 function formatTimestamp(value: string) {

--- a/tests/test_cli/test_analyze.py
+++ b/tests/test_cli/test_analyze.py
@@ -1425,7 +1425,7 @@ class AnalyzeCliTests(unittest.TestCase):
             id="terraform",
             name="Terraform",
             version="1.0.0",
-            trust_level="core",
+            trust_level="deprecated",
             source="built-in",
             author="DeployWhisper",
             maintainer="DeployWhisper",
@@ -1477,6 +1477,9 @@ class AnalyzeCliTests(unittest.TestCase):
         self.assertIn("installs=1842", output.getvalue().lower())
         self.assertIn("pass-rate=100%", output.getvalue().lower())
         self.assertIn("active-issues=1", output.getvalue().lower())
+        self.assertIn("trust=deprecated", output.getvalue().lower())
+        self.assertIn("source=built-in", output.getvalue().lower())
+        self.assertIn("deprecated=true", output.getvalue().lower())
 
     def test_skill_list_catalog_command_fetches_all_registry_pages(self) -> None:
         output = io.StringIO()

--- a/tests/test_cli/test_analyze.py
+++ b/tests/test_cli/test_analyze.py
@@ -1565,6 +1565,7 @@ class AnalyzeCliTests(unittest.TestCase):
         self.assertEqual(ctx.exception.code, 0)
         self.assertIn("terraform", output.getvalue().lower())
         self.assertIn("kubernetes", output.getvalue().lower())
+        self.assertEqual(output.getvalue().lower().count("deprecated=false"), 2)
 
     def test_skill_update_command_reports_noop_when_latest_version_is_installed(
         self,


### PR DESCRIPTION
## Summary

- expose install counts, deterministic pass rates, active issue activity, last update, trust level, and source on Skill catalog cards and details
- clearly mark deprecated Skills on both list and detail routes
- align `deploywhisper skill list --catalog` with trust, source, and explicit deprecation evidence
- preserve readable singular/plural analytics labels and exact update-date browser assertions

## Story and design references

- Story: `_bmad-output/implementation-artifacts/9-7-skill-analytics-and-deprecation-signals.md`
- Epic: Epic 9 — Skills Ecosystem
- Approved UI reference: `docs/design/phase-6-skills-1440.png`

## Documentation

- Updated `docs/skills/analytics.md` with the Story 9.7 browser and CLI evidence contract.
- Updated sprint tracking for Story 9.7 to `done`.

## Verification

- `bash scripts/ci-local.sh` — 855 passed
- `./.venv/bin/python -m pytest tests/test_api tests/test_cli tests/test_infra -v --tb=short` — 347 passed, 19 subtests passed
- `./.venv/bin/python -m unittest discover -q` — 360 passed, 1 skipped
- `npm run ui:test` — 54 passed
- `npm run ui:typecheck` — passed
- `npm run ui:build` — passed
- focused composed Phase 6 Playwright — 4 passed
- `BASE_URL=http://localhost:8080 npm run test:ui-review` — 10 passed
- Ruff and format checks — passed
- visual-verdict against `docs/design/phase-6-skills-1440.png` — 94/100, pass

## Screenshot

- Composed-app screenshot captured from `http://localhost:8080/skills` as `story-9-7-review-skills.png`; visual comparison passed at 94/100.
