### PR TITLE
Story 11.2: manage threshold and reporting defaults

### DIFF
--- a/_bmad-output/implementation-artifacts/11-2-threshold-and-reporting-defaults-management.md
+++ b/_bmad-output/implementation-artifacts/11-2-threshold-and-reporting-defaults-management.md
@@ -39,6 +39,10 @@ So that teams can tune adapter behavior without changing core code.
 - [x] [Review][Decision] Decide whether configured generation must be activated in a production integration in Story 11.2 — Resolved by adding an authenticated persisted-report policy-output endpoint that exercises the configured generation service; Story 11.3 still owns enforcement-mode activation inside specific CI/workflow integrations.
 - [x] [Review][Patch] Canonicalize project keys consistently before policy-settings persistence and lookup [services/settings_service.py:174]
 - [x] [Review][Patch] Prevent built-in settings from claiming integration-specific or customized threshold provenance [services/policy_adapter_settings.py:92]
+- [x] [Review][Patch] Map policy-adapter PUT project-resolution failures through the standard project API error contract [api/routes/settings.py:487]
+- [x] [Review][Patch] Publish policy-adapter settings 400/403/404 error envelopes in OpenAPI and generated client types [api/routes/settings.py:438]
+- [x] [Review][Patch] Mask persisted-report existence from restricted policy-output callers [api/routes/analyses.py:924]
+- [x] [Review][Patch] Keep dynamic policy-setting keys within the AppSetting storage limit [services/settings_service.py:167]
 
 ## Dev Notes
 
@@ -124,6 +128,11 @@ Codex (GPT-5)
 - Second re-review GREEN: `./.venv/bin/python -m pytest tests/test_services/test_policy_adapter_service.py tests/test_services/test_policy_adapter_output_contract.py tests/test_services/test_settings_service.py tests/test_api/test_settings.py tests/test_api/test_analyses.py tests/test_docs/test_workflow_adapter_output_contract.py -q --tb=short` — 152 passed, 76 subtests passed.
 - Second re-review affected CI shard: `./.venv/bin/python -m pytest tests/test_api tests/test_cli tests/test_infra -v --tb=short` — 384 passed, 98 subtests passed.
 - Second re-review full local CI: `bash scripts/ci-local.sh` — passed, including Ruff, formatting, dependency validation, Bandit, compile checks, skill harnesses, and 910 tests.
+- Third re-review RED: new regressions reproduced the inconsistent PUT project error, undocumented settings error responses, restricted missing-report existence leak, and unchecked oversized settings key.
+- Third re-review GREEN: `./.venv/bin/python -m pytest tests/test_services/test_policy_adapter_service.py tests/test_services/test_policy_adapter_output_contract.py tests/test_services/test_settings_service.py tests/test_api/test_settings.py tests/test_api/test_analyses.py tests/test_docs/test_workflow_adapter_output_contract.py -q --tb=short` — 155 passed, 84 subtests passed.
+- Third re-review affected CI shard: `./.venv/bin/python -m pytest tests/test_api tests/test_cli tests/test_infra -v --tb=short` — 386 passed, 103 subtests passed.
+- Third re-review full local CI: `bash scripts/ci-local.sh` — passed, including Ruff, formatting, dependency validation, Bandit, compile checks, skill harnesses, and 911 tests.
+- Independent verification: PASS; all four review findings were confirmed fixed with direct regression coverage and no introduced correctness or security regression identified.
 - UI validation not applicable: no React route, rendered surface, browser interaction, keyboard behavior, or accessibility semantics changed; only generated API type declarations were refreshed.
 
 ### Completion Notes List
@@ -163,3 +172,4 @@ Codex (GPT-5)
 - 2026-08-06: Resolved all BMad review findings, added canonical project-key and integration-query regressions, passed full local CI, and marked the story done.
 - 2026-08-06: Resolved re-review findings for runtime-boundary wording, unknown canonical severities, and persisted scope integrity; retained Story 11.3 as the integration-activation boundary.
 - 2026-08-07: Resolved the second re-review by adding authenticated production policy-output generation, canonical project-key persistence, strict built-in provenance, generated API types, and regression coverage.
+- 2026-08-07: Resolved the third re-review by aligning project error contracts, documenting API errors, masking restricted report existence, enforcing settings-key limits, and passing full local CI.

--- a/_bmad-output/implementation-artifacts/11-2-threshold-and-reporting-defaults-management.md
+++ b/_bmad-output/implementation-artifacts/11-2-threshold-and-reporting-defaults-management.md
@@ -1,0 +1,149 @@
+# Story 11.2: Threshold and Reporting Defaults Management
+
+Status: done
+
+<!-- Generated from updated PRD/architecture/epics plus implementation-readiness-report-2026-05-01.md. -->
+
+## Story
+
+As a platform admin,
+I want configurable thresholds and reporting defaults,
+So that teams can tune adapter behavior without changing core code.
+
+## Acceptance Criteria
+
+1. Given thresholds are configured per project or integration, When adapter output is generated, Then thresholds are applied only to adapter interpretation. And the original evidence, findings, and severity remain auditable.
+
+### Requirement Traceability
+
+- Primary PRD requirements: Epic 11 coverage: ADM-07, ADM-09, WRK-07, RSK-07, NFR-SEC-06.
+- Supporting PRD / NFR / differentiation requirements: See `_bmad-output/planning-artifacts/prd.md`, `_bmad-output/planning-artifacts/architecture.md`, and `_bmad-output/planning-artifacts/implementation-readiness-report-2026-05-01.md`.
+- Coverage intent: Baseline + Delta.
+- Story alignment note: This story was created from the updated Epic 11 plan after the 2026-05-01 readiness rerun. The readiness report verified 187/187 PRD functional requirement IDs in the epics artifact, 38 NFR IDs present, and no critical or major readiness defects.
+
+## Tasks / Subtasks
+
+- [x] Implement and verify acceptance criterion 1. (AC: 1)
+- [x] Reuse existing services, repositories, schemas, and UI/CLI/API helpers before adding new abstractions. (AC: all)
+- [x] Add or update deterministic regression coverage for the changed behavior. (AC: all)
+- [x] Update relevant docs or examples if the story changes user-visible, operator, API, CLI, integration, or contribution behavior. (AC: all)
+- [x] Run required validation and record commands/results in the Dev Agent Record. (AC: all)
+
+### Review Findings
+
+- [x] [Review][Patch] Normalize adapter metadata project keys with the canonical project-key normalizer before comparing them with resolved settings [services/policy_adapter_output_contract.py:138]
+- [x] [Review][Patch] Validate GET/DELETE integration query values consistently with PUT and return the policy-settings error contract [api/routes/settings.py:438]
+
+## Dev Notes
+
+### Epic Context
+
+- Epic: 11. Optional Enforcement Adapters
+- Epic goal: Expose optional enforcement interpretation without changing the advisory core.
+- Epic coverage: ADM-07, ADM-09, WRK-07, RSK-07, NFR-SEC-06
+
+### Architecture and Product Guardrails
+
+- Preserve DeployWhisper's local-first raw artifact boundary: raw IaC, scanner artifacts, incident exports, and sensitive context stay in the user's infrastructure by default.
+- Preserve the advisory-first core. Optional adapters may interpret report outputs, but canonical report semantics remain advisory unless explicit story scope says otherwise.
+- Reuse the shared analysis core and service layer before adapting UI, API, CLI, GitHub, or future workflow surfaces.
+- Keep Evidence Law behavior intact: no high or critical finding without deterministic evidence.
+- Keep project/workspace scope explicit for reports, incidents, topology, outcomes, feedback, scanner imports, and connector-related data.
+- Do not introduce new dependencies unless the active story explicitly requires and justifies them.
+
+### Source Tree Guidance
+
+- API routes belong under `api/routes/` and should use existing `ApiRoute` / `ApiError` envelope patterns.
+- Shared orchestration belongs in `services/`; parsers normalize input, analysis modules score/derive risk, and surfaces adapt outputs.
+- UI work belongs under `frontend/src/screens/` and `frontend/src/components/`, following the existing retired Python UI composition style.
+- CLI behavior belongs under `cli/` and must call the same service-layer paths as UI/API flows.
+- Persistence work belongs under `models/` with Alembic migrations when schema changes are required.
+- Documentation required by a story should be updated in the same workstream.
+
+### Testing Requirements
+
+- Use standard-library `unittest` in the existing `tests/test_*` layout.
+- Add focused regression tests for the layer changed by the story before broad refactors.
+- For Python changes, run `./.venv/bin/ruff check .`, `./.venv/bin/ruff format --check .`, and `./.venv/bin/python -m unittest discover -q` before closing implementation.
+- Use `bash scripts/ci-local.sh` for broader or cross-layer changes.
+
+### Project Structure Notes
+
+- Follow the current repository shape documented in `_bmad-output/project-context.md` and `AGENTS.md`.
+- If implementation reveals a conflict between this story and the current code baseline, keep the smallest compatible change and update the story notes rather than silently drifting from the PRD.
+
+### References
+
+- `_bmad-output/planning-artifacts/epics.md` - source Epic 11 / Story 11.2 definition.
+- `_bmad-output/planning-artifacts/prd.md` - functional and non-functional requirements.
+- `_bmad-output/planning-artifacts/architecture.md` - target architecture, boundaries, and guardrails.
+- `_bmad-output/planning-artifacts/ux-design-specification.md` - UX expectations for user-facing stories.
+- `_bmad-output/planning-artifacts/implementation-readiness-report-2026-05-01.md` - readiness verdict and residual story-format concern.
+- `_bmad-output/project-context.md` - repository-specific implementation rules.
+
+## Dev Agent Record
+
+### Agent Model Used
+
+Codex (GPT-5)
+
+### Implementation Plan
+
+- Reuse the existing policy-adapter contract and application settings repository instead of changing canonical scoring or adding persistence tables.
+- Model strict severity thresholds plus an advisory/warn reporting default, with integration overrides inheriting project and built-in defaults.
+- Add one configured generation service that resolves project key or ID, validates integration scope, applies settings only to policy interpretation, and records the applied snapshot for audit.
+- Expose admin-only, explicitly project-scoped GET/PUT/DELETE management endpoints and keep generated API types and operator documentation aligned.
+- Regression-lock precedence, reset behavior, RBAC, explicit scope, project-ID resolution, threshold validation, and canonical report immutability.
+
+### Debug Log References
+
+- RED: focused policy/settings/API/docs pytest collection failed because `PolicyAdapterSettings` and the management behavior did not exist.
+- GREEN: initial focused suite passed 41 tests and 46 subtests after adding thresholds, persistence, API management, and immutable applied-settings output.
+- Review RED: an internal review found that stored settings lacked a configured runtime generation path, overrides could not be reset, and `project_id` scope was not verified; new tests first failed because the runtime service and delete behavior did not exist.
+- Review GREEN: added `build_configured_policy_adapter_output`, inherited-default deletion, project-ID resolution, and scope guards; focused suite passed 45 tests and 48 subtests.
+- Final review RED/GREEN: missing project scope initially returned 200 for GET/PUT/DELETE; explicit-scope validation changed all three to deterministic `400 missing_project_scope`, and the regression passed with 3 subtests.
+- Final focused regression: `./.venv/bin/python -m pytest tests/test_services/test_policy_adapter_service.py tests/test_services/test_policy_adapter_output_contract.py tests/test_services/test_settings_service.py tests/test_api/test_settings.py tests/test_docs/test_workflow_adapter_output_contract.py -q --tb=short` — 46 passed, 51 subtests passed.
+- Required affected GitHub shard: `./.venv/bin/python -m pytest tests/test_api tests/test_cli tests/test_infra -q --tb=short` — 381 passed, 94 subtests passed.
+- Affected services/docs shard: `./.venv/bin/python -m pytest tests/test_services tests/test_docs -q --tb=short` — 928 passed, 373 subtests passed.
+- Required smoke: `./.venv/bin/python -m unittest discover -q` — 399 passed, 1 skipped; the final broader CI run superseded this after the last route guard.
+- Static/security validation: `./.venv/bin/ruff check .`, `./.venv/bin/ruff format --check .`, and targeted Bandit over the changed service/API modules — passed; 272 files already formatted.
+- Final full local CI: `bash scripts/ci-local.sh` — passed, including Ruff, repo-wide formatting, dependency validation, Bandit, compile checks, skill harnesses, and 905 tests.
+- Generated API types from the current in-process FastAPI OpenAPI document with `openapi-typescript`; the policy-adapter GET/PUT/DELETE contract is present in `frontend/src/api/schema.d.ts`.
+- Independent internal re-review: zero remaining high or medium findings after runtime wiring, reset behavior, project-ID validation, and explicit project-scope fixes.
+- BMad review fixes: canonicalized metadata/resolved/settings project keys before scope comparison and aligned GET/DELETE integration query validation with the write contract and `invalid_policy_adapter_settings` error envelope.
+- Review regression suite: `./.venv/bin/python -m pytest tests/test_services/test_policy_adapter_service.py tests/test_services/test_policy_adapter_output_contract.py tests/test_services/test_settings_service.py tests/test_api/test_settings.py tests/test_docs/test_workflow_adapter_output_contract.py -q --tb=short` — 48 passed, 55 subtests passed.
+- Post-review full local CI: `bash scripts/ci-local.sh` — passed, including Ruff, repo-wide formatting, dependency validation, Bandit, compile checks, skill harnesses, and 906 tests.
+- UI validation not applicable: no React route, rendered surface, browser interaction, keyboard behavior, or accessibility semantics changed; only generated API type declarations were refreshed.
+
+### Completion Notes List
+
+- Added strict frozen policy settings for medium/high/critical defaults, optional disabled thresholds, and advisory/warn below-threshold reporting behavior.
+- Persisted project defaults and integration-specific overrides through the existing application settings repository, with integration -> project -> built-in resolution and DELETE-based reset to inheritance.
+- Added one production generation path that resolves adapter project key or ID, applies the correct integration settings, and rejects cross-project or cross-integration use.
+- Kept policy decisions separate from the canonical advisory report and attached the resolved settings snapshot to the policy envelope for auditability.
+- Added admin-only GET/PUT/DELETE API management with explicit project scope and refreshed generated OpenAPI TypeScript declarations.
+- Documented built-in defaults, precedence, reset semantics, runtime usage, and the unchanged canonical evidence/findings/severity boundary.
+
+### File List
+
+- `_bmad-output/implementation-artifacts/11-2-threshold-and-reporting-defaults-management.md`
+- `_bmad-output/implementation-artifacts/sprint-status.yaml`
+- `api/routes/settings.py`
+- `api/schemas.py`
+- `docs/workflow-adapter-output-contract.md`
+- `frontend/src/api/schema.d.ts`
+- `services/policy_adapter_output_contract.py`
+- `services/policy_adapter_service.py`
+- `services/policy_adapter_settings.py`
+- `services/settings_service.py`
+- `tests/test_api/test_settings.py`
+- `tests/test_docs/test_workflow_adapter_output_contract.py`
+- `tests/test_services/test_policy_adapter_output_contract.py`
+- `tests/test_services/test_policy_adapter_service.py`
+- `tests/test_services/test_settings_service.py`
+
+## Change Log
+
+- 2026-05-01: Story created/aligned from updated PRD, architecture, epics, sprint status, and readiness report.
+- 2026-08-06: Added project/integration threshold and reporting-default management, configured runtime interpretation, reset/inheritance behavior, explicit scope/RBAC safeguards, docs, generated API types, and full regression coverage; moved story to review.
+- 2026-08-06: Resolved all BMad review findings, added canonical project-key and integration-query regressions, passed full local CI, and marked the story done.

--- a/_bmad-output/implementation-artifacts/11-2-threshold-and-reporting-defaults-management.md
+++ b/_bmad-output/implementation-artifacts/11-2-threshold-and-reporting-defaults-management.md
@@ -43,6 +43,8 @@ So that teams can tune adapter behavior without changing core code.
 - [x] [Review][Patch] Publish policy-adapter settings 400/403/404 error envelopes in OpenAPI and generated client types [api/routes/settings.py:438]
 - [x] [Review][Patch] Mask persisted-report existence from restricted policy-output callers [api/routes/analyses.py:924]
 - [x] [Review][Patch] Keep dynamic policy-setting keys within the AppSetting storage limit [services/settings_service.py:167]
+- [x] [Review][Patch] Preserve policy defaults for every valid project and integration scope instead of rejecting composed keys longer than AppSetting.key [services/settings_service.py:165]
+- [x] [Review][Patch] Classify malformed persisted policy settings as server-side integrity failures instead of client-invalid policy output [services/settings_service.py:196]
 
 ## Dev Notes
 
@@ -133,6 +135,10 @@ Codex (GPT-5)
 - Third re-review affected CI shard: `./.venv/bin/python -m pytest tests/test_api tests/test_cli tests/test_infra -v --tb=short` — 386 passed, 103 subtests passed.
 - Third re-review full local CI: `bash scripts/ci-local.sh` — passed, including Ruff, formatting, dependency validation, Bandit, compile checks, skill harnesses, and 911 tests.
 - Independent verification: PASS; all four review findings were confirmed fixed with direct regression coverage and no introduced correctness or security regression identified.
+- Fourth re-review RED: regressions reproduced valid long project/integration scopes failing before built-in resolution and malformed persisted settings being reported as client-invalid output.
+- Fourth re-review GREEN: `./.venv/bin/python -m pytest tests/test_services/test_policy_adapter_service.py tests/test_services/test_policy_adapter_output_contract.py tests/test_services/test_settings_service.py tests/test_api/test_settings.py tests/test_api/test_analyses.py tests/test_docs/test_workflow_adapter_output_contract.py -q --tb=short` — 158 passed, 81 subtests passed.
+- Fourth re-review affected CI shard: `./.venv/bin/python -m pytest tests/test_api tests/test_cli tests/test_infra -v --tb=short` — 388 passed, 103 subtests passed.
+- Fourth re-review full local CI: `bash scripts/ci-local.sh` — passed, including repo-wide Ruff formatting, dependency validation, Bandit, compile checks, skill harnesses, and 912 tests.
 - UI validation not applicable: no React route, rendered surface, browser interaction, keyboard behavior, or accessibility semantics changed; only generated API type declarations were refreshed.
 
 ### Completion Notes List
@@ -144,6 +150,8 @@ Codex (GPT-5)
 - Kept policy decisions separate from the canonical advisory report and attached the resolved settings snapshot to the policy envelope for auditability.
 - Added admin-only GET/PUT/DELETE API management with explicit project scope and refreshed generated OpenAPI TypeScript declarations.
 - Documented built-in defaults, precedence, reset semantics, runtime usage, and the unchanged canonical evidence/findings/severity boundary.
+- Preserved short human-readable settings keys while using deterministic bounded keys for valid long project/integration scopes.
+- Classified malformed persisted policy settings as server integrity failures with a dedicated non-leaking API error contract.
 
 ### File List
 
@@ -173,3 +181,4 @@ Codex (GPT-5)
 - 2026-08-06: Resolved re-review findings for runtime-boundary wording, unknown canonical severities, and persisted scope integrity; retained Story 11.3 as the integration-activation boundary.
 - 2026-08-07: Resolved the second re-review by adding authenticated production policy-output generation, canonical project-key persistence, strict built-in provenance, generated API types, and regression coverage.
 - 2026-08-07: Resolved the third re-review by aligning project error contracts, documenting API errors, masking restricted report existence, enforcing settings-key limits, and passing full local CI.
+- 2026-08-10: Resolved the fourth re-review by supporting valid long policy scopes with bounded deterministic keys, classifying corrupt persisted settings as server integrity failures, and passing focused, CI-shard, and full local validation.

--- a/_bmad-output/implementation-artifacts/11-2-threshold-and-reporting-defaults-management.md
+++ b/_bmad-output/implementation-artifacts/11-2-threshold-and-reporting-defaults-management.md
@@ -45,6 +45,7 @@ So that teams can tune adapter behavior without changing core code.
 - [x] [Review][Patch] Keep dynamic policy-setting keys within the AppSetting storage limit [services/settings_service.py:167]
 - [x] [Review][Patch] Preserve policy defaults for every valid project and integration scope instead of rejecting composed keys longer than AppSetting.key [services/settings_service.py:165]
 - [x] [Review][Patch] Classify malformed persisted policy settings as server-side integrity failures instead of client-invalid policy output [services/settings_service.py:196]
+- [x] [Review][Patch] Correct the completion note to say the persisted-report endpoint preserves and embeds the canonical summary, not the full canonical report payload [_bmad-output/implementation-artifacts/11-2-threshold-and-reporting-defaults-management.md:149]
 
 ## Dev Notes
 
@@ -139,6 +140,8 @@ Codex (GPT-5)
 - Fourth re-review GREEN: `./.venv/bin/python -m pytest tests/test_services/test_policy_adapter_service.py tests/test_services/test_policy_adapter_output_contract.py tests/test_services/test_settings_service.py tests/test_api/test_settings.py tests/test_api/test_analyses.py tests/test_docs/test_workflow_adapter_output_contract.py -q --tb=short` — 158 passed, 81 subtests passed.
 - Fourth re-review affected CI shard: `./.venv/bin/python -m pytest tests/test_api tests/test_cli tests/test_infra -v --tb=short` — 388 passed, 103 subtests passed.
 - Fourth re-review full local CI: `bash scripts/ci-local.sh` — passed, including repo-wide Ruff formatting, dependency validation, Bandit, compile checks, skill harnesses, and 912 tests.
+- Fifth re-review focused regression: `./.venv/bin/python -m pytest tests/test_services/test_policy_adapter_service.py tests/test_services/test_policy_adapter_output_contract.py tests/test_services/test_settings_service.py tests/test_api/test_settings.py tests/test_api/test_analyses.py tests/test_docs/test_workflow_adapter_output_contract.py -q --tb=short` — 158 passed, 81 subtests passed.
+- Fifth re-review full local CI: `bash scripts/ci-local.sh` — passed, including repo-wide Ruff formatting, dependency validation, Bandit, compile checks, skill harnesses, and 912 tests.
 - UI validation not applicable: no React route, rendered surface, browser interaction, keyboard behavior, or accessibility semantics changed; only generated API type declarations were refreshed.
 
 ### Completion Notes List
@@ -146,7 +149,7 @@ Codex (GPT-5)
 - Added strict frozen policy settings for medium/high/critical defaults, optional disabled thresholds, and advisory/warn below-threshold reporting behavior.
 - Persisted project defaults and integration-specific overrides through the existing application settings repository, with integration -> project -> built-in resolution and DELETE-based reset to inheritance.
 - Added one reusable configured-generation service that resolves adapter project key or ID, applies the correct integration settings, and rejects cross-project or cross-integration use.
-- Added an authenticated persisted-report policy-adapter endpoint that applies saved integration/project defaults through the configured-generation service while preserving the canonical report payload.
+- Added an authenticated persisted-report policy-adapter endpoint that applies saved integration/project defaults through the configured-generation service while preserving and embedding the canonical summary; the full report remains separately auditable.
 - Kept policy decisions separate from the canonical advisory report and attached the resolved settings snapshot to the policy envelope for auditability.
 - Added admin-only GET/PUT/DELETE API management with explicit project scope and refreshed generated OpenAPI TypeScript declarations.
 - Documented built-in defaults, precedence, reset semantics, runtime usage, and the unchanged canonical evidence/findings/severity boundary.

--- a/_bmad-output/implementation-artifacts/11-2-threshold-and-reporting-defaults-management.md
+++ b/_bmad-output/implementation-artifacts/11-2-threshold-and-reporting-defaults-management.md
@@ -36,6 +36,9 @@ So that teams can tune adapter behavior without changing core code.
 - [x] [Review][Decision] Clarify the Story 11.2 runtime boundary before claiming production integration — Resolved by retaining the reusable configured-generation service boundary, correcting overstated runtime wording, and leaving integration activation to Story 11.3.
 - [x] [Review][Patch] Reject unknown canonical severities instead of silently applying the reporting default [services/policy_adapter_output_contract.py:163]
 - [x] [Review][Patch] Validate persisted policy-setting payload scope against its storage key before returning it [services/settings_service.py:233]
+- [x] [Review][Decision] Decide whether configured generation must be activated in a production integration in Story 11.2 — Resolved by adding an authenticated persisted-report policy-output endpoint that exercises the configured generation service; Story 11.3 still owns enforcement-mode activation inside specific CI/workflow integrations.
+- [x] [Review][Patch] Canonicalize project keys consistently before policy-settings persistence and lookup [services/settings_service.py:174]
+- [x] [Review][Patch] Prevent built-in settings from claiming integration-specific or customized threshold provenance [services/policy_adapter_settings.py:92]
 
 ## Dev Notes
 
@@ -117,6 +120,10 @@ Codex (GPT-5)
 - BMad re-review fixes: clarified that the configured-generation service is the Story 11.2 boundary rather than an already activated integration, rejected unknown canonical severities, and rejected persisted settings whose payload scope disagrees with their storage key.
 - Review regression suite: `./.venv/bin/python -m pytest tests/test_services/test_policy_adapter_service.py tests/test_services/test_policy_adapter_output_contract.py tests/test_services/test_settings_service.py tests/test_api/test_settings.py tests/test_docs/test_workflow_adapter_output_contract.py -q --tb=short` — 50 passed, 57 subtests passed.
 - Post-review full local CI: `bash scripts/ci-local.sh` — passed, including Ruff, repo-wide formatting, dependency validation, Bandit, compile checks, skill harnesses, and 908 tests.
+- Second re-review RED: the new regressions failed on non-canonical persisted project keys, permissive built-in provenance, and the missing production policy-output route.
+- Second re-review GREEN: `./.venv/bin/python -m pytest tests/test_services/test_policy_adapter_service.py tests/test_services/test_policy_adapter_output_contract.py tests/test_services/test_settings_service.py tests/test_api/test_settings.py tests/test_api/test_analyses.py tests/test_docs/test_workflow_adapter_output_contract.py -q --tb=short` — 152 passed, 76 subtests passed.
+- Second re-review affected CI shard: `./.venv/bin/python -m pytest tests/test_api tests/test_cli tests/test_infra -v --tb=short` — 384 passed, 98 subtests passed.
+- Second re-review full local CI: `bash scripts/ci-local.sh` — passed, including Ruff, formatting, dependency validation, Bandit, compile checks, skill harnesses, and 910 tests.
 - UI validation not applicable: no React route, rendered surface, browser interaction, keyboard behavior, or accessibility semantics changed; only generated API type declarations were refreshed.
 
 ### Completion Notes List
@@ -124,6 +131,7 @@ Codex (GPT-5)
 - Added strict frozen policy settings for medium/high/critical defaults, optional disabled thresholds, and advisory/warn below-threshold reporting behavior.
 - Persisted project defaults and integration-specific overrides through the existing application settings repository, with integration -> project -> built-in resolution and DELETE-based reset to inheritance.
 - Added one reusable configured-generation service that resolves adapter project key or ID, applies the correct integration settings, and rejects cross-project or cross-integration use.
+- Added an authenticated persisted-report policy-adapter endpoint that applies saved integration/project defaults through the configured-generation service while preserving the canonical report payload.
 - Kept policy decisions separate from the canonical advisory report and attached the resolved settings snapshot to the policy envelope for auditability.
 - Added admin-only GET/PUT/DELETE API management with explicit project scope and refreshed generated OpenAPI TypeScript declarations.
 - Documented built-in defaults, precedence, reset semantics, runtime usage, and the unchanged canonical evidence/findings/severity boundary.
@@ -133,6 +141,7 @@ Codex (GPT-5)
 - `_bmad-output/implementation-artifacts/11-2-threshold-and-reporting-defaults-management.md`
 - `_bmad-output/implementation-artifacts/sprint-status.yaml`
 - `api/routes/settings.py`
+- `api/routes/analyses.py`
 - `api/schemas.py`
 - `docs/workflow-adapter-output-contract.md`
 - `frontend/src/api/schema.d.ts`
@@ -141,6 +150,7 @@ Codex (GPT-5)
 - `services/policy_adapter_settings.py`
 - `services/settings_service.py`
 - `tests/test_api/test_settings.py`
+- `tests/test_api/test_analyses.py`
 - `tests/test_docs/test_workflow_adapter_output_contract.py`
 - `tests/test_services/test_policy_adapter_output_contract.py`
 - `tests/test_services/test_policy_adapter_service.py`
@@ -152,3 +162,4 @@ Codex (GPT-5)
 - 2026-08-06: Added project/integration threshold and reporting-default management, configured adapter interpretation, reset/inheritance behavior, explicit scope/RBAC safeguards, docs, generated API types, and full regression coverage; moved story to review.
 - 2026-08-06: Resolved all BMad review findings, added canonical project-key and integration-query regressions, passed full local CI, and marked the story done.
 - 2026-08-06: Resolved re-review findings for runtime-boundary wording, unknown canonical severities, and persisted scope integrity; retained Story 11.3 as the integration-activation boundary.
+- 2026-08-07: Resolved the second re-review by adding authenticated production policy-output generation, canonical project-key persistence, strict built-in provenance, generated API types, and regression coverage.

--- a/_bmad-output/implementation-artifacts/11-2-threshold-and-reporting-defaults-management.md
+++ b/_bmad-output/implementation-artifacts/11-2-threshold-and-reporting-defaults-management.md
@@ -33,6 +33,9 @@ So that teams can tune adapter behavior without changing core code.
 
 - [x] [Review][Patch] Normalize adapter metadata project keys with the canonical project-key normalizer before comparing them with resolved settings [services/policy_adapter_output_contract.py:138]
 - [x] [Review][Patch] Validate GET/DELETE integration query values consistently with PUT and return the policy-settings error contract [api/routes/settings.py:438]
+- [x] [Review][Decision] Clarify the Story 11.2 runtime boundary before claiming production integration — Resolved by retaining the reusable configured-generation service boundary, correcting overstated runtime wording, and leaving integration activation to Story 11.3.
+- [x] [Review][Patch] Reject unknown canonical severities instead of silently applying the reporting default [services/policy_adapter_output_contract.py:163]
+- [x] [Review][Patch] Validate persisted policy-setting payload scope against its storage key before returning it [services/settings_service.py:233]
 
 ## Dev Notes
 
@@ -111,15 +114,16 @@ Codex (GPT-5)
 - Generated API types from the current in-process FastAPI OpenAPI document with `openapi-typescript`; the policy-adapter GET/PUT/DELETE contract is present in `frontend/src/api/schema.d.ts`.
 - Independent internal re-review: zero remaining high or medium findings after runtime wiring, reset behavior, project-ID validation, and explicit project-scope fixes.
 - BMad review fixes: canonicalized metadata/resolved/settings project keys before scope comparison and aligned GET/DELETE integration query validation with the write contract and `invalid_policy_adapter_settings` error envelope.
-- Review regression suite: `./.venv/bin/python -m pytest tests/test_services/test_policy_adapter_service.py tests/test_services/test_policy_adapter_output_contract.py tests/test_services/test_settings_service.py tests/test_api/test_settings.py tests/test_docs/test_workflow_adapter_output_contract.py -q --tb=short` — 48 passed, 55 subtests passed.
-- Post-review full local CI: `bash scripts/ci-local.sh` — passed, including Ruff, repo-wide formatting, dependency validation, Bandit, compile checks, skill harnesses, and 906 tests.
+- BMad re-review fixes: clarified that the configured-generation service is the Story 11.2 boundary rather than an already activated integration, rejected unknown canonical severities, and rejected persisted settings whose payload scope disagrees with their storage key.
+- Review regression suite: `./.venv/bin/python -m pytest tests/test_services/test_policy_adapter_service.py tests/test_services/test_policy_adapter_output_contract.py tests/test_services/test_settings_service.py tests/test_api/test_settings.py tests/test_docs/test_workflow_adapter_output_contract.py -q --tb=short` — 50 passed, 57 subtests passed.
+- Post-review full local CI: `bash scripts/ci-local.sh` — passed, including Ruff, repo-wide formatting, dependency validation, Bandit, compile checks, skill harnesses, and 908 tests.
 - UI validation not applicable: no React route, rendered surface, browser interaction, keyboard behavior, or accessibility semantics changed; only generated API type declarations were refreshed.
 
 ### Completion Notes List
 
 - Added strict frozen policy settings for medium/high/critical defaults, optional disabled thresholds, and advisory/warn below-threshold reporting behavior.
 - Persisted project defaults and integration-specific overrides through the existing application settings repository, with integration -> project -> built-in resolution and DELETE-based reset to inheritance.
-- Added one production generation path that resolves adapter project key or ID, applies the correct integration settings, and rejects cross-project or cross-integration use.
+- Added one reusable configured-generation service that resolves adapter project key or ID, applies the correct integration settings, and rejects cross-project or cross-integration use.
 - Kept policy decisions separate from the canonical advisory report and attached the resolved settings snapshot to the policy envelope for auditability.
 - Added admin-only GET/PUT/DELETE API management with explicit project scope and refreshed generated OpenAPI TypeScript declarations.
 - Documented built-in defaults, precedence, reset semantics, runtime usage, and the unchanged canonical evidence/findings/severity boundary.
@@ -145,5 +149,6 @@ Codex (GPT-5)
 ## Change Log
 
 - 2026-05-01: Story created/aligned from updated PRD, architecture, epics, sprint status, and readiness report.
-- 2026-08-06: Added project/integration threshold and reporting-default management, configured runtime interpretation, reset/inheritance behavior, explicit scope/RBAC safeguards, docs, generated API types, and full regression coverage; moved story to review.
+- 2026-08-06: Added project/integration threshold and reporting-default management, configured adapter interpretation, reset/inheritance behavior, explicit scope/RBAC safeguards, docs, generated API types, and full regression coverage; moved story to review.
 - 2026-08-06: Resolved all BMad review findings, added canonical project-key and integration-query regressions, passed full local CI, and marked the story done.
+- 2026-08-06: Resolved re-review findings for runtime-boundary wording, unknown canonical severities, and persisted scope integrity; retained Story 11.3 as the integration-activation boundary.

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -1,5 +1,5 @@
 # generated: 2026-05-01
-# last_updated: 2026-08-07
+# last_updated: 2026-08-10
 # project: deploywhisper
 # project_key: NOKEY
 # tracking_system: file-system
@@ -35,7 +35,7 @@
 # - Dev moves story to review, then runs code-review
 
 generated: 2026-05-01
-last_updated: 2026-08-07
+last_updated: 2026-08-10
 project: deploywhisper
 project_key: NOKEY
 tracking_system: file-system

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -1,5 +1,5 @@
 # generated: 2026-05-01
-# last_updated: 2026-08-06
+# last_updated: 2026-08-07
 # project: deploywhisper
 # project_key: NOKEY
 # tracking_system: file-system
@@ -35,7 +35,7 @@
 # - Dev moves story to review, then runs code-review
 
 generated: 2026-05-01
-last_updated: 2026-08-06
+last_updated: 2026-08-07
 project: deploywhisper
 project_key: NOKEY
 tracking_system: file-system

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -1,5 +1,5 @@
 # generated: 2026-05-01
-# last_updated: 2026-08-10
+# last_updated: 2026-08-11
 # project: deploywhisper
 # project_key: NOKEY
 # tracking_system: file-system
@@ -35,7 +35,7 @@
 # - Dev moves story to review, then runs code-review
 
 generated: 2026-05-01
-last_updated: 2026-08-10
+last_updated: 2026-08-11
 project: deploywhisper
 project_key: NOKEY
 tracking_system: file-system

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -1,5 +1,5 @@
 # generated: 2026-05-01
-# last_updated: 2026-08-03
+# last_updated: 2026-08-06
 # project: deploywhisper
 # project_key: NOKEY
 # tracking_system: file-system
@@ -35,7 +35,7 @@
 # - Dev moves story to review, then runs code-review
 
 generated: 2026-05-01
-last_updated: 2026-08-03
+last_updated: 2026-08-06
 project: deploywhisper
 project_key: NOKEY
 tracking_system: file-system
@@ -145,7 +145,7 @@ development_status:
 
   epic-11: in-progress
   11-1-policy-adapter-output-contract: done
-  11-2-threshold-and-reporting-defaults-management: ready-for-dev
+  11-2-threshold-and-reporting-defaults-management: done
   11-3-integration-level-enforcement-settings: ready-for-dev
   11-4-enforcement-guardrail-documentation: ready-for-dev
   epic-11-retrospective: optional

--- a/api/routes/analyses.py
+++ b/api/routes/analyses.py
@@ -84,6 +84,7 @@ from services.project_service import (
 )
 from services.project_service import resolve_project_reference
 from services.policy_adapter_output_contract import PolicyAdapterOutputContract
+from services.policy_adapter_settings import PolicyAdapterSettingsIntegrityError
 from services.policy_adapter_service import build_configured_policy_adapter_output
 
 router = APIRouter(prefix="/api/v1/analyses", tags=["analyses"], route_class=ApiRoute)
@@ -977,6 +978,12 @@ def get_policy_adapter_output(
         policy_output = build_configured_policy_adapter_output(adapter_output)
     except PermissionError as exc:
         _raise_authorization_error(exc)
+    except PolicyAdapterSettingsIntegrityError as exc:
+        raise ApiError(
+            status_code=500,
+            code="policy_adapter_settings_integrity_error",
+            message="Stored policy adapter settings failed integrity validation.",
+        ) from exc
     except ValueError as exc:
         raise ApiError(
             status_code=400,

--- a/api/routes/analyses.py
+++ b/api/routes/analyses.py
@@ -19,7 +19,7 @@ from fastapi import (
     Response,
     UploadFile,
 )
-from pydantic import ValidationError
+from pydantic import BaseModel, ValidationError
 
 from api.errors import ApiError, ApiRoute
 from api.schemas import (
@@ -36,6 +36,7 @@ from api.schemas import (
     ErrorResponse,
     FindingFeedbackRequest,
     FindingFeedbackResponse,
+    ResourceMetaPayload,
     SharedReportAccessResponse,
     SharedReportUnlockRequest,
     build_analysis_run_data,
@@ -48,6 +49,10 @@ from services.analysis_service import (
     analyze_uploaded_files,
     build_share_summary,
     resolve_analysis_project_scope,
+)
+from services.adapter_output_contract import (
+    AdapterMetadata,
+    build_adapter_output_contract,
 )
 from services.intake_service import (
     MAX_TOTAL_UPLOAD_BYTES,
@@ -78,11 +83,20 @@ from services.project_service import (
     require_project_permission,
 )
 from services.project_service import resolve_project_reference
+from services.policy_adapter_output_contract import PolicyAdapterOutputContract
+from services.policy_adapter_service import build_configured_policy_adapter_output
 
 router = APIRouter(prefix="/api/v1/analyses", tags=["analyses"], route_class=ApiRoute)
 READ_CHUNK_BYTES = 1024 * 1024
 _HISTORY_ANALYSIS_STATUSES = {"complete", "degraded", "fallback"}
 AnalysisOutcomeFilter = Literal["success", "failure", "rolled_back", "rollback"]
+
+
+class PolicyAdapterOutputResponse(BaseModel):
+    """API envelope for configured policy interpretation of one report."""
+
+    data: PolicyAdapterOutputContract
+    meta: ResourceMetaPayload
 
 
 def _share_cookie_name(report_id: int) -> str:
@@ -886,6 +900,72 @@ async def create_analysis(
             advisory_only=True,
             submitted_artifact_count=len(raw_files),
             accepted_artifact_count=pending_analysis.ready_count,
+        ),
+    )
+
+
+@router.get(
+    "/{report_id}/policy-adapter",
+    response_model=PolicyAdapterOutputResponse,
+    responses={
+        400: {"model": ErrorResponse},
+        403: {"model": ErrorResponse},
+        404: {"model": ErrorResponse},
+        422: {"model": ErrorResponse},
+        500: {"model": ErrorResponse},
+    },
+)
+def get_policy_adapter_output(
+    report_id: int,
+    integration: str = Query(..., min_length=1),
+    authorization: dict[str, object] = Depends(_authorization_context),
+) -> PolicyAdapterOutputResponse:
+    """Generate a configured policy interpretation for one persisted report."""
+    report = fetch_analysis_report(report_id)
+    if report is None:
+        raise ApiError(
+            status_code=404,
+            code="analysis_not_found",
+            message="Analysis report not found.",
+        )
+    project = report.get("project") or {}
+    project_id = project.get("id")
+    if not isinstance(project_id, int):
+        raise ApiError(
+            status_code=500,
+            code="analysis_project_scope_invalid",
+            message="Analysis report project scope is invalid.",
+        )
+    try:
+        _require_api_project_permission(
+            authorization=authorization,
+            capability="report.read",
+            project_id=project_id,
+        )
+        adapter_output = build_adapter_output_contract(
+            build_share_summary(report),
+            AdapterMetadata(
+                adapter=integration,
+                format="workflow_decision",
+                project_id=project_id,
+            ),
+        )
+        policy_output = build_configured_policy_adapter_output(adapter_output)
+    except PermissionError as exc:
+        _raise_authorization_error(exc)
+    except ValueError as exc:
+        raise ApiError(
+            status_code=400,
+            code="invalid_policy_adapter_output",
+            message=str(exc),
+        ) from exc
+    return PolicyAdapterOutputResponse(
+        data=policy_output,
+        meta=build_report_meta(
+            id=report_id,
+            report_schema_version=normalize_report_schema_version(
+                report.get("report_schema_version")
+            ),
         ),
     )
 

--- a/api/routes/analyses.py
+++ b/api/routes/analyses.py
@@ -442,6 +442,38 @@ def _require_report_delete_permission(
     )
 
 
+def _fetch_report_for_authorized_read(
+    *,
+    authorization: dict[str, object],
+    report_id: int,
+) -> dict:
+    require_project_permission(
+        role=authorization["role"],
+        capability="report.read",
+        allowed_project_keys=authorization["allowed_project_keys"],
+    )
+    report = fetch_analysis_report(report_id)
+    if report is None:
+        if has_restricted_project_scope(
+            role=authorization["role"],
+            allowed_project_keys=authorization["allowed_project_keys"],
+        ):
+            raise _project_scope_forbidden_error()
+        raise ApiError(
+            status_code=404,
+            code="analysis_not_found",
+            message="Analysis report not found.",
+        )
+    project = report.get("project") or {}
+    require_project_permission(
+        role=authorization["role"],
+        capability="report.read",
+        project_key=project.get("project_key"),
+        allowed_project_keys=authorization["allowed_project_keys"],
+    )
+    return report
+
+
 def _reject_unscoped_workspace_id(
     *,
     project_id: int | None,
@@ -921,27 +953,19 @@ def get_policy_adapter_output(
     authorization: dict[str, object] = Depends(_authorization_context),
 ) -> PolicyAdapterOutputResponse:
     """Generate a configured policy interpretation for one persisted report."""
-    report = fetch_analysis_report(report_id)
-    if report is None:
-        raise ApiError(
-            status_code=404,
-            code="analysis_not_found",
-            message="Analysis report not found.",
-        )
-    project = report.get("project") or {}
-    project_id = project.get("id")
-    if not isinstance(project_id, int):
-        raise ApiError(
-            status_code=500,
-            code="analysis_project_scope_invalid",
-            message="Analysis report project scope is invalid.",
-        )
     try:
-        _require_api_project_permission(
+        report = _fetch_report_for_authorized_read(
             authorization=authorization,
-            capability="report.read",
-            project_id=project_id,
+            report_id=report_id,
         )
+        project = report.get("project") or {}
+        project_id = project.get("id")
+        if not isinstance(project_id, int):
+            raise ApiError(
+                status_code=500,
+                code="analysis_project_scope_invalid",
+                message="Analysis report project scope is invalid.",
+            )
         adapter_output = build_adapter_output_contract(
             build_share_summary(report),
             AdapterMetadata(

--- a/api/routes/settings.py
+++ b/api/routes/settings.py
@@ -62,6 +62,7 @@ from services.settings_service import (
     save_topology_drift_check_interval_hours,
     validate_provider_settings,
 )
+from services.policy_adapter_settings import PolicyAdapterSettingsIntegrityError
 from services.topology_service import (
     get_topology_status,
     save_topology_definition,
@@ -91,6 +92,14 @@ def _policy_adapter_api_error(exc: ValueError) -> ApiError:
         status_code=400,
         code="invalid_policy_adapter_settings",
         message=str(exc),
+    )
+
+
+def _policy_adapter_integrity_api_error() -> ApiError:
+    return ApiError(
+        status_code=500,
+        code="policy_adapter_settings_integrity_error",
+        message="Stored policy adapter settings failed integrity validation.",
     )
 
 
@@ -480,6 +489,8 @@ def get_policy_adapter_defaults(
         )
     except PermissionError as exc:
         _raise_authorization_error(exc)
+    except PolicyAdapterSettingsIntegrityError as exc:
+        raise _policy_adapter_integrity_api_error() from exc
     except ValueError as exc:
         raise _policy_adapter_api_error(exc) from exc
     return PolicyAdapterSettingsResponse(
@@ -525,6 +536,8 @@ def update_policy_adapter_defaults(
         )
     except PermissionError as exc:
         _raise_authorization_error(exc)
+    except PolicyAdapterSettingsIntegrityError as exc:
+        raise _policy_adapter_integrity_api_error() from exc
     except ValueError as exc:
         raise _policy_adapter_api_error(exc) from exc
     return PolicyAdapterSettingsResponse(
@@ -568,6 +581,8 @@ def reset_policy_adapter_defaults(
         )
     except PermissionError as exc:
         _raise_authorization_error(exc)
+    except PolicyAdapterSettingsIntegrityError as exc:
+        raise _policy_adapter_integrity_api_error() from exc
     except ValueError as exc:
         raise _policy_adapter_api_error(exc) from exc
     return PolicyAdapterSettingsResponse(

--- a/api/routes/settings.py
+++ b/api/routes/settings.py
@@ -14,6 +14,7 @@ from api.schemas import (
     CustomSkillUploadData,
     CustomSkillUploadRequest,
     CustomSkillUploadResponse,
+    ErrorResponse,
     FeedbackSummaryData,
     PolicyAdapterSettingsData,
     PolicyAdapterSettingsRequest,
@@ -43,7 +44,6 @@ from api.schemas import (
 from llm.skill_context import get_custom_skill_statuses, save_custom_skill
 from services.feedback_service import fetch_feedback_summary
 from services.project_service import (
-    ProjectResolutionError,
     has_restricted_project_scope,
     require_project_permission,
     resolve_project_reference,
@@ -80,6 +80,16 @@ def _project_api_error(exc: ValueError) -> ApiError:
     return ApiError(
         status_code=status_code,
         code=code,
+        message=str(exc),
+    )
+
+
+def _policy_adapter_api_error(exc: ValueError) -> ApiError:
+    if getattr(exc, "code", None) is not None:
+        return _project_api_error(exc)
+    return ApiError(
+        status_code=400,
+        code="invalid_policy_adapter_settings",
         message=str(exc),
     )
 
@@ -435,7 +445,17 @@ def update_provider_settings(
     )
 
 
-@settings_router.get("/policy-adapter", response_model=PolicyAdapterSettingsResponse)
+@settings_router.get(
+    "/policy-adapter",
+    response_model=PolicyAdapterSettingsResponse,
+    responses={
+        400: {"model": ErrorResponse},
+        403: {"model": ErrorResponse},
+        404: {"model": ErrorResponse},
+        422: {"model": ErrorResponse},
+        500: {"model": ErrorResponse},
+    },
+)
 def get_policy_adapter_defaults(
     project_id: int | None = Query(default=None),
     project_key: str | None = Query(default=None),
@@ -460,21 +480,25 @@ def get_policy_adapter_defaults(
         )
     except PermissionError as exc:
         _raise_authorization_error(exc)
-    except ProjectResolutionError as exc:
-        raise _project_api_error(exc) from exc
     except ValueError as exc:
-        raise ApiError(
-            status_code=400,
-            code="invalid_policy_adapter_settings",
-            message=str(exc),
-        ) from exc
+        raise _policy_adapter_api_error(exc) from exc
     return PolicyAdapterSettingsResponse(
         data=_policy_adapter_settings_data(resolved),
         meta=build_meta(),
     )
 
 
-@settings_router.put("/policy-adapter", response_model=PolicyAdapterSettingsResponse)
+@settings_router.put(
+    "/policy-adapter",
+    response_model=PolicyAdapterSettingsResponse,
+    responses={
+        400: {"model": ErrorResponse},
+        403: {"model": ErrorResponse},
+        404: {"model": ErrorResponse},
+        422: {"model": ErrorResponse},
+        500: {"model": ErrorResponse},
+    },
+)
 def update_policy_adapter_defaults(
     payload: PolicyAdapterSettingsRequest,
     authorization: dict[str, object] = Depends(_authorization_context),
@@ -502,18 +526,24 @@ def update_policy_adapter_defaults(
     except PermissionError as exc:
         _raise_authorization_error(exc)
     except ValueError as exc:
-        raise ApiError(
-            status_code=400,
-            code="invalid_policy_adapter_settings",
-            message=str(exc),
-        ) from exc
+        raise _policy_adapter_api_error(exc) from exc
     return PolicyAdapterSettingsResponse(
         data=_policy_adapter_settings_data(saved),
         meta=build_meta(),
     )
 
 
-@settings_router.delete("/policy-adapter", response_model=PolicyAdapterSettingsResponse)
+@settings_router.delete(
+    "/policy-adapter",
+    response_model=PolicyAdapterSettingsResponse,
+    responses={
+        400: {"model": ErrorResponse},
+        403: {"model": ErrorResponse},
+        404: {"model": ErrorResponse},
+        422: {"model": ErrorResponse},
+        500: {"model": ErrorResponse},
+    },
+)
 def reset_policy_adapter_defaults(
     project_id: int | None = Query(default=None),
     project_key: str | None = Query(default=None),
@@ -538,14 +568,8 @@ def reset_policy_adapter_defaults(
         )
     except PermissionError as exc:
         _raise_authorization_error(exc)
-    except ProjectResolutionError as exc:
-        raise _project_api_error(exc) from exc
     except ValueError as exc:
-        raise ApiError(
-            status_code=400,
-            code="invalid_policy_adapter_settings",
-            message=str(exc),
-        ) from exc
+        raise _policy_adapter_api_error(exc) from exc
     return PolicyAdapterSettingsResponse(
         data=_policy_adapter_settings_data(inherited),
         meta=build_meta(),

--- a/api/routes/settings.py
+++ b/api/routes/settings.py
@@ -15,6 +15,9 @@ from api.schemas import (
     CustomSkillUploadRequest,
     CustomSkillUploadResponse,
     FeedbackSummaryData,
+    PolicyAdapterSettingsData,
+    PolicyAdapterSettingsRequest,
+    PolicyAdapterSettingsResponse,
     ProviderCapabilityData,
     ProviderOptionData,
     ProviderSettingsData,
@@ -40,6 +43,7 @@ from api.schemas import (
 from llm.skill_context import get_custom_skill_statuses, save_custom_skill
 from services.feedback_service import fetch_feedback_summary
 from services.project_service import (
+    ProjectResolutionError,
     has_restricted_project_scope,
     require_project_permission,
     resolve_project_reference,
@@ -47,11 +51,14 @@ from services.project_service import (
 from services.settings_service import (
     TOPOLOGY_DRIFT_CHECK_INTERVAL_OPTIONS,
     activate_local_mode,
+    delete_policy_adapter_settings,
     get_provider_settings,
+    get_policy_adapter_settings,
     get_topology_drift_check_interval_hours,
     provider_defaults,
     provider_select_options,
     save_provider_settings,
+    save_policy_adapter_settings,
     save_topology_drift_check_interval_hours,
     validate_provider_settings,
 )
@@ -152,6 +159,10 @@ def _provider_options_data() -> list[ProviderOptionData]:
     ]
 
 
+def _policy_adapter_settings_data(settings) -> PolicyAdapterSettingsData:
+    return PolicyAdapterSettingsData(**settings.model_dump(mode="json"))
+
+
 def _topology_status_data(status) -> TopologyStatusData:
     return TopologyStatusData(**status.model_dump(exclude={"payload"}))
 
@@ -232,6 +243,18 @@ def _reject_unscoped_workspace_id(
         status_code=400,
         code="missing_project_scope",
         message="Project scope is required when resolving workspace_id.",
+    )
+
+
+def _require_explicit_project_reference(
+    *, project_id: int | None, project_key: str | None
+) -> None:
+    if project_id is not None or project_key is not None:
+        return
+    raise ApiError(
+        status_code=400,
+        code="missing_project_scope",
+        message="An explicit project_id or project_key is required.",
     )
 
 
@@ -408,6 +431,123 @@ def update_provider_settings(
             settings=_provider_settings_data(saved),
             validation=ProviderValidationData(**validation),
         ),
+        meta=build_meta(),
+    )
+
+
+@settings_router.get("/policy-adapter", response_model=PolicyAdapterSettingsResponse)
+def get_policy_adapter_defaults(
+    project_id: int | None = Query(default=None),
+    project_key: str | None = Query(default=None),
+    integration: str | None = Query(default=None, min_length=1),
+    authorization: dict[str, object] = Depends(_authorization_context),
+) -> PolicyAdapterSettingsResponse:
+    """Return effective project or integration policy-adapter defaults."""
+    _require_explicit_project_reference(
+        project_id=project_id,
+        project_key=project_key,
+    )
+    try:
+        project = _resolve_authorized_topology_project(
+            authorization=authorization,
+            capability="settings.manage",
+            project_id=project_id,
+            project_key=project_key,
+        )
+        resolved = get_policy_adapter_settings(
+            project_key=project.project_key,
+            integration=integration,
+        )
+    except PermissionError as exc:
+        _raise_authorization_error(exc)
+    except ProjectResolutionError as exc:
+        raise _project_api_error(exc) from exc
+    except ValueError as exc:
+        raise ApiError(
+            status_code=400,
+            code="invalid_policy_adapter_settings",
+            message=str(exc),
+        ) from exc
+    return PolicyAdapterSettingsResponse(
+        data=_policy_adapter_settings_data(resolved),
+        meta=build_meta(),
+    )
+
+
+@settings_router.put("/policy-adapter", response_model=PolicyAdapterSettingsResponse)
+def update_policy_adapter_defaults(
+    payload: PolicyAdapterSettingsRequest,
+    authorization: dict[str, object] = Depends(_authorization_context),
+) -> PolicyAdapterSettingsResponse:
+    """Persist project or integration policy-adapter defaults."""
+    _require_explicit_project_reference(
+        project_id=payload.project_id,
+        project_key=payload.project_key,
+    )
+    try:
+        project = _resolve_authorized_topology_project(
+            authorization=authorization,
+            capability="settings.manage",
+            project_id=payload.project_id,
+            project_key=payload.project_key,
+        )
+        saved = save_policy_adapter_settings(
+            project_key=project.project_key,
+            integration=payload.integration,
+            warn_at=payload.warn_at,
+            soft_block_at=payload.soft_block_at,
+            hard_block_at=payload.hard_block_at,
+            reporting_default=payload.reporting_default,
+        )
+    except PermissionError as exc:
+        _raise_authorization_error(exc)
+    except ValueError as exc:
+        raise ApiError(
+            status_code=400,
+            code="invalid_policy_adapter_settings",
+            message=str(exc),
+        ) from exc
+    return PolicyAdapterSettingsResponse(
+        data=_policy_adapter_settings_data(saved),
+        meta=build_meta(),
+    )
+
+
+@settings_router.delete("/policy-adapter", response_model=PolicyAdapterSettingsResponse)
+def reset_policy_adapter_defaults(
+    project_id: int | None = Query(default=None),
+    project_key: str | None = Query(default=None),
+    integration: str | None = Query(default=None, min_length=1),
+    authorization: dict[str, object] = Depends(_authorization_context),
+) -> PolicyAdapterSettingsResponse:
+    """Remove one override and return the newly inherited defaults."""
+    _require_explicit_project_reference(
+        project_id=project_id,
+        project_key=project_key,
+    )
+    try:
+        project = _resolve_authorized_topology_project(
+            authorization=authorization,
+            capability="settings.manage",
+            project_id=project_id,
+            project_key=project_key,
+        )
+        inherited = delete_policy_adapter_settings(
+            project_key=project.project_key,
+            integration=integration,
+        )
+    except PermissionError as exc:
+        _raise_authorization_error(exc)
+    except ProjectResolutionError as exc:
+        raise _project_api_error(exc) from exc
+    except ValueError as exc:
+        raise ApiError(
+            status_code=400,
+            code="invalid_policy_adapter_settings",
+            message=str(exc),
+        ) from exc
+    return PolicyAdapterSettingsResponse(
+        data=_policy_adapter_settings_data(inherited),
         meta=build_meta(),
     )
 

--- a/api/schemas.py
+++ b/api/schemas.py
@@ -167,6 +167,37 @@ class ProviderSettingsResponse(BaseModel):
     meta: MetaPayload
 
 
+class PolicyAdapterSettingsRequest(BaseModel):
+    project_id: int | None = Field(default=None, gt=0)
+    project_key: str | None = Field(default=None, min_length=1)
+    integration: str | None = Field(default=None, min_length=1)
+    warn_at: Literal["low", "medium", "high", "critical"] | None = Field(
+        default="medium"
+    )
+    soft_block_at: Literal["low", "medium", "high", "critical"] | None = Field(
+        default="high"
+    )
+    hard_block_at: Literal["low", "medium", "high", "critical"] | None = Field(
+        default="critical"
+    )
+    reporting_default: Literal["advisory", "warn"] = Field(default="advisory")
+
+
+class PolicyAdapterSettingsData(BaseModel):
+    project_key: str
+    integration: str | None = None
+    source: Literal["built-in", "project", "integration"]
+    warn_at: Literal["low", "medium", "high", "critical"] | None = None
+    soft_block_at: Literal["low", "medium", "high", "critical"] | None = None
+    hard_block_at: Literal["low", "medium", "high", "critical"] | None = None
+    reporting_default: Literal["advisory", "warn"]
+
+
+class PolicyAdapterSettingsResponse(BaseModel):
+    data: PolicyAdapterSettingsData
+    meta: MetaPayload
+
+
 ToolType = Literal[
     "terraform", "kubernetes", "ansible", "jenkins", "cloudformation", "unsupported"
 ]

--- a/docs/workflow-adapter-output-contract.md
+++ b/docs/workflow-adapter-output-contract.md
@@ -147,5 +147,10 @@ Policy-adapter consumers generate configured decisions through
 resolves either adapter `project_key` or `project_id`, selects the integration
 override before the project and built-in defaults, validates that the settings
 scope matches the adapter metadata, and then emits the policy envelope.
-Activating that interpretation in a specific CI or workflow integration remains
-a separate integration concern.
+Authenticated consumers can exercise that production path for a persisted
+report through
+`GET /api/v1/analyses/{report_id}/policy-adapter?integration={integration}`.
+The response applies the saved integration, project, or built-in defaults and
+embeds the unchanged canonical summary beside the policy decision. Activating
+that interpretation as an enforcement mode inside a specific CI or workflow
+integration remains a separate integration concern.

--- a/docs/workflow-adapter-output-contract.md
+++ b/docs/workflow-adapter-output-contract.md
@@ -124,6 +124,25 @@ policy status is `soft-block` or `hard-block`. The adapter interpretation is a
 local workflow decision; it cannot rewrite the canonical severity,
 recommendation, Evidence Law status, evidence, or advisory posture.
 
-This contract does not choose thresholds or integration modes. Those are
-separate, explicitly configured policy concerns. The core remains useful when
-no policy adapter is enabled.
+`PolicyAdapterSettings` manages severity thresholds and the below-threshold
+`reporting_default` without changing core scoring. Built-in defaults interpret
+medium as `warn`, high as `soft-block`, and critical as `hard-block`; reports
+below those thresholds remain `advisory`. Admins can inspect, save, or reset
+project defaults and integration-specific defaults through `GET`, `PUT`, and
+`DELETE`
+`/api/v1/settings/policy-adapter`. Integration-specific defaults take
+precedence over project defaults, which take precedence over the built-in safe
+defaults. Deleting an integration override restores its project defaults;
+deleting a project override restores the built-in defaults.
+
+Threshold evaluation reads only `canonical_summary.severity`. The emitted
+policy envelope records the resolved settings in `applied_settings`, while the
+original canonical severity, findings, evidence, recommendation, Evidence Law
+status, and advisory flags remain unchanged and auditable. Enforcement mode is
+a separate integration concern; the core remains useful when no policy adapter
+is enabled.
+
+Runtime integrations call `build_configured_policy_adapter_output`, which
+resolves either adapter `project_key` or `project_id`, selects the integration
+override before the project and built-in defaults, validates that the settings
+scope matches the adapter metadata, and then emits the policy envelope.

--- a/docs/workflow-adapter-output-contract.md
+++ b/docs/workflow-adapter-output-contract.md
@@ -142,7 +142,10 @@ status, and advisory flags remain unchanged and auditable. Enforcement mode is
 a separate integration concern; the core remains useful when no policy adapter
 is enabled.
 
-Runtime integrations call `build_configured_policy_adapter_output`, which
+Policy-adapter consumers generate configured decisions through
+`build_configured_policy_adapter_output`. This reusable service boundary
 resolves either adapter `project_key` or `project_id`, selects the integration
 override before the project and built-in defaults, validates that the settings
 scope matches the adapter metadata, and then emits the policy envelope.
+Activating that interpretation in a specific CI or workflow integration remains
+a separate integration concern.

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -21,6 +21,46 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/agent/analyses": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Create Agent Analysis
+         * @description Run the canonical analysis path and return the bounded agent contract.
+         */
+        post: operations["create_agent_analysis_api_v1_agent_analyses_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/agent/reports/{report_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Agent Report
+         * @description Return one scoped persisted report through the bounded agent contract.
+         */
+        get: operations["get_agent_report_api_v1_agent_reports__report_id__get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/analyses": {
         parameters: {
             query?: never;
@@ -266,6 +306,34 @@ export interface paths {
         put: operations["update_provider_settings_api_v1_settings_provider_put"];
         post?: never;
         delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/settings/policy-adapter": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Policy Adapter Defaults
+         * @description Return effective project or integration policy-adapter defaults.
+         */
+        get: operations["get_policy_adapter_defaults_api_v1_settings_policy_adapter_get"];
+        /**
+         * Update Policy Adapter Defaults
+         * @description Persist project or integration policy-adapter defaults.
+         */
+        put: operations["update_policy_adapter_defaults_api_v1_settings_policy_adapter_put"];
+        post?: never;
+        /**
+         * Reset Policy Adapter Defaults
+         * @description Remove one override and return the newly inherited defaults.
+         */
+        delete: operations["reset_policy_adapter_defaults_api_v1_settings_policy_adapter_delete"];
         options?: never;
         head?: never;
         patch?: never;
@@ -607,6 +675,330 @@ export interface components {
              * @description Machine-readable uncertainty indicators
              */
             uncertainty_flags?: string[];
+        };
+        /** AgentAnalysisData */
+        AgentAnalysisData: {
+            /**
+             * Schema Version
+             * @default v1
+             * @constant
+             */
+            schema_version: "v1";
+            /** Report Schema Version */
+            report_schema_version: string;
+            /** Report Id */
+            report_id: number;
+            scope: components["schemas"]["AgentScopeData"];
+            verdict: components["schemas"]["AgentVerdictData"];
+            /**
+             * Advisory Only
+             * @default true
+             * @constant
+             */
+            advisory_only: true;
+            /**
+             * Deployment Approval
+             * @default false
+             * @constant
+             */
+            deployment_approval: false;
+            /**
+             * Human Decision Required
+             * @default true
+             * @constant
+             */
+            human_decision_required: true;
+            /**
+             * Approval Statement
+             * @default This output is advisory and is not deployment approval. A human must review the evidence before any deployment decision.
+             * @constant
+             */
+            approval_statement: "This output is advisory and is not deployment approval. A human must review the evidence before any deployment decision.";
+            evidence_law: components["schemas"]["AgentEvidenceLawData"];
+            /** Evidence */
+            evidence?: components["schemas"]["AgentEvidenceData"][];
+            /** Findings */
+            findings?: components["schemas"]["AgentFindingData"][];
+            confidence: components["schemas"]["AgentConfidenceData"];
+            uncertainty: components["schemas"]["AgentUncertaintyData"];
+            /** Context Todos */
+            context_todos?: string[];
+            /** Verification Guidance */
+            verification_guidance?: string[];
+        };
+        /** AgentConfidenceData */
+        AgentConfidenceData: {
+            /** Overall */
+            overall: number;
+            ledger: components["schemas"]["AgentConfidenceLedgerData"];
+        };
+        /** AgentConfidenceLedgerData */
+        AgentConfidenceLedgerData: {
+            /** Contributors */
+            contributors?: string[];
+            /** Confidence Factors */
+            confidence_factors?: string[];
+            /** Why Not Lower */
+            why_not_lower?: string[];
+            /** Why Not Higher */
+            why_not_higher?: string[];
+            /** Uncertainty Drivers */
+            uncertainty_drivers?: string[];
+        };
+        /** AgentContextSourceData */
+        AgentContextSourceData: {
+            /** Source Id */
+            source_id: string;
+            /**
+             * Source Type
+             * @enum {string}
+             */
+            source_type: "artifact" | "topology" | "incident" | "parser" | "evidence" | "ownership" | "external_scanner" | "user_context";
+            /** Source Ref */
+            source_ref?: string | null;
+            /** Scope */
+            scope: string;
+            /**
+             * Freshness Status
+             * @default unknown
+             * @enum {string}
+             */
+            freshness_status: "current" | "stale" | "missing" | "incomplete" | "conflicting" | "unknown" | "empty" | "not_applicable";
+            /** Last Observed At */
+            last_observed_at?: string | null;
+            /** Age Days */
+            age_days?: number | null;
+            /**
+             * Confidence
+             * @default 0
+             */
+            confidence: number;
+            /** Conflicts */
+            conflicts?: string[];
+            /** Limitations */
+            limitations?: string[];
+        };
+        /** AgentEvidenceData */
+        AgentEvidenceData: {
+            /** Evidence Id */
+            evidence_id: string;
+            /** Analysis Id */
+            analysis_id: number;
+            /** Finding Id */
+            finding_id: string;
+            /** Source Type */
+            source_type: string;
+            /** Source Ref */
+            source_ref: string;
+            /**
+             * Artifact
+             * @default
+             */
+            artifact: string;
+            /**
+             * Location
+             * @default
+             */
+            location: string;
+            /**
+             * Resource
+             * @default
+             */
+            resource: string;
+            /**
+             * Operation
+             * @default
+             */
+            operation: string;
+            /** Project Id */
+            project_id?: number | null;
+            /** Project Key */
+            project_key?: string | null;
+            /** Workspace Id */
+            workspace_id?: number | null;
+            /** Workspace Key */
+            workspace_key?: string | null;
+            /**
+             * Source Kind
+             * @default artifact
+             */
+            source_kind: string;
+            /**
+             * Determinism Level
+             * @default deterministic
+             */
+            determinism_level: string;
+            /**
+             * Redaction Status
+             * @default none
+             */
+            redaction_status: string;
+            /** Summary */
+            summary: string;
+            /**
+             * Severity Hint
+             * @enum {string}
+             */
+            severity_hint: "low" | "medium" | "high" | "critical";
+            /** Deterministic */
+            deterministic: boolean;
+            /** Confidence */
+            confidence: number;
+            /** Evidence Label */
+            evidence_label?: string | null;
+            /** Related Change Ids */
+            related_change_ids?: string[];
+            context_source?: components["schemas"]["AgentContextSourceData"] | null;
+        };
+        /** AgentEvidenceLawData */
+        AgentEvidenceLawData: {
+            /**
+             * Status
+             * @enum {string}
+             */
+            status: "Satisfied" | "Needs review" | "Reconciled" | "Detail omitted";
+            /** Detail */
+            detail: string;
+        };
+        /** AgentFindingData */
+        AgentFindingData: {
+            /** Finding Id */
+            finding_id: string;
+            /** Analysis Id */
+            analysis_id: number;
+            /** Title */
+            title: string;
+            /** Description */
+            description: string;
+            /**
+             * Explanation
+             * @default
+             */
+            explanation: string;
+            /** Guidance */
+            guidance?: string[];
+            /**
+             * Severity
+             * @enum {string}
+             */
+            severity: "low" | "medium" | "high" | "critical";
+            /** Category */
+            category: string;
+            /** Deterministic */
+            deterministic: boolean;
+            /** Confidence */
+            confidence: number;
+            /** Uncertainty Note */
+            uncertainty_note?: string | null;
+            /**
+             * Evidence Classification
+             * @default deterministic
+             * @enum {string}
+             */
+            evidence_classification: "deterministic" | "derived" | "external" | "model_inferred" | "user_provided";
+            /** Evidence Refs */
+            evidence_refs?: string[];
+            /** Evidence Label */
+            evidence_label?: string | null;
+            /** Skill Id */
+            skill_id?: string | null;
+        };
+        /** AgentInterfaceMeta */
+        AgentInterfaceMeta: {
+            /**
+             * Interface Schema Version
+             * @default v1
+             * @constant
+             */
+            interface_schema_version: "v1";
+            /**
+             * Operation
+             * @enum {string}
+             */
+            operation: "analysis.submit" | "report.read";
+            /**
+             * Advisory Only
+             * @default true
+             * @constant
+             */
+            advisory_only: true;
+            output_limits?: components["schemas"]["AgentOutputLimitsData"];
+            /**
+             * Truncated
+             * @default false
+             */
+            truncated: boolean;
+            /** Truncated Fields */
+            truncated_fields?: string[];
+        };
+        /** AgentInterfaceResponse */
+        AgentInterfaceResponse: {
+            data: components["schemas"]["AgentAnalysisData"];
+            meta: components["schemas"]["AgentInterfaceMeta"];
+        };
+        /** AgentOutputLimitsData */
+        AgentOutputLimitsData: {
+            /**
+             * Max String Characters
+             * @default 2048
+             */
+            max_string_characters: number;
+            /**
+             * Max Collection Items
+             * @default 50
+             */
+            max_collection_items: number;
+            /**
+             * Max Findings
+             * @default 50
+             */
+            max_findings: number;
+            /**
+             * Max Evidence
+             * @default 100
+             */
+            max_evidence: number;
+        };
+        /** AgentScopeData */
+        AgentScopeData: {
+            /** Project Id */
+            project_id: number;
+            /** Project Key */
+            project_key: string;
+            /** Workspace Id */
+            workspace_id?: number | null;
+            /** Workspace Key */
+            workspace_key?: string | null;
+        };
+        /** AgentUncertaintyData */
+        AgentUncertaintyData: {
+            /** Flags */
+            flags?: string[];
+            /** Summary */
+            summary?: string | null;
+            /** Partial Context */
+            partial_context: boolean;
+            /** Insufficient Context */
+            insufficient_context: boolean;
+            /** Warnings */
+            warnings?: string[];
+        };
+        /** AgentVerdictData */
+        AgentVerdictData: {
+            /** Risk Score */
+            risk_score: number;
+            /**
+             * Severity
+             * @enum {string}
+             */
+            severity: "low" | "medium" | "high" | "critical";
+            /**
+             * Recommendation
+             * @enum {string}
+             */
+            recommendation: "go" | "caution" | "no-go";
+            /** Top Risk */
+            top_risk: string;
         };
         /** AnalysisBulkDeleteData */
         AnalysisBulkDeleteData: {
@@ -1233,6 +1625,24 @@ export interface components {
              * @description Machine-readable topology context limitation labels
              */
             context_limitations?: string[];
+        };
+        /** Body_create_agent_analysis_api_v1_agent_analyses_post */
+        Body_create_agent_analysis_api_v1_agent_analyses_post: {
+            /**
+             * Files
+             * @description Supported deployment artifacts to analyze.
+             */
+            files?: string[] | null;
+            /** Project Id */
+            project_id?: number | null;
+            /** Project Key */
+            project_key?: string | null;
+            /** Workspace Id */
+            workspace_id?: number | null;
+            /** Workspace Key */
+            workspace_key?: string | null;
+            /** Artifact Paths */
+            artifact_paths?: string[] | null;
         };
         /** Body_create_analysis_api_v1_analyses_post */
         Body_create_analysis_api_v1_analyses_post: {
@@ -2816,6 +3226,64 @@ export interface components {
              * @description Pull-request reference when the trigger metadata identifies one.
              */
             readonly pr_ref: string | null;
+        };
+        /** PolicyAdapterSettingsData */
+        PolicyAdapterSettingsData: {
+            /** Project Key */
+            project_key: string;
+            /** Integration */
+            integration?: string | null;
+            /**
+             * Source
+             * @enum {string}
+             */
+            source: "built-in" | "project" | "integration";
+            /** Warn At */
+            warn_at?: ("low" | "medium" | "high" | "critical") | null;
+            /** Soft Block At */
+            soft_block_at?: ("low" | "medium" | "high" | "critical") | null;
+            /** Hard Block At */
+            hard_block_at?: ("low" | "medium" | "high" | "critical") | null;
+            /**
+             * Reporting Default
+             * @enum {string}
+             */
+            reporting_default: "advisory" | "warn";
+        };
+        /** PolicyAdapterSettingsRequest */
+        PolicyAdapterSettingsRequest: {
+            /** Project Id */
+            project_id?: number | null;
+            /** Project Key */
+            project_key?: string | null;
+            /** Integration */
+            integration?: string | null;
+            /**
+             * Warn At
+             * @default medium
+             */
+            warn_at: ("low" | "medium" | "high" | "critical") | null;
+            /**
+             * Soft Block At
+             * @default high
+             */
+            soft_block_at: ("low" | "medium" | "high" | "critical") | null;
+            /**
+             * Hard Block At
+             * @default critical
+             */
+            hard_block_at: ("low" | "medium" | "high" | "critical") | null;
+            /**
+             * Reporting Default
+             * @default advisory
+             * @enum {string}
+             */
+            reporting_default: "advisory" | "warn";
+        };
+        /** PolicyAdapterSettingsResponse */
+        PolicyAdapterSettingsResponse: {
+            data: components["schemas"]["PolicyAdapterSettingsData"];
+            meta: components["schemas"]["MetaPayload"];
         };
         /** PreviousScanDiffData */
         PreviousScanDiffData: {
@@ -4880,6 +5348,151 @@ export interface operations {
             };
         };
     };
+    create_agent_analysis_api_v1_agent_analyses_post: {
+        parameters: {
+            query?: never;
+            header?: {
+                "X-DeployWhisper-Trigger-Type"?: string | null;
+                "X-DeployWhisper-Trigger-Id"?: string | null;
+                "X-DeployWhisper-Actor"?: string | null;
+                "X-DeployWhisper-Project-Role"?: string | null;
+                "X-DeployWhisper-Project-Keys"?: string | null;
+            };
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: {
+            content: {
+                "multipart/form-data": components["schemas"]["Body_create_agent_analysis_api_v1_agent_analyses_post"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AgentInterfaceResponse"];
+                };
+            };
+            /** @description Bad Request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Not Found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Content Too Large */
+            413: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Unprocessable Content */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Internal Server Error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
+    get_agent_report_api_v1_agent_reports__report_id__get: {
+        parameters: {
+            query?: never;
+            header?: {
+                "X-DeployWhisper-Project-Role"?: string | null;
+                "X-DeployWhisper-Project-Keys"?: string | null;
+            };
+            path: {
+                report_id: number;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AgentInterfaceResponse"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Not Found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Unprocessable Content */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Internal Server Error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
     list_analyses_api_v1_analyses_get: {
         parameters: {
             query?: {
@@ -4946,7 +5559,7 @@ export interface operations {
                     "application/json": components["schemas"]["ErrorResponse"];
                 };
             };
-            /** @description Unprocessable Entity */
+            /** @description Unprocessable Content */
             422: {
                 headers: {
                     [name: string]: unknown;
@@ -5030,7 +5643,7 @@ export interface operations {
                     "application/json": components["schemas"]["ErrorResponse"];
                 };
             };
-            /** @description Request Entity Too Large */
+            /** @description Content Too Large */
             413: {
                 headers: {
                     [name: string]: unknown;
@@ -5039,7 +5652,7 @@ export interface operations {
                     "application/json": components["schemas"]["ErrorResponse"];
                 };
             };
-            /** @description Unprocessable Entity */
+            /** @description Unprocessable Content */
             422: {
                 headers: {
                     [name: string]: unknown;
@@ -5111,7 +5724,7 @@ export interface operations {
                     "application/json": components["schemas"]["ErrorResponse"];
                 };
             };
-            /** @description Unprocessable Entity */
+            /** @description Unprocessable Content */
             422: {
                 headers: {
                     [name: string]: unknown;
@@ -5195,7 +5808,7 @@ export interface operations {
                     "application/json": components["schemas"]["ErrorResponse"];
                 };
             };
-            /** @description Unprocessable Entity */
+            /** @description Unprocessable Content */
             422: {
                 headers: {
                     [name: string]: unknown;
@@ -5255,7 +5868,7 @@ export interface operations {
                     "application/json": components["schemas"]["ErrorResponse"];
                 };
             };
-            /** @description Unprocessable Entity */
+            /** @description Unprocessable Content */
             422: {
                 headers: {
                     [name: string]: unknown;
@@ -5319,7 +5932,7 @@ export interface operations {
                     "application/json": components["schemas"]["ErrorResponse"];
                 };
             };
-            /** @description Unprocessable Entity */
+            /** @description Unprocessable Content */
             422: {
                 headers: {
                     [name: string]: unknown;
@@ -5394,7 +6007,7 @@ export interface operations {
                     "application/json": components["schemas"]["ErrorResponse"];
                 };
             };
-            /** @description Unprocessable Entity */
+            /** @description Unprocessable Content */
             422: {
                 headers: {
                     [name: string]: unknown;
@@ -5469,7 +6082,7 @@ export interface operations {
                     "application/json": components["schemas"]["ErrorResponse"];
                 };
             };
-            /** @description Unprocessable Entity */
+            /** @description Unprocessable Content */
             422: {
                 headers: {
                     [name: string]: unknown;
@@ -5536,7 +6149,7 @@ export interface operations {
                     "application/json": components["schemas"]["ErrorResponse"];
                 };
             };
-            /** @description Unprocessable Entity */
+            /** @description Unprocessable Content */
             422: {
                 headers: {
                     [name: string]: unknown;
@@ -5600,7 +6213,7 @@ export interface operations {
                     "application/json": components["schemas"]["ErrorResponse"];
                 };
             };
-            /** @description Unprocessable Entity */
+            /** @description Unprocessable Content */
             422: {
                 headers: {
                     [name: string]: unknown;
@@ -5945,6 +6558,114 @@ export interface operations {
             };
         };
     };
+    get_policy_adapter_defaults_api_v1_settings_policy_adapter_get: {
+        parameters: {
+            query?: {
+                project_id?: number | null;
+                project_key?: string | null;
+                integration?: string | null;
+            };
+            header?: {
+                "X-DeployWhisper-Project-Role"?: string | null;
+                "X-DeployWhisper-Project-Keys"?: string | null;
+            };
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["PolicyAdapterSettingsResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    update_policy_adapter_defaults_api_v1_settings_policy_adapter_put: {
+        parameters: {
+            query?: never;
+            header?: {
+                "X-DeployWhisper-Project-Role"?: string | null;
+                "X-DeployWhisper-Project-Keys"?: string | null;
+            };
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["PolicyAdapterSettingsRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["PolicyAdapterSettingsResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    reset_policy_adapter_defaults_api_v1_settings_policy_adapter_delete: {
+        parameters: {
+            query?: {
+                project_id?: number | null;
+                project_key?: string | null;
+                integration?: string | null;
+            };
+            header?: {
+                "X-DeployWhisper-Project-Role"?: string | null;
+                "X-DeployWhisper-Project-Keys"?: string | null;
+            };
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["PolicyAdapterSettingsResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
     preview_settings_topology_api_v1_settings_topology_preview_post: {
         parameters: {
             query?: never;
@@ -6136,7 +6857,7 @@ export interface operations {
                     "application/json": components["schemas"]["SkillRegistryListResponse"];
                 };
             };
-            /** @description Unprocessable Entity */
+            /** @description Unprocessable Content */
             422: {
                 headers: {
                     [name: string]: unknown;
@@ -6185,7 +6906,7 @@ export interface operations {
                     "application/json": components["schemas"]["ErrorResponse"];
                 };
             };
-            /** @description Unprocessable Entity */
+            /** @description Unprocessable Content */
             422: {
                 headers: {
                     [name: string]: unknown;
@@ -6234,7 +6955,7 @@ export interface operations {
                     "application/json": components["schemas"]["ErrorResponse"];
                 };
             };
-            /** @description Unprocessable Entity */
+            /** @description Unprocessable Content */
             422: {
                 headers: {
                     [name: string]: unknown;
@@ -6286,7 +7007,7 @@ export interface operations {
                     "application/json": components["schemas"]["ErrorResponse"];
                 };
             };
-            /** @description Unprocessable Entity */
+            /** @description Unprocessable Content */
             422: {
                 headers: {
                     [name: string]: unknown;
@@ -6335,7 +7056,7 @@ export interface operations {
                     "application/json": components["schemas"]["ErrorResponse"];
                 };
             };
-            /** @description Unprocessable Entity */
+            /** @description Unprocessable Content */
             422: {
                 headers: {
                     [name: string]: unknown;

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -80,6 +80,26 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/analyses/{report_id}/policy-adapter": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Policy Adapter Output
+         * @description Generate a configured policy interpretation for one persisted report.
+         */
+        get: operations["get_policy_adapter_output_api_v1_analyses__report_id__policy_adapter_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/analyses/{report_id}": {
         parameters: {
             query?: never;
@@ -626,6 +646,145 @@ export interface paths {
 export type webhooks = Record<string, never>;
 export interface components {
     schemas: {
+        /**
+         * AdapterCanonicalSummary
+         * @description Immutable canonical report summary consumed by all workflow adapters.
+         */
+        AdapterCanonicalSummary: {
+            /**
+             * Advisory Only
+             * @description Whether the shared summary is advisory rather than blocking
+             */
+            advisory_only: boolean;
+            /**
+             * Should Block
+             * @description Whether DeployWhisper itself should block deployment
+             */
+            should_block: boolean;
+            /**
+             * Severity
+             * @description Risk severity for the shared summary
+             */
+            severity: string;
+            /**
+             * Recommendation
+             * @description Deploy recommendation for the shared summary
+             */
+            recommendation: string;
+            /**
+             * Headline
+             * @description Top narrative line for PR or approval-thread use
+             */
+            headline: string;
+            /**
+             * Blast Radius Summary
+             * @description Concise blast-radius summary
+             */
+            blast_radius_summary: string;
+            /**
+             * Rollback Summary
+             * @description Concise rollback summary
+             */
+            rollback_summary: string;
+            /**
+             * Uncertainty Summary
+             * @description Concise uncertainty and review note
+             */
+            uncertainty_summary: string;
+            /**
+             * Markdown
+             * @description Markdown-ready advisory summary
+             */
+            markdown: string;
+            /**
+             * Plain Text
+             * @description Plain-text advisory summary
+             */
+            plain_text: string;
+            /** @description Machine-friendly share-summary payload */
+            json_payload: components["schemas"]["FrozenShareSummaryJsonPayload"];
+        };
+        /**
+         * AdapterMetadata
+         * @description Workflow adapter identity and delivery context.
+         */
+        AdapterMetadata: {
+            /**
+             * Adapter
+             * @description Adapter family, such as gitlab or jenkins
+             */
+            adapter: string;
+            /**
+             * Format
+             * @description Adapter output format or destination type
+             */
+            format: string;
+            /**
+             * Version
+             * @description Adapter contract version
+             */
+            version?: string | null;
+            /**
+             * Project Key
+             * @description Project key in scope
+             */
+            project_key?: string | null;
+            /**
+             * Project Id
+             * @description Project ID in scope
+             */
+            project_id?: number | null;
+            /**
+             * Workspace Key
+             * @description Workspace key in scope
+             */
+            workspace_key?: string | null;
+            /**
+             * Workspace Id
+             * @description Workspace ID in scope
+             */
+            workspace_id?: number | null;
+            /**
+             * Invocation Id
+             * @description Adapter invocation or workflow run identifier
+             */
+            invocation_id?: string | null;
+            /**
+             * Delivery Target
+             * @description Adapter-specific delivery target
+             */
+            delivery_target?: string | null;
+            /**
+             * Extra
+             * @description Adapter-specific metadata that does not shadow canonical fields
+             */
+            extra?: {
+                [key: string]: string | number | boolean | null;
+            };
+        };
+        /**
+         * AdapterOutputContract
+         * @description One report-output envelope for future delivery adapters.
+         */
+        AdapterOutputContract: {
+            /**
+             * Contract Version
+             * @description Adapter contract version
+             * @default v1
+             */
+            contract_version: string;
+            /** @description Adapter metadata */
+            adapter_metadata: components["schemas"]["AdapterMetadata"];
+            /** @description Immutable canonical summary */
+            canonical_summary: components["schemas"]["AdapterCanonicalSummary"];
+            /**
+             * Adapter Payload
+             * @description Adapter-specific formatting and delivery fields
+             */
+            adapter_payload?: {
+                [key: string]: unknown;
+            };
+        };
         /** AdvisorySummaryData */
         AdvisorySummaryData: {
             /**
@@ -2601,6 +2760,206 @@ export interface components {
             data: components["schemas"]["FeedbackEventData"];
             meta: components["schemas"]["ResourceMetaPayload"];
         };
+        /**
+         * FrozenShareSummaryContext
+         * @description Immutable context summary for adapter contracts.
+         */
+        FrozenShareSummaryContext: {
+            /**
+             * Score
+             * @description Context completeness score
+             */
+            score: number;
+            /**
+             * Label
+             * @description Context completeness badge label
+             */
+            label: string;
+            /**
+             * Summary
+             * @description Short context completeness summary
+             */
+            summary: string;
+        };
+        /**
+         * FrozenShareSummaryFinding
+         * @description Immutable share-summary finding for adapter contracts.
+         */
+        FrozenShareSummaryFinding: {
+            /**
+             * Title
+             * @description Short finding title for sharing
+             */
+            title: string;
+            /**
+             * Severity
+             * @description Finding severity
+             */
+            severity: string;
+            /**
+             * Evidence Count
+             * @description Evidence items linked to the finding
+             */
+            evidence_count: number;
+            /**
+             * Confidence
+             * @description Finding confidence score
+             */
+            confidence: number;
+            /**
+             * Evidence Label
+             * @description Reviewer-facing label for external or non-DeployWhisper evidence
+             */
+            evidence_label?: string | null;
+        };
+        /**
+         * FrozenShareSummaryJsonPayload
+         * @description Immutable machine-friendly share-summary payload for adapter contracts.
+         */
+        FrozenShareSummaryJsonPayload: {
+            /**
+             * Version
+             * @description Share-summary payload version
+             * @default v1
+             */
+            version: string;
+            /**
+             * Report Schema Version
+             * @description Report schema version used by the source persisted report
+             * @default v2
+             */
+            report_schema_version: string;
+            /**
+             * Report Id
+             * @description Persisted report ID
+             */
+            report_id?: number | null;
+            /**
+             * Report Link
+             * @description Deep link to the report
+             */
+            report_link?: string | null;
+            /**
+             * Rollback Link
+             * @description Deep link to the report rollback view
+             */
+            rollback_link?: string | null;
+            /**
+             * Verdict Banner
+             * @description Verdict banner for PR comments
+             */
+            verdict_banner: string;
+            /**
+             * Evidence Law Status
+             * @description Evidence Law verification status for severe claims
+             * @enum {string}
+             */
+            evidence_law_status: "Satisfied" | "Needs review" | "Reconciled" | "Detail omitted";
+            /**
+             * Evidence Law Detail
+             * @description Human-readable Evidence Law verification detail
+             */
+            evidence_law_detail: string;
+            /**
+             * Headline
+             * @description Top summary line
+             */
+            headline: string;
+            /**
+             * Top Findings
+             * @description Top findings to surface
+             */
+            top_findings?: components["schemas"]["FrozenShareSummaryFinding"][];
+            /**
+             * Evidence Count
+             * @description Total evidence-item count
+             */
+            evidence_count: number;
+            /**
+             * External Evidence Count
+             * @description External scanner evidence items included as review context
+             * @default 0
+             */
+            external_evidence_count: number;
+            /**
+             * External Evidence Summary
+             * @description How external scanner context should be interpreted
+             */
+            external_evidence_summary?: string | null;
+            /**
+             * Scanner Conflicts
+             * @description Scanner-vs-deterministic/context conflicts requiring review
+             */
+            scanner_conflicts?: components["schemas"]["FrozenShareSummaryScannerConflict"][];
+            /**
+             * Blast Radius Summary
+             * @description Concise blast-radius summary
+             */
+            blast_radius_summary: string;
+            /**
+             * Rollback Summary
+             * @description Concise rollback summary
+             */
+            rollback_summary: string;
+            /** @description Context completeness summary */
+            context_completeness: components["schemas"]["FrozenShareSummaryContext"];
+            /**
+             * Advisory Summary
+             * @description Advisory-only review summary
+             */
+            advisory_summary: string;
+        };
+        /**
+         * FrozenShareSummaryScannerConflict
+         * @description Immutable scanner-conflict summary for adapter contracts.
+         */
+        FrozenShareSummaryScannerConflict: {
+            /**
+             * Finding Id
+             * @description Finding with conflicting scanner context
+             */
+            finding_id: string;
+            /**
+             * Finding Title
+             * @description Reviewer-facing finding title
+             */
+            finding_title: string;
+            /**
+             * Scanner Source
+             * @description Scanner evidence source reference
+             */
+            scanner_source: string;
+            /**
+             * Scanner Freshness
+             * @description Scanner source freshness status
+             */
+            scanner_freshness: string;
+            /**
+             * Deterministic Source
+             * @description DeployWhisper deterministic evidence source
+             */
+            deterministic_source: string;
+            /**
+             * Deterministic Freshness
+             * @description DeployWhisper deterministic source freshness status
+             */
+            deterministic_freshness: string;
+            /**
+             * Conflict Summary
+             * @description Short conflict explanation
+             */
+            conflict_summary: string;
+            /**
+             * Confidence Impact
+             * @description How the conflict affects confidence interpretation
+             */
+            confidence_impact: string;
+            /**
+             * Recommended Verification
+             * @description Reviewer action for resolving the conflict
+             */
+            recommended_verification: string;
+        };
         /** HTTPValidationError */
         HTTPValidationError: {
             /** Detail */
@@ -3227,6 +3586,102 @@ export interface components {
              */
             readonly pr_ref: string | null;
         };
+        /**
+         * PolicyAdapterOutputContract
+         * @description Versioned policy interpretation that leaves canonical output advisory.
+         */
+        PolicyAdapterOutputContract: {
+            /**
+             * Contract Version
+             * @description Policy adapter contract version
+             * @default v1
+             */
+            contract_version: string;
+            /** @description Local workflow decision */
+            status: components["schemas"]["PolicyAdapterStatus"];
+            /**
+             * Reasons
+             * @description Reasons for the policy status
+             */
+            reasons: components["schemas"]["PolicyAdapterReason"][];
+            /**
+             * Canonical Report Advisory
+             * @description Confirms policy status does not alter canonical report semantics
+             * @default true
+             * @constant
+             */
+            canonical_report_advisory: true;
+            /** @description Immutable canonical summary and adapter metadata */
+            adapter_output: components["schemas"]["AdapterOutputContract"];
+            /** @description Resolved threshold and reporting defaults used for interpretation */
+            applied_settings?: components["schemas"]["PolicyAdapterSettings"] | null;
+        };
+        /**
+         * PolicyAdapterOutputResponse
+         * @description API envelope for configured policy interpretation of one report.
+         */
+        PolicyAdapterOutputResponse: {
+            data: components["schemas"]["PolicyAdapterOutputContract"];
+            meta: components["schemas"]["ResourceMetaPayload"];
+        };
+        /**
+         * PolicyAdapterReason
+         * @description Structured explanation for a downstream policy interpretation.
+         */
+        PolicyAdapterReason: {
+            /**
+             * Code
+             * @description Stable adapter-owned reason code
+             */
+            code: string;
+            /**
+             * Message
+             * @description Human-readable policy explanation
+             */
+            message: string;
+        };
+        /**
+         * PolicyAdapterSettings
+         * @description Resolved project or integration defaults for policy interpretation.
+         */
+        PolicyAdapterSettings: {
+            /**
+             * Project Key
+             * @description Project owning these defaults
+             */
+            project_key: string;
+            /**
+             * Integration
+             * @description Optional integration identifier for an overriding default
+             */
+            integration?: string | null;
+            /**
+             * Source
+             * @description Scope from which the effective defaults were resolved
+             * @enum {string}
+             */
+            source: "built-in" | "project" | "integration";
+            /**
+             * @description Minimum canonical severity interpreted as warn
+             * @default medium
+             */
+            warn_at: components["schemas"]["PolicySeverity"] | null;
+            /**
+             * @description Minimum canonical severity interpreted as soft-block
+             * @default high
+             */
+            soft_block_at: components["schemas"]["PolicySeverity"] | null;
+            /**
+             * @description Minimum canonical severity interpreted as hard-block
+             * @default critical
+             */
+            hard_block_at: components["schemas"]["PolicySeverity"] | null;
+            /**
+             * @description Adapter status reported when no severity threshold is met
+             * @default advisory
+             */
+            reporting_default: components["schemas"]["PolicyAdapterStatus"];
+        };
         /** PolicyAdapterSettingsData */
         PolicyAdapterSettingsData: {
             /** Project Key */
@@ -3285,6 +3740,18 @@ export interface components {
             data: components["schemas"]["PolicyAdapterSettingsData"];
             meta: components["schemas"]["MetaPayload"];
         };
+        /**
+         * PolicyAdapterStatus
+         * @description Supported downstream policy interpretations.
+         * @enum {string}
+         */
+        PolicyAdapterStatus: "advisory" | "warn" | "soft-block" | "hard-block";
+        /**
+         * PolicySeverity
+         * @description Canonical severities policy thresholds may interpret.
+         * @enum {string}
+         */
+        PolicySeverity: "low" | "medium" | "high" | "critical";
         /** PreviousScanDiffData */
         PreviousScanDiffData: {
             /**
@@ -5695,6 +6162,78 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["AnalysisBulkDeleteResponse"];
+                };
+            };
+            /** @description Bad Request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Not Found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Unprocessable Content */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Internal Server Error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
+    get_policy_adapter_output_api_v1_analyses__report_id__policy_adapter_get: {
+        parameters: {
+            query: {
+                integration: string;
+            };
+            header?: {
+                "X-DeployWhisper-Project-Role"?: string | null;
+                "X-DeployWhisper-Project-Keys"?: string | null;
+            };
+            path: {
+                report_id: number;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["PolicyAdapterOutputResponse"];
                 };
             };
             /** @description Bad Request */

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -7122,13 +7122,49 @@ export interface operations {
                     "application/json": components["schemas"]["PolicyAdapterSettingsResponse"];
                 };
             };
-            /** @description Validation Error */
+            /** @description Bad Request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Not Found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Unprocessable Content */
             422: {
                 headers: {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Internal Server Error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
                 };
             };
         };
@@ -7158,13 +7194,49 @@ export interface operations {
                     "application/json": components["schemas"]["PolicyAdapterSettingsResponse"];
                 };
             };
-            /** @description Validation Error */
+            /** @description Bad Request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Not Found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Unprocessable Content */
             422: {
                 headers: {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Internal Server Error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
                 };
             };
         };
@@ -7194,13 +7266,49 @@ export interface operations {
                     "application/json": components["schemas"]["PolicyAdapterSettingsResponse"];
                 };
             };
-            /** @description Validation Error */
+            /** @description Bad Request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Not Found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Unprocessable Content */
             422: {
                 headers: {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Internal Server Error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
                 };
             };
         };

--- a/services/policy_adapter_output_contract.py
+++ b/services/policy_adapter_output_contract.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from enum import Enum
 from typing import Any, Literal
 
 from pydantic import (
@@ -15,15 +14,13 @@ from pydantic import (
 )
 
 from services.adapter_output_contract import AdapterOutputContract
-
-
-class PolicyAdapterStatus(str, Enum):
-    """Supported downstream policy interpretations."""
-
-    ADVISORY = "advisory"
-    WARN = "warn"
-    SOFT_BLOCK = "soft-block"
-    HARD_BLOCK = "hard-block"
+from services.policy_adapter_settings import (
+    SEVERITY_RANK,
+    PolicyAdapterSettings,
+    PolicyAdapterStatus,
+    PolicySeverity,
+)
+from services.project_service import normalize_project_key
 
 
 class PolicyAdapterReason(BaseModel):
@@ -72,6 +69,10 @@ class PolicyAdapterOutputContract(BaseModel):
     adapter_output: AdapterOutputContract = Field(
         ..., description="Immutable canonical summary and adapter metadata"
     )
+    applied_settings: PolicyAdapterSettings | None = Field(
+        default=None,
+        description="Resolved threshold and reporting defaults used for interpretation",
+    )
 
     @field_validator("status", mode="before")
     @classmethod
@@ -116,10 +117,98 @@ def build_policy_adapter_output_contract(
     *,
     status: PolicyAdapterStatus | str,
     reasons: tuple[PolicyAdapterReason | dict[str, str], ...],
+    applied_settings: PolicyAdapterSettings | None = None,
 ) -> PolicyAdapterOutputContract:
     """Wrap canonical adapter output with a separate local policy interpretation."""
     return PolicyAdapterOutputContract(
         status=status,
         reasons=reasons,
         adapter_output=adapter_output,
+        applied_settings=applied_settings,
+    )
+
+
+def build_policy_adapter_output_from_settings(
+    adapter_output: AdapterOutputContract,
+    settings: PolicyAdapterSettings,
+    *,
+    resolved_project_key: str | None = None,
+) -> PolicyAdapterOutputContract:
+    """Interpret canonical severity with resolved defaults without mutating it."""
+    metadata = adapter_output.adapter_metadata
+    metadata_project_key = (
+        normalize_project_key(metadata.project_key)
+        if metadata.project_key is not None
+        else None
+    )
+    normalized_resolved_key = (
+        normalize_project_key(resolved_project_key)
+        if resolved_project_key is not None
+        else None
+    )
+    if (
+        metadata_project_key is not None
+        and normalized_resolved_key is not None
+        and metadata_project_key != normalized_resolved_key
+    ):
+        raise ValueError("Resolved project does not match adapter metadata.")
+    effective_project_key = metadata_project_key or normalized_resolved_key
+    if effective_project_key is None:
+        raise ValueError("Project ID adapter metadata requires a resolved project key.")
+    if effective_project_key != normalize_project_key(settings.project_key):
+        raise ValueError("Policy adapter settings do not match the adapter project.")
+    if (
+        settings.integration is not None
+        and metadata.adapter.lower() != settings.integration
+    ):
+        raise ValueError(
+            "Policy adapter settings do not match the adapter integration."
+        )
+
+    canonical_severity = str(adapter_output.canonical_summary.severity).strip().lower()
+    try:
+        severity = PolicySeverity(canonical_severity)
+    except ValueError:
+        severity = None
+
+    matched_status: PolicyAdapterStatus | None = None
+    matched_threshold: PolicySeverity | None = None
+    for status, threshold in (
+        (PolicyAdapterStatus.HARD_BLOCK, settings.hard_block_at),
+        (PolicyAdapterStatus.SOFT_BLOCK, settings.soft_block_at),
+        (PolicyAdapterStatus.WARN, settings.warn_at),
+    ):
+        if (
+            severity is not None
+            and threshold is not None
+            and SEVERITY_RANK[severity] >= SEVERITY_RANK[threshold]
+        ):
+            matched_status = status
+            matched_threshold = threshold
+            break
+
+    if matched_status is None:
+        status = settings.reporting_default
+        reason = PolicyAdapterReason(
+            code="reporting_default_applied",
+            message=(
+                f"Canonical severity {canonical_severity or 'unknown'} did not meet a "
+                f"configured threshold; reporting default {status.value} applied."
+            ),
+        )
+    else:
+        status = matched_status
+        reason = PolicyAdapterReason(
+            code="severity_threshold_matched",
+            message=(
+                f"Canonical severity {canonical_severity} met configured "
+                f"{status.value} threshold {matched_threshold.value}."
+            ),
+        )
+
+    return build_policy_adapter_output_contract(
+        adapter_output,
+        status=status,
+        reasons=(reason,),
+        applied_settings=settings,
     )

--- a/services/policy_adapter_output_contract.py
+++ b/services/policy_adapter_output_contract.py
@@ -168,8 +168,10 @@ def build_policy_adapter_output_from_settings(
     canonical_severity = str(adapter_output.canonical_summary.severity).strip().lower()
     try:
         severity = PolicySeverity(canonical_severity)
-    except ValueError:
-        severity = None
+    except ValueError as exc:
+        raise ValueError(
+            f"Unsupported canonical severity: {canonical_severity or 'blank'}."
+        ) from exc
 
     matched_status: PolicyAdapterStatus | None = None
     matched_threshold: PolicySeverity | None = None
@@ -179,8 +181,7 @@ def build_policy_adapter_output_from_settings(
         (PolicyAdapterStatus.WARN, settings.warn_at),
     ):
         if (
-            severity is not None
-            and threshold is not None
+            threshold is not None
             and SEVERITY_RANK[severity] >= SEVERITY_RANK[threshold]
         ):
             matched_status = status

--- a/services/policy_adapter_service.py
+++ b/services/policy_adapter_service.py
@@ -1,0 +1,31 @@
+"""Configured policy-adapter output generation."""
+
+from __future__ import annotations
+
+from services.adapter_output_contract import AdapterOutputContract
+from services.policy_adapter_output_contract import (
+    PolicyAdapterOutputContract,
+    build_policy_adapter_output_from_settings,
+)
+from services.project_service import resolve_project_reference
+from services.settings_service import get_policy_adapter_settings
+
+
+def build_configured_policy_adapter_output(
+    adapter_output: AdapterOutputContract,
+) -> PolicyAdapterOutputContract:
+    """Resolve scoped defaults and apply them to adapter interpretation only."""
+    metadata = adapter_output.adapter_metadata
+    project = resolve_project_reference(
+        project_id=metadata.project_id,
+        project_key=metadata.project_key,
+    )
+    settings = get_policy_adapter_settings(
+        project_key=project.project_key,
+        integration=metadata.adapter,
+    )
+    return build_policy_adapter_output_from_settings(
+        adapter_output,
+        settings,
+        resolved_project_key=project.project_key,
+    )

--- a/services/policy_adapter_settings.py
+++ b/services/policy_adapter_settings.py
@@ -101,6 +101,16 @@ class PolicyAdapterSettings(BaseModel):
             raise ValueError(
                 "Project settings cannot include an integration identifier."
             )
+        if self.source == "built-in" and (
+            self.integration is not None
+            or self.warn_at != PolicySeverity.MEDIUM
+            or self.soft_block_at != PolicySeverity.HIGH
+            or self.hard_block_at != PolicySeverity.CRITICAL
+            or self.reporting_default != PolicyAdapterStatus.ADVISORY
+        ):
+            raise ValueError(
+                "Built-in settings must use the fixed advisory-first defaults."
+            )
 
         configured = [
             threshold

--- a/services/policy_adapter_settings.py
+++ b/services/policy_adapter_settings.py
@@ -41,6 +41,10 @@ SEVERITY_RANK = {
 }
 
 
+class PolicyAdapterSettingsIntegrityError(RuntimeError):
+    """Raised when persisted policy settings fail their storage contract."""
+
+
 class PolicyAdapterSettings(BaseModel):
     """Resolved project or integration defaults for policy interpretation."""
 

--- a/services/policy_adapter_settings.py
+++ b/services/policy_adapter_settings.py
@@ -1,0 +1,117 @@
+"""Pure settings contracts for optional policy-adapter interpretation."""
+
+from __future__ import annotations
+
+from enum import Enum
+from typing import Literal
+
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    StrictStr,
+    field_validator,
+    model_validator,
+)
+
+
+class PolicyAdapterStatus(str, Enum):
+    """Supported downstream policy interpretations."""
+
+    ADVISORY = "advisory"
+    WARN = "warn"
+    SOFT_BLOCK = "soft-block"
+    HARD_BLOCK = "hard-block"
+
+
+class PolicySeverity(str, Enum):
+    """Canonical severities policy thresholds may interpret."""
+
+    LOW = "low"
+    MEDIUM = "medium"
+    HIGH = "high"
+    CRITICAL = "critical"
+
+
+SEVERITY_RANK = {
+    PolicySeverity.LOW: 1,
+    PolicySeverity.MEDIUM: 2,
+    PolicySeverity.HIGH: 3,
+    PolicySeverity.CRITICAL: 4,
+}
+
+
+class PolicyAdapterSettings(BaseModel):
+    """Resolved project or integration defaults for policy interpretation."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    project_key: StrictStr = Field(..., description="Project owning these defaults")
+    integration: StrictStr | None = Field(
+        default=None,
+        description="Optional integration identifier for an overriding default",
+    )
+    source: Literal["built-in", "project", "integration"] = Field(
+        ..., description="Scope from which the effective defaults were resolved"
+    )
+    warn_at: PolicySeverity | None = Field(
+        default=PolicySeverity.MEDIUM,
+        description="Minimum canonical severity interpreted as warn",
+    )
+    soft_block_at: PolicySeverity | None = Field(
+        default=PolicySeverity.HIGH,
+        description="Minimum canonical severity interpreted as soft-block",
+    )
+    hard_block_at: PolicySeverity | None = Field(
+        default=PolicySeverity.CRITICAL,
+        description="Minimum canonical severity interpreted as hard-block",
+    )
+    reporting_default: PolicyAdapterStatus = Field(
+        default=PolicyAdapterStatus.ADVISORY,
+        description="Adapter status reported when no severity threshold is met",
+    )
+
+    @field_validator("project_key", "integration")
+    @classmethod
+    def _normalize_scope_label(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
+        normalized = value.strip().lower()
+        if not normalized:
+            raise ValueError("Policy adapter scope labels must not be blank.")
+        if not all(
+            character.isalnum() or character in {"-", "_", "."}
+            for character in normalized
+        ):
+            raise ValueError(
+                "Policy adapter scope labels may contain letters, numbers, '.', '_', and '-'."
+            )
+        return normalized
+
+    @model_validator(mode="after")
+    def _validate_defaults(self) -> PolicyAdapterSettings:
+        if self.reporting_default not in {
+            PolicyAdapterStatus.ADVISORY,
+            PolicyAdapterStatus.WARN,
+        }:
+            raise ValueError("reporting_default must be advisory or warn.")
+        if self.source == "integration" and self.integration is None:
+            raise ValueError("Integration settings require an integration identifier.")
+        if self.source == "project" and self.integration is not None:
+            raise ValueError(
+                "Project settings cannot include an integration identifier."
+            )
+
+        configured = [
+            threshold
+            for threshold in (self.warn_at, self.soft_block_at, self.hard_block_at)
+            if threshold is not None
+        ]
+        if any(
+            SEVERITY_RANK[current] >= SEVERITY_RANK[next_threshold]
+            for current, next_threshold in zip(configured, configured[1:])
+        ):
+            raise ValueError(
+                "Configured warn, soft-block, and hard-block thresholds must increase in severity."
+            )
+        return self

--- a/services/settings_service.py
+++ b/services/settings_service.py
@@ -21,6 +21,7 @@ from services.policy_adapter_settings import (
     PolicyAdapterStatus,
     PolicySeverity,
 )
+from services.project_service import normalize_project_key
 
 
 class ProviderCapabilitySummary(BaseModel):
@@ -171,14 +172,14 @@ def _policy_adapter_settings_key(
     return f"{POLICY_ADAPTER_SETTINGS_PREFIX}::{project_key}::{scope}"
 
 
-def _policy_scope_label(value: str, *, field: str) -> str:
+def _policy_integration_label(value: str) -> str:
     normalized = value.strip().lower()
     if not normalized:
-        raise ValueError(f"{field} must not be blank.")
+        raise ValueError("integration must not be blank.")
     if not all(
         character.isalnum() or character in {"-", "_", "."} for character in normalized
     ):
-        raise ValueError(f"{field} may contain letters, numbers, '.', '_', and '-'.")
+        raise ValueError("integration may contain letters, numbers, '.', '_', and '-'.")
     return normalized
 
 
@@ -211,11 +212,9 @@ def save_policy_adapter_settings(
     reporting_default: PolicyAdapterStatus | str = PolicyAdapterStatus.ADVISORY,
 ) -> PolicyAdapterSettings:
     """Persist project defaults or an integration-specific override."""
-    normalized_project_key = _policy_scope_label(project_key, field="project_key")
+    normalized_project_key = normalize_project_key(project_key)
     normalized_integration = (
-        _policy_scope_label(integration, field="integration")
-        if integration is not None
-        else None
+        _policy_integration_label(integration) if integration is not None else None
     )
     resolved = PolicyAdapterSettings(
         project_key=normalized_project_key,
@@ -242,11 +241,9 @@ def get_policy_adapter_settings(
     *, project_key: str, integration: str | None = None
 ) -> PolicyAdapterSettings:
     """Resolve integration overrides before project and safe built-in defaults."""
-    normalized_project_key = _policy_scope_label(project_key, field="project_key")
+    normalized_project_key = normalize_project_key(project_key)
     normalized_integration = (
-        _policy_scope_label(integration, field="integration")
-        if integration is not None
-        else None
+        _policy_integration_label(integration) if integration is not None else None
     )
     with SessionLocal() as session:
         if normalized_integration is not None:
@@ -284,11 +281,9 @@ def delete_policy_adapter_settings(
     *, project_key: str, integration: str | None = None
 ) -> PolicyAdapterSettings:
     """Delete one override and return the newly inherited effective defaults."""
-    normalized_project_key = _policy_scope_label(project_key, field="project_key")
+    normalized_project_key = normalize_project_key(project_key)
     normalized_integration = (
-        _policy_scope_label(integration, field="integration")
-        if integration is not None
-        else None
+        _policy_integration_label(integration) if integration is not None else None
     )
     with SessionLocal() as session:
         delete_setting(

--- a/services/settings_service.py
+++ b/services/settings_service.py
@@ -182,6 +182,25 @@ def _policy_scope_label(value: str, *, field: str) -> str:
     return normalized
 
 
+def _load_policy_adapter_settings(
+    value: str,
+    *,
+    project_key: str,
+    integration: str | None,
+) -> PolicyAdapterSettings:
+    loaded = PolicyAdapterSettings.model_validate_json(value)
+    expected_source = "integration" if integration is not None else "project"
+    if (
+        loaded.project_key != project_key
+        or loaded.integration != integration
+        or loaded.source != expected_source
+    ):
+        raise ValueError(
+            "Stored policy adapter settings scope does not match requested scope."
+        )
+    return loaded
+
+
 def save_policy_adapter_settings(
     *,
     project_key: str,
@@ -239,15 +258,21 @@ def get_policy_adapter_settings(
                 ),
             )
             if integration_record is not None:
-                return PolicyAdapterSettings.model_validate_json(
-                    integration_record.value
+                return _load_policy_adapter_settings(
+                    integration_record.value,
+                    project_key=normalized_project_key,
+                    integration=normalized_integration,
                 )
         project_record = get_setting(
             session,
             _policy_adapter_settings_key(project_key=normalized_project_key),
         )
         if project_record is not None:
-            return PolicyAdapterSettings.model_validate_json(project_record.value)
+            return _load_policy_adapter_settings(
+                project_record.value,
+                project_key=normalized_project_key,
+                integration=None,
+            )
 
     return PolicyAdapterSettings(
         project_key=normalized_project_key,

--- a/services/settings_service.py
+++ b/services/settings_service.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import hashlib
 import json
 import os
 
@@ -18,6 +19,7 @@ from models.database import SessionLocal
 from models.repositories.settings import delete_setting, get_setting, upsert_setting
 from services.policy_adapter_settings import (
     PolicyAdapterSettings,
+    PolicyAdapterSettingsIntegrityError,
     PolicyAdapterStatus,
     PolicySeverity,
 )
@@ -171,9 +173,10 @@ def _policy_adapter_settings_key(
 ) -> str:
     scope = f"integration::{integration}" if integration else "project"
     key = f"{POLICY_ADAPTER_SETTINGS_PREFIX}::{project_key}::{scope}"
-    if len(key) > POLICY_ADAPTER_SETTINGS_KEY_MAX_LENGTH:
-        raise ValueError("Policy adapter settings scope exceeds the storage key limit.")
-    return key
+    if len(key) <= POLICY_ADAPTER_SETTINGS_KEY_MAX_LENGTH:
+        return key
+    digest = hashlib.sha256(key.encode("utf-8")).hexdigest()
+    return f"{POLICY_ADAPTER_SETTINGS_PREFIX}::sha256::{digest}"
 
 
 def _policy_integration_label(value: str) -> str:
@@ -193,14 +196,19 @@ def _load_policy_adapter_settings(
     project_key: str,
     integration: str | None,
 ) -> PolicyAdapterSettings:
-    loaded = PolicyAdapterSettings.model_validate_json(value)
+    try:
+        loaded = PolicyAdapterSettings.model_validate_json(value)
+    except ValueError as exc:
+        raise PolicyAdapterSettingsIntegrityError(
+            "Stored policy adapter settings could not be validated."
+        ) from exc
     expected_source = "integration" if integration is not None else "project"
     if (
         loaded.project_key != project_key
         or loaded.integration != integration
         or loaded.source != expected_source
     ):
-        raise ValueError(
+        raise PolicyAdapterSettingsIntegrityError(
             "Stored policy adapter settings scope does not match requested scope."
         )
     return loaded

--- a/services/settings_service.py
+++ b/services/settings_service.py
@@ -163,13 +163,17 @@ PROVIDER_ENV_API_KEYS: dict[str, tuple[str, ...]] = {
 }
 
 POLICY_ADAPTER_SETTINGS_PREFIX = "policy_adapter_defaults"
+POLICY_ADAPTER_SETTINGS_KEY_MAX_LENGTH = 100
 
 
 def _policy_adapter_settings_key(
     *, project_key: str, integration: str | None = None
 ) -> str:
     scope = f"integration::{integration}" if integration else "project"
-    return f"{POLICY_ADAPTER_SETTINGS_PREFIX}::{project_key}::{scope}"
+    key = f"{POLICY_ADAPTER_SETTINGS_PREFIX}::{project_key}::{scope}"
+    if len(key) > POLICY_ADAPTER_SETTINGS_KEY_MAX_LENGTH:
+        raise ValueError("Policy adapter settings scope exceeds the storage key limit.")
+    return key
 
 
 def _policy_integration_label(value: str) -> str:

--- a/services/settings_service.py
+++ b/services/settings_service.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import os
 
 from pydantic import BaseModel, Field
@@ -15,6 +16,11 @@ from llm.providers import (
 )
 from models.database import SessionLocal
 from models.repositories.settings import delete_setting, get_setting, upsert_setting
+from services.policy_adapter_settings import (
+    PolicyAdapterSettings,
+    PolicyAdapterStatus,
+    PolicySeverity,
+)
 
 
 class ProviderCapabilitySummary(BaseModel):
@@ -154,6 +160,123 @@ PROVIDER_ENV_API_KEYS: dict[str, tuple[str, ...]] = {
     "xai": ("XAI_API_KEY",),
     "ollama": (),
 }
+
+POLICY_ADAPTER_SETTINGS_PREFIX = "policy_adapter_defaults"
+
+
+def _policy_adapter_settings_key(
+    *, project_key: str, integration: str | None = None
+) -> str:
+    scope = f"integration::{integration}" if integration else "project"
+    return f"{POLICY_ADAPTER_SETTINGS_PREFIX}::{project_key}::{scope}"
+
+
+def _policy_scope_label(value: str, *, field: str) -> str:
+    normalized = value.strip().lower()
+    if not normalized:
+        raise ValueError(f"{field} must not be blank.")
+    if not all(
+        character.isalnum() or character in {"-", "_", "."} for character in normalized
+    ):
+        raise ValueError(f"{field} may contain letters, numbers, '.', '_', and '-'.")
+    return normalized
+
+
+def save_policy_adapter_settings(
+    *,
+    project_key: str,
+    integration: str | None = None,
+    warn_at: PolicySeverity | str | None = PolicySeverity.MEDIUM,
+    soft_block_at: PolicySeverity | str | None = PolicySeverity.HIGH,
+    hard_block_at: PolicySeverity | str | None = PolicySeverity.CRITICAL,
+    reporting_default: PolicyAdapterStatus | str = PolicyAdapterStatus.ADVISORY,
+) -> PolicyAdapterSettings:
+    """Persist project defaults or an integration-specific override."""
+    normalized_project_key = _policy_scope_label(project_key, field="project_key")
+    normalized_integration = (
+        _policy_scope_label(integration, field="integration")
+        if integration is not None
+        else None
+    )
+    resolved = PolicyAdapterSettings(
+        project_key=normalized_project_key,
+        integration=normalized_integration,
+        source="integration" if normalized_integration else "project",
+        warn_at=warn_at,
+        soft_block_at=soft_block_at,
+        hard_block_at=hard_block_at,
+        reporting_default=reporting_default,
+    )
+    with SessionLocal() as session:
+        upsert_setting(
+            session,
+            key=_policy_adapter_settings_key(
+                project_key=normalized_project_key,
+                integration=normalized_integration,
+            ),
+            value=json.dumps(resolved.model_dump(mode="json"), sort_keys=True),
+        )
+    return resolved
+
+
+def get_policy_adapter_settings(
+    *, project_key: str, integration: str | None = None
+) -> PolicyAdapterSettings:
+    """Resolve integration overrides before project and safe built-in defaults."""
+    normalized_project_key = _policy_scope_label(project_key, field="project_key")
+    normalized_integration = (
+        _policy_scope_label(integration, field="integration")
+        if integration is not None
+        else None
+    )
+    with SessionLocal() as session:
+        if normalized_integration is not None:
+            integration_record = get_setting(
+                session,
+                _policy_adapter_settings_key(
+                    project_key=normalized_project_key,
+                    integration=normalized_integration,
+                ),
+            )
+            if integration_record is not None:
+                return PolicyAdapterSettings.model_validate_json(
+                    integration_record.value
+                )
+        project_record = get_setting(
+            session,
+            _policy_adapter_settings_key(project_key=normalized_project_key),
+        )
+        if project_record is not None:
+            return PolicyAdapterSettings.model_validate_json(project_record.value)
+
+    return PolicyAdapterSettings(
+        project_key=normalized_project_key,
+        source="built-in",
+    )
+
+
+def delete_policy_adapter_settings(
+    *, project_key: str, integration: str | None = None
+) -> PolicyAdapterSettings:
+    """Delete one override and return the newly inherited effective defaults."""
+    normalized_project_key = _policy_scope_label(project_key, field="project_key")
+    normalized_integration = (
+        _policy_scope_label(integration, field="integration")
+        if integration is not None
+        else None
+    )
+    with SessionLocal() as session:
+        delete_setting(
+            session,
+            _policy_adapter_settings_key(
+                project_key=normalized_project_key,
+                integration=normalized_integration,
+            ),
+        )
+    return get_policy_adapter_settings(
+        project_key=normalized_project_key,
+        integration=normalized_integration,
+    )
 
 
 def provider_select_options() -> dict[str, str]:

--- a/tests/test_api/test_analyses.py
+++ b/tests/test_api/test_analyses.py
@@ -630,17 +630,21 @@ class AnalysesApiTests(unittest.TestCase):
         self.assertEqual(payload["meta"]["report_schema_version"], "v2")
 
     def test_policy_adapter_output_enforces_report_scope_access(self) -> None:
-        response = self.client.get(
-            f"/api/v1/analyses/{self.persisted['id']}/policy-adapter",
-            params={"integration": "jenkins"},
-            headers={
-                "X-DeployWhisper-Project-Role": "read-only",
-                "X-DeployWhisper-Project-Keys": "payments",
-            },
-        )
+        for report_id in (self.persisted["id"], 999_999):
+            with self.subTest(report_id=report_id):
+                response = self.client.get(
+                    f"/api/v1/analyses/{report_id}/policy-adapter",
+                    params={"integration": "jenkins"},
+                    headers={
+                        "X-DeployWhisper-Project-Role": "read-only",
+                        "X-DeployWhisper-Project-Keys": "payments",
+                    },
+                )
 
-        self.assertEqual(response.status_code, 403)
-        self.assertEqual(response.json()["error"]["code"], "project_scope_forbidden")
+                self.assertEqual(response.status_code, 403)
+                self.assertEqual(
+                    response.json()["error"]["code"], "project_scope_forbidden"
+                )
 
     def test_blast_radius_api_schema_preserves_topology_context_fields(self) -> None:
         blast_radius = BlastRadiusData.model_validate(

--- a/tests/test_api/test_analyses.py
+++ b/tests/test_api/test_analyses.py
@@ -597,6 +597,51 @@ class AnalysesApiTests(unittest.TestCase):
         self.assertEqual(payload["data"]["audit"]["llm_provider"], "ollama")
         self.assertEqual(payload["data"]["blast_radius"]["direct_count"], 0)
 
+    def test_policy_adapter_output_applies_saved_integration_defaults(self) -> None:
+        project_key = self.persisted["project"]["project_key"]
+        saved = self.client.put(
+            "/api/v1/settings/policy-adapter",
+            json={
+                "project_key": project_key,
+                "integration": "jenkins",
+                "warn_at": "high",
+                "soft_block_at": "critical",
+                "hard_block_at": None,
+                "reporting_default": "advisory",
+            },
+        )
+
+        response = self.client.get(
+            f"/api/v1/analyses/{self.persisted['id']}/policy-adapter",
+            params={"integration": "jenkins"},
+        )
+
+        self.assertEqual(saved.status_code, 200)
+        self.assertEqual(response.status_code, 200)
+        payload = response.json()
+        self.assertEqual(payload["data"]["status"], "advisory")
+        self.assertEqual(payload["data"]["applied_settings"]["source"], "integration")
+        self.assertEqual(payload["data"]["applied_settings"]["integration"], "jenkins")
+        self.assertEqual(
+            payload["data"]["adapter_output"]["canonical_summary"]["severity"],
+            "medium",
+        )
+        self.assertTrue(payload["data"]["canonical_report_advisory"])
+        self.assertEqual(payload["meta"]["report_schema_version"], "v2")
+
+    def test_policy_adapter_output_enforces_report_scope_access(self) -> None:
+        response = self.client.get(
+            f"/api/v1/analyses/{self.persisted['id']}/policy-adapter",
+            params={"integration": "jenkins"},
+            headers={
+                "X-DeployWhisper-Project-Role": "read-only",
+                "X-DeployWhisper-Project-Keys": "payments",
+            },
+        )
+
+        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response.json()["error"]["code"], "project_scope_forbidden")
+
     def test_blast_radius_api_schema_preserves_topology_context_fields(self) -> None:
         blast_radius = BlastRadiusData.model_validate(
             BlastRadiusResult(

--- a/tests/test_api/test_analyses.py
+++ b/tests/test_api/test_analyses.py
@@ -14,6 +14,7 @@ from unittest.mock import patch
 import config as config_module
 import models.database as database_module
 import models.repositories.analysis_reports as analysis_reports_repository_module
+import models.repositories.settings as settings_repository_module
 import models.tables as tables_module
 import services.deployment_outcome_service as deployment_outcome_service_module
 import services.project_service as project_service_module
@@ -645,6 +646,28 @@ class AnalysesApiTests(unittest.TestCase):
                 self.assertEqual(
                     response.json()["error"]["code"], "project_scope_forbidden"
                 )
+
+    def test_policy_adapter_output_reports_corrupt_settings_as_server_error(
+        self,
+    ) -> None:
+        project_key = self.persisted["project"]["project_key"]
+        with database_module.SessionLocal() as session:
+            settings_repository_module.upsert_setting(
+                session,
+                key=f"policy_adapter_defaults::{project_key}::project",
+                value="not-json",
+            )
+
+        response = self.client.get(
+            f"/api/v1/analyses/{self.persisted['id']}/policy-adapter",
+            params={"integration": "jenkins"},
+        )
+
+        self.assertEqual(response.status_code, 500)
+        self.assertEqual(
+            response.json()["error"]["code"],
+            "policy_adapter_settings_integrity_error",
+        )
 
     def test_blast_radius_api_schema_preserves_topology_context_fields(self) -> None:
         blast_radius = BlastRadiusData.model_validate(

--- a/tests/test_api/test_settings.py
+++ b/tests/test_api/test_settings.py
@@ -12,6 +12,7 @@ from unittest.mock import patch
 import config as config_module
 import llm.skill_context as skill_context_module
 import models.database as database_module
+import models.repositories.settings as settings_repository_module
 import models.tables as tables_module
 import services.project_service as project_service_module
 import services.settings_service as settings_service_module
@@ -253,6 +254,27 @@ class SettingsApiTests(unittest.TestCase):
                     response.json()["error"]["code"],
                     "invalid_policy_adapter_settings",
                 )
+
+    def test_policy_adapter_defaults_report_corrupt_storage_as_server_error(
+        self,
+    ) -> None:
+        with database_module.SessionLocal() as session:
+            settings_repository_module.upsert_setting(
+                session,
+                key=(f"policy_adapter_defaults::{self.project.project_key}::project"),
+                value="not-json",
+            )
+
+        response = self.client.get(
+            "/api/v1/settings/policy-adapter",
+            params={"project_key": self.project.project_key},
+        )
+
+        self.assertEqual(response.status_code, 500)
+        self.assertEqual(
+            response.json()["error"]["code"],
+            "policy_adapter_settings_integrity_error",
+        )
 
     def test_openapi_documents_policy_adapter_settings_error_contracts(self) -> None:
         response = self.client.get("/openapi.json")

--- a/tests/test_api/test_settings.py
+++ b/tests/test_api/test_settings.py
@@ -148,6 +148,23 @@ class SettingsApiTests(unittest.TestCase):
         self.assertEqual(response.status_code, 403)
         self.assertEqual(response.json()["error"]["code"], "project_permission_denied")
 
+    def test_policy_adapter_update_preserves_project_resolution_error_contract(
+        self,
+    ) -> None:
+        response = self.client.put(
+            "/api/v1/settings/policy-adapter",
+            json={
+                "project_id": 999_999,
+                "warn_at": "medium",
+                "soft_block_at": "high",
+                "hard_block_at": "critical",
+                "reporting_default": "advisory",
+            },
+        )
+
+        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.json()["error"]["code"], "project_not_found")
+
     def test_policy_adapter_defaults_can_be_reset_to_inherited_scope(self) -> None:
         project_payload = {
             "project_key": self.project.project_key,
@@ -236,6 +253,17 @@ class SettingsApiTests(unittest.TestCase):
                     response.json()["error"]["code"],
                     "invalid_policy_adapter_settings",
                 )
+
+    def test_openapi_documents_policy_adapter_settings_error_contracts(self) -> None:
+        response = self.client.get("/openapi.json")
+
+        self.assertEqual(response.status_code, 200)
+        operations = response.json()["paths"]["/api/v1/settings/policy-adapter"]
+        for method in ("get", "put", "delete"):
+            with self.subTest(method=method):
+                responses = operations[method]["responses"]
+                for status_code in ("400", "403", "404", "422", "500"):
+                    self.assertIn("ErrorResponse", str(responses[status_code]))
 
     def test_preview_and_save_topology_return_validation_payloads(self) -> None:
         topology = {

--- a/tests/test_api/test_settings.py
+++ b/tests/test_api/test_settings.py
@@ -88,6 +88,155 @@ class SettingsApiTests(unittest.TestCase):
         self.assertEqual(payload["data"]["settings"]["request_timeout_seconds"], 120)
         self.assertIn("valid", payload["data"]["validation"])
 
+    def test_policy_adapter_defaults_can_be_managed_per_project_and_integration(
+        self,
+    ) -> None:
+        project_payload = {
+            "project_key": self.project.project_key,
+            "warn_at": "medium",
+            "soft_block_at": "high",
+            "hard_block_at": "critical",
+            "reporting_default": "advisory",
+        }
+        saved_project = self.client.put(
+            "/api/v1/settings/policy-adapter",
+            json=project_payload,
+        )
+        saved_integration = self.client.put(
+            "/api/v1/settings/policy-adapter",
+            json={
+                **project_payload,
+                "integration": "jenkins",
+                "warn_at": "high",
+                "soft_block_at": "critical",
+                "hard_block_at": None,
+                "reporting_default": "warn",
+            },
+        )
+        loaded = self.client.get(
+            "/api/v1/settings/policy-adapter",
+            params={
+                "project_key": self.project.project_key,
+                "integration": "jenkins",
+            },
+        )
+
+        self.assertEqual(saved_project.status_code, 200)
+        self.assertEqual(saved_project.json()["data"]["source"], "project")
+        self.assertEqual(saved_integration.status_code, 200)
+        self.assertEqual(loaded.status_code, 200)
+        self.assertEqual(loaded.json()["data"]["source"], "integration")
+        self.assertEqual(loaded.json()["data"]["reporting_default"], "warn")
+        self.assertIsNone(loaded.json()["data"]["hard_block_at"])
+
+    def test_policy_adapter_defaults_require_admin_settings_permission(self) -> None:
+        response = self.client.put(
+            "/api/v1/settings/policy-adapter",
+            headers={
+                "X-DeployWhisper-Project-Role": "maintainer",
+                "X-DeployWhisper-Project-Keys": self.project.project_key,
+            },
+            json={
+                "project_key": self.project.project_key,
+                "warn_at": "medium",
+                "soft_block_at": "high",
+                "hard_block_at": "critical",
+                "reporting_default": "advisory",
+            },
+        )
+
+        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response.json()["error"]["code"], "project_permission_denied")
+
+    def test_policy_adapter_defaults_can_be_reset_to_inherited_scope(self) -> None:
+        project_payload = {
+            "project_key": self.project.project_key,
+            "warn_at": "medium",
+            "soft_block_at": "high",
+            "hard_block_at": "critical",
+            "reporting_default": "advisory",
+        }
+        self.client.put("/api/v1/settings/policy-adapter", json=project_payload)
+        self.client.put(
+            "/api/v1/settings/policy-adapter",
+            json={
+                **project_payload,
+                "integration": "jenkins",
+                "warn_at": "high",
+                "soft_block_at": "critical",
+                "hard_block_at": None,
+                "reporting_default": "warn",
+            },
+        )
+
+        reset_integration = self.client.delete(
+            "/api/v1/settings/policy-adapter",
+            params={
+                "project_key": self.project.project_key,
+                "integration": "jenkins",
+            },
+        )
+        reset_project = self.client.delete(
+            "/api/v1/settings/policy-adapter",
+            params={"project_key": self.project.project_key},
+        )
+
+        self.assertEqual(reset_integration.status_code, 200)
+        self.assertEqual(reset_integration.json()["data"]["source"], "project")
+        self.assertEqual(reset_project.status_code, 200)
+        self.assertEqual(reset_project.json()["data"]["source"], "built-in")
+
+    def test_policy_adapter_defaults_require_explicit_project_scope(self) -> None:
+        requests = (
+            self.client.get("/api/v1/settings/policy-adapter"),
+            self.client.put(
+                "/api/v1/settings/policy-adapter",
+                json={
+                    "warn_at": "medium",
+                    "soft_block_at": "high",
+                    "hard_block_at": "critical",
+                    "reporting_default": "advisory",
+                },
+            ),
+            self.client.delete("/api/v1/settings/policy-adapter"),
+        )
+
+        for response in requests:
+            with self.subTest(method=response.request.method):
+                self.assertEqual(response.status_code, 400)
+                self.assertEqual(
+                    response.json()["error"]["code"],
+                    "missing_project_scope",
+                )
+
+    def test_policy_adapter_query_integration_validation_matches_write_contract(
+        self,
+    ) -> None:
+        for method in (self.client.get, self.client.delete):
+            with self.subTest(method=method.__name__, integration="empty"):
+                response = method(
+                    "/api/v1/settings/policy-adapter",
+                    params={
+                        "project_key": self.project.project_key,
+                        "integration": "",
+                    },
+                )
+                self.assertEqual(response.status_code, 422)
+
+            with self.subTest(method=method.__name__, integration="whitespace"):
+                response = method(
+                    "/api/v1/settings/policy-adapter",
+                    params={
+                        "project_key": self.project.project_key,
+                        "integration": "   ",
+                    },
+                )
+                self.assertEqual(response.status_code, 400)
+                self.assertEqual(
+                    response.json()["error"]["code"],
+                    "invalid_policy_adapter_settings",
+                )
+
     def test_preview_and_save_topology_return_validation_payloads(self) -> None:
         topology = {
             "services": [

--- a/tests/test_docs/test_workflow_adapter_output_contract.py
+++ b/tests/test_docs/test_workflow_adapter_output_contract.py
@@ -39,6 +39,7 @@ class WorkflowAdapterOutputContractDocumentationTests(unittest.TestCase):
             "/api/v1/settings/policy-adapter",
             "DELETE",
             "build_configured_policy_adapter_output",
+            "/api/v1/analyses/{report_id}/policy-adapter",
         )
         for expected in expected_clauses:
             with self.subTest(expected=expected):

--- a/tests/test_docs/test_workflow_adapter_output_contract.py
+++ b/tests/test_docs/test_workflow_adapter_output_contract.py
@@ -32,6 +32,13 @@ class WorkflowAdapterOutputContractDocumentationTests(unittest.TestCase):
             "advisory`, `warn`, `soft-block`, and `hard-block`",
             "canonical_report_advisory",
             "at least one structured reason",
+            "PolicyAdapterSettings",
+            "project defaults",
+            "integration-specific defaults",
+            "reporting_default",
+            "/api/v1/settings/policy-adapter",
+            "DELETE",
+            "build_configured_policy_adapter_output",
         )
         for expected in expected_clauses:
             with self.subTest(expected=expected):

--- a/tests/test_services/test_policy_adapter_output_contract.py
+++ b/tests/test_services/test_policy_adapter_output_contract.py
@@ -110,6 +110,30 @@ class PolicyAdapterOutputContractTests(unittest.TestCase):
                 with self.assertRaises(ValidationError):
                     PolicyAdapterSettings(**values)
 
+    def test_built_in_settings_cannot_claim_custom_or_integration_scope(self) -> None:
+        invalid_settings = (
+            {
+                "project_key": "payments",
+                "integration": "jenkins",
+                "source": "built-in",
+            },
+            {
+                "project_key": "payments",
+                "source": "built-in",
+                "hard_block_at": None,
+            },
+            {
+                "project_key": "payments",
+                "source": "built-in",
+                "reporting_default": "warn",
+            },
+        )
+
+        for values in invalid_settings:
+            with self.subTest(values=values):
+                with self.assertRaises(ValidationError):
+                    PolicyAdapterSettings(**values)
+
     def test_settings_cannot_be_applied_across_project_or_integration_scope(
         self,
     ) -> None:

--- a/tests/test_services/test_policy_adapter_output_contract.py
+++ b/tests/test_services/test_policy_adapter_output_contract.py
@@ -75,6 +75,16 @@ class PolicyAdapterOutputContractTests(unittest.TestCase):
         self.assertEqual(output.applied_settings.integration, "jenkins")
         self.assertEqual(output.adapter_output.canonical_summary.severity, "low")
 
+    def test_unknown_canonical_severity_is_rejected(self) -> None:
+        adapter_output = _adapter_output(severity="unexpected")
+        settings = PolicyAdapterSettings(
+            project_key="payments",
+            source="project",
+        )
+
+        with self.assertRaisesRegex(ValueError, "Unsupported canonical severity"):
+            build_policy_adapter_output_from_settings(adapter_output, settings)
+
     def test_threshold_settings_reject_ambiguous_or_non_monotonic_values(self) -> None:
         invalid_settings = (
             {

--- a/tests/test_services/test_policy_adapter_output_contract.py
+++ b/tests/test_services/test_policy_adapter_output_contract.py
@@ -12,14 +12,154 @@ from services.adapter_output_contract import (
 )
 from services.analysis_service import build_share_summary
 from services.policy_adapter_output_contract import (
+    PolicyAdapterSettings,
     PolicyAdapterOutputContract,
     PolicyAdapterReason,
     PolicyAdapterStatus,
+    PolicySeverity,
+    build_policy_adapter_output_from_settings,
     build_policy_adapter_output_contract,
 )
 
 
 class PolicyAdapterOutputContractTests(unittest.TestCase):
+    def test_configured_thresholds_change_only_adapter_interpretation(self) -> None:
+        adapter_output = _adapter_output()
+        canonical_before = adapter_output.canonical_summary.model_dump(mode="json")
+        settings = PolicyAdapterSettings(
+            project_key="payments",
+            source="project",
+            warn_at=PolicySeverity.HIGH,
+            soft_block_at=PolicySeverity.CRITICAL,
+            hard_block_at=None,
+            reporting_default=PolicyAdapterStatus.ADVISORY,
+        )
+
+        output = build_policy_adapter_output_from_settings(adapter_output, settings)
+
+        self.assertEqual(output.status, PolicyAdapterStatus.WARN)
+        self.assertEqual(output.applied_settings, settings)
+        self.assertEqual(output.reasons[0].code, "severity_threshold_matched")
+        self.assertEqual(
+            output.adapter_output.canonical_summary.model_dump(mode="json"),
+            canonical_before,
+        )
+        self.assertEqual(output.adapter_output.canonical_summary.severity, "high")
+        self.assertEqual(
+            len(output.adapter_output.canonical_summary.json_payload.top_findings),
+            1,
+        )
+        self.assertEqual(
+            output.adapter_output.canonical_summary.json_payload.top_findings[
+                0
+            ].severity,
+            "high",
+        )
+
+    def test_reporting_default_applies_below_configured_thresholds(self) -> None:
+        adapter_output = _adapter_output(severity="low", adapter="jenkins")
+        settings = PolicyAdapterSettings(
+            project_key="payments",
+            integration="jenkins",
+            source="integration",
+            warn_at=PolicySeverity.HIGH,
+            soft_block_at=PolicySeverity.CRITICAL,
+            hard_block_at=None,
+            reporting_default=PolicyAdapterStatus.WARN,
+        )
+
+        output = build_policy_adapter_output_from_settings(adapter_output, settings)
+
+        self.assertEqual(output.status, PolicyAdapterStatus.WARN)
+        self.assertEqual(output.reasons[0].code, "reporting_default_applied")
+        self.assertEqual(output.applied_settings.integration, "jenkins")
+        self.assertEqual(output.adapter_output.canonical_summary.severity, "low")
+
+    def test_threshold_settings_reject_ambiguous_or_non_monotonic_values(self) -> None:
+        invalid_settings = (
+            {
+                "project_key": "payments",
+                "source": "project",
+                "warn_at": "critical",
+                "soft_block_at": "high",
+            },
+            {
+                "project_key": "payments",
+                "source": "project",
+                "reporting_default": "soft-block",
+            },
+            {
+                "project_key": "payments",
+                "source": "project",
+                "integration": "   ",
+            },
+        )
+
+        for values in invalid_settings:
+            with self.subTest(values=values):
+                with self.assertRaises(ValidationError):
+                    PolicyAdapterSettings(**values)
+
+    def test_settings_cannot_be_applied_across_project_or_integration_scope(
+        self,
+    ) -> None:
+        project_mismatch = PolicyAdapterSettings(
+            project_key="identity",
+            source="project",
+        )
+        integration_mismatch = PolicyAdapterSettings(
+            project_key="payments",
+            integration="gitlab",
+            source="integration",
+        )
+
+        for settings in (project_mismatch, integration_mismatch):
+            with self.subTest(settings=settings):
+                with self.assertRaises(ValueError):
+                    build_policy_adapter_output_from_settings(
+                        _adapter_output(), settings
+                    )
+
+        id_scoped_adapter = build_adapter_output_contract(
+            build_share_summary(_report_payload()),
+            AdapterMetadata(
+                adapter="policy",
+                format="workflow_decision",
+                project_id=42,
+            ),
+        )
+        with self.assertRaises(ValueError):
+            build_policy_adapter_output_from_settings(
+                id_scoped_adapter,
+                PolicyAdapterSettings(project_key="payments", source="project"),
+            )
+
+    def test_project_scope_comparison_uses_canonical_project_keys(self) -> None:
+        adapter_output = build_adapter_output_contract(
+            build_share_summary(_report_payload()),
+            AdapterMetadata(
+                adapter="policy",
+                format="workflow_decision",
+                project_key="Payments_Core",
+            ),
+        )
+        settings = PolicyAdapterSettings(
+            project_key="payments-core",
+            source="project",
+        )
+
+        output = build_policy_adapter_output_from_settings(
+            adapter_output,
+            settings,
+            resolved_project_key="payments-core",
+        )
+
+        self.assertEqual(output.applied_settings.project_key, "payments-core")
+        self.assertEqual(
+            output.adapter_output.adapter_metadata.project_key,
+            "Payments_Core",
+        )
+
     def test_all_policy_statuses_preserve_the_advisory_canonical_report(self) -> None:
         summary = build_share_summary(_report_payload())
         summary_before = summary.model_dump(mode="json")
@@ -179,22 +319,22 @@ class PolicyAdapterOutputContractTests(unittest.TestCase):
             output.reasons[0].message = "Changed"
 
 
-def _adapter_output():
+def _adapter_output(*, severity: str = "high", adapter: str = "policy"):
     return build_adapter_output_contract(
-        build_share_summary(_report_payload()),
+        build_share_summary(_report_payload(severity=severity)),
         AdapterMetadata(
-            adapter="policy",
+            adapter=adapter,
             format="workflow_decision",
             project_key="payments",
         ),
     )
 
 
-def _report_payload() -> dict:
+def _report_payload(*, severity: str = "high") -> dict:
     return {
         "id": 17,
         "report_schema_version": "v2",
-        "severity": "high",
+        "severity": severity,
         "recommendation": "caution",
         "top_risk": "Terraform opened database ingress.",
         "narrative_opening": "CAUTION: review database ingress.",

--- a/tests/test_services/test_policy_adapter_service.py
+++ b/tests/test_services/test_policy_adapter_service.py
@@ -1,0 +1,138 @@
+"""Tests for configured policy-adapter output generation."""
+
+from __future__ import annotations
+
+import os
+import tempfile
+import unittest
+from importlib import reload
+from pathlib import Path
+
+import config as config_module
+import models.database as database_module
+import models.tables as tables_module
+import services.policy_adapter_service as policy_adapter_service_module
+import services.project_service as project_service_module
+import services.settings_service as settings_service_module
+from services.adapter_output_contract import (
+    AdapterMetadata,
+    build_adapter_output_contract,
+)
+from services.analysis_service import build_share_summary
+from services.policy_adapter_settings import PolicyAdapterStatus
+
+
+class PolicyAdapterServiceTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tempdir = tempfile.TemporaryDirectory()
+        self.db_path = Path(self.tempdir.name) / "policy-adapter.db"
+        os.environ["DATABASE_URL"] = f"sqlite:///{self.db_path}"
+        reload(config_module)
+        reload(tables_module)
+        reload(database_module)
+        reload(project_service_module)
+        reload(settings_service_module)
+        reload(policy_adapter_service_module)
+        database_module.init_db()
+        self.project = project_service_module.create_project(
+            project_key="payments",
+            display_name="Payments",
+        )
+
+    def tearDown(self) -> None:
+        database_module.engine.dispose()
+        os.environ.pop("DATABASE_URL", None)
+        self.tempdir.cleanup()
+
+    def test_generation_resolves_integration_then_project_then_built_in(self) -> None:
+        adapter_output = _adapter_output(project_key="payments", adapter="jenkins")
+
+        built_in = policy_adapter_service_module.build_configured_policy_adapter_output(
+            adapter_output
+        )
+        settings_service_module.save_policy_adapter_settings(
+            project_key="payments",
+            warn_at="high",
+            soft_block_at="critical",
+            hard_block_at=None,
+            reporting_default="advisory",
+        )
+        project = policy_adapter_service_module.build_configured_policy_adapter_output(
+            adapter_output
+        )
+        settings_service_module.save_policy_adapter_settings(
+            project_key="payments",
+            integration="jenkins",
+            warn_at="low",
+            soft_block_at="medium",
+            hard_block_at="high",
+            reporting_default="advisory",
+        )
+        integration = (
+            policy_adapter_service_module.build_configured_policy_adapter_output(
+                adapter_output
+            )
+        )
+
+        self.assertEqual(built_in.status, PolicyAdapterStatus.SOFT_BLOCK)
+        self.assertEqual(built_in.applied_settings.source, "built-in")
+        self.assertEqual(project.status, PolicyAdapterStatus.WARN)
+        self.assertEqual(project.applied_settings.source, "project")
+        self.assertEqual(integration.status, PolicyAdapterStatus.HARD_BLOCK)
+        self.assertEqual(integration.applied_settings.source, "integration")
+        self.assertEqual(
+            integration.adapter_output.canonical_summary.model_dump(mode="json"),
+            adapter_output.canonical_summary.model_dump(mode="json"),
+        )
+
+    def test_generation_resolves_and_validates_project_id_scope(self) -> None:
+        settings_service_module.save_policy_adapter_settings(
+            project_key="payments",
+            warn_at="high",
+            soft_block_at="critical",
+            hard_block_at=None,
+            reporting_default="advisory",
+        )
+        adapter_output = _adapter_output(project_id=self.project.id, adapter="jenkins")
+
+        output = policy_adapter_service_module.build_configured_policy_adapter_output(
+            adapter_output
+        )
+
+        self.assertEqual(output.status, PolicyAdapterStatus.WARN)
+        self.assertEqual(output.applied_settings.project_key, "payments")
+        self.assertEqual(
+            output.adapter_output.adapter_metadata.project_id, self.project.id
+        )
+
+
+def _adapter_output(
+    *,
+    adapter: str,
+    project_key: str | None = None,
+    project_id: int | None = None,
+):
+    report = {
+        "id": 17,
+        "report_schema_version": "v2",
+        "severity": "high",
+        "recommendation": "caution",
+        "top_risk": "Terraform opened database ingress.",
+        "narrative_opening": "CAUTION: review database ingress.",
+        "narrative_available": True,
+        "warnings": [],
+        "findings": [],
+        "evidence_items": [],
+        "blast_radius": {},
+        "rollback_plan": {},
+        "context_completeness": {"context_score": 0.9},
+    }
+    return build_adapter_output_contract(
+        build_share_summary(report),
+        AdapterMetadata(
+            adapter=adapter,
+            format="workflow_decision",
+            project_key=project_key,
+            project_id=project_id,
+        ),
+    )

--- a/tests/test_services/test_settings_service.py
+++ b/tests/test_services/test_settings_service.py
@@ -189,6 +189,20 @@ class SettingsServiceTests(unittest.TestCase):
                 with self.assertRaisesRegex(ValueError, "scope does not match"):
                     settings_service_module.get_policy_adapter_settings(**requested)
 
+    def test_policy_adapter_settings_reject_scopes_exceeding_storage_key_limit(
+        self,
+    ) -> None:
+        oversized_scope = {"project_key": "p" * 80, "integration": "jenkins"}
+
+        for operation in (
+            settings_service_module.save_policy_adapter_settings,
+            settings_service_module.get_policy_adapter_settings,
+            settings_service_module.delete_policy_adapter_settings,
+        ):
+            with self.subTest(operation=operation.__name__):
+                with self.assertRaisesRegex(ValueError, "storage key limit"):
+                    operation(**oversized_scope)
+
     def test_provider_profiles_can_be_saved_per_provider_and_switched(self) -> None:
         settings_service_module.save_provider_settings(
             provider="openai",

--- a/tests/test_services/test_settings_service.py
+++ b/tests/test_services/test_settings_service.py
@@ -108,6 +108,24 @@ class SettingsServiceTests(unittest.TestCase):
         self.assertEqual(settings.soft_block_at.value, "high")
         self.assertEqual(settings.hard_block_at.value, "critical")
 
+    def test_policy_adapter_settings_use_canonical_project_keys_for_storage(
+        self,
+    ) -> None:
+        saved = settings_service_module.save_policy_adapter_settings(
+            project_key="Payments_Core",
+            warn_at="high",
+            soft_block_at="critical",
+            hard_block_at=None,
+        )
+
+        loaded = settings_service_module.get_policy_adapter_settings(
+            project_key="payments-core"
+        )
+
+        self.assertEqual(saved.project_key, "payments-core")
+        self.assertEqual(loaded.source, "project")
+        self.assertEqual(loaded.warn_at.value, "high")
+
     def test_policy_adapter_settings_can_reset_to_inherited_defaults(self) -> None:
         settings_service_module.save_policy_adapter_settings(
             project_key="payments",

--- a/tests/test_services/test_settings_service.py
+++ b/tests/test_services/test_settings_service.py
@@ -14,6 +14,7 @@ import models.database as database_module
 import models.repositories.settings as settings_repository_module
 import models.tables as tables_module
 import services.settings_service as settings_service_module
+from services.policy_adapter_settings import PolicyAdapterStatus
 
 
 class SettingsServiceTests(unittest.TestCase):
@@ -55,6 +56,86 @@ class SettingsServiceTests(unittest.TestCase):
             }
         self.assertNotIn("llm_api_key", keys)
         self.assertNotIn("llm_provider_config::openai::api_key", keys)
+
+    def test_policy_adapter_settings_resolve_integration_then_project_defaults(
+        self,
+    ) -> None:
+        project_settings = settings_service_module.save_policy_adapter_settings(
+            project_key="payments",
+            warn_at="medium",
+            soft_block_at="high",
+            hard_block_at="critical",
+            reporting_default="advisory",
+        )
+        integration_settings = settings_service_module.save_policy_adapter_settings(
+            project_key="payments",
+            integration="jenkins",
+            warn_at="high",
+            soft_block_at="critical",
+            hard_block_at=None,
+            reporting_default="warn",
+        )
+
+        resolved_project = settings_service_module.get_policy_adapter_settings(
+            project_key="payments"
+        )
+        resolved_integration = settings_service_module.get_policy_adapter_settings(
+            project_key="payments", integration="jenkins"
+        )
+        unresolved_integration = settings_service_module.get_policy_adapter_settings(
+            project_key="payments", integration="gitlab"
+        )
+
+        self.assertEqual(project_settings.source, "project")
+        self.assertEqual(integration_settings.source, "integration")
+        self.assertEqual(resolved_project.source, "project")
+        self.assertEqual(resolved_integration.source, "integration")
+        self.assertEqual(
+            resolved_integration.reporting_default, PolicyAdapterStatus.WARN
+        )
+        self.assertEqual(unresolved_integration.source, "project")
+        self.assertIsNone(unresolved_integration.integration)
+
+    def test_policy_adapter_settings_use_safe_built_in_defaults(self) -> None:
+        settings = settings_service_module.get_policy_adapter_settings(
+            project_key="payments", integration="jenkins"
+        )
+
+        self.assertEqual(settings.source, "built-in")
+        self.assertEqual(settings.reporting_default, PolicyAdapterStatus.ADVISORY)
+        self.assertEqual(settings.warn_at.value, "medium")
+        self.assertEqual(settings.soft_block_at.value, "high")
+        self.assertEqual(settings.hard_block_at.value, "critical")
+
+    def test_policy_adapter_settings_can_reset_to_inherited_defaults(self) -> None:
+        settings_service_module.save_policy_adapter_settings(
+            project_key="payments",
+            warn_at="medium",
+            soft_block_at="high",
+            hard_block_at="critical",
+            reporting_default="advisory",
+        )
+        settings_service_module.save_policy_adapter_settings(
+            project_key="payments",
+            integration="jenkins",
+            warn_at="high",
+            soft_block_at="critical",
+            hard_block_at=None,
+            reporting_default="warn",
+        )
+
+        inherited_project = settings_service_module.delete_policy_adapter_settings(
+            project_key="payments", integration="jenkins"
+        )
+        inherited_builtin = settings_service_module.delete_policy_adapter_settings(
+            project_key="payments"
+        )
+
+        self.assertEqual(inherited_project.source, "project")
+        self.assertEqual(
+            inherited_project.reporting_default, PolicyAdapterStatus.ADVISORY
+        )
+        self.assertEqual(inherited_builtin.source, "built-in")
 
     def test_provider_profiles_can_be_saved_per_provider_and_switched(self) -> None:
         settings_service_module.save_provider_settings(

--- a/tests/test_services/test_settings_service.py
+++ b/tests/test_services/test_settings_service.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import os
 import tempfile
 import unittest
@@ -136,6 +137,39 @@ class SettingsServiceTests(unittest.TestCase):
             inherited_project.reporting_default, PolicyAdapterStatus.ADVISORY
         )
         self.assertEqual(inherited_builtin.source, "built-in")
+
+    def test_policy_adapter_settings_reject_stored_scope_mismatches(self) -> None:
+        mismatches = (
+            (
+                "policy_adapter_defaults::payments::project",
+                {
+                    "project_key": "identity",
+                    "source": "project",
+                },
+                {"project_key": "payments"},
+            ),
+            (
+                "policy_adapter_defaults::payments::integration::jenkins",
+                {
+                    "project_key": "payments",
+                    "integration": "gitlab",
+                    "source": "integration",
+                },
+                {"project_key": "payments", "integration": "jenkins"},
+            ),
+        )
+
+        for key, stored, requested in mismatches:
+            with self.subTest(key=key):
+                with database_module.SessionLocal() as session:
+                    settings_repository_module.upsert_setting(
+                        session,
+                        key=key,
+                        value=json.dumps(stored),
+                    )
+
+                with self.assertRaisesRegex(ValueError, "scope does not match"):
+                    settings_service_module.get_policy_adapter_settings(**requested)
 
     def test_provider_profiles_can_be_saved_per_provider_and_switched(self) -> None:
         settings_service_module.save_provider_settings(

--- a/tests/test_services/test_settings_service.py
+++ b/tests/test_services/test_settings_service.py
@@ -16,6 +16,7 @@ import models.repositories.settings as settings_repository_module
 import models.tables as tables_module
 import services.settings_service as settings_service_module
 from services.policy_adapter_settings import PolicyAdapterStatus
+from services.policy_adapter_settings import PolicyAdapterSettingsIntegrityError
 
 
 class SettingsServiceTests(unittest.TestCase):
@@ -186,22 +187,55 @@ class SettingsServiceTests(unittest.TestCase):
                         value=json.dumps(stored),
                     )
 
-                with self.assertRaisesRegex(ValueError, "scope does not match"):
+                with self.assertRaisesRegex(
+                    PolicyAdapterSettingsIntegrityError, "scope does not match"
+                ):
                     settings_service_module.get_policy_adapter_settings(**requested)
 
-    def test_policy_adapter_settings_reject_scopes_exceeding_storage_key_limit(
+    def test_policy_adapter_settings_support_scopes_exceeding_plain_key_limit(
         self,
     ) -> None:
-        oversized_scope = {"project_key": "p" * 80, "integration": "jenkins"}
+        long_scope = {"project_key": "p" * 80, "integration": "jenkins"}
 
-        for operation in (
-            settings_service_module.save_policy_adapter_settings,
-            settings_service_module.get_policy_adapter_settings,
-            settings_service_module.delete_policy_adapter_settings,
+        inherited = settings_service_module.get_policy_adapter_settings(**long_scope)
+        saved = settings_service_module.save_policy_adapter_settings(
+            **long_scope,
+            warn_at="high",
+            soft_block_at="critical",
+            hard_block_at=None,
+        )
+        loaded = settings_service_module.get_policy_adapter_settings(**long_scope)
+        with database_module.SessionLocal() as session:
+            keys = [
+                record.key
+                for record in settings_repository_module.list_settings(session)
+                if record.key.startswith("policy_adapter_defaults::")
+            ]
+        reset = settings_service_module.delete_policy_adapter_settings(**long_scope)
+
+        self.assertEqual(inherited.source, "built-in")
+        self.assertEqual(saved.source, "integration")
+        self.assertEqual(loaded.source, "integration")
+        self.assertEqual(len(keys), 1)
+        self.assertIn("::sha256::", keys[0])
+        self.assertLessEqual(len(keys[0]), 100)
+        self.assertEqual(reset.source, "built-in")
+
+    def test_policy_adapter_settings_classify_malformed_storage_as_integrity_error(
+        self,
+    ) -> None:
+        with database_module.SessionLocal() as session:
+            settings_repository_module.upsert_setting(
+                session,
+                key="policy_adapter_defaults::payments::project",
+                value="not-json",
+            )
+
+        with self.assertRaisesRegex(
+            PolicyAdapterSettingsIntegrityError,
+            "could not be validated",
         ):
-            with self.subTest(operation=operation.__name__):
-                with self.assertRaisesRegex(ValueError, "storage key limit"):
-                    operation(**oversized_scope)
+            settings_service_module.get_policy_adapter_settings(project_key="payments")
 
     def test_provider_profiles_can_be_saved_per_provider_and_switched(self) -> None:
         settings_service_module.save_provider_settings(


### PR DESCRIPTION
## Summary
- add project and integration policy-adapter threshold defaults with inherited reset behavior
- apply resolved defaults only to the separate policy interpretation envelope
- expose admin-only GET, PUT, and DELETE settings endpoints with explicit project scope
- preserve canonical evidence, findings, severity, and advisory semantics
- resolve all BMad review findings for project-key normalization and query validation

## Story
- _bmad-output/implementation-artifacts/11-2-threshold-and-reporting-defaults-management.md
- Acceptance criterion 1 completed

## Validation
- Focused Story 11.2 suite: 48 passed, 55 subtests
- Full local CI: 906 tests passed
- Ruff check and format: passed
- Bandit, dependency validation, compilation, and skill harnesses: passed
- OpenAPI TypeScript schema regenerated from the current FastAPI app
- UI browser validation: not applicable; no rendered React surface changed

## Review
BMad adversarial review completed. Two actionable findings were fixed and regression-tested; six false positives or out-of-scope findings were dismissed during triage.