### PR TITLE
Story 11.1: add policy adapter output contract

### DIFF
--- a/_bmad-output/implementation-artifacts/11-1-policy-adapter-output-contract.md
+++ b/_bmad-output/implementation-artifacts/11-1-policy-adapter-output-contract.md
@@ -34,6 +34,13 @@ So that report outputs can be translated into local workflow decisions.
 - [x] [Review][Patch] Reserve scanner-conflict field names from adapter-owned payloads [services/adapter_output_contract.py:261]
 - [x] [Review][Patch] Exercise a non-empty frozen scanner-conflict object in the immutability regression [tests/test_services/test_policy_adapter_output_contract.py:55]
 - [x] [Review][Patch] Compare the emitted canonical summary with the source summary, not only the untouched source with itself [tests/test_services/test_policy_adapter_output_contract.py:53]
+- [x] [Review][Patch] Reject reason text that cannot be serialized as UTF-8 JSON [services/policy_adapter_output_contract.py:39]
+- [x] [Review][Patch] Reject reason codes and messages containing no visible characters [services/policy_adapter_output_contract.py:39]
+- [x] [Review][Patch] Reject bytes coercion for policy status input [services/policy_adapter_output_contract.py:54]
+- [x] [Review][Patch] Reject unordered set input for policy reasons [services/policy_adapter_output_contract.py:55]
+- [x] [Review][Patch] Require an actual boolean true for canonical_report_advisory input [services/policy_adapter_output_contract.py:58]
+- [x] [Review][Patch] Exercise advisory_only and should_block invariant failures independently [tests/test_services/test_policy_adapter_output_contract.py:95]
+- [x] [Review][Patch] Add the changed adapter contract regression file to the story File List [_bmad-output/implementation-artifacts/11-1-policy-adapter-output-contract.md:124]
 
 ## Dev Notes
 
@@ -109,6 +116,10 @@ Codex (GPT-5)
 - Review GREEN: reserved every scanner-conflict model field, added a real non-empty conflict fixture, verified nested field immutability and source-to-output equality, and reran the focused suite — 29 tests and 47 subtests passed.
 - Review affected shard: `./.venv/bin/python -m pytest tests/test_services tests/test_docs -q --tb=short` — 918 passed, 350 subtests passed.
 - Review closure validation: unittest smoke passed with 396 tests and 1 skip; Ruff, format check, targeted Bandit, diff checks, and `bash scripts/ci-local.sh` all passed; full local CI ran 895 tests.
+- Second-review RED: `./.venv/bin/python -m pytest tests/test_services/test_policy_adapter_output_contract.py -q --tb=short` reproduced all coercion, visibility, and serialization gaps with 6 failures; 5 tests and 8 subtests otherwise passed.
+- Second-review GREEN: `./.venv/bin/python -m pytest tests/test_services/test_policy_adapter_output_contract.py tests/test_services/test_adapter_output_contract.py tests/test_docs/test_workflow_adapter_output_contract.py -q --tb=short` — 30 passed, 55 subtests passed.
+- Second-review affected shard: `./.venv/bin/python -m pytest tests/test_services tests/test_docs -q --tb=short` — 919 passed, 358 subtests passed.
+- Second-review closure validation: unittest smoke passed with 396 tests and 1 skip; Ruff, format check, targeted Bandit, diff checks, and `bash scripts/ci-local.sh` all passed; full local CI ran 896 tests.
 - Local mypy was unavailable in `.venv`; the configured GitHub mypy step is non-blocking. No dependency was added solely for local validation.
 - UI validation not applicable: Story 11.1 changes service contracts and documentation only; no React route, rendered surface, browser interaction, keyboard behavior, or accessibility semantics changed.
 
@@ -129,6 +140,7 @@ Codex (GPT-5)
 - `services/adapter_output_contract.py`
 - `services/policy_adapter_output_contract.py`
 - `tests/test_docs/test_workflow_adapter_output_contract.py`
+- `tests/test_services/test_adapter_output_contract.py`
 - `tests/test_services/test_policy_adapter_output_contract.py`
 
 ## Change Log
@@ -136,3 +148,4 @@ Codex (GPT-5)
 - 2026-05-01: Story created/aligned from updated PRD, architecture, epics, sprint status, and readiness report.
 - 2026-08-03: Added the optional policy-adapter output contract, strengthened canonical immutability, documented the boundary, completed full validation, and moved the story to review.
 - 2026-08-03: Resolved all code-review findings, added scanner-conflict shadow and immutability regressions, reran full validation, and marked the story done.
+- 2026-08-03: Closed the second review with strict ordered inputs, UTF-8-visible structured reasons, literal advisory semantics, independent invariant regressions, and another full local CI pass.

--- a/_bmad-output/implementation-artifacts/11-1-policy-adapter-output-contract.md
+++ b/_bmad-output/implementation-artifacts/11-1-policy-adapter-output-contract.md
@@ -41,6 +41,7 @@ So that report outputs can be translated into local workflow decisions.
 - [x] [Review][Patch] Require an actual boolean true for canonical_report_advisory input [services/policy_adapter_output_contract.py:58]
 - [x] [Review][Patch] Exercise advisory_only and should_block invariant failures independently [tests/test_services/test_policy_adapter_output_contract.py:95]
 - [x] [Review][Patch] Add the changed adapter contract regression file to the story File List [_bmad-output/implementation-artifacts/11-1-policy-adapter-output-contract.md:124]
+- [x] [Review][Patch] Reject control characters embedded in otherwise visible policy reason text [services/policy_adapter_output_contract.py:39]
 
 ## Dev Notes
 
@@ -120,6 +121,10 @@ Codex (GPT-5)
 - Second-review GREEN: `./.venv/bin/python -m pytest tests/test_services/test_policy_adapter_output_contract.py tests/test_services/test_adapter_output_contract.py tests/test_docs/test_workflow_adapter_output_contract.py -q --tb=short` — 30 passed, 55 subtests passed.
 - Second-review affected shard: `./.venv/bin/python -m pytest tests/test_services tests/test_docs -q --tb=short` — 919 passed, 358 subtests passed.
 - Second-review closure validation: unittest smoke passed with 396 tests and 1 skip; Ruff, format check, targeted Bandit, diff checks, and `bash scripts/ci-local.sh` all passed; full local CI ran 896 tests.
+- Third-review RED: `./.venv/bin/python -m pytest tests/test_services/test_policy_adapter_output_contract.py -q --tb=short` reproduced embedded control-character acceptance with 3 failures; 5 tests and 14 subtests otherwise passed.
+- Third-review GREEN: the combined policy, adapter, and documentation contract suite passed with 30 tests and 58 subtests after rejecting all non-printable reason characters.
+- Third-review affected shard: `./.venv/bin/python -m pytest tests/test_services tests/test_docs -q --tb=short` — 919 passed, 361 subtests passed.
+- Third-review closure validation: unittest smoke passed with 396 tests and 1 skip; Ruff, format check, targeted Bandit, diff checks, and `bash scripts/ci-local.sh` all passed; full local CI ran 896 tests.
 - Local mypy was unavailable in `.venv`; the configured GitHub mypy step is non-blocking. No dependency was added solely for local validation.
 - UI validation not applicable: Story 11.1 changes service contracts and documentation only; no React route, rendered surface, browser interaction, keyboard behavior, or accessibility semantics changed.
 
@@ -129,6 +134,7 @@ Codex (GPT-5)
 - Supported `advisory`, `warn`, `soft-block`, and `hard-block` interpretations with at least one nonblank structured reason.
 - Reused the Story 5.6 `AdapterOutputContract` and immutable canonical `ShareSummary` instead of duplicating analysis or severity logic.
 - Rejected policy output when the nested canonical summary is not advisory or claims DeployWhisper should block.
+- Rejected embedded control characters in policy reason codes and messages before they reach logs or rendered integration output.
 - Preserved canonical report values for every policy status and closed the remaining nested scanner-conflict immutability gap.
 - Documented construction, ownership boundaries, versioning, and the distinction between optional local policy decisions and canonical advisory semantics.
 
@@ -149,3 +155,4 @@ Codex (GPT-5)
 - 2026-08-03: Added the optional policy-adapter output contract, strengthened canonical immutability, documented the boundary, completed full validation, and moved the story to review.
 - 2026-08-03: Resolved all code-review findings, added scanner-conflict shadow and immutability regressions, reran full validation, and marked the story done.
 - 2026-08-03: Closed the second review with strict ordered inputs, UTF-8-visible structured reasons, literal advisory semantics, independent invariant regressions, and another full local CI pass.
+- 2026-08-03: Closed the third review by rejecting embedded control characters in policy reasons and rerunning focused, affected-shard, security, smoke, and full-CI validation.

--- a/_bmad-output/implementation-artifacts/11-1-policy-adapter-output-contract.md
+++ b/_bmad-output/implementation-artifacts/11-1-policy-adapter-output-contract.md
@@ -1,0 +1,138 @@
+# Story 11.1: Policy Adapter Output Contract
+
+Status: done
+
+<!-- Generated from updated PRD/architecture/epics plus implementation-readiness-report-2026-05-01.md. -->
+
+## Story
+
+As a platform admin,
+I want a policy adapter contract,
+So that report outputs can be translated into local workflow decisions.
+
+## Acceptance Criteria
+
+1. Given a canonical report exists, When a policy adapter consumes it, Then the adapter can output advisory, warn, soft-block, or hard-block status with reasons. And the canonical report remains unchanged and advisory.
+
+### Requirement Traceability
+
+- Primary PRD requirements: Epic 11 coverage: ADM-07, ADM-09, WRK-07, RSK-07, NFR-SEC-06.
+- Supporting PRD / NFR / differentiation requirements: See `_bmad-output/planning-artifacts/prd.md`, `_bmad-output/planning-artifacts/architecture.md`, and `_bmad-output/planning-artifacts/implementation-readiness-report-2026-05-01.md`.
+- Coverage intent: Baseline + Delta.
+- Story alignment note: This story was created from the updated Epic 11 plan after the 2026-05-01 readiness rerun. The readiness report verified 187/187 PRD functional requirement IDs in the epics artifact, 38 NFR IDs present, and no critical or major readiness defects.
+
+## Tasks / Subtasks
+
+- [x] Implement and verify acceptance criterion 1. (AC: 1)
+- [x] Reuse existing services, repositories, schemas, and UI/CLI/API helpers before adding new abstractions. (AC: all)
+- [x] Add or update deterministic regression coverage for the changed behavior. (AC: all)
+- [x] Update relevant docs or examples if the story changes user-visible, operator, API, CLI, integration, or contribution behavior. (AC: all)
+- [x] Run required validation and record commands/results in the Dev Agent Record. (AC: all)
+
+### Review Findings
+
+- [x] [Review][Patch] Reserve scanner-conflict field names from adapter-owned payloads [services/adapter_output_contract.py:261]
+- [x] [Review][Patch] Exercise a non-empty frozen scanner-conflict object in the immutability regression [tests/test_services/test_policy_adapter_output_contract.py:55]
+- [x] [Review][Patch] Compare the emitted canonical summary with the source summary, not only the untouched source with itself [tests/test_services/test_policy_adapter_output_contract.py:53]
+
+## Dev Notes
+
+### Epic Context
+
+- Epic: 11. Optional Enforcement Adapters
+- Epic goal: Expose optional enforcement interpretation without changing the advisory core.
+- Epic coverage: ADM-07, ADM-09, WRK-07, RSK-07, NFR-SEC-06
+
+### Architecture and Product Guardrails
+
+- Preserve DeployWhisper's local-first raw artifact boundary: raw IaC, scanner artifacts, incident exports, and sensitive context stay in the user's infrastructure by default.
+- Preserve the advisory-first core. Optional adapters may interpret report outputs, but canonical report semantics remain advisory unless explicit story scope says otherwise.
+- Reuse the shared analysis core and service layer before adapting UI, API, CLI, GitHub, or future workflow surfaces.
+- Keep Evidence Law behavior intact: no high or critical finding without deterministic evidence.
+- Keep project/workspace scope explicit for reports, incidents, topology, outcomes, feedback, scanner imports, and connector-related data.
+- Do not introduce new dependencies unless the active story explicitly requires and justifies them.
+
+### Source Tree Guidance
+
+- API routes belong under `api/routes/` and should use existing `ApiRoute` / `ApiError` envelope patterns.
+- Shared orchestration belongs in `services/`; parsers normalize input, analysis modules score/derive risk, and surfaces adapt outputs.
+- UI work belongs under `frontend/src/screens/` and `frontend/src/components/`, following the existing retired Python UI composition style.
+- CLI behavior belongs under `cli/` and must call the same service-layer paths as UI/API flows.
+- Persistence work belongs under `models/` with Alembic migrations when schema changes are required.
+- Documentation required by a story should be updated in the same workstream.
+
+### Testing Requirements
+
+- Use standard-library `unittest` in the existing `tests/test_*` layout.
+- Add focused regression tests for the layer changed by the story before broad refactors.
+- For Python changes, run `./.venv/bin/ruff check .`, `./.venv/bin/ruff format --check .`, and `./.venv/bin/python -m unittest discover -q` before closing implementation.
+- Use `bash scripts/ci-local.sh` for broader or cross-layer changes.
+
+### Project Structure Notes
+
+- Follow the current repository shape documented in `_bmad-output/project-context.md` and `AGENTS.md`.
+- If implementation reveals a conflict between this story and the current code baseline, keep the smallest compatible change and update the story notes rather than silently drifting from the PRD.
+
+### References
+
+- `_bmad-output/planning-artifacts/epics.md` - source Epic 11 / Story 11.1 definition.
+- `_bmad-output/planning-artifacts/prd.md` - functional and non-functional requirements.
+- `_bmad-output/planning-artifacts/architecture.md` - target architecture, boundaries, and guardrails.
+- `_bmad-output/planning-artifacts/ux-design-specification.md` - UX expectations for user-facing stories.
+- `_bmad-output/planning-artifacts/implementation-readiness-report-2026-05-01.md` - readiness verdict and residual story-format concern.
+- `_bmad-output/project-context.md` - repository-specific implementation rules.
+
+## Dev Agent Record
+
+### Agent Model Used
+
+Codex (GPT-5)
+
+### Implementation Plan
+
+- Extend the existing immutable workflow-adapter envelope instead of creating a second canonical report shape.
+- Represent policy interpretation as a strict, versioned downstream contract with four explicit statuses and required structured reasons.
+- Reject non-advisory or blocking canonical summaries while keeping optional policy status separate from core report semantics.
+- Regression-lock status coverage, validation, immutability, documentation, and the unchanged advisory report boundary.
+
+### Debug Log References
+
+- RED: `./.venv/bin/python -m pytest tests/test_services/test_policy_adapter_output_contract.py tests/test_docs/test_workflow_adapter_output_contract.py -q --tb=short` — collection failed because `services.policy_adapter_output_contract` did not exist.
+- GREEN: the same focused command passed with 6 tests and 20 subtests after adding the contract and documentation.
+- RED immutability regression: the canonical scanner-conflict collection remained a mutable list through the adapter envelope.
+- GREEN/refactor: added a frozen scanner-conflict summary tuple and reran the combined adapter suite — 29 tests and 46 subtests passed.
+- Affected CI shard: `./.venv/bin/python -m pytest tests/test_services tests/test_docs -q --tb=short` — 918 passed, 349 subtests passed.
+- Required smoke: `./.venv/bin/python -m unittest discover -q` — 396 passed, 1 skipped.
+- Static/security validation: `./.venv/bin/ruff check .`, `./.venv/bin/ruff format --check .`, and `./.venv/bin/python -m bandit -q -r services/adapter_output_contract.py services/policy_adapter_output_contract.py` — passed; 269 files already formatted.
+- Full local CI: `bash scripts/ci-local.sh` — passed, including Ruff, repo-wide formatting, dependency validation, Bandit, compile checks, skill harnesses, and 895 tests.
+- Review RED: the combined adapter-contract suite failed because scanner-conflict `finding_id` was still accepted in `adapter_payload`; 27 tests and 32 subtests otherwise passed.
+- Review GREEN: reserved every scanner-conflict model field, added a real non-empty conflict fixture, verified nested field immutability and source-to-output equality, and reran the focused suite — 29 tests and 47 subtests passed.
+- Review affected shard: `./.venv/bin/python -m pytest tests/test_services tests/test_docs -q --tb=short` — 918 passed, 350 subtests passed.
+- Review closure validation: unittest smoke passed with 396 tests and 1 skip; Ruff, format check, targeted Bandit, diff checks, and `bash scripts/ci-local.sh` all passed; full local CI ran 895 tests.
+- Local mypy was unavailable in `.venv`; the configured GitHub mypy step is non-blocking. No dependency was added solely for local validation.
+- UI validation not applicable: Story 11.1 changes service contracts and documentation only; no React route, rendered surface, browser interaction, keyboard behavior, or accessibility semantics changed.
+
+### Completion Notes List
+
+- Added `PolicyAdapterOutputContract`, `PolicyAdapterStatus`, and `PolicyAdapterReason` as strict frozen Pydantic contracts.
+- Supported `advisory`, `warn`, `soft-block`, and `hard-block` interpretations with at least one nonblank structured reason.
+- Reused the Story 5.6 `AdapterOutputContract` and immutable canonical `ShareSummary` instead of duplicating analysis or severity logic.
+- Rejected policy output when the nested canonical summary is not advisory or claims DeployWhisper should block.
+- Preserved canonical report values for every policy status and closed the remaining nested scanner-conflict immutability gap.
+- Documented construction, ownership boundaries, versioning, and the distinction between optional local policy decisions and canonical advisory semantics.
+
+### File List
+
+- `_bmad-output/implementation-artifacts/11-1-policy-adapter-output-contract.md`
+- `_bmad-output/implementation-artifacts/sprint-status.yaml`
+- `docs/workflow-adapter-output-contract.md`
+- `services/adapter_output_contract.py`
+- `services/policy_adapter_output_contract.py`
+- `tests/test_docs/test_workflow_adapter_output_contract.py`
+- `tests/test_services/test_policy_adapter_output_contract.py`
+
+## Change Log
+
+- 2026-05-01: Story created/aligned from updated PRD, architecture, epics, sprint status, and readiness report.
+- 2026-08-03: Added the optional policy-adapter output contract, strengthened canonical immutability, documented the boundary, completed full validation, and moved the story to review.
+- 2026-08-03: Resolved all code-review findings, added scanner-conflict shadow and immutability regressions, reran full validation, and marked the story done.

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -144,7 +144,7 @@ development_status:
   epic-10-retrospective: optional
 
   epic-11: in-progress
-  11-1-policy-adapter-output-contract: ready-for-dev
+  11-1-policy-adapter-output-contract: done
   11-2-threshold-and-reporting-defaults-management: ready-for-dev
   11-3-integration-level-enforcement-settings: ready-for-dev
   11-4-enforcement-guardrail-documentation: ready-for-dev

--- a/docs/workflow-adapter-output-contract.md
+++ b/docs/workflow-adapter-output-contract.md
@@ -90,3 +90,40 @@ Adapters own:
 This keeps future workflow integrations independent without letting adapter
 formatting drift from the report object users inspect in API, CLI, UI, and
 shared report views.
+
+## Optional Policy Interpretation
+
+Policy adapters add a separate `PolicyAdapterOutputContract` around an existing
+`AdapterOutputContract`. The policy contract exposes a `PolicyAdapterStatus`
+with exactly four values: `advisory`, `warn`, `soft-block`, and `hard-block`.
+Every output requires at least one structured reason with a stable `code` and a
+human-readable `message`.
+
+```python
+from services.policy_adapter_output_contract import (
+    PolicyAdapterReason,
+    PolicyAdapterStatus,
+    build_policy_adapter_output_contract,
+)
+
+policy_output = build_policy_adapter_output_contract(
+    contract,
+    status=PolicyAdapterStatus.WARN,
+    reasons=(
+        PolicyAdapterReason(
+            code="review_required",
+            message="A human must review the deterministic evidence.",
+        ),
+    ),
+)
+```
+
+`canonical_report_advisory` is fixed to `true`. The nested canonical summary
+must keep `advisory_only=true` and `should_block=false`, even when the optional
+policy status is `soft-block` or `hard-block`. The adapter interpretation is a
+local workflow decision; it cannot rewrite the canonical severity,
+recommendation, Evidence Law status, evidence, or advisory posture.
+
+This contract does not choose thresholds or integration modes. Those are
+separate, explicitly configured policy concerns. The core remains useful when
+no policy adapter is enabled.

--- a/services/adapter_output_contract.py
+++ b/services/adapter_output_contract.py
@@ -20,6 +20,7 @@ from services.analysis_service import (
     ShareSummaryContext,
     ShareSummaryFinding,
     ShareSummaryJsonPayload,
+    ShareSummaryScannerConflict,
 )
 
 AdapterMetadataValue = str | int | float | bool | None
@@ -168,6 +169,12 @@ class FrozenShareSummaryContext(ShareSummaryContext):
     model_config = ConfigDict(frozen=True)
 
 
+class FrozenShareSummaryScannerConflict(ShareSummaryScannerConflict):
+    """Immutable scanner-conflict summary for adapter contracts."""
+
+    model_config = ConfigDict(frozen=True)
+
+
 class FrozenShareSummaryJsonPayload(ShareSummaryJsonPayload):
     """Immutable machine-friendly share-summary payload for adapter contracts."""
 
@@ -178,6 +185,10 @@ class FrozenShareSummaryJsonPayload(ShareSummaryJsonPayload):
     )
     context_completeness: FrozenShareSummaryContext = Field(
         ..., description="Context completeness summary"
+    )
+    scanner_conflicts: tuple[FrozenShareSummaryScannerConflict, ...] = Field(
+        default_factory=tuple,
+        description="Scanner-vs-deterministic/context conflicts requiring review",
     )
 
 
@@ -254,6 +265,7 @@ def _reserved_adapter_fields() -> frozenset[str]:
             *FrozenShareSummaryJsonPayload.model_fields,
             *FrozenShareSummaryFinding.model_fields,
             *FrozenShareSummaryContext.model_fields,
+            *FrozenShareSummaryScannerConflict.model_fields,
             "adapter_metadata",
             "adapter_payload",
             "canonical_summary",

--- a/services/policy_adapter_output_contract.py
+++ b/services/policy_adapter_output_contract.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from enum import Enum
-from typing import Literal
+from typing import Any, Literal
 
 from pydantic import (
     BaseModel,
@@ -40,6 +40,17 @@ class PolicyAdapterReason(BaseModel):
         normalized = value.strip()
         if not normalized:
             raise ValueError("Policy adapter reasons must not be blank.")
+        try:
+            normalized.encode("utf-8", errors="strict")
+        except UnicodeEncodeError as exc:
+            raise ValueError(
+                "Policy adapter reasons must be valid UTF-8 text."
+            ) from exc
+        if not any(
+            character.isprintable() and not character.isspace()
+            for character in normalized
+        ):
+            raise ValueError("Policy adapter reasons must contain visible text.")
         return normalized
 
 
@@ -62,6 +73,27 @@ class PolicyAdapterOutputContract(BaseModel):
     adapter_output: AdapterOutputContract = Field(
         ..., description="Immutable canonical summary and adapter metadata"
     )
+
+    @field_validator("status", mode="before")
+    @classmethod
+    def _reject_coerced_status(cls, value: Any) -> Any:
+        if not isinstance(value, str):
+            raise ValueError("Policy adapter status must be a string.")
+        return value
+
+    @field_validator("reasons", mode="before")
+    @classmethod
+    def _reject_unordered_reasons(cls, value: Any) -> Any:
+        if isinstance(value, set | frozenset):
+            raise ValueError("Policy adapter reasons must be ordered.")
+        return value
+
+    @field_validator("canonical_report_advisory", mode="before")
+    @classmethod
+    def _require_literal_advisory_true(cls, value: Any) -> Any:
+        if type(value) is not bool or value is not True:
+            raise ValueError("canonical_report_advisory must be true.")
+        return value
 
     @field_validator("contract_version")
     @classmethod

--- a/services/policy_adapter_output_contract.py
+++ b/services/policy_adapter_output_contract.py
@@ -46,10 +46,9 @@ class PolicyAdapterReason(BaseModel):
             raise ValueError(
                 "Policy adapter reasons must be valid UTF-8 text."
             ) from exc
-        if not any(
-            character.isprintable() and not character.isspace()
-            for character in normalized
-        ):
+        if not all(character.isprintable() for character in normalized):
+            raise ValueError("Policy adapter reasons must contain printable text only.")
+        if not any(not character.isspace() for character in normalized):
             raise ValueError("Policy adapter reasons must contain visible text.")
         return normalized
 

--- a/services/policy_adapter_output_contract.py
+++ b/services/policy_adapter_output_contract.py
@@ -1,0 +1,94 @@
+"""Optional policy interpretation over immutable workflow-adapter output."""
+
+from __future__ import annotations
+
+from enum import Enum
+from typing import Literal
+
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    StrictStr,
+    field_validator,
+    model_validator,
+)
+
+from services.adapter_output_contract import AdapterOutputContract
+
+
+class PolicyAdapterStatus(str, Enum):
+    """Supported downstream policy interpretations."""
+
+    ADVISORY = "advisory"
+    WARN = "warn"
+    SOFT_BLOCK = "soft-block"
+    HARD_BLOCK = "hard-block"
+
+
+class PolicyAdapterReason(BaseModel):
+    """Structured explanation for a downstream policy interpretation."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    code: StrictStr = Field(..., description="Stable adapter-owned reason code")
+    message: StrictStr = Field(..., description="Human-readable policy explanation")
+
+    @field_validator("code", "message")
+    @classmethod
+    def _normalize_nonblank_text(cls, value: str) -> str:
+        normalized = value.strip()
+        if not normalized:
+            raise ValueError("Policy adapter reasons must not be blank.")
+        return normalized
+
+
+class PolicyAdapterOutputContract(BaseModel):
+    """Versioned policy interpretation that leaves canonical output advisory."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    contract_version: StrictStr = Field(
+        default="v1", description="Policy adapter contract version"
+    )
+    status: PolicyAdapterStatus = Field(..., description="Local workflow decision")
+    reasons: tuple[PolicyAdapterReason, ...] = Field(
+        ..., min_length=1, description="Reasons for the policy status"
+    )
+    canonical_report_advisory: Literal[True] = Field(
+        default=True,
+        description="Confirms policy status does not alter canonical report semantics",
+    )
+    adapter_output: AdapterOutputContract = Field(
+        ..., description="Immutable canonical summary and adapter metadata"
+    )
+
+    @field_validator("contract_version")
+    @classmethod
+    def _validate_contract_version(cls, value: str) -> str:
+        if value != "v1":
+            raise ValueError("Policy adapter contract version must be v1.")
+        return value
+
+    @model_validator(mode="after")
+    def _require_advisory_canonical_report(self) -> PolicyAdapterOutputContract:
+        summary = self.adapter_output.canonical_summary
+        if not summary.advisory_only or summary.should_block:
+            raise ValueError(
+                "Policy adapters require an advisory, non-blocking canonical report."
+            )
+        return self
+
+
+def build_policy_adapter_output_contract(
+    adapter_output: AdapterOutputContract,
+    *,
+    status: PolicyAdapterStatus | str,
+    reasons: tuple[PolicyAdapterReason | dict[str, str], ...],
+) -> PolicyAdapterOutputContract:
+    """Wrap canonical adapter output with a separate local policy interpretation."""
+    return PolicyAdapterOutputContract(
+        status=status,
+        reasons=reasons,
+        adapter_output=adapter_output,
+    )

--- a/tests/test_docs/test_workflow_adapter_output_contract.py
+++ b/tests/test_docs/test_workflow_adapter_output_contract.py
@@ -27,6 +27,11 @@ class WorkflowAdapterOutputContractDocumentationTests(unittest.TestCase):
             "`adapter_payload`",
             "Project scope is mandatory",
             "must not shadow canonical fields",
+            "PolicyAdapterOutputContract",
+            "PolicyAdapterStatus",
+            "advisory`, `warn`, `soft-block`, and `hard-block`",
+            "canonical_report_advisory",
+            "at least one structured reason",
         )
         for expected in expected_clauses:
             with self.subTest(expected=expected):

--- a/tests/test_services/test_adapter_output_contract.py
+++ b/tests/test_services/test_adapter_output_contract.py
@@ -61,6 +61,7 @@ class AdapterOutputContractTests(unittest.TestCase):
             {"headline": "Adapter rewrite"},
             {"evidence_law_status": "Needs review"},
             {"evidence_law_detail": "Adapter-specific rewrite"},
+            {"finding_id": "adapter-owned-shadow"},
         ):
             with self.subTest(forbidden_payload=forbidden_payload):
                 with self.assertRaises(AdapterOutputContractError):

--- a/tests/test_services/test_policy_adapter_output_contract.py
+++ b/tests/test_services/test_policy_adapter_output_contract.py
@@ -64,7 +64,7 @@ class PolicyAdapterOutputContractTests(unittest.TestCase):
                 with self.assertRaises(ValidationError):
                     scanner_conflicts[0].finding_id = "mutated"
 
-    def test_policy_output_requires_nonblank_reasons(self) -> None:
+    def test_policy_output_rejects_invalid_reason_text(self) -> None:
         adapter_output = _adapter_output()
 
         with self.assertRaises(ValidationError):
@@ -80,6 +80,9 @@ class PolicyAdapterOutputContractTests(unittest.TestCase):
             {"code": "\u200b", "message": "Review required."},
             {"code": "review_required", "message": "\u200b"},
             {"code": "review_required", "message": "Invalid surrogate: \ud800"},
+            {"code": "policy\x1b[31m", "message": "Review required."},
+            {"code": "review_required", "message": "Hidden NUL: \x00"},
+            {"code": "review_required", "message": "Unexpected\nline break"},
         ):
             with self.subTest(reason=reason):
                 with self.assertRaises(ValidationError):

--- a/tests/test_services/test_policy_adapter_output_contract.py
+++ b/tests/test_services/test_policy_adapter_output_contract.py
@@ -77,6 +77,9 @@ class PolicyAdapterOutputContractTests(unittest.TestCase):
         for reason in (
             {"code": "", "message": "Review required."},
             {"code": "review_required", "message": "   "},
+            {"code": "\u200b", "message": "Review required."},
+            {"code": "review_required", "message": "\u200b"},
+            {"code": "review_required", "message": "Invalid surrogate: \ud800"},
         ):
             with self.subTest(reason=reason):
                 with self.assertRaises(ValidationError):
@@ -87,29 +90,58 @@ class PolicyAdapterOutputContractTests(unittest.TestCase):
                     )
 
     def test_policy_output_rejects_non_advisory_canonical_summary(self) -> None:
-        summary = build_share_summary(_report_payload()).model_copy(
-            update={"advisory_only": False, "should_block": True}
-        )
-        adapter_output = build_adapter_output_contract(
-            summary,
-            AdapterMetadata(
-                adapter="policy",
-                format="workflow_decision",
-                project_key="payments",
-            ),
-        )
-
-        with self.assertRaises(ValidationError):
-            build_policy_adapter_output_contract(
-                adapter_output,
-                status=PolicyAdapterStatus.HARD_BLOCK,
-                reasons=(
-                    PolicyAdapterReason(
-                        code="policy_match",
-                        message="Configured deterministic policy matched.",
+        for advisory_only, should_block in ((False, False), (True, True)):
+            with self.subTest(
+                advisory_only=advisory_only,
+                should_block=should_block,
+            ):
+                summary = build_share_summary(_report_payload()).model_copy(
+                    update={
+                        "advisory_only": advisory_only,
+                        "should_block": should_block,
+                    }
+                )
+                adapter_output = build_adapter_output_contract(
+                    summary,
+                    AdapterMetadata(
+                        adapter="policy",
+                        format="workflow_decision",
+                        project_key="payments",
                     ),
-                ),
-            )
+                )
+
+                with self.assertRaises(ValidationError):
+                    build_policy_adapter_output_contract(
+                        adapter_output,
+                        status=PolicyAdapterStatus.HARD_BLOCK,
+                        reasons=(
+                            PolicyAdapterReason(
+                                code="policy_match",
+                                message="Configured deterministic policy matched.",
+                            ),
+                        ),
+                    )
+
+    def test_policy_output_rejects_ambiguous_coerced_inputs(self) -> None:
+        adapter_output = _adapter_output()
+        reason = PolicyAdapterReason(code="policy_match", message="Policy matched.")
+
+        invalid_inputs = (
+            {"status": b"warn", "reasons": (reason,)},
+            {"status": PolicyAdapterStatus.WARN, "reasons": {reason}},
+            {
+                "status": PolicyAdapterStatus.WARN,
+                "reasons": (reason,),
+                "canonical_report_advisory": 1,
+            },
+        )
+        for invalid_input in invalid_inputs:
+            with self.subTest(invalid_input=invalid_input):
+                with self.assertRaises(ValidationError):
+                    PolicyAdapterOutputContract(
+                        adapter_output=adapter_output,
+                        **invalid_input,
+                    )
 
     def test_policy_output_contract_is_strict_versioned_and_immutable(self) -> None:
         output = build_policy_adapter_output_contract(

--- a/tests/test_services/test_policy_adapter_output_contract.py
+++ b/tests/test_services/test_policy_adapter_output_contract.py
@@ -1,0 +1,214 @@
+"""Tests for optional policy-adapter output contracts."""
+
+from __future__ import annotations
+
+import unittest
+
+from pydantic import ValidationError
+
+from services.adapter_output_contract import (
+    AdapterMetadata,
+    build_adapter_output_contract,
+)
+from services.analysis_service import build_share_summary
+from services.policy_adapter_output_contract import (
+    PolicyAdapterOutputContract,
+    PolicyAdapterReason,
+    PolicyAdapterStatus,
+    build_policy_adapter_output_contract,
+)
+
+
+class PolicyAdapterOutputContractTests(unittest.TestCase):
+    def test_all_policy_statuses_preserve_the_advisory_canonical_report(self) -> None:
+        summary = build_share_summary(_report_payload())
+        summary_before = summary.model_dump(mode="json")
+        adapter_output = build_adapter_output_contract(
+            summary,
+            AdapterMetadata(
+                adapter="policy",
+                format="workflow_decision",
+                project_key="payments",
+            ),
+        )
+
+        for status in PolicyAdapterStatus:
+            with self.subTest(status=status):
+                output = build_policy_adapter_output_contract(
+                    adapter_output,
+                    status=status,
+                    reasons=(
+                        PolicyAdapterReason(
+                            code="review_required",
+                            message="A human must review the deterministic evidence.",
+                        ),
+                    ),
+                )
+
+                self.assertEqual(output.status, status)
+                self.assertEqual(output.reasons[0].code, "review_required")
+                self.assertTrue(output.canonical_report_advisory)
+                self.assertTrue(output.adapter_output.canonical_summary.advisory_only)
+                self.assertFalse(output.adapter_output.canonical_summary.should_block)
+                self.assertEqual(summary.model_dump(mode="json"), summary_before)
+                self.assertEqual(
+                    output.adapter_output.canonical_summary.model_dump(mode="json"),
+                    summary_before,
+                )
+
+                scanner_conflicts = output.adapter_output.canonical_summary.json_payload.scanner_conflicts
+                self.assertIsInstance(scanner_conflicts, tuple)
+                self.assertEqual(len(scanner_conflicts), 1)
+                with self.assertRaises(AttributeError):
+                    scanner_conflicts.append("mutated")
+                with self.assertRaises(ValidationError):
+                    scanner_conflicts[0].finding_id = "mutated"
+
+    def test_policy_output_requires_nonblank_reasons(self) -> None:
+        adapter_output = _adapter_output()
+
+        with self.assertRaises(ValidationError):
+            build_policy_adapter_output_contract(
+                adapter_output,
+                status=PolicyAdapterStatus.WARN,
+                reasons=(),
+            )
+
+        for reason in (
+            {"code": "", "message": "Review required."},
+            {"code": "review_required", "message": "   "},
+        ):
+            with self.subTest(reason=reason):
+                with self.assertRaises(ValidationError):
+                    build_policy_adapter_output_contract(
+                        adapter_output,
+                        status=PolicyAdapterStatus.WARN,
+                        reasons=(reason,),
+                    )
+
+    def test_policy_output_rejects_non_advisory_canonical_summary(self) -> None:
+        summary = build_share_summary(_report_payload()).model_copy(
+            update={"advisory_only": False, "should_block": True}
+        )
+        adapter_output = build_adapter_output_contract(
+            summary,
+            AdapterMetadata(
+                adapter="policy",
+                format="workflow_decision",
+                project_key="payments",
+            ),
+        )
+
+        with self.assertRaises(ValidationError):
+            build_policy_adapter_output_contract(
+                adapter_output,
+                status=PolicyAdapterStatus.HARD_BLOCK,
+                reasons=(
+                    PolicyAdapterReason(
+                        code="policy_match",
+                        message="Configured deterministic policy matched.",
+                    ),
+                ),
+            )
+
+    def test_policy_output_contract_is_strict_versioned_and_immutable(self) -> None:
+        output = build_policy_adapter_output_contract(
+            _adapter_output(),
+            status="soft-block",
+            reasons=(
+                {
+                    "code": "override_required",
+                    "message": "An authorized override is required.",
+                },
+            ),
+        )
+
+        self.assertEqual(output.contract_version, "v1")
+        self.assertEqual(output.status, PolicyAdapterStatus.SOFT_BLOCK)
+        self.assertIn('"status":"soft-block"', output.model_dump_json())
+        with self.assertRaises(ValidationError):
+            PolicyAdapterOutputContract(
+                contract_version="v2",
+                status=PolicyAdapterStatus.ADVISORY,
+                reasons=output.reasons,
+                adapter_output=output.adapter_output,
+            )
+        with self.assertRaises(ValidationError):
+            PolicyAdapterOutputContract(
+                status=PolicyAdapterStatus.ADVISORY,
+                reasons=output.reasons,
+                adapter_output=output.adapter_output,
+                unexpected="value",
+            )
+        with self.assertRaises(ValidationError):
+            output.reasons[0].message = "Changed"
+
+
+def _adapter_output():
+    return build_adapter_output_contract(
+        build_share_summary(_report_payload()),
+        AdapterMetadata(
+            adapter="policy",
+            format="workflow_decision",
+            project_key="payments",
+        ),
+    )
+
+
+def _report_payload() -> dict:
+    return {
+        "id": 17,
+        "report_schema_version": "v2",
+        "severity": "high",
+        "recommendation": "caution",
+        "top_risk": "Terraform opened database ingress.",
+        "narrative_opening": "CAUTION: review database ingress.",
+        "narrative_available": True,
+        "warnings": [],
+        "findings": [
+            {
+                "finding_id": "finding-001",
+                "title": "HIGH: aws_security_group.db",
+                "severity": "high",
+                "confidence": 0.91,
+                "evidence_refs": ["ev-001", "ev-scanner"],
+            }
+        ],
+        "evidence_items": [
+            {
+                "evidence_id": "ev-001",
+                "finding_id": "finding-001",
+                "deterministic": True,
+                "determinism_level": "deterministic",
+                "context_source": {"freshness_status": "current"},
+            },
+            {
+                "evidence_id": "ev-scanner",
+                "finding_id": "finding-001",
+                "source_type": "external_scanner",
+                "source_kind": "external_scanner",
+                "source_ref": "semgrep://results/sg-1",
+                "severity_hint": "critical",
+                "deterministic": True,
+                "determinism_level": "deterministic",
+                "context_source": {
+                    "freshness_status": "current",
+                    "conflicts": [],
+                    "limitations": [],
+                },
+            },
+        ],
+        "blast_radius": {
+            "affected": [{"label": "Primary Database"}],
+            "direct_count": 1,
+            "transitive_count": 0,
+            "warning": None,
+        },
+        "rollback_plan": {
+            "steps": [{"title": "Revert ingress rule"}],
+            "complexity": "low",
+            "complexity_score": 1,
+            "warning": None,
+        },
+        "context_completeness": {"context_score": 0.9},
+    }


### PR DESCRIPTION
Implements Story 11.1 with a strict, versioned policy-adapter output contract supporting advisory, warn, soft-block, and hard-block statuses with structured reasons while preserving the canonical advisory report. Includes review-driven scanner-conflict shadow protection, non-empty nested immutability coverage, canonical value-preservation assertions, documentation, and sprint/story closure. Validation: focused adapter suite 29 passed plus 47 subtests; services/docs shard 918 passed plus 350 subtests; unittest smoke 396 passed with 1 skipped; Ruff and format checks passed; targeted Bandit passed; full local CI passed with 895 tests. UI validation not applicable.