### PR TITLE
Story 11.3: add integration-level enforcement settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -812,8 +812,10 @@ The recommended open-source posture is Action-first. If you want GitHub App
 capabilities, create a private/self-hosted GitHub App in your own account or
 organization and point it at your own DeployWhisper instance. See
 [`docs/github-app-self-hosted-setup.md`](./docs/github-app-self-hosted-setup.md).
-Keep the `DeployWhisper / Risk Analysis` check advisory-only in GitHub branch
-protection; do not add it as a required status check.
+Keep the `DeployWhisper / Risk Analysis` check non-required while its configured
+integration mode is `advisory` or `warn`. Making the check required is an
+explicit operator opt-in for `soft-block` or `hard-block`; the canonical report
+remains advisory-only in every mode.
 
 To scaffold this setup into another repository with a workflow file, README
 update, and optional self-hosted GitHub App notes, run:

--- a/_bmad-output/implementation-artifacts/11-3-integration-level-enforcement-settings.md
+++ b/_bmad-output/implementation-artifacts/11-3-integration-level-enforcement-settings.md
@@ -1,6 +1,6 @@
 # Story 11.3: Integration-Level Enforcement Settings
 
-Status: done
+Status: review
 
 <!-- Generated from updated PRD/architecture/epics plus implementation-readiness-report-2026-05-01.md. -->
 
@@ -28,6 +28,11 @@ So that teams can adopt warnings before blocking.
 - [x] Add or update deterministic regression coverage for the changed behavior. (AC: all)
 - [x] Update relevant docs or examples if the story changes user-visible, operator, API, CLI, integration, or contribution behavior. (AC: all)
 - [x] Run required validation and record commands/results in the Dev Agent Record. (AC: all)
+
+### Review Follow-ups (AI)
+
+- [x] [AI-Review][HIGH] Make GitHub check-run delivery best-effort on neutral-skip and successful-analysis paths while preserving handled webhook results and persisted report references.
+- [x] [AI-Review][LOW] Emit explicit skipped-analysis guidance for sensitive-only, unsupported-only, and mixed rejected artifact sets.
 
 ### Review Findings
 
@@ -102,6 +107,12 @@ So that teams can adopt warnings before blocking.
 
 OpenAI Codex (GPT-5)
 
+### Implementation Plan
+
+- Preserve successful analysis and handled-webhook results when GitHub check delivery fails, while returning a bounded `partial` status and `github_check_run_failed` code without exposing upstream details.
+- Derive skipped-analysis guidance only from aggregate intake statuses so sensitive, unsupported, mixed, and empty artifact sets are explicit without disclosing filenames or contents.
+- Lock both paths with focused regressions before running the required repository validation gates.
+
 ### Debug Log References
 
 - RED: `./.venv/bin/python -m pytest tests/test_services/test_settings_service.py tests/test_services/test_policy_adapter_service.py tests/test_api/test_settings.py tests/test_services/test_github_app_service.py -q --tb=short` - expected failure (`9 failed, 61 passed, 17 subtests passed`) before enforcement settings and decisions existed.
@@ -140,6 +151,13 @@ OpenAI Codex (GPT-5)
 - Fourth review required smoke: `./.venv/bin/python -m unittest discover -q` - `414 tests` passed, `1 skipped`.
 - Fourth review CI-parity shard: `./.venv/bin/python -m pytest tests/test_api tests/test_cli tests/test_infra -v --tb=short` - `395 passed, 111 subtests passed`.
 - Fourth review full local CI: `bash scripts/ci-local.sh` - passed Ruff check/format, dependency integrity, Bandit high-confidence gate, compileall, all skill and prompt-injection gates, and every backend/docs test directory; final services directory reported `921 tests` passing.
+- Deferred-finding RED: `./.venv/bin/python -m pytest tests/test_services/test_github_app_service.py -q --tb=short` reproduced generic skipped-analysis copy and uncaught check-run delivery failures (`6 failed, 26 passed, 6 subtests passed`).
+- Deferred-finding GREEN: the same focused command passed after the fixes (`29 passed, 9 subtests passed`).
+- Deferred-finding quality gates: `./.venv/bin/ruff check .`, `./.venv/bin/ruff format --check .`, and `git diff --check` passed; Ruff reported all 272 files formatted.
+- Deferred-finding required smoke: `./.venv/bin/python -m unittest discover -q` - `414 tests` passed, `1 skipped`.
+- Deferred-finding CI-parity shard: `./.venv/bin/python -m pytest tests/test_api tests/test_cli tests/test_infra -v --tb=short` - `395 passed, 111 subtests passed`.
+- Deferred-finding full local CI: `bash scripts/ci-local.sh` - passed Ruff check/format, dependency integrity, Bandit high-confidence gate with zero high findings, compileall, all skill and prompt-injection gates, and every backend/docs test directory; final services directory reported `924 tests` passing.
+- UI validation not applicable for the deferred findings: no React route, component, rendered surface, browser interaction, keyboard behavior, or accessibility semantics changed.
 
 ### Completion Notes List
 
@@ -154,6 +172,7 @@ OpenAI Codex (GPT-5)
 - Resolved both findings from the third review rerun: policy integration identifiers now use shared boundary normalization before decision construction, and legacy integration-scoped storage has explicit advisory-default coverage.
 - Resolved both findings from the fourth review rerun: GitHub checks only mention a canonical report when one exists, and the external enforcement-decision API now distinguishes malformed integration input from internal decision-validation failures with stable error codes.
 - The fifth review rerun found no Story 11.3 patch or decision gap; two pre-existing GitHub App reliability/copy issues were recorded in deferred work without expanding this story's scope.
+- Resolved both fifth-review deferrals at user request: skipped and successful analyses now survive GitHub check-run delivery failures with bounded partial results, and rejected artifact sets receive explicit sensitive/unsupported/mixed guidance without exposing artifact details.
 
 ### File List
 
@@ -191,3 +210,4 @@ OpenAI Codex (GPT-5)
 - 2026-08-13: Resolved the third review rerun findings for invalid integration input classification and legacy integration-storage coverage.
 - 2026-08-14: Resolved the fourth review rerun findings for no-report GitHub guidance and distinct enforcement-decision error codes.
 - 2026-08-14: Fifth review rerun passed Story 11.3 acceptance and recorded two pre-existing GitHub App issues as deferred work.
+- 2026-08-14: Addressed both deferred fifth-review findings with red-green regressions and full local CI; moved Story 11.3 back to review.

--- a/_bmad-output/implementation-artifacts/11-3-integration-level-enforcement-settings.md
+++ b/_bmad-output/implementation-artifacts/11-3-integration-level-enforcement-settings.md
@@ -31,6 +31,8 @@ So that teams can adopt warnings before blocking.
 
 ### Review Findings
 
+- [x] [Review][Patch] [MEDIUM] Reject blank or otherwise invalid `integration` query values as client errors before enforcement-decision construction; whitespace currently reaches `AdapterMetadata`, is caught with internal invariant failures, and returns HTTP 500 instead of a bounded 4xx response. [api/routes/analyses.py:1028]
+- [x] [Review][Patch] [LOW] Add a legacy integration-scoped storage regression proving persisted settings without `enforcement_mode` load as advisory, matching the documented backward-compatibility guarantee already covered only for project-scoped storage. [tests/test_services/test_settings_service.py:246]
 - [x] [Review][Patch] [MEDIUM] Preserve the resolved inherited project enforcement mode when a backward-compatible client creates its first integration override without `enforcement_mode`; the current source check falls back to the request model's `advisory` default and silently downgrades enforcement. [api/routes/settings.py:529]
 - [x] [Review][Patch] [MEDIUM] Return a server-error contract when the enforcement-decision endpoint encounters internally generated adapter or decision invariant failures; the new route currently reports every `ValueError` as client-side `400 invalid_policy_adapter_output`. [api/routes/analyses.py:1063]
 - [x] [Review][Patch] [MEDIUM] Use enforcement-specific fallback guidance when analysis succeeds but enforcement validation fails; the check summary says the analysis completed, while `_check_run_text()` currently says it could not complete. [integrations/github/app_service.py:585]
@@ -124,6 +126,11 @@ OpenAI Codex (GPT-5)
 - Second review required smoke: `./.venv/bin/python -m unittest discover -q` - `413 tests` passed, `1 skipped`.
 - Second review CI-parity shard: `./.venv/bin/python -m pytest tests/test_api tests/test_cli tests/test_infra -v --tb=short` - `394 passed, 109 subtests passed`.
 - Second review full local CI: `bash scripts/ci-local.sh` - passed Ruff check/format, dependency integrity, Bandit high-confidence gate, compileall, all skill and prompt-injection gates, and every backend/docs test directory; final services directory reported `920 tests` passing.
+- Third review rerun RED: focused analyses/settings-service regressions reproduced invalid integration identifiers returning HTTP 500 (`2 failed, 134 passed, 28 subtests passed`); the legacy integration-storage regression passed immediately.
+- Third review rerun GREEN: `./.venv/bin/python -m pytest tests/test_api/test_analyses.py tests/test_services/test_settings_service.py -q --tb=short` - `134 passed, 30 subtests passed`.
+- Third review required smoke: `./.venv/bin/python -m unittest discover -q` - `414 tests` passed, `1 skipped`.
+- Third review CI-parity shard: `./.venv/bin/python -m pytest tests/test_api tests/test_cli tests/test_infra -v --tb=short` - `395 passed, 111 subtests passed`.
+- Third review full local CI: `bash scripts/ci-local.sh` - passed Ruff check/format, dependency integrity, Bandit high-confidence gate, compileall, all skill and prompt-injection gates, and every backend/docs test directory; final services directory reported `921 tests` passing.
 
 ### Completion Notes List
 
@@ -135,6 +142,7 @@ OpenAI Codex (GPT-5)
 - Resolved all seven code-review findings: added the external capped-decision endpoint, safe GitHub failure results, legacy PUT preservation, accurate skipped-analysis guidance, full mode/default/reset regressions, and executable operator-documentation coverage.
 - Resolved both findings from the Story 11.3 review rerun: enforcement-validation failures now describe the completed analysis accurately, and the decision suite locks every raw-status/configured-mode pairing against upward escalation plus the built-in advisory path.
 - Resolved both findings from the second review rerun: legacy integration overrides retain inherited project enforcement when the field is omitted, and internal enforcement-decision validation failures return a sanitized server-error response.
+- Resolved both findings from the third review rerun: policy integration identifiers now use shared boundary normalization before decision construction, and legacy integration-scoped storage has explicit advisory-default coverage.
 
 ### File List
 
@@ -168,3 +176,4 @@ OpenAI Codex (GPT-5)
 - 2026-08-12: Resolved all seven code-review findings, regenerated the API client contract, completed full validation, and moved the story to done.
 - 2026-08-13: Resolved both findings from the code-review rerun and expanded enforcement-decision regression coverage across the complete status matrix.
 - 2026-08-13: Resolved the second review rerun findings for inherited enforcement preservation and internal error classification, with focused and full-CI regression evidence.
+- 2026-08-13: Resolved the third review rerun findings for invalid integration input classification and legacy integration-storage coverage.

--- a/_bmad-output/implementation-artifacts/11-3-integration-level-enforcement-settings.md
+++ b/_bmad-output/implementation-artifacts/11-3-integration-level-enforcement-settings.md
@@ -31,6 +31,8 @@ So that teams can adopt warnings before blocking.
 
 ### Review Findings
 
+- [x] [Review][Patch] [MEDIUM] Do not claim that a canonical advisory report exists in GitHub check text when analysis was skipped or failed before report persistence; `_check_run_text()` currently appends that sentence even when both `details_url` and `enforcement` are absent. [integrations/github/app_service.py:822]
+- [x] [Review][Patch] [MEDIUM] Give malformed integration identifiers and internal enforcement-decision invariant failures distinct machine-readable API error codes; both paths currently emit `invalid_policy_adapter_output` despite representing caller input versus server-contract failures. [api/routes/analyses.py:1038]
 - [x] [Review][Patch] [MEDIUM] Reject blank or otherwise invalid `integration` query values as client errors before enforcement-decision construction; whitespace currently reaches `AdapterMetadata`, is caught with internal invariant failures, and returns HTTP 500 instead of a bounded 4xx response. [api/routes/analyses.py:1028]
 - [x] [Review][Patch] [LOW] Add a legacy integration-scoped storage regression proving persisted settings without `enforcement_mode` load as advisory, matching the documented backward-compatibility guarantee already covered only for project-scoped storage. [tests/test_services/test_settings_service.py:246]
 - [x] [Review][Patch] [MEDIUM] Preserve the resolved inherited project enforcement mode when a backward-compatible client creates its first integration override without `enforcement_mode`; the current source check falls back to the request model's `advisory` default and silently downgrades enforcement. [api/routes/settings.py:529]
@@ -131,6 +133,11 @@ OpenAI Codex (GPT-5)
 - Third review required smoke: `./.venv/bin/python -m unittest discover -q` - `414 tests` passed, `1 skipped`.
 - Third review CI-parity shard: `./.venv/bin/python -m pytest tests/test_api tests/test_cli tests/test_infra -v --tb=short` - `395 passed, 111 subtests passed`.
 - Third review full local CI: `bash scripts/ci-local.sh` - passed Ruff check/format, dependency integrity, Bandit high-confidence gate, compileall, all skill and prompt-injection gates, and every backend/docs test directory; final services directory reported `921 tests` passing.
+- Fourth review RED: focused GitHub App and analyses API regressions reproduced misleading no-report guidance and the shared client/server error code (`5 failed, 127 passed, 27 subtests passed`).
+- Fourth review GREEN: `./.venv/bin/python -m pytest tests/test_services/test_github_app_service.py tests/test_api/test_analyses.py -q --tb=short` - `130 passed, 29 subtests passed`.
+- Fourth review required smoke: `./.venv/bin/python -m unittest discover -q` - `414 tests` passed, `1 skipped`.
+- Fourth review CI-parity shard: `./.venv/bin/python -m pytest tests/test_api tests/test_cli tests/test_infra -v --tb=short` - `395 passed, 111 subtests passed`.
+- Fourth review full local CI: `bash scripts/ci-local.sh` - passed Ruff check/format, dependency integrity, Bandit high-confidence gate, compileall, all skill and prompt-injection gates, and every backend/docs test directory; final services directory reported `921 tests` passing.
 
 ### Completion Notes List
 
@@ -143,6 +150,7 @@ OpenAI Codex (GPT-5)
 - Resolved both findings from the Story 11.3 review rerun: enforcement-validation failures now describe the completed analysis accurately, and the decision suite locks every raw-status/configured-mode pairing against upward escalation plus the built-in advisory path.
 - Resolved both findings from the second review rerun: legacy integration overrides retain inherited project enforcement when the field is omitted, and internal enforcement-decision validation failures return a sanitized server-error response.
 - Resolved both findings from the third review rerun: policy integration identifiers now use shared boundary normalization before decision construction, and legacy integration-scoped storage has explicit advisory-default coverage.
+- Resolved both findings from the fourth review rerun: GitHub checks only mention a canonical report when one exists, and the external enforcement-decision API now distinguishes malformed integration input from internal decision-validation failures with stable error codes.
 
 ### File List
 
@@ -177,3 +185,4 @@ OpenAI Codex (GPT-5)
 - 2026-08-13: Resolved both findings from the code-review rerun and expanded enforcement-decision regression coverage across the complete status matrix.
 - 2026-08-13: Resolved the second review rerun findings for inherited enforcement preservation and internal error classification, with focused and full-CI regression evidence.
 - 2026-08-13: Resolved the third review rerun findings for invalid integration input classification and legacy integration-storage coverage.
+- 2026-08-14: Resolved the fourth review rerun findings for no-report GitHub guidance and distinct enforcement-decision error codes.

--- a/_bmad-output/implementation-artifacts/11-3-integration-level-enforcement-settings.md
+++ b/_bmad-output/implementation-artifacts/11-3-integration-level-enforcement-settings.md
@@ -31,6 +31,8 @@ So that teams can adopt warnings before blocking.
 
 ### Review Findings
 
+- [x] [Review][Patch] [MEDIUM] Use enforcement-specific fallback guidance when analysis succeeds but enforcement validation fails; the check summary says the analysis completed, while `_check_run_text()` currently says it could not complete. [integrations/github/app_service.py:585]
+- [x] [Review][Patch] [MEDIUM] Expand enforcement-decision regression coverage across raw policy statuses, including raw statuses below the configured ceiling, so the no-upward-escalation invariant and advisory-first built-in decision path cannot drift. [tests/test_services/test_policy_adapter_service.py:108]
 - [x] [Review][Patch] [HIGH] Expose the capped enforcement decision through a shared external API contract so CI and future adapters can consume `configured_mode`, `effective_status`, and `should_block` without reimplementing policy logic. [api/routes/analyses.py:96]
 - [x] [Review][Patch] [HIGH] Handle policy-setting integrity and enforcement-contract failures after successful GitHub analysis instead of crashing before a check run is posted. [integrations/github/app_service.py:553]
 - [x] [Review][Patch] [MEDIUM] Preserve an existing enforcement mode when backward-compatible clients omit the newly added field during a settings update. [api/routes/settings.py:529]
@@ -110,6 +112,11 @@ OpenAI Codex (GPT-5)
 - Review CI-parity shard: `./.venv/bin/python -m pytest tests/test_api tests/test_cli tests/test_infra -v --tb=short` - `392 passed, 109 subtests passed`.
 - Review generated-client verification: OpenAPI schema regenerated from the local app; frontend production build passed; Vitest reported `55 passed`.
 - Remote CI correction: the first PR API/CLI/infra run found a stale mirrored sprint-status header date; after aligning it with `last_updated`, the focused metadata regression and full shard were rerun.
+- Review rerun RED: `./.venv/bin/python -m pytest tests/test_services/test_github_app_service.py tests/test_services/test_policy_adapter_service.py -q --tb=short` reproduced the inaccurate enforcement fallback guidance (`2 failed, 30 passed, 22 subtests passed`).
+- Review rerun GREEN: the same focused command passed after the fix (`30 passed, 22 subtests passed`).
+- Review rerun quality gates: `./.venv/bin/ruff check .`, `./.venv/bin/ruff format --check .`, and `git diff --check` passed; Ruff reported all 272 files formatted.
+- Review rerun CI-parity shard: `./.venv/bin/python -m pytest tests/test_api tests/test_cli tests/test_infra -v --tb=short` - `392 passed, 109 subtests passed`.
+- Review rerun full local CI: `bash scripts/ci-local.sh` - passed Ruff check/format, dependency integrity, Bandit high-confidence gate (0 high findings), compileall, all skill and prompt-injection gates, and every backend/docs test directory; final services directory reported `920 tests` passing.
 
 ### Completion Notes List
 
@@ -119,6 +126,7 @@ OpenAI Codex (GPT-5)
 - Updated integration/operator documentation and the generated TypeScript API schema. The external `deploywhisper/analyze-action` repository remains the owner of its runtime implementation and can consume this shared contract without changing the canonical analysis response.
 - Implementation is stacked on the unmerged Story 11.2 branch because Story 11.3 directly extends its policy settings/output services.
 - Resolved all seven code-review findings: added the external capped-decision endpoint, safe GitHub failure results, legacy PUT preservation, accurate skipped-analysis guidance, full mode/default/reset regressions, and executable operator-documentation coverage.
+- Resolved both findings from the Story 11.3 review rerun: enforcement-validation failures now describe the completed analysis accurately, and the decision suite locks every raw-status/configured-mode pairing against upward escalation plus the built-in advisory path.
 
 ### File List
 
@@ -150,3 +158,4 @@ OpenAI Codex (GPT-5)
 - 2026-05-01: Story created/aligned from updated PRD, architecture, epics, sprint status, and readiness report.
 - 2026-08-11: Added advisory-first integration enforcement settings, shared capped decisions, GitHub check enforcement, deterministic regression coverage, API schema generation, and operator documentation; moved story to review.
 - 2026-08-12: Resolved all seven code-review findings, regenerated the API client contract, completed full validation, and moved the story to done.
+- 2026-08-13: Resolved both findings from the code-review rerun and expanded enforcement-decision regression coverage across the complete status matrix.

--- a/_bmad-output/implementation-artifacts/11-3-integration-level-enforcement-settings.md
+++ b/_bmad-output/implementation-artifacts/11-3-integration-level-enforcement-settings.md
@@ -1,0 +1,151 @@
+# Story 11.3: Integration-Level Enforcement Settings
+
+Status: done
+
+<!-- Generated from updated PRD/architecture/epics plus implementation-readiness-report-2026-05-01.md. -->
+
+## Story
+
+As a platform admin,
+I want enforcement mode configured per integration,
+So that teams can adopt warnings before blocking.
+
+## Acceptance Criteria
+
+1. Given GitHub, CI, or future integrations are configured, When enforcement settings are changed, Then each integration can use advisory, warn, soft-block, or hard-block mode. And defaults preserve advisory-first behavior.
+
+### Requirement Traceability
+
+- Primary PRD requirements: Epic 11 coverage: ADM-07, ADM-09, WRK-07, RSK-07, NFR-SEC-06.
+- Supporting PRD / NFR / differentiation requirements: See `_bmad-output/planning-artifacts/prd.md`, `_bmad-output/planning-artifacts/architecture.md`, and `_bmad-output/planning-artifacts/implementation-readiness-report-2026-05-01.md`.
+- Coverage intent: Baseline + Delta.
+- Story alignment note: This story was created from the updated Epic 11 plan after the 2026-05-01 readiness rerun. The readiness report verified 187/187 PRD functional requirement IDs in the epics artifact, 38 NFR IDs present, and no critical or major readiness defects.
+
+## Tasks / Subtasks
+
+- [x] Implement and verify acceptance criterion 1. (AC: 1)
+- [x] Reuse existing services, repositories, schemas, and UI/CLI/API helpers before adding new abstractions. (AC: all)
+- [x] Add or update deterministic regression coverage for the changed behavior. (AC: all)
+- [x] Update relevant docs or examples if the story changes user-visible, operator, API, CLI, integration, or contribution behavior. (AC: all)
+- [x] Run required validation and record commands/results in the Dev Agent Record. (AC: all)
+
+### Review Findings
+
+- [x] [Review][Patch] [HIGH] Expose the capped enforcement decision through a shared external API contract so CI and future adapters can consume `configured_mode`, `effective_status`, and `should_block` without reimplementing policy logic. [api/routes/analyses.py:96]
+- [x] [Review][Patch] [HIGH] Handle policy-setting integrity and enforcement-contract failures after successful GitHub analysis instead of crashing before a check run is posted. [integrations/github/app_service.py:553]
+- [x] [Review][Patch] [MEDIUM] Preserve an existing enforcement mode when backward-compatible clients omit the newly added field during a settings update. [api/routes/settings.py:529]
+- [x] [Review][Patch] [MEDIUM] Stop using the enforcement-error fallback copy for neutral no-supported-artifact checks, where analysis was intentionally skipped rather than failing. [integrations/github/app_service.py:416]
+- [x] [Review][Patch] [MEDIUM] Add full GitHub webhook regressions for advisory, warn, and soft-block decisions, including emitted conclusion, summary, and guidance text. [tests/test_services/test_github_app_service.py:123]
+- [x] [Review][Patch] [MEDIUM] Add API regressions for built-in advisory mode and reset inheritance so the new response/default contract cannot drift. [tests/test_api/test_settings.py:92]
+- [x] [Review][Patch] [LOW] Lock operator-facing branch-protection guidance and the canonical `github` integration key with an executable documentation regression. [docs/github-app.md:65]
+
+## Dev Notes
+
+### Epic Context
+
+- Epic: 11. Optional Enforcement Adapters
+- Epic goal: Expose optional enforcement interpretation without changing the advisory core.
+- Epic coverage: ADM-07, ADM-09, WRK-07, RSK-07, NFR-SEC-06
+
+### Architecture and Product Guardrails
+
+- Preserve DeployWhisper's local-first raw artifact boundary: raw IaC, scanner artifacts, incident exports, and sensitive context stay in the user's infrastructure by default.
+- Preserve the advisory-first core. Optional adapters may interpret report outputs, but canonical report semantics remain advisory unless explicit story scope says otherwise.
+- Reuse the shared analysis core and service layer before adapting UI, API, CLI, GitHub, or future workflow surfaces.
+- Keep Evidence Law behavior intact: no high or critical finding without deterministic evidence.
+- Keep project/workspace scope explicit for reports, incidents, topology, outcomes, feedback, scanner imports, and connector-related data.
+- Do not introduce new dependencies unless the active story explicitly requires and justifies them.
+
+### Source Tree Guidance
+
+- API routes belong under `api/routes/` and should use existing `ApiRoute` / `ApiError` envelope patterns.
+- Shared orchestration belongs in `services/`; parsers normalize input, analysis modules score/derive risk, and surfaces adapt outputs.
+- UI work belongs under `frontend/src/screens/` and `frontend/src/components/`, following the existing retired Python UI composition style.
+- CLI behavior belongs under `cli/` and must call the same service-layer paths as UI/API flows.
+- Persistence work belongs under `models/` with Alembic migrations when schema changes are required.
+- Documentation required by a story should be updated in the same workstream.
+
+### Testing Requirements
+
+- Use standard-library `unittest` in the existing `tests/test_*` layout.
+- Add focused regression tests for the layer changed by the story before broad refactors.
+- For Python changes, run `./.venv/bin/ruff check .`, `./.venv/bin/ruff format --check .`, and `./.venv/bin/python -m unittest discover -q` before closing implementation.
+- Use `bash scripts/ci-local.sh` for broader or cross-layer changes.
+
+### Project Structure Notes
+
+- Follow the current repository shape documented in `_bmad-output/project-context.md` and `AGENTS.md`.
+- If implementation reveals a conflict between this story and the current code baseline, keep the smallest compatible change and update the story notes rather than silently drifting from the PRD.
+
+### References
+
+- `_bmad-output/planning-artifacts/epics.md` - source Epic 11 / Story 11.3 definition.
+- `_bmad-output/planning-artifacts/prd.md` - functional and non-functional requirements.
+- `_bmad-output/planning-artifacts/architecture.md` - target architecture, boundaries, and guardrails.
+- `_bmad-output/planning-artifacts/ux-design-specification.md` - UX expectations for user-facing stories.
+- `_bmad-output/planning-artifacts/implementation-readiness-report-2026-05-01.md` - readiness verdict and residual story-format concern.
+- `_bmad-output/project-context.md` - repository-specific implementation rules.
+
+## Dev Agent Record
+
+### Agent Model Used
+
+OpenAI Codex (GPT-5)
+
+### Debug Log References
+
+- RED: `./.venv/bin/python -m pytest tests/test_services/test_settings_service.py tests/test_services/test_policy_adapter_service.py tests/test_api/test_settings.py tests/test_services/test_github_app_service.py -q --tb=short` - expected failure (`9 failed, 61 passed, 17 subtests passed`) before enforcement settings and decisions existed.
+- GREEN: the same focused command - `66 passed, 21 subtests passed`.
+- Expanded regression: policy settings/output, analyses/settings APIs, GitHub App, and contract docs - `191 passed, 113 subtests passed`.
+- Generated API contract: temporary local app plus `OPENAPI_URL=http://127.0.0.1:18133/api/v1/openapi.json npm run ui:gen-api` - passed.
+- Full local CI: `bash scripts/ci-local.sh` - passed Ruff check/format, dependency integrity, Bandit high-confidence gate (0 high findings), compileall, skill scenarios, prompt-injection gate, and every backend/docs test directory; final services directory reported `915 tests` passing.
+- Required smoke: `./.venv/bin/python -m unittest discover -q` - `408 tests` passed, `1 skipped`.
+- CI-parity shard: `./.venv/bin/python -m pytest tests/test_api tests/test_cli tests/test_infra -v --tb=short` - `389 passed, 103 subtests passed`.
+- Generated-client verification: `npm --prefix frontend run build` - passed; `npm --prefix frontend test` - `55 passed`.
+- UI validation not applicable: no React route, component, rendered surface, interaction, keyboard behavior, or accessibility semantics changed; only generated API type declarations changed.
+- Review RED: five focused regressions reproduced the missing external decision endpoint, legacy PUT reset, GitHub enforcement exception, skipped-analysis copy, and documentation gaps (`5 failed`).
+- Review GREEN: focused analyses/settings/GitHub suites passed after fixes; documentation contract rerun reported `3 passed, 26 subtests passed`.
+- Review full local CI: `bash scripts/ci-local.sh` - Ruff, formatting, dependency integrity, Bandit, compileall, all skill/prompt gates, and `919 tests` passed.
+- Review required smoke: `./.venv/bin/python -m unittest discover -q` - `411 tests` passed, `1 skipped`.
+- Review CI-parity shard: `./.venv/bin/python -m pytest tests/test_api tests/test_cli tests/test_infra -v --tb=short` - `392 passed, 109 subtests passed`.
+- Review generated-client verification: OpenAPI schema regenerated from the local app; frontend production build passed; Vitest reported `55 passed`.
+
+### Completion Notes List
+
+- Added project/integration `enforcement_mode` persistence and API exposure for `advisory`, `warn`, `soft-block`, and `hard-block`, with advisory defaults and backward-compatible loading of Story 11.2 settings.
+- Added a shared immutable enforcement decision that preserves raw policy status, caps effective status at the explicit integration mode, and keeps canonical reports advisory/non-blocking.
+- Routed GitHub App checks through the shared policy/enforcement path: advisory/warn remain non-blocking, soft-block maps to `action_required`, and hard-block maps to `failure`; summaries expose raw, configured, and effective statuses.
+- Updated integration/operator documentation and the generated TypeScript API schema. The external `deploywhisper/analyze-action` repository remains the owner of its runtime implementation and can consume this shared contract without changing the canonical analysis response.
+- Implementation is stacked on the unmerged Story 11.2 branch because Story 11.3 directly extends its policy settings/output services.
+- Resolved all seven code-review findings: added the external capped-decision endpoint, safe GitHub failure results, legacy PUT preservation, accurate skipped-analysis guidance, full mode/default/reset regressions, and executable operator-documentation coverage.
+
+### File List
+
+- README.md
+- _bmad-output/implementation-artifacts/11-3-integration-level-enforcement-settings.md
+- _bmad-output/implementation-artifacts/sprint-status.yaml
+- api/routes/settings.py
+- api/routes/analyses.py
+- api/schemas.py
+- docs/ci-advisory-consumption.md
+- docs/github-action.md
+- docs/github-app-self-hosted-setup.md
+- docs/github-app.md
+- docs/workflow-adapter-output-contract.md
+- frontend/src/api/schema.d.ts
+- integrations/github/app_service.py
+- services/policy_adapter_service.py
+- services/policy_adapter_settings.py
+- services/settings_service.py
+- tests/test_api/test_settings.py
+- tests/test_api/test_analyses.py
+- tests/test_docs/test_workflow_adapter_output_contract.py
+- tests/test_services/test_github_app_service.py
+- tests/test_services/test_policy_adapter_service.py
+- tests/test_services/test_settings_service.py
+
+## Change Log
+
+- 2026-05-01: Story created/aligned from updated PRD, architecture, epics, sprint status, and readiness report.
+- 2026-08-11: Added advisory-first integration enforcement settings, shared capped decisions, GitHub check enforcement, deterministic regression coverage, API schema generation, and operator documentation; moved story to review.
+- 2026-08-12: Resolved all seven code-review findings, regenerated the API client contract, completed full validation, and moved the story to done.

--- a/_bmad-output/implementation-artifacts/11-3-integration-level-enforcement-settings.md
+++ b/_bmad-output/implementation-artifacts/11-3-integration-level-enforcement-settings.md
@@ -37,6 +37,12 @@ So that teams can adopt warnings before blocking.
 ### Review Findings
 
 - [x] [Review][Patch] Add a combined GitHub webhook regression proving an enforcement-decision failure remains bounded when the fallback failure check cannot be delivered. [tests/test_services/test_github_app_service.py:435]
+- [x] [Review][Patch] Implement and verify the GitHub Action/CI enforcement consumer in `deploywhisper/analyze-action` using the canonical `github-action` integration key, validated v1 decision contract, auditable outputs, and configured blocking exit behavior.
+- [x] [Review][Patch] Treat a missing integer check-run ID as a delivery failure so a malformed GitHub success response cannot silently discard a soft/hard enforcement signal. [integrations/github/app_service.py:888]
+- [x] [Review][Patch] Return project-scope failures as failed results with the original machine-readable project code and a separate check-delivery code when both failures occur. [integrations/github/app_service.py:668]
+- [x] [Review][Patch] Preserve an existing or inherited enforcement mode in the shared settings service when non-HTTP callers omit the new field. [services/settings_service.py:218]
+- [x] [Review][Patch] Describe unknown future intake rejection states without incorrectly claiming that no changed artifacts were available. [integrations/github/app_service.py:852]
+- [x] [Review][Patch] Standardize the GitHub Action integration identifier as `github-action` across runtime, documentation, and executable contract examples. [docs/github-action.md:70]
 - [x] [Review][Patch] Synchronize both sprint-status `last_updated` values with the Story 11.3 completion date. [_bmad-output/implementation-artifacts/sprint-status.yaml:2]
 - [x] [Review][Patch] Remove the contradictory instruction to follow the retired Python UI composition style; project context establishes the React SPA as the only current UI framework. [_bmad-output/implementation-artifacts/11-3-integration-level-enforcement-settings.md:78]
 - [x] [Review][Patch] Make GitHub project-scope failure check-run delivery best-effort so a secondary GitHub API failure cannot escape the handled webhook result. [integrations/github/app_service.py:681]
@@ -173,13 +179,20 @@ OpenAI Codex (GPT-5)
 - Seventh review required smoke: `./.venv/bin/python -m unittest discover -q` - `414 tests` passed, `1 skipped`.
 - Seventh review full local CI: `bash scripts/ci-local.sh` passed Ruff check/format, dependency integrity, Bandit with zero high-severity findings, compileall, skill and prompt-injection gates, and every backend/docs test directory; `926 tests` passed.
 - UI validation not applicable for the seventh review: no React route, component, rendered surface, browser interaction, keyboard behavior, or accessibility semantics changed.
+- Eighth review RED: focused regressions reproduced missing check-run ID acceptance, project failures reported as success, lost primary project codes on compounded failures, shared-service enforcement downgrades, and misleading unknown intake guidance (`5 failed`).
+- Eighth review app GREEN: focused settings/GitHub App/API suites passed (`87 passed, 30 subtests passed`); GitHub Action contract and adapter-contract suites passed (`31 passed, 54 subtests passed`).
+- Eighth review CI-parity shard: `./.venv/bin/python -m pytest tests/test_api tests/test_cli tests/test_infra -v --tb=short` - `395 passed, 111 subtests passed`.
+- Eighth review required smoke: `./.venv/bin/python -m unittest discover -q` - `414 tests` passed, `1 skipped`.
+- Eighth review full local CI: `bash scripts/ci-local.sh` passed Ruff check/format, dependency integrity, Bandit with zero high-severity findings, compileall, skill and prompt-injection gates, and every backend/docs test directory; final services directory reported `930 tests` passing.
+- External action validation in `/tmp/analyze-action`: `python3 -m unittest discover -s tests -q` passed `62 tests`; compileall, non-repository `run_action.py --help`, and `git diff --check` passed.
+- UI validation not applicable for the eighth review: no React route, component, rendered surface, browser interaction, keyboard behavior, or accessibility semantics changed.
 
 ### Completion Notes List
 
 - Added project/integration `enforcement_mode` persistence and API exposure for `advisory`, `warn`, `soft-block`, and `hard-block`, with advisory defaults and backward-compatible loading of Story 11.2 settings.
 - Added a shared immutable enforcement decision that preserves raw policy status, caps effective status at the explicit integration mode, and keeps canonical reports advisory/non-blocking.
 - Routed GitHub App checks through the shared policy/enforcement path: advisory/warn remain non-blocking, soft-block maps to `action_required`, and hard-block maps to `failure`; summaries expose raw, configured, and effective statuses.
-- Updated integration/operator documentation and the generated TypeScript API schema. The external `deploywhisper/analyze-action` repository remains the owner of its runtime implementation and can consume this shared contract without changing the canonical analysis response.
+- Updated integration/operator documentation and the generated TypeScript API schema. The external `deploywhisper/analyze-action` runtime now consumes the shared enforcement contract without changing the canonical analysis response.
 - Implementation is stacked on the unmerged Story 11.2 branch because Story 11.3 directly extends its policy settings/output services.
 - Resolved all seven code-review findings: added the external capped-decision endpoint, safe GitHub failure results, legacy PUT preservation, accurate skipped-analysis guidance, full mode/default/reset regressions, and executable operator-documentation coverage.
 - Resolved both findings from the Story 11.3 review rerun: enforcement-validation failures now describe the completed analysis accurately, and the decision suite locks every raw-status/configured-mode pairing against upward escalation plus the built-in advisory path.
@@ -190,6 +203,7 @@ OpenAI Codex (GPT-5)
 - Resolved both fifth-review deferrals at user request: skipped and successful analyses now survive GitHub check-run delivery failures with bounded partial results, and rejected artifact sets receive explicit sensitive/unsupported/mixed guidance without exposing artifact details.
 - Resolved both sixth-review findings: story guidance now points only to the current React SPA conventions, and project-scope failures preserve handled webhook results when GitHub check-run delivery also fails.
 - Resolved both seventh-review findings: compounded enforcement/check-delivery failures now have explicit regression coverage, and sprint completion timestamps are internally consistent.
+- Resolved every eighth-review finding: the standalone action now enforces the validated `github-action` decision, malformed check-run responses fail explicitly, project and delivery failures remain separately machine-readable, shared service updates preserve enforcement, and all integration keys/guidance are consistent.
 
 ### File List
 
@@ -199,6 +213,7 @@ OpenAI Codex (GPT-5)
 - _bmad-output/implementation-artifacts/sprint-status.yaml
 - api/routes/settings.py
 - api/routes/analyses.py
+- api/routes/github_app.py
 - api/schemas.py
 - docs/ci-advisory-consumption.md
 - docs/github-action.md
@@ -212,10 +227,14 @@ OpenAI Codex (GPT-5)
 - services/settings_service.py
 - tests/test_api/test_settings.py
 - tests/test_api/test_analyses.py
+- tests/test_api/test_github_app.py
+- tests/test_docs/test_github_action_integration_contract.py
 - tests/test_docs/test_workflow_adapter_output_contract.py
+- tests/test_services/test_adapter_output_contract.py
 - tests/test_services/test_github_app_service.py
 - tests/test_services/test_policy_adapter_service.py
 - tests/test_services/test_settings_service.py
+- External repository `deploywhisper/analyze-action`: `README.md`, `action.yml`, `action_runtime.py`, `tests/test_action_runtime.py`
 
 ## Change Log
 
@@ -230,3 +249,4 @@ OpenAI Codex (GPT-5)
 - 2026-08-14: Addressed both deferred fifth-review findings with red-green regressions and full local CI; moved Story 11.3 back to review.
 - 2026-08-17: Addressed all sixth-review findings with a focused red-green regression and full local CI; moved Story 11.3 to done.
 - 2026-08-18: Addressed all seventh-review findings with compounded-failure regressions, synchronized sprint metadata, and full local CI; retained done status.
+- 2026-08-18: Addressed all eighth-review findings across the app and standalone action repositories, completed CI enforcement consumption, and retained done status after full validation.

--- a/_bmad-output/implementation-artifacts/11-3-integration-level-enforcement-settings.md
+++ b/_bmad-output/implementation-artifacts/11-3-integration-level-enforcement-settings.md
@@ -1,6 +1,6 @@
 # Story 11.3: Integration-Level Enforcement Settings
 
-Status: review
+Status: done
 
 <!-- Generated from updated PRD/architecture/epics plus implementation-readiness-report-2026-05-01.md. -->
 
@@ -36,6 +36,8 @@ So that teams can adopt warnings before blocking.
 
 ### Review Findings
 
+- [x] [Review][Patch] Remove the contradictory instruction to follow the retired Python UI composition style; project context establishes the React SPA as the only current UI framework. [_bmad-output/implementation-artifacts/11-3-integration-level-enforcement-settings.md:78]
+- [x] [Review][Patch] Make GitHub project-scope failure check-run delivery best-effort so a secondary GitHub API failure cannot escape the handled webhook result. [integrations/github/app_service.py:681]
 - [x] [Review][Defer] Best-effort handle GitHub check-run creation failures on neutral-skip and successful-analysis paths [integrations/github/app_service.py:421] — deferred, pre-existing
 - [x] [Review][Defer] Distinguish sensitive-only and unsupported-only skipped PR artifacts in GitHub guidance [integrations/github/app_service.py:414] — deferred, pre-existing
 - [x] [Review][Patch] [MEDIUM] Do not claim that a canonical advisory report exists in GitHub check text when analysis was skipped or failed before report persistence; `_check_run_text()` currently appends that sentence even when both `details_url` and `enforcement` are absent. [integrations/github/app_service.py:822]
@@ -75,7 +77,7 @@ So that teams can adopt warnings before blocking.
 
 - API routes belong under `api/routes/` and should use existing `ApiRoute` / `ApiError` envelope patterns.
 - Shared orchestration belongs in `services/`; parsers normalize input, analysis modules score/derive risk, and surfaces adapt outputs.
-- UI work belongs under `frontend/src/screens/` and `frontend/src/components/`, following the existing retired Python UI composition style.
+- UI work belongs under `frontend/src/screens/` and `frontend/src/components/`, following the current React SPA component and theme conventions.
 - CLI behavior belongs under `cli/` and must call the same service-layer paths as UI/API flows.
 - Persistence work belongs under `models/` with Alembic migrations when schema changes are required.
 - Documentation required by a story should be updated in the same workstream.
@@ -158,6 +160,12 @@ OpenAI Codex (GPT-5)
 - Deferred-finding CI-parity shard: `./.venv/bin/python -m pytest tests/test_api tests/test_cli tests/test_infra -v --tb=short` - `395 passed, 111 subtests passed`.
 - Deferred-finding full local CI: `bash scripts/ci-local.sh` - passed Ruff check/format, dependency integrity, Bandit high-confidence gate with zero high findings, compileall, all skill and prompt-injection gates, and every backend/docs test directory; final services directory reported `924 tests` passing.
 - UI validation not applicable for the deferred findings: no React route, component, rendered surface, browser interaction, keyboard behavior, or accessibility semantics changed.
+- Sixth review RED: `./.venv/bin/python -m pytest tests/test_services/test_github_app_service.py -q --tb=short` reproduced the unhandled project-scope/check-delivery failure (`1 failed, 29 passed, 9 subtests passed`).
+- Sixth review GREEN: the same focused GitHub App suite passed after the bounded partial-result fix (`30 passed, 9 subtests passed`).
+- Sixth review quality gates: `./.venv/bin/ruff check .`, repo-wide `./.venv/bin/ruff format --check .`, and `git diff --check` passed; Ruff reported all 272 files formatted.
+- Sixth review required smoke: `./.venv/bin/python -m unittest discover -q` passed.
+- Sixth review full local CI: `bash scripts/ci-local.sh` passed Ruff check/format, dependency integrity, Bandit with zero high-severity findings, compileall, skill and prompt-injection gates, and every backend/docs test directory; `925 tests` passed.
+- UI validation not applicable for the sixth review: no React route, component, rendered surface, browser interaction, keyboard behavior, or accessibility semantics changed.
 
 ### Completion Notes List
 
@@ -173,6 +181,7 @@ OpenAI Codex (GPT-5)
 - Resolved both findings from the fourth review rerun: GitHub checks only mention a canonical report when one exists, and the external enforcement-decision API now distinguishes malformed integration input from internal decision-validation failures with stable error codes.
 - The fifth review rerun found no Story 11.3 patch or decision gap; two pre-existing GitHub App reliability/copy issues were recorded in deferred work without expanding this story's scope.
 - Resolved both fifth-review deferrals at user request: skipped and successful analyses now survive GitHub check-run delivery failures with bounded partial results, and rejected artifact sets receive explicit sensitive/unsupported/mixed guidance without exposing artifact details.
+- Resolved both sixth-review findings: story guidance now points only to the current React SPA conventions, and project-scope failures preserve handled webhook results when GitHub check-run delivery also fails.
 
 ### File List
 
@@ -211,3 +220,4 @@ OpenAI Codex (GPT-5)
 - 2026-08-14: Resolved the fourth review rerun findings for no-report GitHub guidance and distinct enforcement-decision error codes.
 - 2026-08-14: Fifth review rerun passed Story 11.3 acceptance and recorded two pre-existing GitHub App issues as deferred work.
 - 2026-08-14: Addressed both deferred fifth-review findings with red-green regressions and full local CI; moved Story 11.3 back to review.
+- 2026-08-17: Addressed all sixth-review findings with a focused red-green regression and full local CI; moved Story 11.3 to done.

--- a/_bmad-output/implementation-artifacts/11-3-integration-level-enforcement-settings.md
+++ b/_bmad-output/implementation-artifacts/11-3-integration-level-enforcement-settings.md
@@ -31,6 +31,8 @@ So that teams can adopt warnings before blocking.
 
 ### Review Findings
 
+- [x] [Review][Patch] [MEDIUM] Preserve the resolved inherited project enforcement mode when a backward-compatible client creates its first integration override without `enforcement_mode`; the current source check falls back to the request model's `advisory` default and silently downgrades enforcement. [api/routes/settings.py:529]
+- [x] [Review][Patch] [MEDIUM] Return a server-error contract when the enforcement-decision endpoint encounters internally generated adapter or decision invariant failures; the new route currently reports every `ValueError` as client-side `400 invalid_policy_adapter_output`. [api/routes/analyses.py:1063]
 - [x] [Review][Patch] [MEDIUM] Use enforcement-specific fallback guidance when analysis succeeds but enforcement validation fails; the check summary says the analysis completed, while `_check_run_text()` currently says it could not complete. [integrations/github/app_service.py:585]
 - [x] [Review][Patch] [MEDIUM] Expand enforcement-decision regression coverage across raw policy statuses, including raw statuses below the configured ceiling, so the no-upward-escalation invariant and advisory-first built-in decision path cannot drift. [tests/test_services/test_policy_adapter_service.py:108]
 - [x] [Review][Patch] [HIGH] Expose the capped enforcement decision through a shared external API contract so CI and future adapters can consume `configured_mode`, `effective_status`, and `should_block` without reimplementing policy logic. [api/routes/analyses.py:96]
@@ -117,6 +119,11 @@ OpenAI Codex (GPT-5)
 - Review rerun quality gates: `./.venv/bin/ruff check .`, `./.venv/bin/ruff format --check .`, and `git diff --check` passed; Ruff reported all 272 files formatted.
 - Review rerun CI-parity shard: `./.venv/bin/python -m pytest tests/test_api tests/test_cli tests/test_infra -v --tb=short` - `392 passed, 109 subtests passed`.
 - Review rerun full local CI: `bash scripts/ci-local.sh` - passed Ruff check/format, dependency integrity, Bandit high-confidence gate (0 high findings), compileall, all skill and prompt-injection gates, and every backend/docs test directory; final services directory reported `920 tests` passing.
+- Second review rerun RED: focused settings/analyses API regressions reproduced the inherited-mode downgrade and client-error misclassification (`2 failed, 118 passed, 33 subtests passed`).
+- Second review rerun GREEN: `./.venv/bin/python -m pytest tests/test_api/test_settings.py tests/test_api/test_analyses.py -q --tb=short` - `120 passed, 33 subtests passed`.
+- Second review required smoke: `./.venv/bin/python -m unittest discover -q` - `413 tests` passed, `1 skipped`.
+- Second review CI-parity shard: `./.venv/bin/python -m pytest tests/test_api tests/test_cli tests/test_infra -v --tb=short` - `394 passed, 109 subtests passed`.
+- Second review full local CI: `bash scripts/ci-local.sh` - passed Ruff check/format, dependency integrity, Bandit high-confidence gate, compileall, all skill and prompt-injection gates, and every backend/docs test directory; final services directory reported `920 tests` passing.
 
 ### Completion Notes List
 
@@ -127,6 +134,7 @@ OpenAI Codex (GPT-5)
 - Implementation is stacked on the unmerged Story 11.2 branch because Story 11.3 directly extends its policy settings/output services.
 - Resolved all seven code-review findings: added the external capped-decision endpoint, safe GitHub failure results, legacy PUT preservation, accurate skipped-analysis guidance, full mode/default/reset regressions, and executable operator-documentation coverage.
 - Resolved both findings from the Story 11.3 review rerun: enforcement-validation failures now describe the completed analysis accurately, and the decision suite locks every raw-status/configured-mode pairing against upward escalation plus the built-in advisory path.
+- Resolved both findings from the second review rerun: legacy integration overrides retain inherited project enforcement when the field is omitted, and internal enforcement-decision validation failures return a sanitized server-error response.
 
 ### File List
 
@@ -159,3 +167,4 @@ OpenAI Codex (GPT-5)
 - 2026-08-11: Added advisory-first integration enforcement settings, shared capped decisions, GitHub check enforcement, deterministic regression coverage, API schema generation, and operator documentation; moved story to review.
 - 2026-08-12: Resolved all seven code-review findings, regenerated the API client contract, completed full validation, and moved the story to done.
 - 2026-08-13: Resolved both findings from the code-review rerun and expanded enforcement-decision regression coverage across the complete status matrix.
+- 2026-08-13: Resolved the second review rerun findings for inherited enforcement preservation and internal error classification, with focused and full-CI regression evidence.

--- a/_bmad-output/implementation-artifacts/11-3-integration-level-enforcement-settings.md
+++ b/_bmad-output/implementation-artifacts/11-3-integration-level-enforcement-settings.md
@@ -109,6 +109,7 @@ OpenAI Codex (GPT-5)
 - Review required smoke: `./.venv/bin/python -m unittest discover -q` - `411 tests` passed, `1 skipped`.
 - Review CI-parity shard: `./.venv/bin/python -m pytest tests/test_api tests/test_cli tests/test_infra -v --tb=short` - `392 passed, 109 subtests passed`.
 - Review generated-client verification: OpenAPI schema regenerated from the local app; frontend production build passed; Vitest reported `55 passed`.
+- Remote CI correction: the first PR API/CLI/infra run found a stale mirrored sprint-status header date; after aligning it with `last_updated`, the focused metadata regression and full shard were rerun.
 
 ### Completion Notes List
 

--- a/_bmad-output/implementation-artifacts/11-3-integration-level-enforcement-settings.md
+++ b/_bmad-output/implementation-artifacts/11-3-integration-level-enforcement-settings.md
@@ -36,6 +36,8 @@ So that teams can adopt warnings before blocking.
 
 ### Review Findings
 
+- [x] [Review][Patch] Add a combined GitHub webhook regression proving an enforcement-decision failure remains bounded when the fallback failure check cannot be delivered. [tests/test_services/test_github_app_service.py:435]
+- [x] [Review][Patch] Synchronize both sprint-status `last_updated` values with the Story 11.3 completion date. [_bmad-output/implementation-artifacts/sprint-status.yaml:2]
 - [x] [Review][Patch] Remove the contradictory instruction to follow the retired Python UI composition style; project context establishes the React SPA as the only current UI framework. [_bmad-output/implementation-artifacts/11-3-integration-level-enforcement-settings.md:78]
 - [x] [Review][Patch] Make GitHub project-scope failure check-run delivery best-effort so a secondary GitHub API failure cannot escape the handled webhook result. [integrations/github/app_service.py:681]
 - [x] [Review][Defer] Best-effort handle GitHub check-run creation failures on neutral-skip and successful-analysis paths [integrations/github/app_service.py:421] — deferred, pre-existing
@@ -166,6 +168,11 @@ OpenAI Codex (GPT-5)
 - Sixth review required smoke: `./.venv/bin/python -m unittest discover -q` passed.
 - Sixth review full local CI: `bash scripts/ci-local.sh` passed Ruff check/format, dependency integrity, Bandit with zero high-severity findings, compileall, skill and prompt-injection gates, and every backend/docs test directory; `925 tests` passed.
 - UI validation not applicable for the sixth review: no React route, component, rendered surface, browser interaction, keyboard behavior, or accessibility semantics changed.
+- Seventh review focused regression: `./.venv/bin/python -m pytest tests/test_services/test_github_app_service.py -q --tb=short` - `31 passed, 11 subtests passed`, including both enforcement-failure/check-delivery combinations.
+- Seventh review quality gates: `./.venv/bin/ruff check .`, repo-wide `./.venv/bin/ruff format --check .`, and `git diff --check` passed; Ruff reported all 272 files formatted.
+- Seventh review required smoke: `./.venv/bin/python -m unittest discover -q` - `414 tests` passed, `1 skipped`.
+- Seventh review full local CI: `bash scripts/ci-local.sh` passed Ruff check/format, dependency integrity, Bandit with zero high-severity findings, compileall, skill and prompt-injection gates, and every backend/docs test directory; `926 tests` passed.
+- UI validation not applicable for the seventh review: no React route, component, rendered surface, browser interaction, keyboard behavior, or accessibility semantics changed.
 
 ### Completion Notes List
 
@@ -182,6 +189,7 @@ OpenAI Codex (GPT-5)
 - The fifth review rerun found no Story 11.3 patch or decision gap; two pre-existing GitHub App reliability/copy issues were recorded in deferred work without expanding this story's scope.
 - Resolved both fifth-review deferrals at user request: skipped and successful analyses now survive GitHub check-run delivery failures with bounded partial results, and rejected artifact sets receive explicit sensitive/unsupported/mixed guidance without exposing artifact details.
 - Resolved both sixth-review findings: story guidance now points only to the current React SPA conventions, and project-scope failures preserve handled webhook results when GitHub check-run delivery also fails.
+- Resolved both seventh-review findings: compounded enforcement/check-delivery failures now have explicit regression coverage, and sprint completion timestamps are internally consistent.
 
 ### File List
 
@@ -221,3 +229,4 @@ OpenAI Codex (GPT-5)
 - 2026-08-14: Fifth review rerun passed Story 11.3 acceptance and recorded two pre-existing GitHub App issues as deferred work.
 - 2026-08-14: Addressed both deferred fifth-review findings with red-green regressions and full local CI; moved Story 11.3 back to review.
 - 2026-08-17: Addressed all sixth-review findings with a focused red-green regression and full local CI; moved Story 11.3 to done.
+- 2026-08-18: Addressed all seventh-review findings with compounded-failure regressions, synchronized sprint metadata, and full local CI; retained done status.

--- a/_bmad-output/implementation-artifacts/11-3-integration-level-enforcement-settings.md
+++ b/_bmad-output/implementation-artifacts/11-3-integration-level-enforcement-settings.md
@@ -31,6 +31,8 @@ So that teams can adopt warnings before blocking.
 
 ### Review Findings
 
+- [x] [Review][Defer] Best-effort handle GitHub check-run creation failures on neutral-skip and successful-analysis paths [integrations/github/app_service.py:421] — deferred, pre-existing
+- [x] [Review][Defer] Distinguish sensitive-only and unsupported-only skipped PR artifacts in GitHub guidance [integrations/github/app_service.py:414] — deferred, pre-existing
 - [x] [Review][Patch] [MEDIUM] Do not claim that a canonical advisory report exists in GitHub check text when analysis was skipped or failed before report persistence; `_check_run_text()` currently appends that sentence even when both `details_url` and `enforcement` are absent. [integrations/github/app_service.py:822]
 - [x] [Review][Patch] [MEDIUM] Give malformed integration identifiers and internal enforcement-decision invariant failures distinct machine-readable API error codes; both paths currently emit `invalid_policy_adapter_output` despite representing caller input versus server-contract failures. [api/routes/analyses.py:1038]
 - [x] [Review][Patch] [MEDIUM] Reject blank or otherwise invalid `integration` query values as client errors before enforcement-decision construction; whitespace currently reaches `AdapterMetadata`, is caught with internal invariant failures, and returns HTTP 500 instead of a bounded 4xx response. [api/routes/analyses.py:1028]
@@ -151,10 +153,12 @@ OpenAI Codex (GPT-5)
 - Resolved both findings from the second review rerun: legacy integration overrides retain inherited project enforcement when the field is omitted, and internal enforcement-decision validation failures return a sanitized server-error response.
 - Resolved both findings from the third review rerun: policy integration identifiers now use shared boundary normalization before decision construction, and legacy integration-scoped storage has explicit advisory-default coverage.
 - Resolved both findings from the fourth review rerun: GitHub checks only mention a canonical report when one exists, and the external enforcement-decision API now distinguishes malformed integration input from internal decision-validation failures with stable error codes.
+- The fifth review rerun found no Story 11.3 patch or decision gap; two pre-existing GitHub App reliability/copy issues were recorded in deferred work without expanding this story's scope.
 
 ### File List
 
 - README.md
+- _bmad-output/implementation-artifacts/deferred-work.md
 - _bmad-output/implementation-artifacts/11-3-integration-level-enforcement-settings.md
 - _bmad-output/implementation-artifacts/sprint-status.yaml
 - api/routes/settings.py
@@ -186,3 +190,4 @@ OpenAI Codex (GPT-5)
 - 2026-08-13: Resolved the second review rerun findings for inherited enforcement preservation and internal error classification, with focused and full-CI regression evidence.
 - 2026-08-13: Resolved the third review rerun findings for invalid integration input classification and legacy integration-storage coverage.
 - 2026-08-14: Resolved the fourth review rerun findings for no-report GitHub guidance and distinct enforcement-decision error codes.
+- 2026-08-14: Fifth review rerun passed Story 11.3 acceptance and recorded two pre-existing GitHub App issues as deferred work.

--- a/_bmad-output/implementation-artifacts/11-3-integration-level-enforcement-settings.md
+++ b/_bmad-output/implementation-artifacts/11-3-integration-level-enforcement-settings.md
@@ -36,6 +36,9 @@ So that teams can adopt warnings before blocking.
 
 ### Review Findings
 
+- [x] [Review][Patch] [HIGH] Validate that the standalone Action's `effective_status` is the minimum of `policy_output.status` and `configured_mode`; the current consumer accepts a contradictory `hard-block`/`hard-block`/`advisory` payload with `should_block=false` and exits successfully, violating its documented fail-closed enforcement contract. [external deploywhisper/analyze-action:action_runtime.py:636]
+- [x] [Review][Patch] [MEDIUM] Stop the policy-adapter service test from reloading the enforcement decision model behind the already-imported API response schema; running that service suite before the new enforcement endpoint regression leaves two Pydantic class identities and makes the valid endpoint request return HTTP 500. [tests/test_services/test_policy_adapter_service.py:35]
+- [x] [Review][Patch] [MEDIUM] Validate the pushed `deploywhisper/analyze-action` feature branch through `deploywhisper/action-smoke-consumer` and record the GitHub Actions run URL/result; the story records only local unit checks even though project context makes remote consumer validation mandatory for action changes. [_bmad-output/implementation-artifacts/11-3-integration-level-enforcement-settings.md:187]
 - [x] [Review][Patch] Add a combined GitHub webhook regression proving an enforcement-decision failure remains bounded when the fallback failure check cannot be delivered. [tests/test_services/test_github_app_service.py:435]
 - [x] [Review][Patch] Implement and verify the GitHub Action/CI enforcement consumer in `deploywhisper/analyze-action` using the canonical `github-action` integration key, validated v1 decision contract, auditable outputs, and configured blocking exit behavior.
 - [x] [Review][Patch] Treat a missing integer check-run ID as a delivery failure so a malformed GitHub success response cannot silently discard a soft/hard enforcement signal. [integrations/github/app_service.py:888]
@@ -185,7 +188,13 @@ OpenAI Codex (GPT-5)
 - Eighth review required smoke: `./.venv/bin/python -m unittest discover -q` - `414 tests` passed, `1 skipped`.
 - Eighth review full local CI: `bash scripts/ci-local.sh` passed Ruff check/format, dependency integrity, Bandit with zero high-severity findings, compileall, skill and prompt-injection gates, and every backend/docs test directory; final services directory reported `930 tests` passing.
 - External action validation in `/tmp/analyze-action`: `python3 -m unittest discover -s tests -q` passed `62 tests`; compileall, non-repository `run_action.py --help`, and `git diff --check` passed.
+- Ninth review RED: the standalone Action accepted a contradictory `hard-block` policy status, `hard-block` configured mode, and `advisory` effective status with `should_block=false`; the combined policy-service/API sequence also reproduced an order-dependent HTTP 500 (`1 failed, 4 passed, 16 subtests passed`).
+- Ninth review GREEN: the Action now validates the effective-status ceiling before trusting `should_block`; its `62 tests`, compileall, and `git diff --check` passed. The app's focused order-dependent regression passed (`5 passed, 16 subtests passed`).
+- Ninth review app validation: the combined Story 11.3 suite passed (`228 passed, 149 subtests passed`), required smoke passed (`414 tests`, `1 skipped`), CI-parity API/CLI/infra shard passed (`395 passed, 111 subtests passed`), and `bash scripts/ci-local.sh` passed all gates with `930 tests`.
+- Ninth review quality gates: `./.venv/bin/ruff check .`, repo-wide `./.venv/bin/ruff format --check .`, and `git diff --check` passed; Ruff reported all 272 files formatted.
+- External Action closeout: commit `63de84f` was pushed to `feature/11-3-integration-enforcement-settings`; temporary consumer PR `deploywhisper/action-smoke-consumer#14` passed against the feature branch in [GitHub Actions run 34099865597](https://github.com/deploywhisper/action-smoke-consumer/actions/runs/34099865597) and was closed without merge.
 - UI validation not applicable for the eighth review: no React route, component, rendered surface, browser interaction, keyboard behavior, or accessibility semantics changed.
+- UI validation not applicable for the ninth review: no React route, component, rendered surface, browser interaction, keyboard behavior, or accessibility semantics changed.
 
 ### Completion Notes List
 
@@ -204,6 +213,7 @@ OpenAI Codex (GPT-5)
 - Resolved both sixth-review findings: story guidance now points only to the current React SPA conventions, and project-scope failures preserve handled webhook results when GitHub check-run delivery also fails.
 - Resolved both seventh-review findings: compounded enforcement/check-delivery failures now have explicit regression coverage, and sprint completion timestamps are internally consistent.
 - Resolved every eighth-review finding: the standalone action now enforces the validated `github-action` decision, malformed check-run responses fail explicitly, project and delivery failures remain separately machine-readable, shared service updates preserve enforcement, and all integration keys/guidance are consistent.
+- Resolved every ninth-review finding: the Action rejects contradictory effective statuses before deciding its exit code, the app regression suite no longer corrupts the API response model through module reloads, and the pushed Action branch passed the required external consumer smoke.
 
 ### File List
 
@@ -250,3 +260,4 @@ OpenAI Codex (GPT-5)
 - 2026-08-17: Addressed all sixth-review findings with a focused red-green regression and full local CI; moved Story 11.3 to done.
 - 2026-08-18: Addressed all seventh-review findings with compounded-failure regressions, synchronized sprint metadata, and full local CI; retained done status.
 - 2026-08-18: Addressed all eighth-review findings across the app and standalone action repositories, completed CI enforcement consumption, and retained done status after full validation.
+- 2026-09-07: Addressed all ninth-review findings, passed focused and full local validation, and verified the pushed standalone Action through the external smoke consumer; retained done status.

--- a/_bmad-output/implementation-artifacts/deferred-work.md
+++ b/_bmad-output/implementation-artifacts/deferred-work.md
@@ -75,3 +75,7 @@
 ## Deferred from: code review of 11-3-integration-level-enforcement-settings.md (2026-08-17)
 
 - Resolved 2026-08-17: GitHub project-scope failures now return a bounded partial webhook result when check-run delivery also fails, while retaining the original project error in sanitized operator guidance [integrations/github/app_service.py:681].
+
+## Deferred from: code review of 11-3-integration-level-enforcement-settings.md (2026-08-18)
+
+- Resolved 2026-08-18: Project-scope failures now return failed results with their original machine-readable root-cause code; compounded GitHub check delivery failures are exposed separately through `delivery_code` [integrations/github/app_service.py:668].

--- a/_bmad-output/implementation-artifacts/deferred-work.md
+++ b/_bmad-output/implementation-artifacts/deferred-work.md
@@ -66,3 +66,8 @@
 ## Deferred from: code review of 10-4-prompt-injection-test-suite.md (2026-07-31)
 
 - Resolved 2026-07-31: Release-blocking claims such as `Stop the release` and `Release should be blocked` now contradict a GO recommendation [llm/prompt_security.py:97].
+
+## Deferred from: code review of 11-3-integration-level-enforcement-settings.md (2026-08-14)
+
+- GitHub check-run creation failures on neutral-skip and successful-analysis paths are not handled as best-effort delivery failures [integrations/github/app_service.py:421]. Deferred as pre-existing GitHub App reliability hardening because both direct `_create_check_run()` calls and their exception behavior existed before Story 11.3.
+- GitHub skipped-analysis guidance does not distinguish sensitive-only, unsupported-only, and mixed rejected artifact sets [integrations/github/app_service.py:414]. Deferred as pre-existing intake-copy hardening because the shared empty-accepted-files message existed before Story 11.3 and does not affect enforcement-mode resolution.

--- a/_bmad-output/implementation-artifacts/deferred-work.md
+++ b/_bmad-output/implementation-artifacts/deferred-work.md
@@ -71,3 +71,7 @@
 
 - Resolved 2026-08-14: GitHub check-run creation failures on neutral-skip and successful-analysis paths now return bounded partial results while preserving handled webhook state and persisted report references [integrations/github/app_service.py:421].
 - Resolved 2026-08-14: GitHub skipped-analysis guidance now distinguishes sensitive-only, unsupported-only, mixed rejected, and empty artifact sets without exposing filenames or contents [integrations/github/app_service.py:414].
+
+## Deferred from: code review of 11-3-integration-level-enforcement-settings.md (2026-08-17)
+
+- Resolved 2026-08-17: GitHub project-scope failures now return a bounded partial webhook result when check-run delivery also fails, while retaining the original project error in sanitized operator guidance [integrations/github/app_service.py:681].

--- a/_bmad-output/implementation-artifacts/deferred-work.md
+++ b/_bmad-output/implementation-artifacts/deferred-work.md
@@ -69,5 +69,5 @@
 
 ## Deferred from: code review of 11-3-integration-level-enforcement-settings.md (2026-08-14)
 
-- GitHub check-run creation failures on neutral-skip and successful-analysis paths are not handled as best-effort delivery failures [integrations/github/app_service.py:421]. Deferred as pre-existing GitHub App reliability hardening because both direct `_create_check_run()` calls and their exception behavior existed before Story 11.3.
-- GitHub skipped-analysis guidance does not distinguish sensitive-only, unsupported-only, and mixed rejected artifact sets [integrations/github/app_service.py:414]. Deferred as pre-existing intake-copy hardening because the shared empty-accepted-files message existed before Story 11.3 and does not affect enforcement-mode resolution.
+- Resolved 2026-08-14: GitHub check-run creation failures on neutral-skip and successful-analysis paths now return bounded partial results while preserving handled webhook state and persisted report references [integrations/github/app_service.py:421].
+- Resolved 2026-08-14: GitHub skipped-analysis guidance now distinguishes sensitive-only, unsupported-only, mixed rejected, and empty artifact sets without exposing filenames or contents [integrations/github/app_service.py:414].

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -1,5 +1,5 @@
 # generated: 2026-05-01
-# last_updated: 2026-08-14
+# last_updated: 2026-08-18
 # project: deploywhisper
 # project_key: NOKEY
 # tracking_system: file-system
@@ -35,7 +35,7 @@
 # - Dev moves story to review, then runs code-review
 
 generated: 2026-05-01
-last_updated: 2026-08-14
+last_updated: 2026-08-18
 project: deploywhisper
 project_key: NOKEY
 tracking_system: file-system

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -1,5 +1,5 @@
 # generated: 2026-05-01
-# last_updated: 2026-08-11
+# last_updated: 2026-08-12
 # project: deploywhisper
 # project_key: NOKEY
 # tracking_system: file-system

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -1,5 +1,5 @@
 # generated: 2026-05-01
-# last_updated: 2026-08-12
+# last_updated: 2026-08-13
 # project: deploywhisper
 # project_key: NOKEY
 # tracking_system: file-system
@@ -35,7 +35,7 @@
 # - Dev moves story to review, then runs code-review
 
 generated: 2026-05-01
-last_updated: 2026-08-12
+last_updated: 2026-08-13
 project: deploywhisper
 project_key: NOKEY
 tracking_system: file-system

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -146,7 +146,7 @@ development_status:
   epic-11: in-progress
   11-1-policy-adapter-output-contract: done
   11-2-threshold-and-reporting-defaults-management: done
-  11-3-integration-level-enforcement-settings: done
+  11-3-integration-level-enforcement-settings: review
   11-4-enforcement-guardrail-documentation: ready-for-dev
   epic-11-retrospective: optional
 

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -1,5 +1,5 @@
 # generated: 2026-05-01
-# last_updated: 2026-08-13
+# last_updated: 2026-08-14
 # project: deploywhisper
 # project_key: NOKEY
 # tracking_system: file-system
@@ -35,7 +35,7 @@
 # - Dev moves story to review, then runs code-review
 
 generated: 2026-05-01
-last_updated: 2026-08-13
+last_updated: 2026-08-14
 project: deploywhisper
 project_key: NOKEY
 tracking_system: file-system

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -35,7 +35,7 @@
 # - Dev moves story to review, then runs code-review
 
 generated: 2026-05-01
-last_updated: 2026-08-11
+last_updated: 2026-08-12
 project: deploywhisper
 project_key: NOKEY
 tracking_system: file-system
@@ -146,7 +146,7 @@ development_status:
   epic-11: in-progress
   11-1-policy-adapter-output-contract: done
   11-2-threshold-and-reporting-defaults-management: done
-  11-3-integration-level-enforcement-settings: ready-for-dev
+  11-3-integration-level-enforcement-settings: done
   11-4-enforcement-guardrail-documentation: ready-for-dev
   epic-11-retrospective: optional
 

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -146,7 +146,7 @@ development_status:
   epic-11: in-progress
   11-1-policy-adapter-output-contract: done
   11-2-threshold-and-reporting-defaults-management: done
-  11-3-integration-level-enforcement-settings: review
+  11-3-integration-level-enforcement-settings: done
   11-4-enforcement-guardrail-documentation: ready-for-dev
   epic-11-retrospective: optional
 

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -1,5 +1,5 @@
 # generated: 2026-05-01
-# last_updated: 2026-08-18
+# last_updated: 2026-09-07
 # project: deploywhisper
 # project_key: NOKEY
 # tracking_system: file-system
@@ -35,7 +35,7 @@
 # - Dev moves story to review, then runs code-review
 
 generated: 2026-05-01
-last_updated: 2026-08-18
+last_updated: 2026-09-07
 project: deploywhisper
 project_key: NOKEY
 tracking_system: file-system

--- a/api/routes/analyses.py
+++ b/api/routes/analyses.py
@@ -1035,7 +1035,7 @@ def get_integration_enforcement_decision(
     except ValueError as exc:
         raise ApiError(
             status_code=400,
-            code="invalid_policy_adapter_output",
+            code="invalid_integration_identifier",
             message="Integration identifier is invalid.",
         ) from exc
     try:
@@ -1072,7 +1072,7 @@ def get_integration_enforcement_decision(
     except ValueError as exc:
         raise ApiError(
             status_code=500,
-            code="invalid_policy_adapter_output",
+            code="integration_enforcement_decision_invalid",
             message="Integration enforcement decision could not be validated.",
         ) from exc
     return IntegrationEnforcementDecisionResponse(

--- a/api/routes/analyses.py
+++ b/api/routes/analyses.py
@@ -85,7 +85,11 @@ from services.project_service import (
 from services.project_service import resolve_project_reference
 from services.policy_adapter_output_contract import PolicyAdapterOutputContract
 from services.policy_adapter_settings import PolicyAdapterSettingsIntegrityError
-from services.policy_adapter_service import build_configured_policy_adapter_output
+from services.policy_adapter_service import (
+    IntegrationEnforcementDecision,
+    build_configured_policy_adapter_output,
+    build_integration_enforcement_decision,
+)
 
 router = APIRouter(prefix="/api/v1/analyses", tags=["analyses"], route_class=ApiRoute)
 READ_CHUNK_BYTES = 1024 * 1024
@@ -97,6 +101,13 @@ class PolicyAdapterOutputResponse(BaseModel):
     """API envelope for configured policy interpretation of one report."""
 
     data: PolicyAdapterOutputContract
+    meta: ResourceMetaPayload
+
+
+class IntegrationEnforcementDecisionResponse(BaseModel):
+    """API envelope for an integration's capped enforcement decision."""
+
+    data: IntegrationEnforcementDecision
     meta: ResourceMetaPayload
 
 
@@ -992,6 +1003,71 @@ def get_policy_adapter_output(
         ) from exc
     return PolicyAdapterOutputResponse(
         data=policy_output,
+        meta=build_report_meta(
+            id=report_id,
+            report_schema_version=normalize_report_schema_version(
+                report.get("report_schema_version")
+            ),
+        ),
+    )
+
+
+@router.get(
+    "/{report_id}/enforcement-decision",
+    response_model=IntegrationEnforcementDecisionResponse,
+    responses={
+        400: {"model": ErrorResponse},
+        403: {"model": ErrorResponse},
+        404: {"model": ErrorResponse},
+        422: {"model": ErrorResponse},
+        500: {"model": ErrorResponse},
+    },
+)
+def get_integration_enforcement_decision(
+    report_id: int,
+    integration: str = Query(..., min_length=1),
+    authorization: dict[str, object] = Depends(_authorization_context),
+) -> IntegrationEnforcementDecisionResponse:
+    """Return the auditable, integration-capped decision for one report."""
+    try:
+        report = _fetch_report_for_authorized_read(
+            authorization=authorization,
+            report_id=report_id,
+        )
+        project = report.get("project") or {}
+        project_id = project.get("id")
+        if not isinstance(project_id, int):
+            raise ApiError(
+                status_code=500,
+                code="analysis_project_scope_invalid",
+                message="Analysis report project scope is invalid.",
+            )
+        decision = build_integration_enforcement_decision(
+            build_adapter_output_contract(
+                build_share_summary(report),
+                AdapterMetadata(
+                    adapter=integration,
+                    format="workflow_decision",
+                    project_id=project_id,
+                ),
+            )
+        )
+    except PermissionError as exc:
+        _raise_authorization_error(exc)
+    except PolicyAdapterSettingsIntegrityError as exc:
+        raise ApiError(
+            status_code=500,
+            code="policy_adapter_settings_integrity_error",
+            message="Stored policy adapter settings failed integrity validation.",
+        ) from exc
+    except ValueError as exc:
+        raise ApiError(
+            status_code=400,
+            code="invalid_policy_adapter_output",
+            message=str(exc),
+        ) from exc
+    return IntegrationEnforcementDecisionResponse(
+        data=decision,
         meta=build_report_meta(
             id=report_id,
             report_schema_version=normalize_report_schema_version(

--- a/api/routes/analyses.py
+++ b/api/routes/analyses.py
@@ -1062,9 +1062,9 @@ def get_integration_enforcement_decision(
         ) from exc
     except ValueError as exc:
         raise ApiError(
-            status_code=400,
+            status_code=500,
             code="invalid_policy_adapter_output",
-            message=str(exc),
+            message="Integration enforcement decision could not be validated.",
         ) from exc
     return IntegrationEnforcementDecisionResponse(
         data=decision,

--- a/api/routes/analyses.py
+++ b/api/routes/analyses.py
@@ -90,6 +90,7 @@ from services.policy_adapter_service import (
     build_configured_policy_adapter_output,
     build_integration_enforcement_decision,
 )
+from services.settings_service import normalize_policy_integration_label
 
 router = APIRouter(prefix="/api/v1/analyses", tags=["analyses"], route_class=ApiRoute)
 READ_CHUNK_BYTES = 1024 * 1024
@@ -1030,6 +1031,14 @@ def get_integration_enforcement_decision(
 ) -> IntegrationEnforcementDecisionResponse:
     """Return the auditable, integration-capped decision for one report."""
     try:
+        normalized_integration = normalize_policy_integration_label(integration)
+    except ValueError as exc:
+        raise ApiError(
+            status_code=400,
+            code="invalid_policy_adapter_output",
+            message="Integration identifier is invalid.",
+        ) from exc
+    try:
         report = _fetch_report_for_authorized_read(
             authorization=authorization,
             report_id=report_id,
@@ -1046,7 +1055,7 @@ def get_integration_enforcement_decision(
             build_adapter_output_contract(
                 build_share_summary(report),
                 AdapterMetadata(
-                    adapter=integration,
+                    adapter=normalized_integration,
                     format="workflow_decision",
                     project_id=project_id,
                 ),

--- a/api/routes/github_app.py
+++ b/api/routes/github_app.py
@@ -152,6 +152,7 @@ async def github_app_webhook(request: Request) -> dict[str, object]:
             "report_url": result.report_url,
             "status": getattr(result, "status", "ok"),
             "code": getattr(result, "code", None),
+            "delivery_code": getattr(result, "delivery_code", None),
             "marketplace_url": config.marketplace_url,
             "install_url": config.install_url,
             "advisory_only": True,

--- a/api/routes/settings.py
+++ b/api/routes/settings.py
@@ -532,9 +532,7 @@ def update_policy_adapter_defaults(
                 project_key=project.project_key,
                 integration=payload.integration,
             )
-            expected_source = "integration" if payload.integration else "project"
-            if current.source == expected_source:
-                enforcement_mode = current.enforcement_mode
+            enforcement_mode = current.enforcement_mode
         saved = save_policy_adapter_settings(
             project_key=project.project_key,
             integration=payload.integration,

--- a/api/routes/settings.py
+++ b/api/routes/settings.py
@@ -526,6 +526,15 @@ def update_policy_adapter_defaults(
             project_id=payload.project_id,
             project_key=payload.project_key,
         )
+        enforcement_mode = payload.enforcement_mode
+        if "enforcement_mode" not in payload.model_fields_set:
+            current = get_policy_adapter_settings(
+                project_key=project.project_key,
+                integration=payload.integration,
+            )
+            expected_source = "integration" if payload.integration else "project"
+            if current.source == expected_source:
+                enforcement_mode = current.enforcement_mode
         saved = save_policy_adapter_settings(
             project_key=project.project_key,
             integration=payload.integration,
@@ -533,6 +542,7 @@ def update_policy_adapter_defaults(
             soft_block_at=payload.soft_block_at,
             hard_block_at=payload.hard_block_at,
             reporting_default=payload.reporting_default,
+            enforcement_mode=enforcement_mode,
         )
     except PermissionError as exc:
         _raise_authorization_error(exc)

--- a/api/routes/settings.py
+++ b/api/routes/settings.py
@@ -526,13 +526,11 @@ def update_policy_adapter_defaults(
             project_id=payload.project_id,
             project_key=payload.project_key,
         )
-        enforcement_mode = payload.enforcement_mode
-        if "enforcement_mode" not in payload.model_fields_set:
-            current = get_policy_adapter_settings(
-                project_key=project.project_key,
-                integration=payload.integration,
-            )
-            enforcement_mode = current.enforcement_mode
+        enforcement_mode = (
+            payload.enforcement_mode
+            if "enforcement_mode" in payload.model_fields_set
+            else None
+        )
         saved = save_policy_adapter_settings(
             project_key=project.project_key,
             integration=payload.integration,

--- a/api/schemas.py
+++ b/api/schemas.py
@@ -181,6 +181,9 @@ class PolicyAdapterSettingsRequest(BaseModel):
         default="critical"
     )
     reporting_default: Literal["advisory", "warn"] = Field(default="advisory")
+    enforcement_mode: Literal["advisory", "warn", "soft-block", "hard-block"] = Field(
+        default="advisory"
+    )
 
 
 class PolicyAdapterSettingsData(BaseModel):
@@ -191,6 +194,7 @@ class PolicyAdapterSettingsData(BaseModel):
     soft_block_at: Literal["low", "medium", "high", "critical"] | None = None
     hard_block_at: Literal["low", "medium", "high", "critical"] | None = None
     reporting_default: Literal["advisory", "warn"]
+    enforcement_mode: Literal["advisory", "warn", "soft-block", "hard-block"]
 
 
 class PolicyAdapterSettingsResponse(BaseModel):

--- a/docs/ci-advisory-consumption.md
+++ b/docs/ci-advisory-consumption.md
@@ -1,6 +1,6 @@
 # CI Advisory Consumption
 
-DeployWhisper remains advisory in automation contexts.
+DeployWhisper's canonical analysis remains advisory in automation contexts.
 
 - `data.advisory.should_block` is always `false`
 - `data.advisory.requires_attention` tells the pipeline or PR bot whether humans should take a closer look
@@ -14,7 +14,17 @@ DeployWhisper remains advisory in automation contexts.
 - The share-configuration API is disabled unless `DEPLOYWHISPER_SHARE_TOKEN` is set; callers must send that value in `X-DeployWhisper-Share-Token`
 - CLI and API responses preserve `severity`, `recommendation`, `partial_context`, and `narrative_degraded` for machine-readable uncertainty handling
 - High-risk or degraded analyses still return success payloads; non-zero CLI exit codes are reserved for operational failures such as unreadable files, missing project scope, or shared-analysis crashes
-- Future workflow adapters should wrap `data.share_summary` with adapter identity through the shared [workflow adapter output contract](./workflow-adapter-output-contract.md) instead of redefining severity, recommendation, or Evidence Law fields.
+- Workflow adapters should wrap `data.share_summary` with adapter identity through the shared [workflow adapter output contract](./workflow-adapter-output-contract.md) instead of redefining severity, recommendation, or Evidence Law fields.
+
+Optional integration enforcement is separate from this canonical response.
+Admins configure project or integration settings through
+`/api/v1/settings/policy-adapter`; modes are `advisory`, `warn`, `soft-block`,
+and `hard-block`, and the default is `advisory`. Integration consumers must use
+the shared policy/enforcement service so the raw policy status, configured
+mode, and effective status remain auditable. Do not infer a blocking decision
+directly from `data.advisory`, risk score, severity, or recommendation. For a
+persisted report, request the shared decision from
+`GET /api/v1/analyses/{report_id}/enforcement-decision?integration={integration}`.
 
 ## CLI Example
 
@@ -67,6 +77,7 @@ PY
 
 ## CI Guidance
 
-- Do not use DeployWhisper to fail a pipeline based only on risk score or recommendation in v1
+- Do not fail a pipeline based only on risk score or recommendation
+- Keep the integration in `advisory` or `warn` mode until the team explicitly opts into `soft-block` or `hard-block`
 - Use `requires_attention` and `uncertainty_flags` to decide when to notify reviewers, enrich PR comments, or request additional manual checks
 - Treat non-zero CLI exit codes as operational failures, not advisory outcomes

--- a/docs/github-action.md
+++ b/docs/github-action.md
@@ -57,11 +57,17 @@ inputs that satisfy it. If an installed action tag does not expose project-scope
 inputs, update the action tag or route through a scope-deriving integration
 endpoint before using it with a project-scoped DeployWhisper server.
 
-DeployWhisper remains advisory in CI. Successful analysis should not fail a
+DeployWhisper's canonical result remains advisory in CI. Successful analysis should not fail a
 workflow based only on risk score or recommendation. Consumers should use
 `data.advisory.requires_attention` to decide whether to notify reviewers or add
 manual checks. Advisory-first boundary: the action surfaces evidence and
 recommendations for review, but does not enforce deployment blocking by itself.
+An action runtime that supports opt-in enforcement must consume the configured
+policy decision, default to `advisory`, and keep raw policy and effective
+integration statuses distinct. The external `deploywhisper/analyze-action`
+repository owns that runtime behavior; this repository owns the shared API and
+contract at
+`GET /api/v1/analyses/{report_id}/enforcement-decision?integration=github-action`.
 
 ## Canonical Report Output Mapping
 

--- a/docs/github-action.md
+++ b/docs/github-action.md
@@ -60,13 +60,15 @@ endpoint before using it with a project-scoped DeployWhisper server.
 DeployWhisper's canonical result remains advisory in CI. Successful analysis should not fail a
 workflow based only on risk score or recommendation. Consumers should use
 `data.advisory.requires_attention` to decide whether to notify reviewers or add
-manual checks. Advisory-first boundary: the action surfaces evidence and
-recommendations for review, but does not enforce deployment blocking by itself.
-An action runtime that supports opt-in enforcement must consume the configured
-policy decision, default to `advisory`, and keep raw policy and effective
-integration statuses distinct. The external `deploywhisper/analyze-action`
-repository owns that runtime behavior; this repository owns the shared API and
-contract at
+manual checks. Advisory-first boundary: the action does not block unless the
+`github-action` integration is explicitly configured for an effective
+`soft-block` or `hard-block` decision. After persisting a report, the action
+consumes the configured policy decision, defaults to `advisory`, and keeps raw
+policy and effective integration statuses distinct. It fails the action only
+when the server's validated `should_block` decision is true; it does not derive
+blocking from severity, risk score, or recommendation. The external
+`deploywhisper/analyze-action` repository owns that runtime behavior; this
+repository owns the shared API and contract at
 `GET /api/v1/analyses/{report_id}/enforcement-decision?integration=github-action`.
 
 ## Canonical Report Output Mapping
@@ -83,6 +85,10 @@ action should not invent a separate report contract.
 | `recommendation` | `data.advisory.recommendation`, falling back to `data.share_summary.recommendation` when advisory is blank |
 | `share-summary-json` | JSON-encoded `data.share_summary.json_payload` |
 | `share-summary-markdown` | `data.share_summary.markdown` |
+| `policy-status` | `data.policy_output.status` from the enforcement decision |
+| `configured-mode` | `data.configured_mode` from the enforcement decision |
+| `effective-status` | `data.effective_status` from the enforcement decision |
+| `should-block` | `data.should_block` from the enforcement decision |
 
 GitHub Action outputs are strings. The `share-summary-json` output is a
 JSON-encoded string of `data.share_summary.json_payload`; consumers should parse

--- a/docs/github-app-self-hosted-setup.md
+++ b/docs/github-app-self-hosted-setup.md
@@ -18,7 +18,7 @@ Use this guide if you want:
 - You create the GitHub App in your own GitHub account or organization
 - GitHub sends webhooks to your own DeployWhisper server
 - Your own DeployWhisper server fetches changed PR artifacts
-- Your own DeployWhisper server creates advisory check runs and report links
+- Your own DeployWhisper server creates policy-aware check runs and advisory report links
 - The app does not need to be public or listed on GitHub Marketplace
 - App creation, account or organization selection, and repository selection happen in GitHub's own Developer Settings and Install App UI
 
@@ -147,9 +147,9 @@ optional OAuth helper route. They are not required for the manual setup path.
 4. Confirm DeployWhisper downloads the changed files within the shared 50 MB limit
 5. Confirm DeployWhisper persists a report
 6. Confirm a check run named `DeployWhisper / Risk Analysis` appears on the PR
-7. Confirm the check remains advisory-only and does not block merge on its own
+7. Confirm the check summary reports policy status, configured mode, and effective status
 8. Confirm the report link opens your own DeployWhisper server
-9. Confirm branch protection does not list `DeployWhisper / Risk Analysis` as a required status check
+9. For the default `advisory` mode, confirm branch protection does not list `DeployWhisper / Risk Analysis` as a required status check
 
 ## Troubleshooting
 
@@ -189,10 +189,12 @@ optional OAuth helper route. They are not required for the manual setup path.
 
 ### Branch protection blocks merge on DeployWhisper
 
-DeployWhisper is advisory-only. Remove `DeployWhisper / Risk Analysis` from
-required status checks in GitHub branch protection. Teams can still read the
-check result, but DeployWhisper should not be configured as the component that
-blocks merges.
+The canonical DeployWhisper report is advisory-only, but the GitHub integration
+can explicitly enforce policy. Inspect the check summary's configured mode. If
+it is `advisory` or `warn`, remove `DeployWhisper / Risk Analysis` from required
+status checks. If it is `soft-block` or `hard-block`, a required check is an
+intentional operator control; change the integration setting before removing
+that protection.
 
 ## Action-first recommendation
 

--- a/docs/github-app.md
+++ b/docs/github-app.md
@@ -62,11 +62,34 @@ Optional:
 - Webhook verification uses `X-Hub-Signature-256`
 - Pull request webhook actions `opened`, `reopened`, and `synchronize` can trigger automatic advisory analyses when PR automation is enabled
 - Supported changed artifacts are downloaded from GitHub, filtered through the shared intake rules, and sent through the existing parse/assess/persist pipeline
-- Check runs are advisory-only: `success` for `GO`, `neutral` for `CAUTION`, `failure` for `NO-GO`
+- Check runs resolve the `github` integration policy settings and expose raw policy status, configured enforcement mode, and effective status in the summary
+- The default `advisory` mode reports `success` for `GO` and `neutral` for other recommendations; `warn` also remains neutral
+- Explicit `soft-block` and `hard-block` modes produce `action_required` and `failure` conclusions respectively when the effective policy status is blocking
 - When checks are enabled, `APP_BASE_URL` or `PUBLIC_APP_URL` must point at a reachable DeployWhisper server so the GitHub PR Details link opens the full report
-- Do not configure `DeployWhisper / Risk Analysis` as a required status check in branch protection
+- Do not make `DeployWhisper / Risk Analysis` required while the integration uses `advisory` or `warn`; requiring it is an explicit operator choice for a blocking mode
 - Shared report URLs remain the deep-link target for richer investigation
 - `/reports/{id}` opens the React read-only Report screen, hides mutable internal actions, respects password-protected shares, and preserves `?compare=previous` comparison links
+
+Configure GitHub enforcement through the policy-adapter settings API. New and
+existing integrations remain advisory unless an operator explicitly opts into a
+blocking mode:
+
+```json
+{
+  "project_key": "your-project-key",
+  "integration": "github",
+  "warn_at": "medium",
+  "soft_block_at": "high",
+  "hard_block_at": "critical",
+  "reporting_default": "advisory",
+  "enforcement_mode": "advisory"
+}
+```
+
+Send this payload with `PUT /api/v1/settings/policy-adapter`. Supported
+enforcement modes are `advisory`, `warn`, `soft-block`, and `hard-block`.
+Do not make `DeployWhisper / Risk Analysis` required until the integration has
+been deliberately configured for a blocking mode.
 
 ## Manual installation flow
 

--- a/docs/workflow-adapter-output-contract.md
+++ b/docs/workflow-adapter-output-contract.md
@@ -125,7 +125,9 @@ local workflow decision; it cannot rewrite the canonical severity,
 recommendation, Evidence Law status, evidence, or advisory posture.
 
 `PolicyAdapterSettings` manages severity thresholds and the below-threshold
-`reporting_default` without changing core scoring. Built-in defaults interpret
+`reporting_default` without changing core scoring. Its `enforcement_mode` is an
+explicit integration-level ceiling with the same four statuses. Built-in and
+legacy stored settings default that mode to `advisory`. Built-in thresholds interpret
 medium as `warn`, high as `soft-block`, and critical as `hard-block`; reports
 below those thresholds remain `advisory`. Admins can inspect, save, or reset
 project defaults and integration-specific defaults through `GET`, `PUT`, and
@@ -138,9 +140,16 @@ deleting a project override restores the built-in defaults.
 Threshold evaluation reads only `canonical_summary.severity`. The emitted
 policy envelope records the resolved settings in `applied_settings`, while the
 original canonical severity, findings, evidence, recommendation, Evidence Law
-status, and advisory flags remain unchanged and auditable. Enforcement mode is
-a separate integration concern; the core remains useful when no policy adapter
-is enabled.
+status, and advisory flags remain unchanged and auditable.
+
+Integrations apply settings through
+`build_integration_enforcement_decision`. The decision records the raw
+`policy_output.status`, configured `enforcement_mode`, capped
+`effective_status`, and `should_block` separately. The configured mode is a
+ceiling: `advisory` always stays non-blocking, `warn` can surface warnings but
+cannot block, `soft-block` can enforce raw soft/hard outcomes as soft blocks,
+and `hard-block` preserves the raw policy status. This supports gradual rollout
+without allowing an integration to enforce beyond its explicit opt-in.
 
 Policy-adapter consumers generate configured decisions through
 `build_configured_policy_adapter_output`. This reusable service boundary
@@ -151,6 +160,10 @@ Authenticated consumers can exercise that production path for a persisted
 report through
 `GET /api/v1/analyses/{report_id}/policy-adapter?integration={integration}`.
 The response applies the saved integration, project, or built-in defaults and
-embeds the unchanged canonical summary beside the policy decision. Activating
-that interpretation as an enforcement mode inside a specific CI or workflow
-integration remains a separate integration concern.
+embeds the unchanged canonical summary beside the raw policy decision. Consumers
+that need the capped integration result use
+`GET /api/v1/analyses/{report_id}/enforcement-decision?integration={integration}`.
+That response exposes `configured_mode`, `effective_status`, `should_block`, and
+the nested raw `policy_output` from the same service used by GitHub App checks.
+CI and future adapters should consume this endpoint rather than deriving
+blocking behavior from canonical severity or recommendation.

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -100,6 +100,26 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/analyses/{report_id}/enforcement-decision": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Integration Enforcement Decision
+         * @description Return the auditable, integration-capped decision for one report.
+         */
+        get: operations["get_integration_enforcement_decision_api_v1_analyses__report_id__enforcement_decision_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/analyses/{report_id}": {
         parameters: {
             query?: never;
@@ -3160,6 +3180,31 @@ export interface components {
             /** Message */
             message: string;
         };
+        /**
+         * IntegrationEnforcementDecision
+         * @description Auditable integration decision kept separate from canonical analysis.
+         */
+        IntegrationEnforcementDecision: {
+            /**
+             * Contract Version
+             * @default v1
+             * @constant
+             */
+            contract_version: "v1";
+            configured_mode: components["schemas"]["PolicyAdapterStatus"];
+            effective_status: components["schemas"]["PolicyAdapterStatus"];
+            /** Should Block */
+            should_block: boolean;
+            policy_output: components["schemas"]["PolicyAdapterOutputContract"];
+        };
+        /**
+         * IntegrationEnforcementDecisionResponse
+         * @description API envelope for an integration's capped enforcement decision.
+         */
+        IntegrationEnforcementDecisionResponse: {
+            data: components["schemas"]["IntegrationEnforcementDecision"];
+            meta: components["schemas"]["ResourceMetaPayload"];
+        };
         /** InteractionRiskData */
         InteractionRiskData: {
             /**
@@ -3681,6 +3726,11 @@ export interface components {
              * @default advisory
              */
             reporting_default: components["schemas"]["PolicyAdapterStatus"];
+            /**
+             * @description Maximum integration enforcement level explicitly enabled
+             * @default advisory
+             */
+            enforcement_mode: components["schemas"]["PolicyAdapterStatus"];
         };
         /** PolicyAdapterSettingsData */
         PolicyAdapterSettingsData: {
@@ -3704,6 +3754,11 @@ export interface components {
              * @enum {string}
              */
             reporting_default: "advisory" | "warn";
+            /**
+             * Enforcement Mode
+             * @enum {string}
+             */
+            enforcement_mode: "advisory" | "warn" | "soft-block" | "hard-block";
         };
         /** PolicyAdapterSettingsRequest */
         PolicyAdapterSettingsRequest: {
@@ -3734,6 +3789,12 @@ export interface components {
              * @enum {string}
              */
             reporting_default: "advisory" | "warn";
+            /**
+             * Enforcement Mode
+             * @default advisory
+             * @enum {string}
+             */
+            enforcement_mode: "advisory" | "warn" | "soft-block" | "hard-block";
         };
         /** PolicyAdapterSettingsResponse */
         PolicyAdapterSettingsResponse: {
@@ -6234,6 +6295,78 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["PolicyAdapterOutputResponse"];
+                };
+            };
+            /** @description Bad Request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Not Found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Unprocessable Content */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Internal Server Error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
+    get_integration_enforcement_decision_api_v1_analyses__report_id__enforcement_decision_get: {
+        parameters: {
+            query: {
+                integration: string;
+            };
+            header?: {
+                "X-DeployWhisper-Project-Role"?: string | null;
+                "X-DeployWhisper-Project-Keys"?: string | null;
+            };
+            path: {
+                report_id: number;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["IntegrationEnforcementDecisionResponse"];
                 };
             };
             /** @description Bad Request */

--- a/integrations/github/app_service.py
+++ b/integrations/github/app_service.py
@@ -125,6 +125,7 @@ class GitHubWebhookResult:
     note: str
     status: str = "ok"
     code: str | None = None
+    delivery_code: str | None = None
 
 
 @dataclass(frozen=True)
@@ -679,8 +680,9 @@ def _project_scope_failure_result(
 ) -> GitHubWebhookResult:
     note = f"{code}: {message}"
     check_run_id = None
-    status = "ok"
-    result_code = None
+    status = "failed"
+    result_code = code
+    delivery_code = None
     if config.checks_enabled:
         try:
             check_run_id = _create_check_run(
@@ -697,8 +699,7 @@ def _project_scope_failure_result(
             )
         except GitHubAppRequestError:
             note = f"{note} Check run could not be created."
-            status = "partial"
-            result_code = CHECK_RUN_DELIVERY_ERROR_CODE
+            delivery_code = CHECK_RUN_DELIVERY_ERROR_CODE
     return GitHubWebhookResult(
         event=event_name,
         action=action,
@@ -710,6 +711,7 @@ def _project_scope_failure_result(
         note=note,
         status=status,
         code=result_code,
+        delivery_code=delivery_code,
     )
 
 
@@ -865,6 +867,11 @@ def _skipped_analysis_guidance(statuses: set[str]) -> str:
             "Changed artifacts were excluded because they may contain sensitive "
             "data or use unsupported formats, so no policy decision was evaluated."
         )
+    if statuses:
+        return (
+            "Changed artifacts were excluded for an unrecognized intake reason, "
+            "so no policy decision was evaluated."
+        )
     return "No changed artifacts were available, so no policy decision was evaluated."
 
 
@@ -897,7 +904,7 @@ def _create_check_run(
     details_url: str | None,
     text: str | None,
     api_base_url: str,
-) -> int | None:
+) -> int:
     payload: dict[str, Any] = {
         "name": title,
         "head_sha": head_sha,
@@ -923,7 +930,9 @@ def _create_check_run(
         check_run_id = response.get("id")
         if isinstance(check_run_id, int):
             return check_run_id
-    return None
+    raise GitHubAppRequestError(
+        "GitHub check-runs API did not return a valid check run id."
+    )
 
 
 def _generate_installation_access_token(

--- a/integrations/github/app_service.py
+++ b/integrations/github/app_service.py
@@ -678,22 +678,27 @@ def _project_scope_failure_result(
     config: GitHubAppConfig,
 ) -> GitHubWebhookResult:
     note = f"{code}: {message}"
-    check_run_id = (
-        _create_check_run(
-            owner=owner,
-            repo_name=repo_name,
-            head_sha=head_sha,
-            installation_token=installation_token,
-            conclusion="neutral",
-            title=DEFAULT_CHECK_RUN_NAME,
-            summary=note,
-            details_url=None,
-            text=_check_run_text(details_url=None),
-            api_base_url=config.api_base_url,
-        )
-        if config.checks_enabled
-        else None
-    )
+    check_run_id = None
+    status = "ok"
+    result_code = None
+    if config.checks_enabled:
+        try:
+            check_run_id = _create_check_run(
+                owner=owner,
+                repo_name=repo_name,
+                head_sha=head_sha,
+                installation_token=installation_token,
+                conclusion="neutral",
+                title=DEFAULT_CHECK_RUN_NAME,
+                summary=note,
+                details_url=None,
+                text=_check_run_text(details_url=None, fallback_guidance=note),
+                api_base_url=config.api_base_url,
+            )
+        except GitHubAppRequestError:
+            note = f"{note} Check run could not be created."
+            status = "partial"
+            result_code = CHECK_RUN_DELIVERY_ERROR_CODE
     return GitHubWebhookResult(
         event=event_name,
         action=action,
@@ -703,6 +708,8 @@ def _project_scope_failure_result(
         report_id=None,
         report_url=None,
         note=note,
+        status=status,
+        code=result_code,
     )
 
 

--- a/integrations/github/app_service.py
+++ b/integrations/github/app_service.py
@@ -18,8 +18,16 @@ from typing import Any
 from urllib import error, parse, request
 
 from config import settings
+from services.adapter_output_contract import (
+    AdapterMetadata,
+    build_adapter_output_contract,
+)
 from services.project_service import ProjectResolutionError, resolve_project_reference
-from services.analysis_service import AnalysisPersistenceError, analyze_uploaded_files
+from services.analysis_service import (
+    AnalysisPersistenceError,
+    analyze_uploaded_files,
+    build_share_summary,
+)
 from services.intake_service import (
     MAX_TOTAL_UPLOAD_BYTES,
     build_pending_analysis,
@@ -27,6 +35,14 @@ from services.intake_service import (
     uniquify_artifact_names,
 )
 from services.report_service import build_share_report_link
+from services.policy_adapter_service import (
+    IntegrationEnforcementDecision,
+    build_integration_enforcement_decision,
+)
+from services.policy_adapter_settings import (
+    PolicyAdapterSettingsIntegrityError,
+    PolicyAdapterStatus,
+)
 
 DEFAULT_GITHUB_API_BASE_URL = "https://api.github.com"
 DEFAULT_GITHUB_AUTHORIZE_URL = "https://github.com/login/oauth/authorize"
@@ -412,7 +428,13 @@ def handle_github_app_webhook(
                 title=DEFAULT_CHECK_RUN_NAME,
                 summary=note,
                 details_url=None,
-                text=_check_run_text(details_url=None),
+                text=_check_run_text(
+                    details_url=None,
+                    fallback_guidance=(
+                        "No supported changed artifacts were available, so no "
+                        "policy decision was evaluated."
+                    ),
+                ),
                 api_base_url=config.api_base_url,
             )
             if config.checks_enabled
@@ -539,16 +561,67 @@ def handle_github_app_webhook(
     check_run_id = None
     if config.checks_enabled:
         report_url = _check_run_details_url(report_id, config=config)
+        try:
+            enforcement = build_integration_enforcement_decision(
+                build_adapter_output_contract(
+                    build_share_summary(result.persisted_report),
+                    AdapterMetadata(
+                        adapter="github",
+                        format="github_check_run",
+                        project_key=project.project_key,
+                    ),
+                )
+            )
+        except (PolicyAdapterSettingsIntegrityError, ValueError) as exc:
+            code = (
+                "policy_adapter_settings_integrity_error"
+                if isinstance(exc, PolicyAdapterSettingsIntegrityError)
+                else "invalid_policy_adapter_output"
+            )
+            note = (
+                "DeployWhisper analysis completed, but the integration enforcement "
+                "decision could not be validated."
+            )
+            try:
+                check_run_id = _create_check_run(
+                    owner=owner,
+                    repo_name=repo_name,
+                    head_sha=head_sha,
+                    installation_token=installation_token,
+                    conclusion="failure",
+                    title=DEFAULT_CHECK_RUN_NAME,
+                    summary=note,
+                    details_url=report_url,
+                    text=_check_run_text(details_url=report_url),
+                    api_base_url=config.api_base_url,
+                )
+            except GitHubAppRequestError:
+                note = f"{note} Failure check run could not be created."
+            return GitHubWebhookResult(
+                event=event_name,
+                action=action,
+                handled=True,
+                automatic_analysis_triggered=True,
+                check_run_id=check_run_id,
+                report_id=report_id,
+                report_url=report_url,
+                note=note,
+                status="failed",
+                code=code,
+            )
         check_run_id = _create_check_run(
             owner=owner,
             repo_name=repo_name,
             head_sha=head_sha,
             installation_token=installation_token,
-            conclusion=_check_run_conclusion(result.assessment.recommendation),
+            conclusion=_check_run_conclusion(
+                result.assessment.recommendation,
+                enforcement.effective_status,
+            ),
             title=DEFAULT_CHECK_RUN_NAME,
-            summary=_check_run_summary(result.persisted_report),
+            summary=_check_run_summary(result.persisted_report, enforcement),
             details_url=report_url,
-            text=_check_run_text(details_url=report_url),
+            text=_check_run_text(details_url=report_url, enforcement=enforcement),
             api_base_url=config.api_base_url,
         )
     return GitHubWebhookResult(
@@ -682,16 +755,24 @@ def _download_repo_file(
     return None
 
 
-def _check_run_conclusion(recommendation: str) -> str:
+def _check_run_conclusion(
+    recommendation: str,
+    enforcement_status: PolicyAdapterStatus | str,
+) -> str:
+    status = PolicyAdapterStatus(enforcement_status)
+    if status == PolicyAdapterStatus.SOFT_BLOCK:
+        return "action_required"
+    if status == PolicyAdapterStatus.HARD_BLOCK:
+        return "failure"
     recommendation_value = str(recommendation).strip().lower()
-    if recommendation_value == "go":
+    if status == PolicyAdapterStatus.ADVISORY and recommendation_value == "go":
         return "success"
-    if recommendation_value == "caution":
-        return "neutral"
-    return "failure"
+    return "neutral"
 
 
-def _check_run_summary(report: dict[str, Any]) -> str:
+def _check_run_summary(
+    report: dict[str, Any], enforcement: IntegrationEnforcementDecision
+) -> str:
     headline = str(
         report.get("narrative_opening") or report.get("top_risk") or ""
     ).strip()
@@ -700,21 +781,42 @@ def _check_run_summary(report: dict[str, Any]) -> str:
     recommendation = str(report.get("recommendation") or "unknown").upper()
     severity = str(report.get("severity") or "unknown").upper()
     score = int(report.get("risk_score") or 0)
+    raw_status = enforcement.policy_output.status.value
+    configured_mode = enforcement.configured_mode.value
+    effective_status = enforcement.effective_status.value
     return (
         f"{headline}\n\n"
         f"Severity: {severity}\n"
         f"Recommendation: {recommendation}\n"
         f"Risk score: {score}\n"
-        "DeployWhisper remains advisory-only and never blocks merge on its own.\n"
-        "Do not configure this check as a required status check."
+        f"Policy status: {raw_status}\n"
+        f"Configured enforcement mode: {configured_mode}\n"
+        f"Effective integration status: {effective_status}\n"
+        "The canonical DeployWhisper report remains advisory-only."
     )
 
 
 def _check_run_text(
     *,
     details_url: str | None,
+    enforcement: IntegrationEnforcementDecision | None = None,
+    fallback_guidance: str | None = None,
 ) -> str:
-    lines = ["DeployWhisper is advisory-only. Do not mark this check as required."]
+    if fallback_guidance is not None:
+        guidance = fallback_guidance
+    elif enforcement is None:
+        guidance = "DeployWhisper analysis could not complete; inspect this check before proceeding."
+    elif enforcement.should_block:
+        guidance = (
+            "This integration is explicitly configured to enforce the effective "
+            f"{enforcement.effective_status.value} policy status."
+        )
+    else:
+        guidance = (
+            "This integration is non-blocking at its configured "
+            f"{enforcement.configured_mode.value} enforcement mode."
+        )
+    lines = [guidance, "The canonical DeployWhisper report remains advisory-only."]
     if details_url:
         lines.insert(0, f"[Open the full DeployWhisper report]({details_url})")
     return "\n\n".join(lines)

--- a/integrations/github/app_service.py
+++ b/integrations/github/app_service.py
@@ -819,7 +819,9 @@ def _check_run_text(
             "This integration is non-blocking at its configured "
             f"{enforcement.configured_mode.value} enforcement mode."
         )
-    lines = [guidance, "The canonical DeployWhisper report remains advisory-only."]
+    lines = [guidance]
+    if details_url is not None or enforcement is not None:
+        lines.append("The canonical DeployWhisper report remains advisory-only.")
     if details_url:
         lines.insert(0, f"[Open the full DeployWhisper report]({details_url})")
     return "\n\n".join(lines)

--- a/integrations/github/app_service.py
+++ b/integrations/github/app_service.py
@@ -592,7 +592,10 @@ def handle_github_app_webhook(
                     title=DEFAULT_CHECK_RUN_NAME,
                     summary=note,
                     details_url=report_url,
-                    text=_check_run_text(details_url=report_url),
+                    text=_check_run_text(
+                        details_url=report_url,
+                        fallback_guidance=note,
+                    ),
                     api_base_url=config.api_base_url,
                 )
             except GitHubAppRequestError:

--- a/integrations/github/app_service.py
+++ b/integrations/github/app_service.py
@@ -48,6 +48,7 @@ DEFAULT_GITHUB_API_BASE_URL = "https://api.github.com"
 DEFAULT_GITHUB_AUTHORIZE_URL = "https://github.com/login/oauth/authorize"
 DEFAULT_GITHUB_ACCESS_TOKEN_URL = "https://github.com/login/oauth/access_token"
 DEFAULT_CHECK_RUN_NAME = "DeployWhisper / Risk Analysis"
+CHECK_RUN_DELIVERY_ERROR_CODE = "github_check_run_failed"
 PULL_REQUEST_TRIGGER_ACTIONS = {"opened", "reopened", "synchronize"}
 _STATE_MAX_AGE_SECONDS = 600
 _UPLOAD_LIMIT_MESSAGE = (
@@ -417,29 +418,31 @@ def handle_github_app_webhook(
         if item.status == "ready"
     ]
     if not accepted_files:
-        note = "No supported changed artifacts were available from this pull request."
-        check_run_id = (
-            _create_check_run(
-                owner=owner,
-                repo_name=repo_name,
-                head_sha=head_sha,
-                installation_token=installation_token,
-                conclusion="neutral",
-                title=DEFAULT_CHECK_RUN_NAME,
-                summary=note,
-                details_url=None,
-                text=_check_run_text(
+        note = _skipped_analysis_guidance({item.status for item in pending.items})
+        check_run_id = None
+        status = "ok"
+        code = None
+        if config.checks_enabled:
+            try:
+                check_run_id = _create_check_run(
+                    owner=owner,
+                    repo_name=repo_name,
+                    head_sha=head_sha,
+                    installation_token=installation_token,
+                    conclusion="neutral",
+                    title=DEFAULT_CHECK_RUN_NAME,
+                    summary=note,
                     details_url=None,
-                    fallback_guidance=(
-                        "No supported changed artifacts were available, so no "
-                        "policy decision was evaluated."
+                    text=_check_run_text(
+                        details_url=None,
+                        fallback_guidance=note,
                     ),
-                ),
-                api_base_url=config.api_base_url,
-            )
-            if config.checks_enabled
-            else None
-        )
+                    api_base_url=config.api_base_url,
+                )
+            except GitHubAppRequestError:
+                note = f"{note} Neutral check run could not be created."
+                status = "partial"
+                code = CHECK_RUN_DELIVERY_ERROR_CODE
         return GitHubWebhookResult(
             event=event_name,
             action=action,
@@ -449,6 +452,8 @@ def handle_github_app_webhook(
             report_id=None,
             report_url=None,
             note=note,
+            status=status,
+            code=code,
         )
 
     if config.checks_enabled:
@@ -559,6 +564,9 @@ def handle_github_app_webhook(
     report_id = int(result.persisted_report["id"])
     report_url = build_share_report_link(report_id)
     check_run_id = None
+    note = "GitHub App webhook processed and advisory analysis completed."
+    status = "ok"
+    code = None
     if config.checks_enabled:
         report_url = _check_run_details_url(report_id, config=config)
         try:
@@ -612,21 +620,26 @@ def handle_github_app_webhook(
                 status="failed",
                 code=code,
             )
-        check_run_id = _create_check_run(
-            owner=owner,
-            repo_name=repo_name,
-            head_sha=head_sha,
-            installation_token=installation_token,
-            conclusion=_check_run_conclusion(
-                result.assessment.recommendation,
-                enforcement.effective_status,
-            ),
-            title=DEFAULT_CHECK_RUN_NAME,
-            summary=_check_run_summary(result.persisted_report, enforcement),
-            details_url=report_url,
-            text=_check_run_text(details_url=report_url, enforcement=enforcement),
-            api_base_url=config.api_base_url,
-        )
+        try:
+            check_run_id = _create_check_run(
+                owner=owner,
+                repo_name=repo_name,
+                head_sha=head_sha,
+                installation_token=installation_token,
+                conclusion=_check_run_conclusion(
+                    result.assessment.recommendation,
+                    enforcement.effective_status,
+                ),
+                title=DEFAULT_CHECK_RUN_NAME,
+                summary=_check_run_summary(result.persisted_report, enforcement),
+                details_url=report_url,
+                text=_check_run_text(details_url=report_url, enforcement=enforcement),
+                api_base_url=config.api_base_url,
+            )
+        except GitHubAppRequestError:
+            note = f"{note} Check run could not be created."
+            status = "partial"
+            code = CHECK_RUN_DELIVERY_ERROR_CODE
     return GitHubWebhookResult(
         event=event_name,
         action=action,
@@ -635,7 +648,9 @@ def handle_github_app_webhook(
         check_run_id=check_run_id,
         report_id=report_id,
         report_url=report_url,
-        note="GitHub App webhook processed and advisory analysis completed.",
+        note=note,
+        status=status,
+        code=code,
     )
 
 
@@ -825,6 +840,25 @@ def _check_run_text(
     if details_url:
         lines.insert(0, f"[Open the full DeployWhisper report]({details_url})")
     return "\n\n".join(lines)
+
+
+def _skipped_analysis_guidance(statuses: set[str]) -> str:
+    if statuses == {"sensitive"}:
+        return (
+            "Changed artifacts were excluded because they may contain sensitive "
+            "data, so no policy decision was evaluated."
+        )
+    if statuses == {"unsupported"}:
+        return (
+            "Changed artifacts use unsupported formats, so no policy decision "
+            "was evaluated."
+        )
+    if statuses == {"sensitive", "unsupported"}:
+        return (
+            "Changed artifacts were excluded because they may contain sensitive "
+            "data or use unsupported formats, so no policy decision was evaluated."
+        )
+    return "No changed artifacts were available, so no policy decision was evaluated."
 
 
 def _check_run_details_url(

--- a/services/policy_adapter_service.py
+++ b/services/policy_adapter_service.py
@@ -2,6 +2,10 @@
 
 from __future__ import annotations
 
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
 from services.adapter_output_contract import AdapterOutputContract
 from services.policy_adapter_output_contract import (
     PolicyAdapterOutputContract,
@@ -9,6 +13,48 @@ from services.policy_adapter_output_contract import (
 )
 from services.project_service import resolve_project_reference
 from services.settings_service import get_policy_adapter_settings
+from services.policy_adapter_settings import PolicyAdapterStatus
+
+
+_STATUS_RANK = {
+    PolicyAdapterStatus.ADVISORY: 0,
+    PolicyAdapterStatus.WARN: 1,
+    PolicyAdapterStatus.SOFT_BLOCK: 2,
+    PolicyAdapterStatus.HARD_BLOCK: 3,
+}
+
+
+class IntegrationEnforcementDecision(BaseModel):
+    """Auditable integration decision kept separate from canonical analysis."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    contract_version: Literal["v1"] = Field(default="v1")
+    configured_mode: PolicyAdapterStatus
+    effective_status: PolicyAdapterStatus
+    should_block: bool
+    policy_output: PolicyAdapterOutputContract
+
+    @model_validator(mode="after")
+    def _validate_decision(self) -> IntegrationEnforcementDecision:
+        settings = self.policy_output.applied_settings
+        if settings is None or settings.enforcement_mode != self.configured_mode:
+            raise ValueError(
+                "Enforcement decision must match the policy output's applied settings."
+            )
+        expected_status = min(
+            (self.policy_output.status, self.configured_mode),
+            key=_STATUS_RANK.__getitem__,
+        )
+        if self.effective_status != expected_status:
+            raise ValueError("Effective status must apply the configured mode ceiling.")
+        expected_block = expected_status in {
+            PolicyAdapterStatus.SOFT_BLOCK,
+            PolicyAdapterStatus.HARD_BLOCK,
+        }
+        if self.should_block != expected_block:
+            raise ValueError("Blocking flag must match the effective status.")
+        return self
 
 
 def build_configured_policy_adapter_output(
@@ -28,4 +74,25 @@ def build_configured_policy_adapter_output(
         adapter_output,
         settings,
         resolved_project_key=project.project_key,
+    )
+
+
+def build_integration_enforcement_decision(
+    adapter_output: AdapterOutputContract,
+) -> IntegrationEnforcementDecision:
+    """Apply the configured integration ceiling to raw policy interpretation."""
+    policy_output = build_configured_policy_adapter_output(adapter_output)
+    settings = policy_output.applied_settings
+    if settings is None:
+        raise ValueError("Configured policy output must include applied settings.")
+    configured_mode = settings.enforcement_mode
+    effective_status = min(
+        (policy_output.status, configured_mode), key=_STATUS_RANK.__getitem__
+    )
+    return IntegrationEnforcementDecision(
+        configured_mode=configured_mode,
+        effective_status=effective_status,
+        should_block=effective_status
+        in {PolicyAdapterStatus.SOFT_BLOCK, PolicyAdapterStatus.HARD_BLOCK},
+        policy_output=policy_output,
     )

--- a/services/policy_adapter_settings.py
+++ b/services/policy_adapter_settings.py
@@ -74,6 +74,10 @@ class PolicyAdapterSettings(BaseModel):
         default=PolicyAdapterStatus.ADVISORY,
         description="Adapter status reported when no severity threshold is met",
     )
+    enforcement_mode: PolicyAdapterStatus = Field(
+        default=PolicyAdapterStatus.ADVISORY,
+        description="Maximum integration enforcement level explicitly enabled",
+    )
 
     @field_validator("project_key", "integration")
     @classmethod
@@ -111,6 +115,7 @@ class PolicyAdapterSettings(BaseModel):
             or self.soft_block_at != PolicySeverity.HIGH
             or self.hard_block_at != PolicySeverity.CRITICAL
             or self.reporting_default != PolicyAdapterStatus.ADVISORY
+            or self.enforcement_mode != PolicyAdapterStatus.ADVISORY
         ):
             raise ValueError(
                 "Built-in settings must use the fixed advisory-first defaults."

--- a/services/settings_service.py
+++ b/services/settings_service.py
@@ -179,7 +179,8 @@ def _policy_adapter_settings_key(
     return f"{POLICY_ADAPTER_SETTINGS_PREFIX}::sha256::{digest}"
 
 
-def _policy_integration_label(value: str) -> str:
+def normalize_policy_integration_label(value: str) -> str:
+    """Normalize and validate a policy-adapter integration identifier."""
     normalized = value.strip().lower()
     if not normalized:
         raise ValueError("integration must not be blank.")
@@ -227,7 +228,9 @@ def save_policy_adapter_settings(
     """Persist project defaults or an integration-specific override."""
     normalized_project_key = normalize_project_key(project_key)
     normalized_integration = (
-        _policy_integration_label(integration) if integration is not None else None
+        normalize_policy_integration_label(integration)
+        if integration is not None
+        else None
     )
     resolved = PolicyAdapterSettings(
         project_key=normalized_project_key,
@@ -257,7 +260,9 @@ def get_policy_adapter_settings(
     """Resolve integration overrides before project and safe built-in defaults."""
     normalized_project_key = normalize_project_key(project_key)
     normalized_integration = (
-        _policy_integration_label(integration) if integration is not None else None
+        normalize_policy_integration_label(integration)
+        if integration is not None
+        else None
     )
     with SessionLocal() as session:
         if normalized_integration is not None:
@@ -297,7 +302,9 @@ def delete_policy_adapter_settings(
     """Delete one override and return the newly inherited effective defaults."""
     normalized_project_key = normalize_project_key(project_key)
     normalized_integration = (
-        _policy_integration_label(integration) if integration is not None else None
+        normalize_policy_integration_label(integration)
+        if integration is not None
+        else None
     )
     with SessionLocal() as session:
         delete_setting(

--- a/services/settings_service.py
+++ b/services/settings_service.py
@@ -222,6 +222,7 @@ def save_policy_adapter_settings(
     soft_block_at: PolicySeverity | str | None = PolicySeverity.HIGH,
     hard_block_at: PolicySeverity | str | None = PolicySeverity.CRITICAL,
     reporting_default: PolicyAdapterStatus | str = PolicyAdapterStatus.ADVISORY,
+    enforcement_mode: PolicyAdapterStatus | str = PolicyAdapterStatus.ADVISORY,
 ) -> PolicyAdapterSettings:
     """Persist project defaults or an integration-specific override."""
     normalized_project_key = normalize_project_key(project_key)
@@ -236,6 +237,7 @@ def save_policy_adapter_settings(
         soft_block_at=soft_block_at,
         hard_block_at=hard_block_at,
         reporting_default=reporting_default,
+        enforcement_mode=enforcement_mode,
     )
     with SessionLocal() as session:
         upsert_setting(

--- a/services/settings_service.py
+++ b/services/settings_service.py
@@ -223,7 +223,7 @@ def save_policy_adapter_settings(
     soft_block_at: PolicySeverity | str | None = PolicySeverity.HIGH,
     hard_block_at: PolicySeverity | str | None = PolicySeverity.CRITICAL,
     reporting_default: PolicyAdapterStatus | str = PolicyAdapterStatus.ADVISORY,
-    enforcement_mode: PolicyAdapterStatus | str = PolicyAdapterStatus.ADVISORY,
+    enforcement_mode: PolicyAdapterStatus | str | None = None,
 ) -> PolicyAdapterSettings:
     """Persist project defaults or an integration-specific override."""
     normalized_project_key = normalize_project_key(project_key)
@@ -232,6 +232,11 @@ def save_policy_adapter_settings(
         if integration is not None
         else None
     )
+    if enforcement_mode is None:
+        enforcement_mode = get_policy_adapter_settings(
+            project_key=normalized_project_key,
+            integration=normalized_integration,
+        ).enforcement_mode
     resolved = PolicyAdapterSettings(
         project_key=normalized_project_key,
         integration=normalized_integration,

--- a/tests/test_api/test_analyses.py
+++ b/tests/test_api/test_analyses.py
@@ -704,6 +704,24 @@ class AnalysesApiTests(unittest.TestCase):
                     "policy_adapter_settings_integrity_error",
                 )
 
+    def test_enforcement_decision_reports_internal_invariant_failure_as_server_error(
+        self,
+    ) -> None:
+        with patch(
+            "api.routes.analyses.build_integration_enforcement_decision",
+            side_effect=ValueError("internal invariant detail"),
+        ):
+            response = self.client.get(
+                f"/api/v1/analyses/{self.persisted['id']}/enforcement-decision",
+                params={"integration": "jenkins"},
+            )
+
+        self.assertEqual(response.status_code, 500)
+        self.assertEqual(
+            response.json()["error"]["code"], "invalid_policy_adapter_output"
+        )
+        self.assertNotIn("internal invariant detail", response.text)
+
     def test_blast_radius_api_schema_preserves_topology_context_fields(self) -> None:
         blast_radius = BlastRadiusData.model_validate(
             BlastRadiusResult(

--- a/tests/test_api/test_analyses.py
+++ b/tests/test_api/test_analyses.py
@@ -630,22 +630,55 @@ class AnalysesApiTests(unittest.TestCase):
         self.assertTrue(payload["data"]["canonical_report_advisory"])
         self.assertEqual(payload["meta"]["report_schema_version"], "v2")
 
-    def test_policy_adapter_output_enforces_report_scope_access(self) -> None:
-        for report_id in (self.persisted["id"], 999_999):
-            with self.subTest(report_id=report_id):
-                response = self.client.get(
-                    f"/api/v1/analyses/{report_id}/policy-adapter",
-                    params={"integration": "jenkins"},
-                    headers={
-                        "X-DeployWhisper-Project-Role": "read-only",
-                        "X-DeployWhisper-Project-Keys": "payments",
-                    },
-                )
+    def test_enforcement_decision_exposes_capped_status_for_external_adapters(
+        self,
+    ) -> None:
+        project_key = self.persisted["project"]["project_key"]
+        saved = self.client.put(
+            "/api/v1/settings/policy-adapter",
+            json={
+                "project_key": project_key,
+                "integration": "jenkins",
+                "warn_at": "low",
+                "soft_block_at": None,
+                "hard_block_at": "medium",
+                "reporting_default": "advisory",
+                "enforcement_mode": "warn",
+            },
+        )
 
-                self.assertEqual(response.status_code, 403)
-                self.assertEqual(
-                    response.json()["error"]["code"], "project_scope_forbidden"
-                )
+        response = self.client.get(
+            f"/api/v1/analyses/{self.persisted['id']}/enforcement-decision",
+            params={"integration": "jenkins"},
+        )
+
+        self.assertEqual(saved.status_code, 200)
+        self.assertEqual(response.status_code, 200)
+        payload = response.json()
+        self.assertEqual(payload["data"]["configured_mode"], "warn")
+        self.assertEqual(payload["data"]["effective_status"], "warn")
+        self.assertFalse(payload["data"]["should_block"])
+        self.assertEqual(payload["data"]["policy_output"]["status"], "hard-block")
+        self.assertTrue(payload["data"]["policy_output"]["canonical_report_advisory"])
+        self.assertEqual(payload["meta"]["report_schema_version"], "v2")
+
+    def test_policy_adapter_output_enforces_report_scope_access(self) -> None:
+        for endpoint in ("policy-adapter", "enforcement-decision"):
+            for report_id in (self.persisted["id"], 999_999):
+                with self.subTest(endpoint=endpoint, report_id=report_id):
+                    response = self.client.get(
+                        f"/api/v1/analyses/{report_id}/{endpoint}",
+                        params={"integration": "jenkins"},
+                        headers={
+                            "X-DeployWhisper-Project-Role": "read-only",
+                            "X-DeployWhisper-Project-Keys": "payments",
+                        },
+                    )
+
+                    self.assertEqual(response.status_code, 403)
+                    self.assertEqual(
+                        response.json()["error"]["code"], "project_scope_forbidden"
+                    )
 
     def test_policy_adapter_output_reports_corrupt_settings_as_server_error(
         self,
@@ -658,16 +691,18 @@ class AnalysesApiTests(unittest.TestCase):
                 value="not-json",
             )
 
-        response = self.client.get(
-            f"/api/v1/analyses/{self.persisted['id']}/policy-adapter",
-            params={"integration": "jenkins"},
-        )
+        for endpoint in ("policy-adapter", "enforcement-decision"):
+            with self.subTest(endpoint=endpoint):
+                response = self.client.get(
+                    f"/api/v1/analyses/{self.persisted['id']}/{endpoint}",
+                    params={"integration": "jenkins"},
+                )
 
-        self.assertEqual(response.status_code, 500)
-        self.assertEqual(
-            response.json()["error"]["code"],
-            "policy_adapter_settings_integrity_error",
-        )
+                self.assertEqual(response.status_code, 500)
+                self.assertEqual(
+                    response.json()["error"]["code"],
+                    "policy_adapter_settings_integrity_error",
+                )
 
     def test_blast_radius_api_schema_preserves_topology_context_fields(self) -> None:
         blast_radius = BlastRadiusData.model_validate(

--- a/tests/test_api/test_analyses.py
+++ b/tests/test_api/test_analyses.py
@@ -718,7 +718,8 @@ class AnalysesApiTests(unittest.TestCase):
 
         self.assertEqual(response.status_code, 500)
         self.assertEqual(
-            response.json()["error"]["code"], "invalid_policy_adapter_output"
+            response.json()["error"]["code"],
+            "integration_enforcement_decision_invalid",
         )
         self.assertNotIn("internal invariant detail", response.text)
 
@@ -734,7 +735,8 @@ class AnalysesApiTests(unittest.TestCase):
 
                 self.assertEqual(response.status_code, 400)
                 self.assertEqual(
-                    response.json()["error"]["code"], "invalid_policy_adapter_output"
+                    response.json()["error"]["code"],
+                    "invalid_integration_identifier",
                 )
 
     def test_blast_radius_api_schema_preserves_topology_context_fields(self) -> None:

--- a/tests/test_api/test_analyses.py
+++ b/tests/test_api/test_analyses.py
@@ -722,6 +722,21 @@ class AnalysesApiTests(unittest.TestCase):
         )
         self.assertNotIn("internal invariant detail", response.text)
 
+    def test_enforcement_decision_rejects_invalid_integration_as_client_error(
+        self,
+    ) -> None:
+        for integration in ("   ", "github/action"):
+            with self.subTest(integration=integration):
+                response = self.client.get(
+                    f"/api/v1/analyses/{self.persisted['id']}/enforcement-decision",
+                    params={"integration": integration},
+                )
+
+                self.assertEqual(response.status_code, 400)
+                self.assertEqual(
+                    response.json()["error"]["code"], "invalid_policy_adapter_output"
+                )
+
     def test_blast_radius_api_schema_preserves_topology_context_fields(self) -> None:
         blast_radius = BlastRadiusData.model_validate(
             BlastRadiusResult(

--- a/tests/test_api/test_github_app.py
+++ b/tests/test_api/test_github_app.py
@@ -106,6 +106,7 @@ class GitHubAppRouteTests(unittest.TestCase):
                 "note": "ok",
                 "status": "ok",
                 "code": None,
+                "delivery_code": None,
             },
         )()
 
@@ -126,6 +127,7 @@ class GitHubAppRouteTests(unittest.TestCase):
         self.assertEqual(body["data"]["report_id"], 17)
         self.assertEqual(body["data"]["status"], "ok")
         self.assertIsNone(body["data"]["code"])
+        self.assertIsNone(body["data"]["delivery_code"])
 
     @patch("api.routes.github_app.handle_github_app_webhook")
     def test_webhook_returns_persistence_failure_without_report_identifier(

--- a/tests/test_api/test_settings.py
+++ b/tests/test_api/test_settings.py
@@ -184,6 +184,35 @@ class SettingsApiTests(unittest.TestCase):
                     response.json()["data"]["enforcement_mode"], "hard-block"
                 )
 
+    def test_legacy_integration_put_preserves_inherited_project_enforcement_mode(
+        self,
+    ) -> None:
+        project_payload = {
+            "project_key": self.project.project_key,
+            "warn_at": "medium",
+            "soft_block_at": "high",
+            "hard_block_at": "critical",
+            "reporting_default": "advisory",
+            "enforcement_mode": "hard-block",
+        }
+        self.client.put("/api/v1/settings/policy-adapter", json=project_payload)
+
+        response = self.client.put(
+            "/api/v1/settings/policy-adapter",
+            json={
+                "project_key": self.project.project_key,
+                "integration": "jenkins",
+                "warn_at": "high",
+                "soft_block_at": "critical",
+                "hard_block_at": None,
+                "reporting_default": "warn",
+            },
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()["data"]["source"], "integration")
+        self.assertEqual(response.json()["data"]["enforcement_mode"], "hard-block")
+
     def test_policy_adapter_defaults_require_admin_settings_permission(self) -> None:
         response = self.client.put(
             "/api/v1/settings/policy-adapter",

--- a/tests/test_api/test_settings.py
+++ b/tests/test_api/test_settings.py
@@ -98,6 +98,7 @@ class SettingsApiTests(unittest.TestCase):
             "soft_block_at": "high",
             "hard_block_at": "critical",
             "reporting_default": "advisory",
+            "enforcement_mode": "warn",
         }
         saved_project = self.client.put(
             "/api/v1/settings/policy-adapter",
@@ -112,6 +113,7 @@ class SettingsApiTests(unittest.TestCase):
                 "soft_block_at": "critical",
                 "hard_block_at": None,
                 "reporting_default": "warn",
+                "enforcement_mode": "soft-block",
             },
         )
         loaded = self.client.get(
@@ -128,7 +130,59 @@ class SettingsApiTests(unittest.TestCase):
         self.assertEqual(loaded.status_code, 200)
         self.assertEqual(loaded.json()["data"]["source"], "integration")
         self.assertEqual(loaded.json()["data"]["reporting_default"], "warn")
+        self.assertEqual(loaded.json()["data"]["enforcement_mode"], "soft-block")
         self.assertIsNone(loaded.json()["data"]["hard_block_at"])
+
+    def test_policy_adapter_defaults_reject_unknown_enforcement_mode(self) -> None:
+        response = self.client.put(
+            "/api/v1/settings/policy-adapter",
+            json={
+                "project_key": self.project.project_key,
+                "enforcement_mode": "block-everything",
+            },
+        )
+
+        self.assertEqual(response.status_code, 422)
+
+    def test_policy_adapter_defaults_expose_advisory_built_in_mode(self) -> None:
+        response = self.client.get(
+            "/api/v1/settings/policy-adapter",
+            params={"project_key": self.project.project_key},
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()["data"]["source"], "built-in")
+        self.assertEqual(response.json()["data"]["enforcement_mode"], "advisory")
+
+    def test_legacy_policy_adapter_put_preserves_existing_enforcement_mode(
+        self,
+    ) -> None:
+        for integration in (None, "jenkins"):
+            with self.subTest(integration=integration):
+                initial = {
+                    "project_key": self.project.project_key,
+                    "integration": integration,
+                    "warn_at": "medium",
+                    "soft_block_at": "high",
+                    "hard_block_at": "critical",
+                    "reporting_default": "advisory",
+                    "enforcement_mode": "hard-block",
+                }
+                self.client.put("/api/v1/settings/policy-adapter", json=initial)
+
+                response = self.client.put(
+                    "/api/v1/settings/policy-adapter",
+                    json={
+                        key: value
+                        for key, value in initial.items()
+                        if key != "enforcement_mode"
+                    },
+                )
+
+                self.assertEqual(response.status_code, 200)
+                self.assertEqual(
+                    response.json()["data"]["enforcement_mode"], "hard-block"
+                )
 
     def test_policy_adapter_defaults_require_admin_settings_permission(self) -> None:
         response = self.client.put(
@@ -173,6 +227,7 @@ class SettingsApiTests(unittest.TestCase):
             "soft_block_at": "high",
             "hard_block_at": "critical",
             "reporting_default": "advisory",
+            "enforcement_mode": "warn",
         }
         self.client.put("/api/v1/settings/policy-adapter", json=project_payload)
         self.client.put(
@@ -184,6 +239,7 @@ class SettingsApiTests(unittest.TestCase):
                 "soft_block_at": "critical",
                 "hard_block_at": None,
                 "reporting_default": "warn",
+                "enforcement_mode": "hard-block",
             },
         )
 
@@ -201,8 +257,10 @@ class SettingsApiTests(unittest.TestCase):
 
         self.assertEqual(reset_integration.status_code, 200)
         self.assertEqual(reset_integration.json()["data"]["source"], "project")
+        self.assertEqual(reset_integration.json()["data"]["enforcement_mode"], "warn")
         self.assertEqual(reset_project.status_code, 200)
         self.assertEqual(reset_project.json()["data"]["source"], "built-in")
+        self.assertEqual(reset_project.json()["data"]["enforcement_mode"], "advisory")
 
     def test_policy_adapter_defaults_require_explicit_project_scope(self) -> None:
         requests = (

--- a/tests/test_docs/test_github_action_integration_contract.py
+++ b/tests/test_docs/test_github_action_integration_contract.py
@@ -29,6 +29,7 @@ class GitHubActionIntegrationContractTests(unittest.TestCase):
             "share_summary.json_payload",
             "docs/schemas/report-v2.md",
             "JSON-encoded string",
+            "integration=github-action",
         ):
             with self.subTest(expected=expected):
                 self.assertIn(expected, content)
@@ -48,6 +49,10 @@ class GitHubActionIntegrationContractTests(unittest.TestCase):
                 "recommendation": "data.advisory.recommendation, falling back to data.share_summary.recommendation when advisory is blank",
                 "share-summary-json": "JSON-encoded data.share_summary.json_payload",
                 "share-summary-markdown": "data.share_summary.markdown",
+                "policy-status": "data.policy_output.status from the enforcement decision",
+                "configured-mode": "data.configured_mode from the enforcement decision",
+                "effective-status": "data.effective_status from the enforcement decision",
+                "should-block": "data.should_block from the enforcement decision",
             },
             mapping,
         )
@@ -73,7 +78,7 @@ class GitHubActionIntegrationContractTests(unittest.TestCase):
 
         expected_clauses = (
             "Consumers should use `data.advisory.requires_attention` to decide whether to notify reviewers or add manual checks.",
-            "Advisory-first boundary: the action surfaces evidence and recommendations for review, but does not enforce deployment blocking by itself.",
+            "Advisory-first boundary: the action does not block unless the `github-action` integration is explicitly configured for an effective `soft-block` or `hard-block` decision.",
             "Local-first boundary: raw IaC, scanner artifacts, incident exports, and sensitive context stay in the user's infrastructure by default.",
             "External model calls should receive structured summaries, not raw uploads.",
             "Secret-storage prohibition: the action contract must not persist API tokens, provider credentials, raw infrastructure state, or deployment secrets.",

--- a/tests/test_docs/test_workflow_adapter_output_contract.py
+++ b/tests/test_docs/test_workflow_adapter_output_contract.py
@@ -36,10 +36,14 @@ class WorkflowAdapterOutputContractDocumentationTests(unittest.TestCase):
             "project defaults",
             "integration-specific defaults",
             "reporting_default",
+            "enforcement_mode",
             "/api/v1/settings/policy-adapter",
             "DELETE",
             "build_configured_policy_adapter_output",
+            "build_integration_enforcement_decision",
             "/api/v1/analyses/{report_id}/policy-adapter",
+            "/api/v1/analyses/{report_id}/enforcement-decision",
+            "`configured_mode`, `effective_status`, `should_block`",
         )
         for expected in expected_clauses:
             with self.subTest(expected=expected):

--- a/tests/test_services/test_adapter_output_contract.py
+++ b/tests/test_services/test_adapter_output_contract.py
@@ -344,7 +344,7 @@ class AdapterOutputContractTests(unittest.TestCase):
         contract = build_adapter_output_contract(
             summary,
             AdapterMetadata(
-                adapter="github-actions",
+                adapter="github-action",
                 format="pr_comment",
                 project_key="payments",
             ),

--- a/tests/test_services/test_github_app_service.py
+++ b/tests/test_services/test_github_app_service.py
@@ -431,6 +431,10 @@ class GitHubAppServiceTests(unittest.TestCase):
                 self.assertEqual(
                     create_check_run.call_args.kwargs["conclusion"], "failure"
                 )
+                check_text = create_check_run.call_args.kwargs["text"]
+                self.assertIn("analysis completed", check_text)
+                self.assertIn("enforcement decision could not be validated", check_text)
+                self.assertNotIn("analysis could not complete", check_text)
                 self.assertNotIn(str(error), result.note)
                 create_check_run.reset_mock()
 

--- a/tests/test_services/test_github_app_service.py
+++ b/tests/test_services/test_github_app_service.py
@@ -490,6 +490,69 @@ class GitHubAppServiceTests(unittest.TestCase):
                 create_check_run.reset_mock()
 
     @patch("integrations.github.app_service._create_check_run")
+    @patch("integrations.github.app_service.build_integration_enforcement_decision")
+    @patch("integrations.github.app_service.analyze_uploaded_files")
+    @patch("integrations.github.app_service._load_pull_request_artifacts")
+    @patch("integrations.github.app_service._generate_installation_access_token")
+    def test_enforcement_failure_survives_failure_check_delivery_failure(
+        self,
+        generate_installation_access_token,
+        load_pull_request_artifacts,
+        analyze_uploaded_files,
+        build_enforcement_decision,
+        create_check_run,
+    ) -> None:
+        generate_installation_access_token.return_value = "installation-token"
+        load_pull_request_artifacts.return_value = [("plan.tf", b'resource "x" "y" {}')]
+        analyze_uploaded_files.return_value = type(
+            "Result",
+            (),
+            {
+                "assessment": type("Assessment", (), {"recommendation": "caution"})(),
+                "persisted_report": {"id": 21},
+            },
+        )()
+        create_check_run.side_effect = app_service.GitHubAppRequestError(
+            "github upstream detail"
+        )
+        cases = (
+            (
+                PolicyAdapterSettingsIntegrityError("corrupt stored mode"),
+                "policy_adapter_settings_integrity_error",
+            ),
+            (ValueError("invalid adapter contract"), "invalid_policy_adapter_output"),
+        )
+
+        for error, expected_code in cases:
+            with self.subTest(expected_code=expected_code):
+                build_enforcement_decision.side_effect = error
+
+                result = app_service.handle_github_app_webhook(
+                    event_name="pull_request",
+                    payload={
+                        "action": "opened",
+                        "number": 6,
+                        "installation": {"id": 42},
+                        "repository": {
+                            "name": "deploywhisper",
+                            "owner": {"login": "deploywhisper"},
+                        },
+                        "pull_request": {"number": 6, "head": {"sha": "bad123"}},
+                    },
+                )
+
+                self.assertTrue(result.handled)
+                self.assertTrue(result.automatic_analysis_triggered)
+                self.assertIsNone(result.check_run_id)
+                self.assertEqual(result.report_id, 21)
+                self.assertEqual(result.status, "failed")
+                self.assertEqual(result.code, expected_code)
+                self.assertIn("analysis completed", result.note)
+                self.assertIn("Failure check run could not be created", result.note)
+                self.assertNotIn(str(error), result.note)
+                self.assertNotIn("github upstream detail", result.note)
+
+    @patch("integrations.github.app_service._create_check_run")
     @patch("integrations.github.app_service._load_pull_request_artifacts")
     @patch("integrations.github.app_service._generate_installation_access_token")
     def test_github_webhook_describes_skipped_analysis_without_failure_copy(

--- a/tests/test_services/test_github_app_service.py
+++ b/tests/test_services/test_github_app_service.py
@@ -737,6 +737,54 @@ class GitHubAppServiceTests(unittest.TestCase):
     @patch("integrations.github.app_service.analyze_uploaded_files")
     @patch("integrations.github.app_service._load_pull_request_artifacts")
     @patch("integrations.github.app_service._generate_installation_access_token")
+    def test_project_scope_failure_survives_check_run_delivery_failure(
+        self,
+        generate_installation_access_token,
+        load_pull_request_artifacts,
+        analyze_uploaded_files,
+        create_check_run,
+    ) -> None:
+        os.environ["DEPLOYWHISPER_GITHUB_PROJECT_KEY"] = "wrong-project"
+        generate_installation_access_token.return_value = "installation-token"
+        create_check_run.side_effect = app_service.GitHubAppRequestError(
+            "github upstream detail"
+        )
+
+        try:
+            result = app_service.handle_github_app_webhook(
+                event_name="pull_request",
+                payload={
+                    "action": "opened",
+                    "number": 3,
+                    "installation": {"id": 42},
+                    "repository": {
+                        "name": "deploywhisper",
+                        "owner": {"login": "deploywhisper"},
+                    },
+                    "pull_request": {
+                        "number": 3,
+                        "head": {"sha": "abc123"},
+                    },
+                },
+            )
+        finally:
+            os.environ.pop("DEPLOYWHISPER_GITHUB_PROJECT_KEY", None)
+
+        load_pull_request_artifacts.assert_not_called()
+        analyze_uploaded_files.assert_not_called()
+        self.assertTrue(result.handled)
+        self.assertFalse(result.automatic_analysis_triggered)
+        self.assertIsNone(result.check_run_id)
+        self.assertEqual(result.status, "partial")
+        self.assertEqual(result.code, "github_check_run_failed")
+        self.assertIn("project_not_found", result.note)
+        self.assertIn("Check run could not be created", result.note)
+        self.assertNotIn("github upstream detail", result.note)
+
+    @patch("integrations.github.app_service._create_check_run")
+    @patch("integrations.github.app_service.analyze_uploaded_files")
+    @patch("integrations.github.app_service._load_pull_request_artifacts")
+    @patch("integrations.github.app_service._generate_installation_access_token")
     def test_handle_github_app_webhook_handles_malformed_project_override(
         self,
         generate_installation_access_token,

--- a/tests/test_services/test_github_app_service.py
+++ b/tests/test_services/test_github_app_service.py
@@ -18,6 +18,10 @@ import models.tables as tables_module
 import services.project_service as project_service_module
 from integrations.github import app_service
 from llm.narrator import NarrativeResult
+from services.policy_adapter_settings import (
+    PolicyAdapterSettingsIntegrityError,
+    PolicyAdapterStatus,
+)
 
 
 class GitHubAppServiceTests(unittest.TestCase):
@@ -122,10 +126,19 @@ class GitHubAppServiceTests(unittest.TestCase):
         )
         self.assertEqual(result.state_return_to, "/settings")
 
-    def test_check_run_conclusion_matches_story_contract(self) -> None:
-        self.assertEqual(app_service._check_run_conclusion("go"), "success")
-        self.assertEqual(app_service._check_run_conclusion("caution"), "neutral")
-        self.assertEqual(app_service._check_run_conclusion("no-go"), "failure")
+    def test_check_run_conclusion_respects_explicit_enforcement_mode(self) -> None:
+        self.assertEqual(app_service._check_run_conclusion("go", "advisory"), "success")
+        self.assertEqual(
+            app_service._check_run_conclusion("no-go", "advisory"), "neutral"
+        )
+        self.assertEqual(app_service._check_run_conclusion("no-go", "warn"), "neutral")
+        self.assertEqual(
+            app_service._check_run_conclusion("no-go", "soft-block"),
+            "action_required",
+        )
+        self.assertEqual(
+            app_service._check_run_conclusion("no-go", "hard-block"), "failure"
+        )
 
     @patch("integrations.github.app_service._create_check_run")
     @patch("integrations.github.app_service.analyze_uploaded_files")
@@ -204,6 +217,254 @@ class GitHubAppServiceTests(unittest.TestCase):
             analyze_uploaded_files.call_args.args,
             ([("plan.tf", b'resource "x" "y" {}')],),
         )
+
+    @patch("integrations.github.app_service._create_check_run")
+    @patch("integrations.github.app_service.build_integration_enforcement_decision")
+    @patch("integrations.github.app_service.analyze_uploaded_files")
+    @patch("integrations.github.app_service._load_pull_request_artifacts")
+    @patch("integrations.github.app_service._generate_installation_access_token")
+    def test_handle_github_app_webhook_enforces_explicit_blocking_decision(
+        self,
+        generate_installation_access_token,
+        load_pull_request_artifacts,
+        analyze_uploaded_files,
+        build_enforcement_decision,
+        create_check_run,
+    ) -> None:
+        generate_installation_access_token.return_value = "installation-token"
+        load_pull_request_artifacts.return_value = [("plan.tf", b'resource "x" "y" {}')]
+        analyze_uploaded_files.return_value = type(
+            "Result",
+            (),
+            {
+                "assessment": type("Assessment", (), {"recommendation": "no-go"})(),
+                "persisted_report": {
+                    "id": 19,
+                    "severity": "critical",
+                    "recommendation": "no-go",
+                },
+            },
+        )()
+        build_enforcement_decision.return_value = type(
+            "Decision",
+            (),
+            {
+                "configured_mode": PolicyAdapterStatus.HARD_BLOCK,
+                "effective_status": PolicyAdapterStatus.HARD_BLOCK,
+                "should_block": True,
+                "policy_output": type(
+                    "PolicyOutput",
+                    (),
+                    {"status": PolicyAdapterStatus.HARD_BLOCK},
+                )(),
+            },
+        )()
+        create_check_run.return_value = 993
+
+        app_service.handle_github_app_webhook(
+            event_name="pull_request",
+            payload={
+                "action": "opened",
+                "number": 4,
+                "installation": {"id": 42},
+                "repository": {
+                    "name": "deploywhisper",
+                    "owner": {"login": "deploywhisper"},
+                },
+                "pull_request": {
+                    "number": 4,
+                    "head": {"sha": "def456"},
+                },
+            },
+        )
+
+        self.assertEqual(create_check_run.call_args.kwargs["conclusion"], "failure")
+        self.assertIn(
+            "Configured enforcement mode: hard-block",
+            create_check_run.call_args.kwargs["summary"],
+        )
+        adapter_output = build_enforcement_decision.call_args.args[0]
+        self.assertEqual(adapter_output.adapter_metadata.adapter, "github")
+        self.assertEqual(
+            adapter_output.adapter_metadata.project_key,
+            "deploywhisper-deploywhisper",
+        )
+
+    @patch("integrations.github.app_service._create_check_run")
+    @patch("integrations.github.app_service.build_integration_enforcement_decision")
+    @patch("integrations.github.app_service.analyze_uploaded_files")
+    @patch("integrations.github.app_service._load_pull_request_artifacts")
+    @patch("integrations.github.app_service._generate_installation_access_token")
+    def test_github_webhook_maps_every_effective_enforcement_mode(
+        self,
+        generate_installation_access_token,
+        load_pull_request_artifacts,
+        analyze_uploaded_files,
+        build_enforcement_decision,
+        create_check_run,
+    ) -> None:
+        generate_installation_access_token.return_value = "installation-token"
+        load_pull_request_artifacts.return_value = [("plan.tf", b'resource "x" "y" {}')]
+        analyze_uploaded_files.return_value = type(
+            "Result",
+            (),
+            {
+                "assessment": type("Assessment", (), {"recommendation": "no-go"})(),
+                "persisted_report": {
+                    "id": 20,
+                    "severity": "critical",
+                    "recommendation": "no-go",
+                },
+            },
+        )()
+        expected = {
+            PolicyAdapterStatus.ADVISORY: "neutral",
+            PolicyAdapterStatus.WARN: "neutral",
+            PolicyAdapterStatus.SOFT_BLOCK: "action_required",
+            PolicyAdapterStatus.HARD_BLOCK: "failure",
+        }
+
+        for mode, conclusion in expected.items():
+            with self.subTest(mode=mode):
+                build_enforcement_decision.return_value = type(
+                    "Decision",
+                    (),
+                    {
+                        "configured_mode": mode,
+                        "effective_status": mode,
+                        "should_block": mode
+                        in {
+                            PolicyAdapterStatus.SOFT_BLOCK,
+                            PolicyAdapterStatus.HARD_BLOCK,
+                        },
+                        "policy_output": type(
+                            "PolicyOutput",
+                            (),
+                            {"status": PolicyAdapterStatus.HARD_BLOCK},
+                        )(),
+                    },
+                )()
+
+                app_service.handle_github_app_webhook(
+                    event_name="pull_request",
+                    payload={
+                        "action": "opened",
+                        "number": 5,
+                        "installation": {"id": 42},
+                        "repository": {
+                            "name": "deploywhisper",
+                            "owner": {"login": "deploywhisper"},
+                        },
+                        "pull_request": {
+                            "number": 5,
+                            "head": {"sha": "fed654"},
+                        },
+                    },
+                )
+
+                call = create_check_run.call_args.kwargs
+                self.assertEqual(call["conclusion"], conclusion)
+                self.assertIn("Policy status: hard-block", call["summary"])
+                self.assertIn(
+                    f"Configured enforcement mode: {mode.value}", call["summary"]
+                )
+                self.assertIn(
+                    f"Effective integration status: {mode.value}", call["summary"]
+                )
+                self.assertIn(
+                    "canonical DeployWhisper report remains advisory-only", call["text"]
+                )
+                create_check_run.reset_mock()
+
+    @patch("integrations.github.app_service._create_check_run")
+    @patch("integrations.github.app_service.build_integration_enforcement_decision")
+    @patch("integrations.github.app_service.analyze_uploaded_files")
+    @patch("integrations.github.app_service._load_pull_request_artifacts")
+    @patch("integrations.github.app_service._generate_installation_access_token")
+    def test_github_webhook_reports_invalid_enforcement_configuration(
+        self,
+        generate_installation_access_token,
+        load_pull_request_artifacts,
+        analyze_uploaded_files,
+        build_enforcement_decision,
+        create_check_run,
+    ) -> None:
+        generate_installation_access_token.return_value = "installation-token"
+        load_pull_request_artifacts.return_value = [("plan.tf", b'resource "x" "y" {}')]
+        analyze_uploaded_files.return_value = type(
+            "Result",
+            (),
+            {
+                "assessment": type("Assessment", (), {"recommendation": "caution"})(),
+                "persisted_report": {"id": 21},
+            },
+        )()
+        create_check_run.return_value = 994
+        cases = (
+            (
+                PolicyAdapterSettingsIntegrityError("corrupt stored mode"),
+                "policy_adapter_settings_integrity_error",
+            ),
+            (ValueError("invalid adapter contract"), "invalid_policy_adapter_output"),
+        )
+
+        for error, expected_code in cases:
+            with self.subTest(expected_code=expected_code):
+                build_enforcement_decision.side_effect = error
+                result = app_service.handle_github_app_webhook(
+                    event_name="pull_request",
+                    payload={
+                        "action": "opened",
+                        "number": 6,
+                        "installation": {"id": 42},
+                        "repository": {
+                            "name": "deploywhisper",
+                            "owner": {"login": "deploywhisper"},
+                        },
+                        "pull_request": {"number": 6, "head": {"sha": "bad123"}},
+                    },
+                )
+
+                self.assertEqual(result.status, "failed")
+                self.assertEqual(result.code, expected_code)
+                self.assertEqual(result.report_id, 21)
+                self.assertEqual(
+                    create_check_run.call_args.kwargs["conclusion"], "failure"
+                )
+                self.assertNotIn(str(error), result.note)
+                create_check_run.reset_mock()
+
+    @patch("integrations.github.app_service._create_check_run")
+    @patch("integrations.github.app_service._load_pull_request_artifacts")
+    @patch("integrations.github.app_service._generate_installation_access_token")
+    def test_github_webhook_describes_skipped_analysis_without_failure_copy(
+        self,
+        generate_installation_access_token,
+        load_pull_request_artifacts,
+        create_check_run,
+    ) -> None:
+        generate_installation_access_token.return_value = "installation-token"
+        load_pull_request_artifacts.return_value = []
+        create_check_run.return_value = 995
+
+        result = app_service.handle_github_app_webhook(
+            event_name="pull_request",
+            payload={
+                "action": "opened",
+                "number": 7,
+                "installation": {"id": 42},
+                "repository": {
+                    "name": "deploywhisper",
+                    "owner": {"login": "deploywhisper"},
+                },
+                "pull_request": {"number": 7, "head": {"sha": "empty1"}},
+            },
+        )
+
+        text = create_check_run.call_args.kwargs["text"]
+        self.assertFalse(result.automatic_analysis_triggered)
+        self.assertIn("No supported changed artifacts", text)
+        self.assertNotIn("analysis could not complete", text)
 
     @patch("integrations.github.app_service.analyze_uploaded_files")
     @patch("integrations.github.app_service._load_pull_request_artifacts")
@@ -846,3 +1107,10 @@ class GitHubAppServiceTests(unittest.TestCase):
             "`DEPLOYWHISPER_GITHUB_APP_CLIENT_SECRET`\n",
             main_settings,
         )
+
+    def test_github_app_docs_lock_enforcement_configuration_contract(self) -> None:
+        docs = Path("docs/github-app.md").read_text(encoding="utf-8")
+
+        self.assertIn('"integration": "github"', docs)
+        self.assertIn('"enforcement_mode": "advisory"', docs)
+        self.assertIn("Do not make `DeployWhisper / Risk Analysis` required", docs)

--- a/tests/test_services/test_github_app_service.py
+++ b/tests/test_services/test_github_app_service.py
@@ -469,6 +469,7 @@ class GitHubAppServiceTests(unittest.TestCase):
         self.assertFalse(result.automatic_analysis_triggered)
         self.assertIn("No supported changed artifacts", text)
         self.assertNotIn("analysis could not complete", text)
+        self.assertNotIn("canonical DeployWhisper report", text)
 
     @patch("integrations.github.app_service.analyze_uploaded_files")
     @patch("integrations.github.app_service._load_pull_request_artifacts")
@@ -803,6 +804,10 @@ class GitHubAppServiceTests(unittest.TestCase):
         self.assertNotIn(
             "database is read-only",
             create_check_run.call_args.kwargs["summary"],
+        )
+        self.assertNotIn(
+            "canonical DeployWhisper report",
+            create_check_run.call_args.kwargs["text"],
         )
 
     @patch("integrations.github.app_service._create_check_run")

--- a/tests/test_services/test_github_app_service.py
+++ b/tests/test_services/test_github_app_service.py
@@ -270,6 +270,47 @@ class GitHubAppServiceTests(unittest.TestCase):
         self.assertNotIn("github upstream detail", result.note)
 
     @patch("integrations.github.app_service._create_check_run")
+    @patch("integrations.github.app_service.analyze_uploaded_files")
+    @patch("integrations.github.app_service._load_pull_request_artifacts")
+    @patch("integrations.github.app_service._generate_installation_access_token")
+    def test_project_scope_failure_preserves_machine_readable_root_cause(
+        self,
+        generate_installation_access_token,
+        load_pull_request_artifacts,
+        analyze_uploaded_files,
+        create_check_run,
+    ) -> None:
+        os.environ["DEPLOYWHISPER_GITHUB_PROJECT_KEY"] = "wrong-project"
+        generate_installation_access_token.return_value = "installation-token"
+        create_check_run.return_value = 994
+
+        try:
+            result = app_service.handle_github_app_webhook(
+                event_name="pull_request",
+                payload={
+                    "action": "opened",
+                    "number": 3,
+                    "installation": {"id": 42},
+                    "repository": {
+                        "name": "deploywhisper",
+                        "owner": {"login": "deploywhisper"},
+                    },
+                    "pull_request": {
+                        "number": 3,
+                        "head": {"sha": "abc123"},
+                    },
+                },
+            )
+        finally:
+            os.environ.pop("DEPLOYWHISPER_GITHUB_PROJECT_KEY", None)
+
+        load_pull_request_artifacts.assert_not_called()
+        analyze_uploaded_files.assert_not_called()
+        self.assertEqual(result.status, "failed")
+        self.assertEqual(result.code, "project_not_found")
+        self.assertIsNone(result.delivery_code)
+
+    @patch("integrations.github.app_service._create_check_run")
     @patch("integrations.github.app_service.build_integration_enforcement_decision")
     @patch("integrations.github.app_service.analyze_uploaded_files")
     @patch("integrations.github.app_service._load_pull_request_artifacts")
@@ -637,6 +678,14 @@ class GitHubAppServiceTests(unittest.TestCase):
                     self.assertNotIn(term, text)
                 create_check_run.reset_mock()
 
+    def test_skipped_analysis_guidance_does_not_mislabel_unknown_rejections(
+        self,
+    ) -> None:
+        guidance = app_service._skipped_analysis_guidance({"quarantined"})
+
+        self.assertIn("unrecognized intake reason", guidance)
+        self.assertNotIn("No changed artifacts were available", guidance)
+
     @patch("integrations.github.app_service._create_check_run")
     @patch("integrations.github.app_service._load_pull_request_artifacts")
     @patch("integrations.github.app_service._generate_installation_access_token")
@@ -838,8 +887,9 @@ class GitHubAppServiceTests(unittest.TestCase):
         self.assertTrue(result.handled)
         self.assertFalse(result.automatic_analysis_triggered)
         self.assertIsNone(result.check_run_id)
-        self.assertEqual(result.status, "partial")
-        self.assertEqual(result.code, "github_check_run_failed")
+        self.assertEqual(result.status, "failed")
+        self.assertEqual(result.code, "project_not_found")
+        self.assertEqual(result.delivery_code, "github_check_run_failed")
         self.assertIn("project_not_found", result.note)
         self.assertIn("Check run could not be created", result.note)
         self.assertNotIn("github upstream detail", result.note)
@@ -1347,6 +1397,29 @@ class GitHubAppServiceTests(unittest.TestCase):
             body["output"]["text"],
             "[Open the full DeployWhisper report](https://deploywhisper.example.com/reports/17)",
         )
+
+    @patch("integrations.github.app_service._github_api_json")
+    def test_create_check_run_rejects_missing_response_id(
+        self, github_api_json
+    ) -> None:
+        github_api_json.return_value = {}
+
+        with self.assertRaisesRegex(
+            app_service.GitHubAppRequestError,
+            "did not return a valid check run id",
+        ):
+            app_service._create_check_run(
+                owner="deploywhisper",
+                repo_name="deploywhisper",
+                head_sha="abc123",
+                installation_token="installation-token",
+                conclusion="failure",
+                title=app_service.DEFAULT_CHECK_RUN_NAME,
+                summary="Enforcement result",
+                details_url="https://deploywhisper.example.com/reports/17",
+                text="Review required.",
+                api_base_url="https://api.github.com",
+            )
 
     def test_self_hosted_setup_docs_keep_oauth_optional(self) -> None:
         docs = Path("docs/github-app-self-hosted-setup.md").read_text(encoding="utf-8")

--- a/tests/test_services/test_github_app_service.py
+++ b/tests/test_services/test_github_app_service.py
@@ -219,6 +219,57 @@ class GitHubAppServiceTests(unittest.TestCase):
         )
 
     @patch("integrations.github.app_service._create_check_run")
+    @patch("integrations.github.app_service.analyze_uploaded_files")
+    @patch("integrations.github.app_service._load_pull_request_artifacts")
+    @patch("integrations.github.app_service._generate_installation_access_token")
+    def test_successful_analysis_survives_check_run_delivery_failure(
+        self,
+        generate_installation_access_token,
+        load_pull_request_artifacts,
+        analyze_uploaded_files,
+        create_check_run,
+    ) -> None:
+        generate_installation_access_token.return_value = "installation-token"
+        load_pull_request_artifacts.return_value = [("plan.tf", b'resource "x" "y" {}')]
+        analyze_uploaded_files.return_value = type(
+            "Result",
+            (),
+            {
+                "assessment": type("Assessment", (), {"recommendation": "caution"})(),
+                "persisted_report": {"id": 17},
+            },
+        )()
+        create_check_run.side_effect = app_service.GitHubAppRequestError(
+            "github upstream detail"
+        )
+
+        result = app_service.handle_github_app_webhook(
+            event_name="pull_request",
+            payload={
+                "action": "opened",
+                "number": 3,
+                "installation": {"id": 42},
+                "repository": {
+                    "name": "deploywhisper",
+                    "owner": {"login": "deploywhisper"},
+                },
+                "pull_request": {"number": 3, "head": {"sha": "abc123"}},
+            },
+        )
+
+        self.assertTrue(result.handled)
+        self.assertTrue(result.automatic_analysis_triggered)
+        self.assertIsNone(result.check_run_id)
+        self.assertEqual(result.report_id, 17)
+        self.assertEqual(
+            result.report_url, "https://deploywhisper.example.com/reports/17"
+        )
+        self.assertEqual(result.status, "partial")
+        self.assertEqual(result.code, "github_check_run_failed")
+        self.assertIn("Check run could not be created", result.note)
+        self.assertNotIn("github upstream detail", result.note)
+
+    @patch("integrations.github.app_service._create_check_run")
     @patch("integrations.github.app_service.build_integration_enforcement_decision")
     @patch("integrations.github.app_service.analyze_uploaded_files")
     @patch("integrations.github.app_service._load_pull_request_artifacts")
@@ -467,9 +518,99 @@ class GitHubAppServiceTests(unittest.TestCase):
 
         text = create_check_run.call_args.kwargs["text"]
         self.assertFalse(result.automatic_analysis_triggered)
-        self.assertIn("No supported changed artifacts", text)
+        self.assertIn("No changed artifacts were available", text)
         self.assertNotIn("analysis could not complete", text)
         self.assertNotIn("canonical DeployWhisper report", text)
+
+    @patch("integrations.github.app_service._create_check_run")
+    @patch("integrations.github.app_service._load_pull_request_artifacts")
+    @patch("integrations.github.app_service._generate_installation_access_token")
+    def test_github_webhook_explains_sensitive_and_unsupported_skips(
+        self,
+        generate_installation_access_token,
+        load_pull_request_artifacts,
+        create_check_run,
+    ) -> None:
+        generate_installation_access_token.return_value = "installation-token"
+        create_check_run.return_value = 995
+        cases = (
+            ([(".env", b"SECRET=value")], ("sensitive",), ("unsupported",)),
+            (
+                [("notes.txt", b"plain text")],
+                ("unsupported",),
+                ("sensitive",),
+            ),
+            (
+                [(".env", b"SECRET=value"), ("notes.txt", b"plain text")],
+                ("sensitive", "unsupported"),
+                (),
+            ),
+        )
+
+        for raw_files, expected_terms, absent_terms in cases:
+            with self.subTest(raw_files=[name for name, _ in raw_files]):
+                load_pull_request_artifacts.return_value = raw_files
+
+                result = app_service.handle_github_app_webhook(
+                    event_name="pull_request",
+                    payload={
+                        "action": "opened",
+                        "number": 7,
+                        "installation": {"id": 42},
+                        "repository": {
+                            "name": "deploywhisper",
+                            "owner": {"login": "deploywhisper"},
+                        },
+                        "pull_request": {"number": 7, "head": {"sha": "empty1"}},
+                    },
+                )
+
+                text = create_check_run.call_args.kwargs["text"].lower()
+                self.assertFalse(result.automatic_analysis_triggered)
+                for term in expected_terms:
+                    self.assertIn(term, text)
+                    self.assertIn(term, result.note.lower())
+                for term in absent_terms:
+                    self.assertNotIn(term, text)
+                create_check_run.reset_mock()
+
+    @patch("integrations.github.app_service._create_check_run")
+    @patch("integrations.github.app_service._load_pull_request_artifacts")
+    @patch("integrations.github.app_service._generate_installation_access_token")
+    def test_skipped_analysis_survives_check_run_delivery_failure(
+        self,
+        generate_installation_access_token,
+        load_pull_request_artifacts,
+        create_check_run,
+    ) -> None:
+        generate_installation_access_token.return_value = "installation-token"
+        load_pull_request_artifacts.return_value = []
+        create_check_run.side_effect = app_service.GitHubAppRequestError(
+            "github upstream detail"
+        )
+
+        result = app_service.handle_github_app_webhook(
+            event_name="pull_request",
+            payload={
+                "action": "opened",
+                "number": 7,
+                "installation": {"id": 42},
+                "repository": {
+                    "name": "deploywhisper",
+                    "owner": {"login": "deploywhisper"},
+                },
+                "pull_request": {"number": 7, "head": {"sha": "empty1"}},
+            },
+        )
+
+        self.assertTrue(result.handled)
+        self.assertFalse(result.automatic_analysis_triggered)
+        self.assertIsNone(result.check_run_id)
+        self.assertIsNone(result.report_id)
+        self.assertEqual(result.status, "partial")
+        self.assertEqual(result.code, "github_check_run_failed")
+        self.assertIn("Neutral check run could not be created", result.note)
+        self.assertNotIn("github upstream detail", result.note)
 
     @patch("integrations.github.app_service.analyze_uploaded_files")
     @patch("integrations.github.app_service._load_pull_request_artifacts")

--- a/tests/test_services/test_policy_adapter_service.py
+++ b/tests/test_services/test_policy_adapter_service.py
@@ -105,6 +105,41 @@ class PolicyAdapterServiceTests(unittest.TestCase):
             output.adapter_output.adapter_metadata.project_id, self.project.id
         )
 
+    def test_enforcement_mode_caps_raw_policy_status_without_mutating_it(self) -> None:
+        adapter_output = _adapter_output(project_key="payments", adapter="jenkins")
+
+        expected = {
+            PolicyAdapterStatus.ADVISORY: (PolicyAdapterStatus.ADVISORY, False),
+            PolicyAdapterStatus.WARN: (PolicyAdapterStatus.WARN, False),
+            PolicyAdapterStatus.SOFT_BLOCK: (PolicyAdapterStatus.SOFT_BLOCK, True),
+            PolicyAdapterStatus.HARD_BLOCK: (PolicyAdapterStatus.HARD_BLOCK, True),
+        }
+        for mode, (effective_status, should_block) in expected.items():
+            with self.subTest(mode=mode):
+                settings_service_module.save_policy_adapter_settings(
+                    project_key="payments",
+                    integration="jenkins",
+                    warn_at="low",
+                    soft_block_at="medium",
+                    hard_block_at="high",
+                    enforcement_mode=mode,
+                )
+
+                decision = policy_adapter_service_module.build_integration_enforcement_decision(
+                    adapter_output
+                )
+
+                self.assertEqual(
+                    decision.policy_output.status, PolicyAdapterStatus.HARD_BLOCK
+                )
+                self.assertEqual(decision.configured_mode, mode)
+                self.assertEqual(decision.effective_status, effective_status)
+                self.assertEqual(decision.should_block, should_block)
+                self.assertTrue(decision.policy_output.canonical_report_advisory)
+                self.assertFalse(
+                    decision.policy_output.adapter_output.canonical_summary.should_block
+                )
+
 
 def _adapter_output(
     *,

--- a/tests/test_services/test_policy_adapter_service.py
+++ b/tests/test_services/test_policy_adapter_service.py
@@ -105,40 +105,65 @@ class PolicyAdapterServiceTests(unittest.TestCase):
             output.adapter_output.adapter_metadata.project_id, self.project.id
         )
 
-    def test_enforcement_mode_caps_raw_policy_status_without_mutating_it(self) -> None:
-        adapter_output = _adapter_output(project_key="payments", adapter="jenkins")
-
-        expected = {
-            PolicyAdapterStatus.ADVISORY: (PolicyAdapterStatus.ADVISORY, False),
-            PolicyAdapterStatus.WARN: (PolicyAdapterStatus.WARN, False),
-            PolicyAdapterStatus.SOFT_BLOCK: (PolicyAdapterStatus.SOFT_BLOCK, True),
-            PolicyAdapterStatus.HARD_BLOCK: (PolicyAdapterStatus.HARD_BLOCK, True),
+    def test_enforcement_mode_caps_without_escalating_raw_policy_status(self) -> None:
+        statuses = tuple(PolicyAdapterStatus)
+        status_rank = {status: rank for rank, status in enumerate(statuses)}
+        severity_by_status = {
+            PolicyAdapterStatus.ADVISORY: "low",
+            PolicyAdapterStatus.WARN: "medium",
+            PolicyAdapterStatus.SOFT_BLOCK: "high",
+            PolicyAdapterStatus.HARD_BLOCK: "critical",
         }
-        for mode, (effective_status, should_block) in expected.items():
-            with self.subTest(mode=mode):
-                settings_service_module.save_policy_adapter_settings(
-                    project_key="payments",
-                    integration="jenkins",
-                    warn_at="low",
-                    soft_block_at="medium",
-                    hard_block_at="high",
-                    enforcement_mode=mode,
-                )
 
-                decision = policy_adapter_service_module.build_integration_enforcement_decision(
-                    adapter_output
-                )
+        for raw_status in statuses:
+            for mode in statuses:
+                expected_status = min((raw_status, mode), key=status_rank.__getitem__)
+                with self.subTest(raw_status=raw_status, mode=mode):
+                    settings_service_module.save_policy_adapter_settings(
+                        project_key="payments",
+                        integration="jenkins",
+                        enforcement_mode=mode,
+                    )
+                    adapter_output = _adapter_output(
+                        project_key="payments",
+                        adapter="jenkins",
+                        severity=severity_by_status[raw_status],
+                    )
 
-                self.assertEqual(
-                    decision.policy_output.status, PolicyAdapterStatus.HARD_BLOCK
-                )
-                self.assertEqual(decision.configured_mode, mode)
-                self.assertEqual(decision.effective_status, effective_status)
-                self.assertEqual(decision.should_block, should_block)
-                self.assertTrue(decision.policy_output.canonical_report_advisory)
-                self.assertFalse(
-                    decision.policy_output.adapter_output.canonical_summary.should_block
-                )
+                    decision = policy_adapter_service_module.build_integration_enforcement_decision(
+                        adapter_output
+                    )
+
+                    self.assertEqual(decision.policy_output.status, raw_status)
+                    self.assertEqual(decision.configured_mode, mode)
+                    self.assertEqual(decision.effective_status, expected_status)
+                    self.assertEqual(
+                        decision.should_block,
+                        expected_status
+                        in {
+                            PolicyAdapterStatus.SOFT_BLOCK,
+                            PolicyAdapterStatus.HARD_BLOCK,
+                        },
+                    )
+                    self.assertTrue(decision.policy_output.canonical_report_advisory)
+                    self.assertFalse(
+                        decision.policy_output.adapter_output.canonical_summary.should_block
+                    )
+
+    def test_enforcement_decision_uses_advisory_built_in_default(self) -> None:
+        decision = policy_adapter_service_module.build_integration_enforcement_decision(
+            _adapter_output(
+                project_key="payments",
+                adapter="future-integration",
+                severity="critical",
+            )
+        )
+
+        self.assertEqual(decision.policy_output.applied_settings.source, "built-in")
+        self.assertEqual(decision.policy_output.status, PolicyAdapterStatus.HARD_BLOCK)
+        self.assertEqual(decision.configured_mode, PolicyAdapterStatus.ADVISORY)
+        self.assertEqual(decision.effective_status, PolicyAdapterStatus.ADVISORY)
+        self.assertFalse(decision.should_block)
 
 
 def _adapter_output(
@@ -146,11 +171,12 @@ def _adapter_output(
     adapter: str,
     project_key: str | None = None,
     project_id: int | None = None,
+    severity: str = "high",
 ):
     report = {
         "id": 17,
         "report_schema_version": "v2",
-        "severity": "high",
+        "severity": severity,
         "recommendation": "caution",
         "top_risk": "Terraform opened database ingress.",
         "narrative_opening": "CAUTION: review database ingress.",

--- a/tests/test_services/test_policy_adapter_service.py
+++ b/tests/test_services/test_policy_adapter_service.py
@@ -32,7 +32,6 @@ class PolicyAdapterServiceTests(unittest.TestCase):
         reload(database_module)
         reload(project_service_module)
         reload(settings_service_module)
-        reload(policy_adapter_service_module)
         database_module.init_db()
         self.project = project_service_module.create_project(
             project_key="payments",

--- a/tests/test_services/test_settings_service.py
+++ b/tests/test_services/test_settings_service.py
@@ -118,6 +118,26 @@ class SettingsServiceTests(unittest.TestCase):
         self.assertEqual(settings.soft_block_at.value, "high")
         self.assertEqual(settings.hard_block_at.value, "critical")
 
+    def test_policy_adapter_service_update_preserves_existing_enforcement_mode(
+        self,
+    ) -> None:
+        settings_service_module.save_policy_adapter_settings(
+            project_key="payments",
+            integration="jenkins",
+            enforcement_mode="hard-block",
+        )
+
+        updated = settings_service_module.save_policy_adapter_settings(
+            project_key="payments",
+            integration="jenkins",
+            warn_at="high",
+            soft_block_at="critical",
+            hard_block_at=None,
+            reporting_default="warn",
+        )
+
+        self.assertEqual(updated.enforcement_mode, PolicyAdapterStatus.HARD_BLOCK)
+
     def test_policy_adapter_settings_use_canonical_project_keys_for_storage(
         self,
     ) -> None:

--- a/tests/test_services/test_settings_service.py
+++ b/tests/test_services/test_settings_service.py
@@ -68,6 +68,7 @@ class SettingsServiceTests(unittest.TestCase):
             soft_block_at="high",
             hard_block_at="critical",
             reporting_default="advisory",
+            enforcement_mode="warn",
         )
         integration_settings = settings_service_module.save_policy_adapter_settings(
             project_key="payments",
@@ -76,6 +77,7 @@ class SettingsServiceTests(unittest.TestCase):
             soft_block_at="critical",
             hard_block_at=None,
             reporting_default="warn",
+            enforcement_mode="soft-block",
         )
 
         resolved_project = settings_service_module.get_policy_adapter_settings(
@@ -95,8 +97,14 @@ class SettingsServiceTests(unittest.TestCase):
         self.assertEqual(
             resolved_integration.reporting_default, PolicyAdapterStatus.WARN
         )
+        self.assertEqual(
+            resolved_integration.enforcement_mode, PolicyAdapterStatus.SOFT_BLOCK
+        )
         self.assertEqual(unresolved_integration.source, "project")
         self.assertIsNone(unresolved_integration.integration)
+        self.assertEqual(
+            unresolved_integration.enforcement_mode, PolicyAdapterStatus.WARN
+        )
 
     def test_policy_adapter_settings_use_safe_built_in_defaults(self) -> None:
         settings = settings_service_module.get_policy_adapter_settings(
@@ -105,6 +113,7 @@ class SettingsServiceTests(unittest.TestCase):
 
         self.assertEqual(settings.source, "built-in")
         self.assertEqual(settings.reporting_default, PolicyAdapterStatus.ADVISORY)
+        self.assertEqual(settings.enforcement_mode, PolicyAdapterStatus.ADVISORY)
         self.assertEqual(settings.warn_at.value, "medium")
         self.assertEqual(settings.soft_block_at.value, "high")
         self.assertEqual(settings.hard_block_at.value, "critical")
@@ -236,6 +245,31 @@ class SettingsServiceTests(unittest.TestCase):
             "could not be validated",
         ):
             settings_service_module.get_policy_adapter_settings(project_key="payments")
+
+    def test_policy_adapter_settings_default_legacy_storage_to_advisory_enforcement(
+        self,
+    ) -> None:
+        with database_module.SessionLocal() as session:
+            settings_repository_module.upsert_setting(
+                session,
+                key="policy_adapter_defaults::payments::project",
+                value=json.dumps(
+                    {
+                        "project_key": "payments",
+                        "source": "project",
+                        "warn_at": "medium",
+                        "soft_block_at": "high",
+                        "hard_block_at": "critical",
+                        "reporting_default": "advisory",
+                    }
+                ),
+            )
+
+        loaded = settings_service_module.get_policy_adapter_settings(
+            project_key="payments"
+        )
+
+        self.assertEqual(loaded.enforcement_mode, PolicyAdapterStatus.ADVISORY)
 
     def test_provider_profiles_can_be_saved_per_provider_and_switched(self) -> None:
         settings_service_module.save_provider_settings(

--- a/tests/test_services/test_settings_service.py
+++ b/tests/test_services/test_settings_service.py
@@ -271,6 +271,34 @@ class SettingsServiceTests(unittest.TestCase):
 
         self.assertEqual(loaded.enforcement_mode, PolicyAdapterStatus.ADVISORY)
 
+    def test_integration_policy_settings_default_legacy_storage_to_advisory_enforcement(
+        self,
+    ) -> None:
+        with database_module.SessionLocal() as session:
+            settings_repository_module.upsert_setting(
+                session,
+                key="policy_adapter_defaults::payments::integration::jenkins",
+                value=json.dumps(
+                    {
+                        "project_key": "payments",
+                        "integration": "jenkins",
+                        "source": "integration",
+                        "warn_at": "medium",
+                        "soft_block_at": "high",
+                        "hard_block_at": "critical",
+                        "reporting_default": "advisory",
+                    }
+                ),
+            )
+
+        loaded = settings_service_module.get_policy_adapter_settings(
+            project_key="payments",
+            integration="jenkins",
+        )
+
+        self.assertEqual(loaded.source, "integration")
+        self.assertEqual(loaded.enforcement_mode, PolicyAdapterStatus.ADVISORY)
+
     def test_provider_profiles_can_be_saved_per_provider_and_switched(self) -> None:
         settings_service_module.save_provider_settings(
             provider="openai",


### PR DESCRIPTION
## Summary
- Add project/integration enforcement modes with advisory-first defaults and legacy update preservation.
- Expose raw and capped policy decisions through a shared API contract.
- Apply explicit enforcement modes to GitHub App checks with bounded, machine-readable failure handling.
- Harden malformed check-run responses, project/delivery error separation, shared service updates, and skipped-intake guidance.
- Complete the CI consumer in companion action PR https://github.com/deploywhisper/analyze-action/pull/7.

## BMad review closure
- Resolves every Story 11.3 reviewer finding, including the cross-repository GitHub Action acceptance gap.
- Standardizes the action integration key as `github-action`.
- Keeps canonical reports advisory; only validated adapter decisions may block an integration.

## Validation
- Focused app suites: 101 passed, 72 subtests passed.
- `./.venv/bin/python -m pytest tests/test_api tests/test_cli tests/test_infra -v --tb=short`: 395 passed, 111 subtests passed.
- `./.venv/bin/python -m unittest discover -q`: 414 passed, 1 skipped.
- `bash scripts/ci-local.sh`: passed Ruff, repo-wide format, dependency integrity, Bandit (0 high), compileall, skill/prompt gates, and all backend/docs directories; final services directory reported 930 tests passing.
- Companion action suite: 62 passed; compileall, non-repository CLI entrypoint, and diff checks passed.

UI validation not applicable: no React route, component, rendered surface, interaction, keyboard behavior, or accessibility semantics changed.

## Remaining manual verification
- Published Marketplace tag smoke against a live DeployWhisper server remains release-time verification.