### PR TITLE
Story 10.1: add stable agent JSON CLI mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -500,7 +500,7 @@ DeployWhisper includes a headless CLI entrypoint for local or CI usage.
 ### Analyze Artifacts
 
 ```bash
-python cli.py analyze path/to/plan.json path/to/deployment.yaml
+deploywhisper analyze --project payments path/to/plan.json path/to/deployment.yaml
 ```
 
 The CLI prints structured JSON containing:
@@ -510,6 +510,18 @@ The CLI prints structured JSON containing:
 - advisory summary
 - share summary
 - persisted report metadata
+
+AI coding agents can request the stable advisory contract:
+
+```bash
+deploywhisper analyze --agent-json --project payments path/to/plan.json
+```
+
+The agent contract is schema-versioned and includes explicit project scope,
+verdict, Evidence Law status, evidence, findings, confidence, uncertainty,
+context TODOs, verification guidance, and immutable fields stating that the
+result is advisory and is not deployment approval. See
+[Agent JSON CLI Output](docs/ai-safety/agent-json-output.md).
 
 ### Inspect Skill Status
 

--- a/_bmad-output/implementation-artifacts/10-1-agent-json-cli-mode.md
+++ b/_bmad-output/implementation-artifacts/10-1-agent-json-cli-mode.md
@@ -1,0 +1,137 @@
+# Story 10.1: Agent JSON CLI Mode
+
+Status: done
+
+<!-- Generated from updated PRD/architecture/epics plus implementation-readiness-report-2026-05-01.md. -->
+
+## Story
+
+As a DeployWhisper user,
+I want stable JSON output from the CLI,
+So that I can consume deployment-risk analysis without scraping human text.
+
+## Acceptance Criteria
+
+1. Given the CLI runs with `--agent-json`, When analysis completes, Then output includes schema version, verdict, advisory-only status, evidence, findings, confidence, uncertainty, context TODOs, and verification guidance. And output explicitly states it is not deployment approval.
+
+### Requirement Traceability
+
+- Primary PRD requirements: Epic 10 coverage: AIA-01..10, RSK-11, AIA-related NFR-SEC requirements, DOC-24.
+- Supporting PRD / NFR / differentiation requirements: See `_bmad-output/planning-artifacts/prd.md`, `_bmad-output/planning-artifacts/architecture.md`, and `_bmad-output/planning-artifacts/implementation-readiness-report-2026-05-01.md`.
+- Coverage intent: Baseline + Delta.
+- Story alignment note: This story was created from the updated Epic 10 plan after the 2026-05-01 readiness rerun. The readiness report verified 187/187 PRD functional requirement IDs in the epics artifact, 38 NFR IDs present, and no critical or major readiness defects.
+
+## Tasks / Subtasks
+
+- [x] Implement and verify acceptance criterion 1. (AC: 1)
+- [x] Reuse existing services, repositories, schemas, and UI/CLI/API helpers before adding new abstractions. (AC: all)
+- [x] Add or update deterministic regression coverage for the changed behavior. (AC: all)
+- [x] Update relevant docs or examples if the story changes user-visible, operator, API, CLI, integration, or contribution behavior. (AC: all)
+- [x] Run required validation and record commands/results in the Dev Agent Record. (AC: all)
+
+### Review Findings
+
+- [x] [Review][Patch] Isolate and lock the nested v1 agent contract so shared API schema evolution cannot silently change evidence, findings, or confidence output; add direct builder coverage for workspace scope and empty collections. [services/agent_interface_service.py:47]
+- [x] [Review][Patch] Deduplicate verification guidance by normalized text rather than exact casing so equivalent instructions are not repeated. [services/agent_interface_service.py:87]
+
+## Dev Notes
+
+### Epic Context
+
+- Epic: 10. AI Infrastructure Safety and Agent-Native Review
+- Epic goal: Serve AI coding agents safely without letting them bypass human judgment.
+- Epic coverage: AIA-01..10, RSK-11, AIA-related NFR-SEC requirements, DOC-24
+
+### Architecture and Product Guardrails
+
+- Preserve DeployWhisper's local-first raw artifact boundary: raw IaC, scanner artifacts, incident exports, and sensitive context stay in the user's infrastructure by default.
+- Preserve the advisory-first core. Optional adapters may interpret report outputs, but canonical report semantics remain advisory unless explicit story scope says otherwise.
+- Reuse the shared analysis core and service layer before adapting UI, API, CLI, GitHub, or future workflow surfaces.
+- Keep Evidence Law behavior intact: no high or critical finding without deterministic evidence.
+- Keep project/workspace scope explicit for reports, incidents, topology, outcomes, feedback, scanner imports, and connector-related data.
+- Do not introduce new dependencies unless the active story explicitly requires and justifies them.
+
+### Source Tree Guidance
+
+- API routes belong under `api/routes/` and should use existing `ApiRoute` / `ApiError` envelope patterns.
+- Shared orchestration belongs in `services/`; parsers normalize input, analysis modules score/derive risk, and surfaces adapt outputs.
+- UI work belongs under `frontend/src/screens/` and `frontend/src/components/`, following the existing retired Python UI composition style.
+- CLI behavior belongs under `cli/` and must call the same service-layer paths as UI/API flows.
+- Persistence work belongs under `models/` with Alembic migrations when schema changes are required.
+- Documentation required by a story should be updated in the same workstream.
+
+### Testing Requirements
+
+- Use standard-library `unittest` in the existing `tests/test_*` layout.
+- Add focused regression tests for the layer changed by the story before broad refactors.
+- For Python changes, run `./.venv/bin/ruff check .`, `./.venv/bin/ruff format --check .`, and `./.venv/bin/python -m unittest discover -q` before closing implementation.
+- Use `bash scripts/ci-local.sh` for broader or cross-layer changes.
+
+### Project Structure Notes
+
+- Follow the current repository shape documented in `_bmad-output/project-context.md` and `AGENTS.md`.
+- If implementation reveals a conflict between this story and the current code baseline, keep the smallest compatible change and update the story notes rather than silently drifting from the PRD.
+
+### References
+
+- `_bmad-output/planning-artifacts/epics.md` - source Epic 10 / Story 10.1 definition.
+- `_bmad-output/planning-artifacts/prd.md` - functional and non-functional requirements.
+- `_bmad-output/planning-artifacts/architecture.md` - target architecture, boundaries, and guardrails.
+- `_bmad-output/planning-artifacts/ux-design-specification.md` - UX expectations for user-facing stories.
+- `_bmad-output/planning-artifacts/implementation-readiness-report-2026-05-01.md` - readiness verdict and residual story-format concern.
+- `_bmad-output/project-context.md` - repository-specific implementation rules.
+
+## Dev Agent Record
+
+### Agent Model Used
+
+Codex (GPT-5)
+
+### Implementation Plan
+
+- Preserve the default CLI JSON contract and run the shared analysis core exactly once.
+- Add an architecture-owned agent interface adapter with strict Pydantic models and an independently versioned v1 output contract.
+- Derive evidence, findings, verdict, confidence, uncertainty, scope, Evidence Law status, context TODOs, and verification guidance from the canonical analysis response.
+- Lock immutable advisory and human-decision guardrails with CLI and service regressions.
+- Document the agent schema, safe consumption rules, and operational-error behavior.
+
+### Debug Log References
+
+- RED: `./.venv/bin/python -m pytest tests/test_cli/test_analyze.py::AnalyzeCliTests::test_analyze_agent_json_emits_stable_advisory_contract -q --tb=short` — failed because `--agent-json` was not recognized.
+- GREEN: the focused agent contract regression passed after implementation.
+- Focused agent coverage: agent success contract, structured operational error, and verification-guidance aggregation — 3 passed.
+- Full affected CLI/service coverage after review fixes: `./.venv/bin/python -m pytest tests/test_services/test_agent_interface_service.py tests/test_cli/test_analyze.py -q --tb=short` — 88 passed.
+- CI-parity shard: `./.venv/bin/python -m pytest tests/test_api tests/test_cli tests/test_infra -v --tb=short` — 349 passed, 19 subtests passed.
+- Full local CI after review fixes: `bash scripts/ci-local.sh` — passed, including Ruff, format, dependency validation, Bandit, compile checks, Skill harnesses, and 858 tests.
+- Required smoke: `./.venv/bin/python -m unittest discover -q` — 360 passed, 1 skipped.
+- Manual CLI sanity: `./.venv/bin/python cli.py analyze --help` — documented `--agent-json` successfully.
+- UI validation not applicable: Story 10.1 changes only the CLI/service contract and documentation; no React or browser-visible surface changed.
+
+### Completion Notes List
+
+- Added `deploywhisper analyze --agent-json` without changing default CLI JSON or operational error envelopes.
+- Added a strict v1 agent contract with report schema version, explicit project/workspace scope, verdict, Evidence Law status, canonical evidence and findings, confidence ledger, uncertainty, context TODOs, and deduplicated verification guidance.
+- Added immutable `advisory_only=true`, `deployment_approval=false`, `human_decision_required=true`, and explicit non-approval wording so agents cannot interpret the result as deployment approval.
+- Reused the existing canonical `AnalysisRunData` and shared analysis/persistence path; the agent mode performs no duplicate analysis and introduces no dependency or persistence change.
+- Added deterministic success, failure, exact-shape, shared-core call-count, and guidance aggregation coverage.
+- Isolated every nested v1 evidence, finding, context-source, and confidence-ledger field behind strict agent-owned models so additive API schema changes cannot alter the agent contract.
+- Added direct builder regressions for exact nested keys, workspace scope, empty collections, and immutable approval guardrails; guidance deduplication now ignores equivalent casing and whitespace.
+- Documented agent invocation, schema evolution, human review requirements, forbidden autonomous approval/deployment/remediation behavior, and operational-error interpretation.
+
+### File List
+
+- `_bmad-output/implementation-artifacts/10-1-agent-json-cli-mode.md`
+- `_bmad-output/implementation-artifacts/sprint-status.yaml`
+- `README.md`
+- `cli/analyze.py`
+- `docs/ai-safety/agent-json-output.md`
+- `docs/ci-advisory-consumption.md`
+- `services/agent_interface_service.py`
+- `tests/test_cli/test_analyze.py`
+- `tests/test_services/test_agent_interface_service.py`
+
+## Change Log
+
+- 2026-05-01: Story created/aligned from updated PRD, architecture, epics, sprint status, and readiness report.
+- 2026-07-28: Implemented and verified the stable advisory `--agent-json` CLI contract; moved Story 10.1 to review.
+- 2026-07-28: Resolved all code-review findings, reran focused and full validation, and moved Story 10.1 to done.

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -136,7 +136,7 @@ development_status:
   epic-9-retrospective: optional
 
   epic-10: in-progress
-  10-1-agent-json-cli-mode: ready-for-dev
+  10-1-agent-json-cli-mode: done
   10-2-mcp-compatible-or-equivalent-agent-interface: ready-for-dev
   10-3-ai-generated-iac-provenance-and-risk-patterns: ready-for-dev
   10-4-prompt-injection-test-suite: ready-for-dev

--- a/cli/analyze.py
+++ b/cli/analyze.py
@@ -38,6 +38,7 @@ from services.analysis_service import (
     build_share_summary,
     resolve_analysis_project_scope,
 )
+from services.agent_interface_service import build_agent_analysis_data
 from services.benchmark_corpus_service import (
     BenchmarkCorpusValidationError,
     validate_benchmark_corpus,
@@ -523,6 +524,7 @@ def _run_analyze(
     project_key: str | None = None,
     workspace_id: int | None = None,
     workspace_key: str | None = None,
+    agent_json: bool = False,
 ) -> int:
     if not paths:
         _emit_json(
@@ -639,22 +641,26 @@ def _run_analyze(
             stream=sys.stderr,
         )
         return 1
-    payload = {
-        "data": build_analysis_run_data(
-            intake=pending_analysis,
-            result=result,
-            advisory=_analysis_run_advisory(result),
-            share_summary=build_share_summary(result.persisted_report),
-        ).model_dump(),
-        "meta": build_meta(
-            api_version="v1",
-            report_schema_version=REPORT_SCHEMA_VERSION,
-            interface="cli",
-            advisory_only=True,
-            submitted_artifact_count=len(raw_files),
-            accepted_artifact_count=pending_analysis.ready_count,
-        ),
-    }
+    analysis_data = build_analysis_run_data(
+        intake=pending_analysis,
+        result=result,
+        advisory=_analysis_run_advisory(result),
+        share_summary=build_share_summary(result.persisted_report),
+    )
+    if agent_json:
+        payload = build_agent_analysis_data(analysis_data).model_dump(mode="json")
+    else:
+        payload = {
+            "data": analysis_data.model_dump(),
+            "meta": build_meta(
+                api_version="v1",
+                report_schema_version=REPORT_SCHEMA_VERSION,
+                interface="cli",
+                advisory_only=True,
+                submitted_artifact_count=len(raw_files),
+                accepted_artifact_count=pending_analysis.ready_count,
+            ),
+        }
     _emit_json(payload, stream=sys.stdout)
     return 0
 
@@ -1169,6 +1175,11 @@ def build_parser() -> argparse.ArgumentParser:
         help="Optional numeric workspace/environment id for the analysis.",
     )
     analyze_parser.add_argument(
+        "--agent-json",
+        action="store_true",
+        help="Emit stable advisory JSON for AI-agent consumption.",
+    )
+    analyze_parser.add_argument(
         "paths", nargs="*", help="Artifact file paths to analyze."
     )
 
@@ -1532,6 +1543,7 @@ def main() -> None:
                 project_key=getattr(args, "project_key", None),
                 workspace_id=getattr(args, "workspace_id", None),
                 workspace_key=getattr(args, "workspace_key", None),
+                agent_json=getattr(args, "agent_json", False),
             )
         )
     if args.command == "project" and args.project_command == "create":

--- a/docs/ai-safety/agent-json-output.md
+++ b/docs/ai-safety/agent-json-output.md
@@ -1,0 +1,77 @@
+# Agent JSON CLI Output
+
+DeployWhisper provides a stable, machine-readable advisory contract for AI
+coding agents:
+
+```bash
+deploywhisper analyze \
+  --agent-json \
+  --project payments \
+  path/to/plan.json > deploywhisper-agent.json
+```
+
+The command runs the same local-first analysis and persistence path used by the
+standard CLI and API. `--agent-json` changes only the successful output shape;
+it does not run a second analysis or give the calling agent additional
+authority.
+
+## Safety contract
+
+Every successful agent payload includes these immutable guardrails:
+
+```json
+{
+  "schema_version": "v1",
+  "advisory_only": true,
+  "deployment_approval": false,
+  "human_decision_required": true,
+  "approval_statement": "This output is advisory and is not deployment approval. A human must review the evidence before any deployment decision."
+}
+```
+
+An agent must not translate a DeployWhisper recommendation or risk score into
+autonomous approval, deployment, or remediation. A human reviewer remains
+responsible for the deployment decision. Non-zero CLI exit codes indicate
+operational failure, not an advisory risk outcome.
+
+## Stable v1 fields
+
+The top-level v1 contract contains:
+
+- `schema_version`: agent-output contract version
+- `report_schema_version`: canonical persisted report version
+- `report_id`: persisted analysis identifier
+- `scope`: explicit project and optional workspace identity
+- `verdict`: risk score, severity, recommendation, and top risk
+- `advisory_only`, `deployment_approval`, `human_decision_required`, and
+  `approval_statement`: non-approval guardrails
+- `evidence_law`: severe-claim verification status and detail
+- `evidence`: canonical evidence items with stable references and confidence
+- `findings`: canonical findings, evidence references, confidence, uncertainty,
+  and finding-level guidance
+- `confidence`: overall verdict confidence and the confidence ledger
+- `uncertainty`: flags, context summary, completeness state, and warnings
+- `context_todos`: missing context that would improve future analysis
+- `verification_guidance`: deduplicated human verification steps from findings,
+  incident matches, scanner conflicts, and narrative guidance
+
+Consumers should branch on `schema_version` before parsing. New optional report
+details can evolve under `report_schema_version`; incompatible changes to the
+agent contract require a new agent `schema_version`.
+
+## Operational errors
+
+Operational failures continue to use the existing structured error envelope on
+standard error:
+
+```json
+{
+  "error": {
+    "code": "missing_artifacts",
+    "message": "At least one artifact file is required.",
+    "details": {}
+  }
+}
+```
+
+Do not treat an operational error as a low-risk or approved result.

--- a/docs/ci-advisory-consumption.md
+++ b/docs/ci-advisory-consumption.md
@@ -27,6 +27,16 @@ print(payload["data"]["share_summary"]["plain_text"])
 PY
 ```
 
+AI coding agents should use the stable agent contract:
+
+```bash
+deploywhisper analyze --agent-json --project payments plan.json > agent.json
+```
+
+The agent payload includes explicit non-approval guardrails, canonical evidence
+and findings, confidence and uncertainty, context TODOs, and deduplicated human
+verification steps. See [Agent JSON CLI Output](./ai-safety/agent-json-output.md).
+
 ## API Example
 
 ```bash

--- a/services/agent_interface_service.py
+++ b/services/agent_interface_service.py
@@ -1,0 +1,295 @@
+"""Stable advisory output contracts for AI-agent interfaces."""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from api.schemas import (
+    AnalysisRunData,
+    DeployRecommendation,
+    RiskSeverity,
+)
+from evidence.models import (
+    ContextSourceFreshness,
+    ContextSourceType,
+    FindingEvidenceClassification,
+)
+from pydantic import BaseModel, ConfigDict, Field
+from services.confidence_ledger import EvidenceLawStatus
+
+
+AGENT_OUTPUT_SCHEMA_VERSION = "v1"
+AGENT_APPROVAL_STATEMENT = (
+    "This output is advisory and is not deployment approval. "
+    "A human must review the evidence before any deployment decision."
+)
+_HUMAN_REVIEW_GUIDANCE = (
+    "Have a human reviewer inspect the evidence and findings before deployment."
+)
+
+
+class _AgentContractModel(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+
+class AgentScopeData(_AgentContractModel):
+    project_id: int
+    project_key: str
+    workspace_id: int | None = None
+    workspace_key: str | None = None
+
+
+class AgentVerdictData(_AgentContractModel):
+    risk_score: int
+    severity: RiskSeverity
+    recommendation: DeployRecommendation
+    top_risk: str
+
+
+class AgentEvidenceLawData(_AgentContractModel):
+    status: EvidenceLawStatus
+    detail: str
+
+
+class AgentContextSourceData(_AgentContractModel):
+    source_id: str
+    source_type: ContextSourceType
+    source_ref: str | None = None
+    scope: str
+    freshness_status: ContextSourceFreshness = "unknown"
+    last_observed_at: str | None = None
+    age_days: int | None = Field(default=None, ge=0)
+    confidence: float = Field(default=0.0, ge=0.0, le=1.0, allow_inf_nan=False)
+    conflicts: list[str] = Field(default_factory=list)
+    limitations: list[str] = Field(default_factory=list)
+
+
+class AgentEvidenceData(_AgentContractModel):
+    evidence_id: str
+    analysis_id: int
+    finding_id: str
+    source_type: str
+    source_ref: str
+    artifact: str = ""
+    location: str = ""
+    resource: str = ""
+    operation: str = ""
+    project_id: int | None = None
+    project_key: str | None = None
+    workspace_id: int | None = None
+    workspace_key: str | None = None
+    source_kind: str = "artifact"
+    determinism_level: str = "deterministic"
+    redaction_status: str = "none"
+    summary: str
+    severity_hint: RiskSeverity
+    deterministic: bool
+    confidence: float = Field(..., ge=0.0, le=1.0)
+    evidence_label: str | None = None
+    related_change_ids: list[str] = Field(default_factory=list)
+    context_source: AgentContextSourceData | None = None
+
+
+class AgentFindingData(_AgentContractModel):
+    finding_id: str
+    analysis_id: int
+    title: str
+    description: str
+    explanation: str = ""
+    guidance: list[str] = Field(default_factory=list)
+    severity: RiskSeverity
+    category: str
+    deterministic: bool
+    confidence: float = Field(..., ge=0.0, le=1.0)
+    uncertainty_note: str | None = None
+    evidence_classification: FindingEvidenceClassification = "deterministic"
+    evidence_refs: list[str] = Field(default_factory=list)
+    evidence_label: str | None = None
+    skill_id: str | None = None
+
+
+class AgentConfidenceLedgerData(_AgentContractModel):
+    contributors: list[str] = Field(default_factory=list)
+    confidence_factors: list[str] = Field(default_factory=list)
+    why_not_lower: list[str] = Field(default_factory=list)
+    why_not_higher: list[str] = Field(default_factory=list)
+    uncertainty_drivers: list[str] = Field(default_factory=list)
+
+
+class AgentConfidenceData(_AgentContractModel):
+    overall: float = Field(..., ge=0.0, le=1.0)
+    ledger: AgentConfidenceLedgerData
+
+
+class AgentUncertaintyData(_AgentContractModel):
+    flags: list[str] = Field(default_factory=list)
+    summary: str | None = None
+    partial_context: bool
+    insufficient_context: bool
+    warnings: list[str] = Field(default_factory=list)
+
+
+class AgentAnalysisData(_AgentContractModel):
+    schema_version: Literal["v1"] = AGENT_OUTPUT_SCHEMA_VERSION
+    report_schema_version: str
+    report_id: int
+    scope: AgentScopeData
+    verdict: AgentVerdictData
+    advisory_only: Literal[True] = True
+    deployment_approval: Literal[False] = False
+    human_decision_required: Literal[True] = True
+    approval_statement: Literal[
+        "This output is advisory and is not deployment approval. "
+        "A human must review the evidence before any deployment decision."
+    ] = AGENT_APPROVAL_STATEMENT
+    evidence_law: AgentEvidenceLawData
+    evidence: list[AgentEvidenceData] = Field(default_factory=list)
+    findings: list[AgentFindingData] = Field(default_factory=list)
+    confidence: AgentConfidenceData
+    uncertainty: AgentUncertaintyData
+    context_todos: list[str] = Field(default_factory=list)
+    verification_guidance: list[str] = Field(default_factory=list)
+
+
+def _append_unique(values: list[str], candidate: object) -> None:
+    text = str(candidate).strip()
+    normalized = " ".join(text.split()).casefold()
+    if normalized and all(
+        " ".join(existing.split()).casefold() != normalized for existing in values
+    ):
+        values.append(text)
+
+
+def collect_agent_verification_guidance(analysis: AnalysisRunData) -> list[str]:
+    """Collect deterministic human-review steps without changing report semantics."""
+    guidance: list[str] = []
+    for finding in analysis.findings:
+        for item in finding.guidance:
+            _append_unique(guidance, item)
+    for incident_match in analysis.incident_matches:
+        for item in incident_match.verification_guidance:
+            _append_unique(guidance, item)
+    for conflict in analysis.share_summary.json_payload.scanner_conflicts:
+        _append_unique(guidance, conflict.recommended_verification)
+    for item in analysis.narrative.guidance:
+        _append_unique(guidance, item)
+    _append_unique(guidance, _HUMAN_REVIEW_GUIDANCE)
+    return guidance
+
+
+def build_agent_analysis_data(analysis: AnalysisRunData) -> AgentAnalysisData:
+    """Adapt one canonical analysis result into the stable agent JSON contract."""
+    context = analysis.assessment.context_completeness
+    report = analysis.persisted_report
+    share_payload = analysis.share_summary.json_payload
+    workspace = report.workspace
+    warnings: list[str] = []
+    for item in [*analysis.assessment.warnings, *analysis.narrative.warnings]:
+        _append_unique(warnings, item)
+
+    return AgentAnalysisData(
+        report_schema_version=report.report_schema_version,
+        report_id=report.id,
+        scope=AgentScopeData(
+            project_id=report.project.id,
+            project_key=report.project.project_key,
+            workspace_id=workspace.id if workspace is not None else None,
+            workspace_key=workspace.workspace_key if workspace is not None else None,
+        ),
+        verdict=AgentVerdictData(
+            risk_score=analysis.assessment.score,
+            severity=analysis.assessment.severity,
+            recommendation=analysis.assessment.recommendation,
+            top_risk=analysis.assessment.top_risk,
+        ),
+        evidence_law=AgentEvidenceLawData(
+            status=share_payload.evidence_law_status,
+            detail=share_payload.evidence_law_detail,
+        ),
+        evidence=[
+            AgentEvidenceData(
+                evidence_id=item.evidence_id,
+                analysis_id=item.analysis_id,
+                finding_id=item.finding_id,
+                source_type=item.source_type,
+                source_ref=item.source_ref,
+                artifact=item.artifact,
+                location=item.location,
+                resource=item.resource,
+                operation=item.operation,
+                project_id=item.project_id,
+                project_key=item.project_key,
+                workspace_id=item.workspace_id,
+                workspace_key=item.workspace_key,
+                source_kind=item.source_kind,
+                determinism_level=item.determinism_level,
+                redaction_status=item.redaction_status,
+                summary=item.summary,
+                severity_hint=item.severity_hint,
+                deterministic=item.deterministic,
+                confidence=item.confidence,
+                evidence_label=item.evidence_label,
+                related_change_ids=item.related_change_ids,
+                context_source=(
+                    AgentContextSourceData(
+                        source_id=item.context_source.source_id,
+                        source_type=item.context_source.source_type,
+                        source_ref=item.context_source.source_ref,
+                        scope=item.context_source.scope,
+                        freshness_status=item.context_source.freshness_status,
+                        last_observed_at=item.context_source.last_observed_at,
+                        age_days=item.context_source.age_days,
+                        confidence=item.context_source.confidence,
+                        conflicts=item.context_source.conflicts,
+                        limitations=item.context_source.limitations,
+                    )
+                    if item.context_source is not None
+                    else None
+                ),
+            )
+            for item in analysis.evidence_items
+        ],
+        findings=[
+            AgentFindingData(
+                finding_id=item.finding_id,
+                analysis_id=item.analysis_id,
+                title=item.title,
+                description=item.description,
+                explanation=item.explanation,
+                guidance=item.guidance,
+                severity=item.severity,
+                category=item.category,
+                deterministic=item.deterministic,
+                confidence=item.confidence,
+                uncertainty_note=item.uncertainty_note,
+                evidence_classification=item.evidence_classification,
+                evidence_refs=item.evidence_refs,
+                evidence_label=item.evidence_label,
+                skill_id=item.skill_id,
+            )
+            for item in analysis.findings
+        ],
+        confidence=AgentConfidenceData(
+            overall=analysis.assessment.confidence,
+            ledger=AgentConfidenceLedgerData(
+                contributors=analysis.assessment.confidence_ledger.contributors,
+                confidence_factors=(
+                    analysis.assessment.confidence_ledger.confidence_factors
+                ),
+                why_not_lower=analysis.assessment.confidence_ledger.why_not_lower,
+                why_not_higher=analysis.assessment.confidence_ledger.why_not_higher,
+                uncertainty_drivers=(
+                    analysis.assessment.confidence_ledger.uncertainty_drivers
+                ),
+            ),
+        ),
+        uncertainty=AgentUncertaintyData(
+            flags=analysis.advisory.uncertainty_flags,
+            summary=context.uncertainty,
+            partial_context=context.partial_context,
+            insufficient_context=context.insufficient_context,
+            warnings=warnings,
+        ),
+        context_todos=context.context_todos,
+        verification_guidance=collect_agent_verification_guidance(analysis),
+    )

--- a/tests/test_cli/test_analyze.py
+++ b/tests/test_cli/test_analyze.py
@@ -329,6 +329,134 @@ class AnalyzeCliTests(unittest.TestCase):
         self.assertIn("recommended_verification", conflicts[0])
         self.assertIn("Scanner conflict", share_summary["markdown"])
 
+    def test_analyze_agent_json_emits_stable_advisory_contract(self) -> None:
+        project_service_module.create_project(
+            project_key="payments",
+            display_name="Payments",
+        )
+        artifact_path = Path(self.tempdir.name) / "plan.json"
+        artifact_path.write_text('{"resource_changes": []}', encoding="utf-8")
+        output = io.StringIO()
+        persisted_report = self._persisted_report_with_scanner_conflict()
+        project = project_service_module.get_project_by_project_key("payments")
+        self.assertIsNotNone(project)
+        persisted_report["project"] = project.model_dump(mode="json")
+        persisted_report["confidence"] = 0.73
+        persisted_report["confidence_ledger"] = {
+            "contributors": ["Deterministic Terraform evidence."],
+            "confidence_factors": ["Parser coverage was complete."],
+            "why_not_lower": ["The scanner conflict remains unresolved."],
+            "why_not_higher": ["Deterministic evidence bounds the severity."],
+            "uncertainty_drivers": ["Scanner severity conflicts with local proof."],
+        }
+        persisted_report["context_completeness"].update(
+            {
+                "uncertainty": "Scanner conflict requires human verification.",
+                "context_todos": ["Confirm the intended ingress policy."],
+                "partial_context": True,
+                "insufficient_context": True,
+            }
+        )
+        result = self._analysis_result_with_persisted_report(persisted_report)
+
+        with (
+            patch(
+                "cli.analyze.analyze_uploaded_files",
+                return_value=result,
+            ) as analyze_mock,
+            patch(
+                "sys.argv",
+                [
+                    "deploywhisper",
+                    "analyze",
+                    "--agent-json",
+                    "--project",
+                    "payments",
+                    str(artifact_path),
+                ],
+            ),
+            redirect_stdout(output),
+        ):
+            with self.assertRaises(SystemExit) as ctx:
+                main()
+
+        self.assertEqual(ctx.exception.code, 0)
+        analyze_mock.assert_called_once()
+        payload = json.loads(output.getvalue())
+        self.assertEqual(
+            set(payload),
+            {
+                "schema_version",
+                "report_schema_version",
+                "report_id",
+                "scope",
+                "verdict",
+                "advisory_only",
+                "deployment_approval",
+                "human_decision_required",
+                "approval_statement",
+                "evidence_law",
+                "evidence",
+                "findings",
+                "confidence",
+                "uncertainty",
+                "context_todos",
+                "verification_guidance",
+            },
+        )
+        self.assertEqual(payload["schema_version"], "v1")
+        self.assertEqual(payload["report_schema_version"], "v2")
+        self.assertEqual(payload["report_id"], persisted_report["id"])
+        self.assertEqual(payload["scope"]["project_key"], "payments")
+        self.assertIsNone(payload["scope"]["workspace_key"])
+        self.assertEqual(
+            payload["verdict"],
+            {
+                "risk_score": persisted_report["risk_score"],
+                "severity": persisted_report["severity"],
+                "recommendation": persisted_report["recommendation"],
+                "top_risk": persisted_report["top_risk"],
+            },
+        )
+        self.assertTrue(payload["advisory_only"])
+        self.assertFalse(payload["deployment_approval"])
+        self.assertTrue(payload["human_decision_required"])
+        self.assertIn("not deployment approval", payload["approval_statement"].lower())
+        self.assertIn(
+            payload["evidence_law"]["status"],
+            {"Satisfied", "Needs review", "Reconciled"},
+        )
+        self.assertTrue(payload["evidence_law"]["detail"])
+        self.assertEqual(payload["evidence"][0]["evidence_id"], "ev-det")
+        self.assertEqual(payload["findings"][0]["finding_id"], "finding-001")
+        self.assertEqual(payload["findings"][0]["confidence"], 0.62)
+        self.assertEqual(payload["confidence"]["overall"], 0.73)
+        self.assertEqual(
+            payload["confidence"]["ledger"]["uncertainty_drivers"],
+            ["Scanner severity conflicts with local proof."],
+        )
+        self.assertEqual(
+            payload["uncertainty"]["summary"],
+            "Scanner conflict requires human verification.",
+        )
+        self.assertTrue(payload["uncertainty"]["partial_context"])
+        self.assertTrue(payload["uncertainty"]["insufficient_context"])
+        self.assertIn("context_todos", payload["uncertainty"]["flags"])
+        self.assertEqual(
+            payload["context_todos"],
+            ["Confirm the intended ingress policy."],
+        )
+        self.assertIn(
+            "Review scanner evidence before acting.",
+            payload["verification_guidance"],
+        )
+        self.assertTrue(
+            any(
+                "human reviewer" in guidance.lower()
+                for guidance in payload["verification_guidance"]
+            )
+        )
+
     def test_load_artifacts_preserves_mixed_relative_codeowners_absolute_artifact(
         self,
     ) -> None:
@@ -2767,6 +2895,39 @@ class AnalyzeCliTests(unittest.TestCase):
                 [
                     "deploywhisper",
                     "analyze",
+                    "--project",
+                    "payments",
+                    str(missing_path),
+                ],
+            ),
+            redirect_stdout(stdout),
+            redirect_stderr(stderr),
+        ):
+            with self.assertRaises(SystemExit) as ctx:
+                main()
+
+        self.assertEqual(ctx.exception.code, 2)
+        self.assertEqual(stdout.getvalue(), "")
+        payload = json.loads(stderr.getvalue())
+        self.assertEqual(payload["error"]["code"], "artifact_read_failed")
+        self.assertEqual(payload["error"]["details"]["path"], str(missing_path))
+
+    def test_analyze_agent_json_preserves_structured_operational_errors(self) -> None:
+        project_service_module.create_project(
+            project_key="payments",
+            display_name="Payments",
+        )
+        missing_path = Path(self.tempdir.name) / "missing-agent-plan.json"
+        stdout = io.StringIO()
+        stderr = io.StringIO()
+
+        with (
+            patch(
+                "sys.argv",
+                [
+                    "deploywhisper",
+                    "analyze",
+                    "--agent-json",
                     "--project",
                     "payments",
                     str(missing_path),

--- a/tests/test_services/test_agent_interface_service.py
+++ b/tests/test_services/test_agent_interface_service.py
@@ -1,0 +1,266 @@
+"""Tests for stable AI-agent output adaptation."""
+
+from __future__ import annotations
+
+import unittest
+from types import SimpleNamespace
+
+from services.agent_interface_service import (
+    AGENT_APPROVAL_STATEMENT,
+    build_agent_analysis_data,
+    collect_agent_verification_guidance,
+)
+
+
+class AgentInterfaceServiceTests(unittest.TestCase):
+    @staticmethod
+    def _analysis(*, include_items: bool, include_workspace: bool) -> SimpleNamespace:
+        context_source = SimpleNamespace(
+            source_id="artifact:plan",
+            source_type="artifact",
+            source_ref="plan.json",
+            scope="project:payments/workspace:prod",
+            freshness_status="current",
+            last_observed_at="2026-07-28T10:00:00Z",
+            age_days=0,
+            confidence=0.92,
+            conflicts=[],
+            limitations=[],
+        )
+        evidence = SimpleNamespace(
+            evidence_id="ev-1",
+            analysis_id=42,
+            finding_id="finding-1",
+            source_type="artifact",
+            source_ref="terraform://plan.json#aws_security_group.main",
+            artifact="plan.json",
+            location="plan.json:12",
+            resource="aws_security_group.main",
+            operation="modify",
+            project_id=7,
+            project_key="payments",
+            workspace_id=9,
+            workspace_key="prod",
+            source_kind="artifact",
+            determinism_level="deterministic",
+            redaction_status="none",
+            summary="Ingress changed.",
+            severity_hint="high",
+            deterministic=True,
+            confidence=0.92,
+            evidence_label=None,
+            related_change_ids=["chg-1"],
+            context_source=context_source,
+        )
+        finding = SimpleNamespace(
+            finding_id="finding-1",
+            analysis_id=42,
+            title="Public ingress",
+            description="Ingress may be public.",
+            explanation="Public ingress expands exposure.",
+            guidance=["Confirm the ingress policy."],
+            severity="high",
+            category="network",
+            deterministic=True,
+            confidence=0.92,
+            uncertainty_note=None,
+            evidence_classification="deterministic",
+            evidence_refs=["ev-1"],
+            evidence_label=None,
+            skill_id=None,
+        )
+        workspace = (
+            SimpleNamespace(id=9, workspace_key="prod") if include_workspace else None
+        )
+        return SimpleNamespace(
+            findings=[finding] if include_items else [],
+            evidence_items=[evidence] if include_items else [],
+            incident_matches=[],
+            share_summary=SimpleNamespace(
+                json_payload=SimpleNamespace(
+                    evidence_law_status="Satisfied",
+                    evidence_law_detail="Severe claims have deterministic evidence.",
+                    scanner_conflicts=[],
+                )
+            ),
+            narrative=SimpleNamespace(guidance=[], warnings=[]),
+            advisory=SimpleNamespace(uncertainty_flags=[]),
+            assessment=SimpleNamespace(
+                score=78,
+                severity="high",
+                recommendation="no-go",
+                top_risk="Public ingress",
+                confidence=0.92,
+                confidence_ledger=SimpleNamespace(
+                    contributors=["Public ingress"],
+                    confidence_factors=["Deterministic artifact evidence"],
+                    why_not_lower=["The ingress is public."],
+                    why_not_higher=["No credential exposure was observed."],
+                    uncertainty_drivers=[],
+                ),
+                context_completeness=SimpleNamespace(
+                    uncertainty=None,
+                    partial_context=False,
+                    insufficient_context=False,
+                    context_todos=[],
+                ),
+                warnings=[],
+            ),
+            persisted_report=SimpleNamespace(
+                id=42,
+                report_schema_version="1.0",
+                project=SimpleNamespace(id=7, project_key="payments"),
+                workspace=workspace,
+            ),
+        )
+
+    def test_verification_guidance_is_ordered_deduplicated_and_human_gated(
+        self,
+    ) -> None:
+        analysis = SimpleNamespace(
+            findings=[
+                SimpleNamespace(
+                    guidance=[
+                        "Confirm the ingress policy.",
+                        "Confirm the ingress policy.",
+                    ]
+                )
+            ],
+            incident_matches=[
+                SimpleNamespace(
+                    verification_guidance=["Compare against the incident pattern."]
+                )
+            ],
+            share_summary=SimpleNamespace(
+                json_payload=SimpleNamespace(
+                    scanner_conflicts=[
+                        SimpleNamespace(
+                            recommended_verification="Reconcile scanner evidence."
+                        )
+                    ]
+                )
+            ),
+            narrative=SimpleNamespace(
+                guidance=[
+                    "  compare   AGAINST the incident pattern.  ",
+                    "Confirm the ingress policy.",
+                ]
+            ),
+        )
+
+        guidance = collect_agent_verification_guidance(analysis)
+
+        self.assertEqual(
+            guidance,
+            [
+                "Confirm the ingress policy.",
+                "Compare against the incident pattern.",
+                "Reconcile scanner evidence.",
+                "Have a human reviewer inspect the evidence and findings before deployment.",
+            ],
+        )
+
+    def test_builder_locks_nested_v1_contract_keys(self) -> None:
+        payload = build_agent_analysis_data(
+            self._analysis(include_items=True, include_workspace=True)
+        ).model_dump(mode="json")
+
+        self.assertEqual(
+            set(payload["evidence"][0]),
+            {
+                "evidence_id",
+                "analysis_id",
+                "finding_id",
+                "source_type",
+                "source_ref",
+                "artifact",
+                "location",
+                "resource",
+                "operation",
+                "project_id",
+                "project_key",
+                "workspace_id",
+                "workspace_key",
+                "source_kind",
+                "determinism_level",
+                "redaction_status",
+                "summary",
+                "severity_hint",
+                "deterministic",
+                "confidence",
+                "evidence_label",
+                "related_change_ids",
+                "context_source",
+            },
+        )
+        self.assertEqual(
+            set(payload["evidence"][0]["context_source"]),
+            {
+                "source_id",
+                "source_type",
+                "source_ref",
+                "scope",
+                "freshness_status",
+                "last_observed_at",
+                "age_days",
+                "confidence",
+                "conflicts",
+                "limitations",
+            },
+        )
+        self.assertEqual(
+            set(payload["findings"][0]),
+            {
+                "finding_id",
+                "analysis_id",
+                "title",
+                "description",
+                "explanation",
+                "guidance",
+                "severity",
+                "category",
+                "deterministic",
+                "confidence",
+                "uncertainty_note",
+                "evidence_classification",
+                "evidence_refs",
+                "evidence_label",
+                "skill_id",
+            },
+        )
+        self.assertEqual(
+            set(payload["confidence"]["ledger"]),
+            {
+                "contributors",
+                "confidence_factors",
+                "why_not_lower",
+                "why_not_higher",
+                "uncertainty_drivers",
+            },
+        )
+
+    def test_builder_preserves_workspace_scope_and_empty_collections(self) -> None:
+        payload = build_agent_analysis_data(
+            self._analysis(include_items=False, include_workspace=True)
+        ).model_dump(mode="json")
+
+        self.assertEqual(
+            payload["scope"],
+            {
+                "project_id": 7,
+                "project_key": "payments",
+                "workspace_id": 9,
+                "workspace_key": "prod",
+            },
+        )
+        self.assertEqual(payload["evidence"], [])
+        self.assertEqual(payload["findings"], [])
+        self.assertEqual(payload["context_todos"], [])
+        self.assertTrue(payload["advisory_only"])
+        self.assertFalse(payload["deployment_approval"])
+        self.assertTrue(payload["human_decision_required"])
+        self.assertEqual(payload["approval_statement"], AGENT_APPROVAL_STATEMENT)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a separately versioned, advisory-only agent JSON contract to the shared CLI analysis path
- isolate nested v1 evidence, finding, context-source, and confidence schemas from API model evolution
- preserve structured operational errors and add human-approval guardrails
- document safe agent and CI consumption

## Review fixes
- lock exact nested v1 contract keys with direct builder regressions for workspace and empty payloads
- deduplicate verification guidance using casefolded, whitespace-normalized comparisons

## Validation
- 88 focused CLI/service tests passed
- 349 API/CLI/infra tests plus 19 subtests passed
- full local CI passed with 858 tests, Ruff, format, dependency checks, Bandit, compile checks, and skill harnesses
- root unittest smoke passed: 360 tests, 1 skipped
- UI validation not applicable